### PR TITLE
add Dockerfile & docker-compose for pd

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+notes/**
+.github
+.firebaserc
+theme
+book.toml
+*.md
+Dockerfile
+docker-compose.yml
+*.json
+target/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM rust:1.54.0 as build
+
+WORKDIR /usr/src
+COPY . .
+
+# Fetch dependencies in a separate layer, so that they can be cached.
+RUN cargo fetch --locked
+
+RUN cargo build --bin pd --release --frozen && \
+    mkdir -p /out && \
+    mv target/release/pd /out/pd
+
+# Install the penumbra daemon into the runtime image.
+
+# TODO(eliza): it would be nice to be able to run the Penumbra daemon in a
+# `scratch` image rather than Debian or Alpine. However, then we'd have to build
+# with a statically linked libc (read: musl), and musl's malloc exhibits
+# pathologically poor performance for Tokio applications...
+FROM debian:buster-slim as runtime
+WORKDIR /penumbra
+COPY --from=build /out/pd /usr/bin/pd
+ENV RUST_LOG=warn,pd=info,penumbra=info
+CMD [ "/usr/bin/pd" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.9"
+services:
+    # The Penumbra daemon
+    pd:
+        container_name: penumbra
+        build: "."
+        environment:
+            - RUST_LOG=${RUST_LOG:-warn,pd=info,penumbra=info}
+        command:
+            pd --host 0.0.0.0
+        networks:
+            localnet:
+                ipv4_address: 192.167.10.6
+
+    # The Tendermint node
+    tendermint:
+        container_name: tendermint
+        image: "tendermint/tendermint"
+        ports:
+            - "26656-26657:26656-26657"
+            - "6060:6060"
+            - "27000:26660"
+        volumes:
+            - "/tmp:/tendermint"
+        command: node --proxy-app=tcp://pd:26658
+        depends_on:
+            - pd
+        networks:
+            localnet:
+                ipv4_address: 192.167.10.2
+
+networks:
+    localnet:
+        driver: bridge
+        ipam:
+            driver: default
+            config:
+            -
+                subnet: 192.167.10.0/16


### PR DESCRIPTION
This branch adds an initial setup for running a Penumbra node using
`docker-compose`, and a `Dockerfile` for building a `pd` docker image.

There's some room for additional work here. In particular:

- the `docker-compose` file could also include Prometheus and
  Grafana containers (and Prometheus can be configured to scrape metrics
  from both Tendermint *and* pd)
- the correct way to volume mount the Tendermint dir so that it can be
  effected by running tendermint CLI commands locally on the host (for
  dev purposes) remains to be figured out
- `docker-compose` configuration should probably make a private network
  for tendermint -> pd RPCs so that nothing else on the host is allowed
  to talk to the pd process' ABCI RPCs
- Tendermint has a nifty [docker-compose config][1] for running a local
  testnet of several nodes in Docker, we might want something like that
  as well for dev purposes?
- I should actually write down how to test this.
- Docker image Rust build times could be improved using [experimental
  Docker features][2]; I punted on this for now because I didn't want
  to introduce potential complexity for anyone trying to run this...
- It would be cool to use a `scratch` base image rather than Debian,
  but then we would need a statically linked libc (read: musl), which
  is its own can of worms...

We may want to eventually have separate `docker-compose` configs for
actually distributing to run in production and for spinning up dev
testnets. But, for now, this basically Just Works.

[1]: https://docs.tendermint.com/master/networks/docker-compose.html
[2]: https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md#run---mounttypecache