### PR TITLE
destroy horrible submodule

### DIFF
--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -35,6 +33,7 @@ jobs:
       - name: Build API docs
         run: |
           cargo doc --no-deps
+          cargo doc --no-deps -p tower-abci
       - name: Move API docs to subdirectory
         run: |
           if [ -d "firebase-tmp" ]; then rm -rf firebase-tmp; fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,8 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -25,8 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -42,8 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -61,8 +55,6 @@ jobs:
   #  runs-on: ubuntu-latest
   #  steps:
   #    - uses: actions/checkout@v2
-  #      with:
-  #        submodules: true
   #    - uses: actions-rs/toolchain@v1
   #      with:
   #        profile: minimal

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tower-abci"]
-	path = tower-abci
-	url = https://github.com/penumbra-zone/tower-abci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,7 @@
 
 members = [
   "penumbra",
-  "tower-abci",
 ]
-
-## Used for tower-abci
 
 [patch.crates-io]
 tracing = { git = "https://github.com/tokio-rs/tracing/", branch = "v0.1.x" }

--- a/penumbra/Cargo.toml
+++ b/penumbra/Cargo.toml
@@ -12,12 +12,10 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# Workspace dependencies
-tower-abci = { path = "../tower-abci" }
-# External dependencies
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tower = { version = "0.4", features = ["full"]}
+tower-abci = { git = "https://github.com/penumbra-zone/tower-abci/" }
 tracing = "0.1"
 structopt = "0.3"
 tracing-subscriber = "0.2"


### PR DESCRIPTION
Currently, a Git submodule is used to include the `tower-abci` crate in
the workspace, rather than a Cargo git dependency. This is in order to
build `tower-abci`'s documentation via `cargo doc`. However, git
submodules are terrible<sup>\[citation needed\]</sup>, and introduce a
lot of friction to basic development workflows.

It's possible to build the RustDoc documentation for the `penumbra` and
`tower-abci` crates without building external dependencies, *without*
the use of a submodule. This can be done by changing the docs build to
run two commands, `cargo doc --no-deps` (to build `penumbra`'s RustDoc)
and `cargo doc --no-deps -p tower-abci` (to build the `tower-abci`
RustDoc). This doesn't require using git submodules, which should make
everyone's life easier.

Therefore, this branch changes the build configuration and nukes the
submodule.

**Sidenote**: it turns out the process for _removing_ a submodule
requires [three entire steps][1], which seems entirely par for the
course for Git's worst feature...

[1]: https://stackoverflow.com/a/16162000