### PR TITLE
proto: add skeleton of penumbra-proto crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+  "proto",
   "penumbra",
 ]
 

--- a/penumbra/Cargo.toml
+++ b/penumbra/Cargo.toml
@@ -12,6 +12,9 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# Workspace dependencies
+penumbra-proto = { path = "../proto" }
+# External dependencies
 bytes = "1"
 tokio = { version = "1", features = ["full"]}
 tower = { version = "0.4", features = ["full"]}

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "penumbra-proto"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bytes = "1"
+prost = "0.8"
+
+[build-dependencies]
+prost-build = { version = "0.8" }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,0 +1,29 @@
+use prost_build;
+use std::io::Result;
+
+fn main() -> Result<()> {
+    let mut config = prost_build::Config::new();
+
+    // Specify which parts of the protos should have their `bytes` fields
+    // converted to Rust `Bytes` (= zero-copy view into a shared buffer) rather
+    // than `Vec<u8>`.
+    //
+    // The upside of using the `Bytes` type is that it avoids copies while
+    // parsing the protos.
+    //
+    // The downside is that the underlying buffer is kept alive as long as there
+    // is at least one view into it, so holding on to a small amount of data
+    // (e.g., a hash) could keep a much larger buffer live for a long time,
+    // increasing memory use.
+    //
+    // Getting this tradeoff perfect isn't essential, but it's useful to keep in mind.
+    config.bytes(&[
+        // Transactions have a lot of `bytes` fields that need to be converted
+        // into fixed-size byte arrays anyways, so there's no point allocating
+        // into a temporary vector.
+        ".penumbra.transaction",
+    ]);
+
+    config.compile_protos(&["proto/transaction.proto"], &["proto/"])?;
+    Ok(())
+}

--- a/proto/proto/transaction.proto
+++ b/proto/proto/transaction.proto
@@ -1,0 +1,81 @@
+syntax = "proto3";
+package penumbra.transaction;
+
+// A Penumbra transaction.
+message Transaction {
+  TransactionBody body = 1;
+  // The binding signature is stored separately from the transaction body that it signs.
+  bytes binding_sig = 2;
+}
+
+// The body of a transaction.
+message TransactionBody {
+  // A list of actions (state changes) performed by this transaction.
+  repeated Action actions = 1;
+  // The root of some previous state of the note commitment tree.
+  bytes anchor = 2;
+  // The maximum height that this transaction can be included in the chain.
+  uint32 expiry_height = 3;
+  // The chain this transaction is intended for.  Including this prevents
+  // replaying a transaction on one chain onto a different chain.
+  string chain_id = 4;
+}
+
+// A state change performed by a transaction.
+message Action {
+  oneof action {
+    Fee fee = 1;
+    Spend spend = 2;
+    Output output = 3;
+  }
+}
+
+// Specifies fees paid by a transaction.
+message Fee {
+    uint64 amount = 1;
+}
+
+// Spends a shielded note.
+message Spend {
+  SpendBody body = 1;
+  // The spend authorization signature is stored separately from the spend body it authorizes.
+  bytes auth_sig = 2;
+}
+
+// The body of a spend description, stored separately from the signatures that authorize it.
+message SpendBody {
+  // A commitment to the value of the input note.
+  bytes cv = 1;
+  // The nullifier of the input note.
+  bytes nullifier = 3;
+  // The randomized validating key for the spend authorization signature.
+  bytes rk = 4;
+  // The spend proof.
+  bytes zkproof = 5;
+}
+
+// Creates a new shielded note.
+message Output {
+  OutputBody body = 1;
+  // An encrypted memo. 528 bytes.
+  bytes encrypted_memo = 2;
+  // The key material used for note encryption, wrapped in encryption to the
+  // sender's outgoing viewing key. 80 bytes.
+  bytes ovk_wrapped_key = 3;
+}
+
+// The body of an output description, not including a memo or ovk wrapping.
+// Splitting this data out allows its use where the memo / ovk wrapping is not
+// required (e.g., IBC).
+message OutputBody {
+  // A commitment to the value of the output note. 32 bytes.
+  bytes cv = 1;
+  // The u-coordinate of the note commitment for the output note. 32 bytes.
+  bytes cmu = 2;
+  // The encoding of an ephemeral public key. 32 bytes.
+  bytes ephemeral_key = 3;
+  // An encryption of the newly created note. 80 bytes.
+  bytes encrypted_note = 4;
+  // The output proof. 192 bytes.
+  bytes zkproof = 5;
+}

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -1,0 +1,23 @@
+//! Protobuf definitions for Penumbra.
+//!
+//! This crate only contains the `.proto` files and the Rust types generated
+//! from them.  These types only handle parsing the wire format; validation
+//! should be performed by converting them into an appropriate domain type, as
+//! in the following diagram:
+//!
+//! ```ascii
+//! ┌───────┐          ┌──────────────┐               ┌──────────────┐
+//! │encoded│ protobuf │penumbra_proto│ TryFrom/Into  │ domain types │
+//! │ bytes │<──wire ─>│    types     │<─validation ─>│(other crates)│
+//! └───────┘  format  └──────────────┘   boundary    └──────────────┘
+//! ```
+//!
+//! The [`Protobuf`] marker trait can be implemented on a domain type to ensure
+//! these conversions exist.
+
+pub mod transaction {
+    include!(concat!(env!("OUT_DIR"), "/penumbra.transaction.rs"));
+}
+
+mod protobuf;
+pub use protobuf::Protobuf;

--- a/proto/src/protobuf.rs
+++ b/proto/src/protobuf.rs
@@ -1,0 +1,8 @@
+/// A marker trait that captures the relationships between a domain type (`Self`) and a protobuf type (`P`).
+pub trait Protobuf<P>: Sized
+where
+    P: prost::Message,
+    P: std::convert::From<Self>,
+    Self: std::convert::TryFrom<P>,
+{
+}


### PR DESCRIPTION
This adds a skeleton of a crate that holds Protobuf definitions of Penumbra
datatypes, and a `transaction.proto` file with some scratch work on transaction
structure definitions.