### PR TITLE
docs: add decaf377 to rustdoc

### DIFF
--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -32,8 +32,9 @@ jobs:
 
       - name: Build API docs
         run: |
-          cargo doc --no-deps
+          cargo doc --no-deps -p decaf377
           cargo doc --no-deps -p tower-abci
+          cargo doc --no-deps
           # This is useful until ABCI changes are merged upstream
           # https://github.com/informalsystems/tendermint-rs/pull/862
           cargo doc --no-deps -p tendermint


### PR DESCRIPTION
This should be removed at some point in the future when we publish a crate.