### PR TITLE
deps: switch back to main branch in decaf377-rdsa

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377" }
-decaf377-rdsa = { git = "https://github.com/penumbra-zone/decaf377-rdsa", branch = "stuff-for-pen-keys" }
+decaf377-rdsa = { git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 hex = "0.4"
 blake2b_simd = "0.5"
 ark-ff = "0.3"


### PR DESCRIPTION
I pinned to a branch over in `decaf377-dsa` when implementing the keys stuff, we can switch back to main now as it was merged (https://github.com/penumbra-zone/decaf377-rdsa/pull/1)