### PR TITLE
Update spec with user-facing addresses/keys diagram and consistent FMD terminology

### DIFF
--- a/spec/SUMMARY.md
+++ b/spec/SUMMARY.md
@@ -4,7 +4,7 @@
 - [Concepts and Mechanisms](./concepts.md)
   - [Validators]()
   - [Epochs and Threshold Decryption](./concepts/epochs_threshold.md)
-  - [Addresses and Keys]()
+  - [Addresses and Keys](./concepts/addresses_keys.md)
   - [Notes, Nullifiers, and Trees](./concepts/notes_nullifiers_trees.md)
   - [Transactions](./concepts/transactions.md)
   - [Staking and Delegation](./concepts/stake.md)

--- a/spec/concepts/addresses_keys.md
+++ b/spec/concepts/addresses_keys.md
@@ -1,0 +1,60 @@
+# Addresses and Keys
+
+Value transferred on Penumbra is sent to *shielded payment addresses*; these
+addresses are derived from *spending keys* through a sequence of intermediate
+keys that represent different levels of attenuated capability:
+
+```mermaid
+flowchart BT
+    subgraph Address
+    end;
+    subgraph DTK[Detection Key]
+    end;
+    subgraph IVK[Incoming Viewing Key]
+    end;
+    subgraph OVK[Outgoing Viewing Key]
+    end;
+    subgraph FVK[Full Viewing Key]
+    end;
+    subgraph SK[Spending Key]
+    end;
+
+    index(Diversifier Index);
+    div{ };
+
+    SK --> FVK;
+    FVK --> OVK;
+    FVK --> IVK;
+
+    index --> div;
+    IVK ----> div;
+    div --> Address & DTK;
+    DTK --> Address;
+```
+
+From bottom to top:
+
+- the *spending key* is the root capability, representing spending authority;
+- the *full viewing key* represents the capability to view all transactions related to the spending authority;
+- the *outgoing viewing key* represents the capability to view only outgoing transactions, and is used to recover information about previously sent transactions;
+- the *incoming viewing key* represents the capability to view only incoming transactions, and is used to scan the block chain for incoming transactions.
+
+Penumbra allows the same spending authority to present multiple, publicly
+unlinkable addresses, keyed by an 11-byte *diversifier index*.  Each choice of
+diversifier index gives a distinct shielded payment address. Because these
+addresses share a common incoming viewing key, the cost of scanning the
+blockchain does not increase with the number of addresses in use.
+
+Finally, Penumbra also allows outsourcing *probabilistic* transaction detection
+to third parties using [fuzzy message detection](../crypto/fmd.md).  Each
+address has a *detection key*; a third party can use this key to detect
+transactions that might be relevant to that key.  Like a Bloom filter, this
+detection has false positives but no false negatives, so detection will find all
+relevant transactions, as well as some amount of unrelated cover traffic.
+Unlike incoming viewing keys, detection keys are not shared between diversified
+addresses, allowing fine-grained control of delegation.
+
+This diagram shows only the user-visible parts of the key hierarchy.
+Internally, each of these keys has different components, described in detail in
+the [Addresses and Keys](../crypto/addresses_keys.md) section of the
+[Cryptographic Protocol](../crypto.md) chapter.

--- a/spec/crypto/fmd.md
+++ b/spec/crypto/fmd.md
@@ -32,13 +32,13 @@ generalization of the original definition where the false positive probability
 is set by the sender instead of the receiver, and discusses why this is useful.
 
 * In [Constructing S-FMD](./fmd/construction.md), we realize the new definition
-using a variant of one of the original FMD constructions, and extend it in two
-ways:
-    1. to support *diversified detection*, allowing multiple, publicly
-    unlinkable addresses to be scanned by a single detection key; 
-    2. to support arbitrarily precise detection with compact, constant-size keys.  
+using a variant of one of the original FMD constructions, and extend it in two ways:
+    1. to support arbitrarily precise detection with compact, constant-size keys;
+    2. to support *diversified detection*, allowing multiple, publicly
+    unlinkable addresses to be scanned by a single detection key.
 
-    The resulting construction can then be integrated into the Sapling key heirarchy.
+Unfortunately, these extensions are not mutually compatible, so we only use the
+first one, and record the second for posterity.
 
 * In [Parameter Considerations](./fmd/considerations.md), we discuss how the
 false positive rates should be chosen.

--- a/spec/crypto/fmd/construction.md
+++ b/spec/crypto/fmd/construction.md
@@ -6,24 +6,25 @@ the form $p = 2^{-n}$; the third supports arbitrary fractional probabilities
 using a much more complex and expensive construction.  
 
 The first two schemes, R-FMD1 and R-FMD2, are constructed similarly to a Bloom
-filter: the `Flag` procedure encrypts a number of `1` bits, and the `Test`
+filter: the `CreateClue` procedure encrypts a number of `1` bits, and the `Examine`
 procedure uses information in a detection key to check whether some subset of
 them are `1`, returning `true` if so and `false` otherwise.  The false positive
 probability is controlled by extracting only a subset of the information in the
 root key into the detection key, so that it can only check a subset of the bits
-encoded in the flag ciphertext.  We focus on R-FMD2, which provides more compact
+encoded in the clue.  We focus on R-FMD2, which provides more compact
 ciphertexts and chosen-ciphertext security.
 
 In this section, we:
 
 * recall the construction of R-FMD2, changing notation from the paper;
 * adapt R-FMD2 to S-FMD2, which provides sender FMD instead of receiver FMD;
-* extend S-FMD2 to support diversified detection, allowing multiple, unlinkable
-  flag keys to be detected by a single detection key;
 * extend S-FMD2 to use deterministic derivation, allowing 32-byte flag and
   detection keys to support arbitrary-precision false positive probabilities;
+* extend S-FMD2 to support diversified detection, allowing multiple, unlinkable
+  flag keys to be detected by a single detection key (though, as this extension
+  conflicts with the preceding one, we do not use it);
 * summarize the resulting construction and describe how it can be integrated
-  with the Sapling key heirarchy.
+  with a Sapling- or Orchard-style key hierarchy.
 
 ## The R-FMD2 construction
 
@@ -41,7 +42,7 @@ functions.
 
 Choose a generator $B \xleftarrow \\$ \mathbb G$.  For $i = 1,\ldots,\gamma$,
 choose $x_i \xleftarrow \\$ \Z_q$ and compute $X_i = [x_i]B$.  Return the *root
-key* $rk \gets (x_1, \ldots, x_\gamma)$ and the *flag key* $fk \gets (B, X_1,
+key* $rk \gets (x_1, \ldots, x_\gamma)$ and the *clue key* $ck \gets (B, X_1,
 \ldots, X_\gamma)$.
 
 ###### `R-FMD2/Extract`
@@ -51,7 +52,7 @@ On input $p = 2^{-n}$ and root key $rk$, parse $(x_1, \ldots, x_\gamma)
 
 ###### `R-FMD2/Flag`
 
-On input $fk$, first parse $(B, X_1, \ldots, X_n) \gets fk$, then proceed as
+On input $ck$, first parse $(B, X_1, \ldots, X_n) \gets ck$, then proceed as
 follows:
 
 1. Choose $r \xleftarrow \\$ \Z_q$ and compute $P \gets [r]B$.
@@ -62,12 +63,12 @@ follows:
 4. Compute $m \gets H_2(P || c_1 || \cdots || c_\gamma)$.
 5. Compute $y \gets (z - m)r^{-1}$.
 
-Return the *flag ciphertext* $fc \gets (P, y, c_1, \ldots, c_\gamma)$.
+Return the *clue* $c \gets (P, y, c_1, \ldots, c_\gamma)$.
 
-###### `R-FMD2/Test`
+###### `R-FMD2/Examine`
 
-On input $dk$, $fc$, first parse $(x_1, \ldots, x_n) \gets dk$, $(P, y, c_1,
-\ldots, c_\gamma) \gets fc$, then proceed as follows:
+On input $dk$, $c$, first parse $(x_1, \ldots, x_n) \gets dk$, $(P, y, c_1,
+\ldots, c_\gamma) \gets c$, then proceed as follows:
 
 1. Compute $m \gets H_2(P || c_1 || \cdots || c_\gamma)$.
 2. Recompute $Q$ as $Q \gets [y]P + [m]B$.
@@ -90,7 +91,7 @@ so the detector will recompute the $Q$ used by the sender; then, since $[r]X_i =
 [r][x_i]B = [x_i]P$, the detector's $k_i \gets H_1(P || [x_i]P || Q)$ is the
 same as the sender's $k_i \gets H_1(P || [r]X_i || Q)$.
 
-On the other hand, if the ciphertext was created with a different flag key, the
+On the other hand, if the clue was created with a different clue key, the
 resulting $k_i$ will be random bits, giving the desired $2^{-n}$ false positive
 probability.
 
@@ -130,11 +131,11 @@ The S-FMD2 construction then works as follows:
 
 For $i = 1,\ldots,\gamma$, choose $x_i \xleftarrow \\$ \Z_q$ and compute $X_i =
 [x_i]B$.  Return the *detection key* $dk \gets (x_1, \ldots, x_\gamma)$ and the
-*flag key* $fk \gets (X_1, \ldots, X_\gamma)$.
+*clue key* $ck \gets (X_1, \ldots, X_\gamma)$.
 
-###### `S-FMD2/Flag`
+###### `S-FMD2/CreateClue`
 
-On input flag key $fk$, first parse $(X_1, \ldots, X_n) \gets fk$, then proceed
+On input clue key $ck$, first parse $(X_1, \ldots, X_n) \gets ck$, then proceed
 as follows:
 
 1. Choose $r \xleftarrow \\$ \Z_q$ and compute $P \gets [r]B$.
@@ -145,13 +146,14 @@ as follows:
 4. Compute $m \gets H_2(P || n || c_1 || \cdots || c_n)$.
 5. Compute $y \gets (z - m)r^{-1}$.
 
-Return the *flag ciphertext* $fc \gets (P, y, c_1, \ldots, c_n)$.
+Return the *clue* $c \gets (P, y, n, c_1, \ldots, c_n)$.  (We include $n$
+explicitly rather than have it specified implicitly by $c_n$ to reduce the risk
+of implementation confusion).
 
-###### `S-FMD2/Test`
+###### `S-FMD2/Examine`
 
-On input detection key $dk$ and flag ciphertext $fc$, first parse $(x_1, \ldots,
-x_\gamma) \gets dk$ and $(P, y, c_1, \ldots, c_n) \gets fc$, then proceed as
-follows:
+On input detection key $dk$ and clue $c$, first parse $(x_1, \ldots, x_\gamma)
+\gets dk$ and $(P, y, n, c_1, \ldots, c_n) \gets c$, then proceed as follows:
 
 1. Compute $m \gets H_2(P || n || c_1 || \cdots || c_n)$.
 2. Recompute $Q$ as $Q \gets [y]P + [m]B$.
@@ -164,15 +166,63 @@ If all plaintext bits $b_i = 1$, return $1$ (match); otherwise, return $0$.
 The value of $n$ is included in the ciphertext hash to ensure that the encoding
 of the ciphertext bits is non-malleable.  Otherwise, the construction is identical.
 
+## Compact clue and detection keys
+
+One obstacle to FMD integration is the size of the clue keys.  Clue keys are
+required to create clues, so senders who wish to create clues need to obtain the
+receiver's clue key.  Ideally, the clue keys would be bundled with other address
+data, so that clues can be included with all messages, rather than being an
+opt-in mechanism with a much more limited anonymity set.
+
+However, the size of clue keys makes this difficult.  A clue key supporting
+false positive probabilities down to $2^{-\gamma}$ requires $\gamma$ group
+elements; for instance, supporting probabilities down to $2^{-14} = 1/16384$
+with a 256-bit group requires 448-byte flag keys.  It would be much more
+convenient to have smaller keys.
+
+One way to do this is to use a deterministic key derivation mechanism similar to
+[BIP32] to derive a sequence of child keypairs from a single parent keypair, and
+use that sequence as the components of a flag / detection keypair.  To do this,
+we define a hash function $H_4 : \mathbb G \times \mathbb Z \rightarrow \mathbb
+Z_q$.  Then given a parent keypair $(x, X = [x]B)$, child keys can be derived as 
+$$
+\begin{align}
+x_i &\gets x + H_4(X || i) \\
+X_i &\gets X + [H_4(X || i)] B
+\end{align}
+$$
+with $X_i = [x_i]B$.  Unlike BIP32, there is only one sequence of keypairs, so
+there is no need for a chain code to namespace different levels of derivation,
+although of course the hash function $H_4$ should be domain-separated.
+
+Applying this to S-FMD2, the scalar $x$ becomes the *detection key*, and the
+point $X$ becomes the *clue key*.  The former detection key is renamed the
+*expanded detection key* $(x_1, \ldots, x_\gamma)$, and the former clue key is
+renamed the *expanded clue key* $(X_1, \ldots, X_\gamma)$; these are derived
+from the detection and clue keys respectively.
+
+In addition, it is no longer necessary to select the minimum false
+positive probability as a global parameter $\gamma$ prior to key generation, as
+the compact keys can be extended to arbitrary length (and thus arbitrary false
+positive probabilities).
+
+Deterministic derivation is only possible in the S-FMD setting, not the R-FMD
+setting, because S-FMD does not require any separation of capability between the
+component keys used for each bit of the Bloom filter.  Public deterministic
+derivation does not allow separation of capability: given $X$ and any child
+secret $x_i$, it's possible to recover the parent secret $x$ and therefore the
+entire subtree of secret keys.  Thus, it cannot be used for R-FMD, where the
+detection key is created by disclosing only some of the bits of the root key.
+
 ## Diversified detection: from S-FMD2 to S-FMD2-d
 
 The Sapling design provides viewing keys that support *diversified addresses*: a
 collection of publicly unlinkable addresses whose activity can be scanned by a
 common viewing key.  For integration with Sapling, as well as other
 applications, it would be useful to support *diversified detection*: a
-collection of publicly unlinkable *diversified flag keys* that share a common
+collection of publicly unlinkable *diversified clue keys* that share a common
 detection key.  This collection is indexed by data called a *diversifier*; each
-choice of diversifier gives a different diversified flag key corresponding to
+choice of diversifier gives a different diversified clue key corresponding to
 the same detection key.
 
 In the Sapling design, diversified addresses are implemented by selecting the
@@ -186,14 +236,17 @@ keys.
 
 A similar approach can be applied to S-FMD2, but some modifications to the tag
 mechanism are required to avoid use of the basepoint in the `Test` procedure.
+**Unfortunately, this extension is not compatible with compact clue and
+detection keys, so although it is presented here for posterity, it is not used
+in Penumbra**.
 
 Let $\mathcal D$ be the set of diversifiers, and let $H_3 : \mathcal D
 \rightarrow \mathbb G$ be a group-valued hash function.  At a high level, our
 goal is to replace use of a common basepoint $B$ with a *diversified basepoint*
 $B_d = H_3(d)$ for some $d \in \mathcal D$.  
 
-Our goal is to have diversified flag keys, so we first replace $B$ by $B_d$ in
-`KeyGen`, so that $X_i = [x_i]B_d$ and the components of the flag key are
+Our goal is to have diversified clue keys, so we first replace $B$ by $B_d$ in
+`KeyGen`, so that $X_i = [x_i]B_d$ and the components of the clue key are
 parameterized by the diversifier $d$.  The sender will compute the key bits as
 $$
 k_i \gets H_1( P || [r]X_i || Q),
@@ -225,10 +278,10 @@ Q \gets & [y]P_1 + [m]P_2 \\
 =& [z]P_2.
 \end{align}
 $$
-The point $P_2$ must be included in the flag ciphertext, increasing its size,
+The point $P_2$ must be included in the clue, increasing its size,
 but detection no longer involves use of a basepoint (diversified or otherwise).
 
-Concretely, this mechanism works as follows, splitting out generation of flag
+Concretely, this mechanism works as follows, splitting out generation of clue
 keys (diversifier-dependent) from generation of detection keys:
 
 ###### `S-FMD2-d/KeyGen`
@@ -240,13 +293,13 @@ return the *detection key* $dk \gets (x_1, \ldots, x_\gamma)$.
 
 On input detection key $dk$ and diversifier $d$, first parse $(x_1, \ldots,
 x_\gamma) \gets dk$.  Then compute the diversified base $B_d \gets H_3(d)$, and
-use it to compute $X_i = [x_i]B_d$.  Return the *diversified flag key* $fk_d
+use it to compute $X_i = [x_i]B_d$.  Return the *diversified clue key* $ck_d
 \gets (X_1, \ldots, X_\gamma)$.
 
-###### `S-FMD2-d/Flag`
+###### `S-FMD2-d/CreateClue`
 
-On input diversified flag key $fk_d$ and diversifier $d$, first parse $(X_1, \ldots, X_n)
-\gets fk_d$, then proceed as follows:
+On input diversified clue key $ck_d$ and diversifier $d$, first parse $(X_1, \ldots, X_n)
+\gets ck_d$, then proceed as follows:
 
 1. Compute the diversified base $B_d \gets H_3(d)$.
 1. Choose $r_1 \xleftarrow \\$ \Z_q$ and compute $P_1 \gets [r]B_d$.
@@ -258,12 +311,12 @@ On input diversified flag key $fk_d$ and diversifier $d$, first parse $(X_1, \ld
 4. Compute $m \gets H_2(P_1 || P_2 || n || c_1 || \cdots || c_n)$.
 5. Compute $y \gets (z - m) \frac {r_2} {r_1}$.
 
-Return the *flag ciphertext* $fc \gets (P_1, P_2, y, c_1, \ldots, c_n)$.
+Return the *clue* $c \gets (P_1, P_2, y, n, c_1, \ldots, c_n)$.
 
-###### `S-FMD2-d/Test`
+###### `S-FMD2-d/Examine`
 
-On input detection key $dk$ and flag ciphertext $fc$, first parse $(x_1, \ldots,
-x_\gamma) \gets dk$ and $(P_1, P_2, y, c_1, \ldots, c_n) \gets fc$, then proceed as
+On input detection key $dk$ and clue $c$, first parse $(x_1, \ldots,
+x_\gamma) \gets dk$ and $(P_1, P_2, y, n, c_1, \ldots, c_n) \gets c$, then proceed as
 follows:
 
 1. Compute $m \gets H_2(P_1 || P_2 || n || c_1 || \cdots || c_n)$.
@@ -274,61 +327,16 @@ follows:
 
 If all plaintext bits $b_i = 1$, return $1$ (match); otherwise, return $0$.
 
-## Deterministic flag key generation
+Unfortunately, this extension does not seem to be possible to combine with the
+compact clue and detection keys extension described above.  The detection key
+components $x_i$ must be derived from the parent secret and (the hash of) public
+data, but diversified detection requires that different public data (clue keys)
+have the same detection key components.
 
-One remaining obstacle is the size of the flag keys.  A flag key supporting
-false positive probabilities down to $2^{-\gamma}$ requires $\gamma$ group
-elements; for instance, supporting probabilities down to $2^{-14} = 1/16384$
-with a 256-bit group requires 448-byte flag keys.  It would be much more
-convenient to have smaller keys.
-
-One way to do this is to use a deterministic key derivation mechanism similar to
-[BIP32] to derive a sequence of child keypairs from a single parent keypair, and
-use that sequence as the components of a flag / detection keypair.  To do this,
-we define a hash function $H_4 : \mathbb G \times \mathbb Z \rightarrow \mathbb
-Z_q$.  Then given a parent keypair $(x, X = [x]B)$, child keys can be derived as 
-$$
-\begin{align}
-x_i &\gets x + H_4(X || i) \\
-X_i &\gets X + [H_4(X || i)] B
-\end{align}
-$$
-with $X_i = [x_i]B$.  Unlike BIP32, there is only one sequence of keypairs, so
-there is no need for a chain code to namespace different levels of derivation,
-although of course the hash function $H_4$ should be domain-separated.
-
-Applying this to S-FMD2, the scalar $x$ becomes the *compact detection key*, and
-the point $X$ becomes the *compact flag key*.  The full detection key $(x_1,
-\ldots, x_\gamma)$ can be derived from the compact detection key $x$, and the
-full flag key $(X_1, \ldots, X_\gamma)$ can be derived from the compact flag key
-$X$.  In addition, it is no longer necessary to select the minimum false
-positive probability as a global parameter $\gamma$ prior to key generation, as
-the compact keys can be extended to arbitrary length (and thus arbitrary false
-positive probabilities).
-
-Deterministic derivation is only possible in the S-FMD setting, not the R-FMD
-setting, because S-FMD does not require any separation of capability between the
-component keys used for each bit of the Bloom filter.  Public deterministic
-derivation does not allow separation of capability: given $X$ and any child
-secret $x_i$, it's possible to recover the parent secret $x$ and therefore the
-entire subtree of secret keys.  Thus, it cannot be used for R-FMD, where the
-detection key is created by disclosing only some of the bits of the root key.
-
-Unfortunately, this optimization does not seem to be possible to combine with
-diversified detection.  The detection key components $x_i$ must be derived from
-the parent secret and (the hash of) public data, but diversified detection
-requires that different public data (flag keys) have the same detection key
-components.
-
-- [ ] Is there some clever way to sidestep this issue? seems somewhat fundamental.
-
-
-## Sapling Integration
-
-- [ ] Pick diversified detection XOR deterministic flag key generation
-- [ ] Addresses include a flag key / compact flag key
-  - [ ] 32-byte compact flag keys are probably workable, 320-448 byte full flag keys are probably not.
-
+Of the two extensions, compact clue keys are much more important, because they
+allow clue keys to be included in an address, and this allows message detection
+to be a default behavior of the system, rather than an opt-in behavior of a
+select few users.  
 
 [fmd-paper]: https://eprint.iacr.org/2021/089
 [BIP32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki

--- a/spec/crypto/fmd/sender-receiver.md
+++ b/spec/crypto/fmd/sender-receiver.md
@@ -22,30 +22,29 @@ probability.
 ## Receiver FMD
 
 The paper's original definition of fuzzy message detection is as a tuple of
-algorithms `(KeyGen, Flag, Extract, Test)`.  The receiver uses `KeyGen` to
-generate a *root key* and a *flag key*[^1].  A sender uses the
-receiver's flag key as input to `Flag` to produce a *flag ciphertext*.  The
-`Extract` algorithm takes the root key and a false positive rate $p$
-(chosen from some set of supported rates), and produces a *detection key*.  This
-detection key can be applied to a flag ciphertext using `Test` to produce a
-detection result.
+algorithms `(KeyGen, CreateClue, Extract, Examine)`.[^1]  The receiver uses
+`KeyGen` to generate a *root key* and a *clue key*.  A sender uses the
+receiver's clue key as input to `CreateClue` to produce a *clue*.  The `Extract`
+algorithm takes the root key and a false positive rate $p$ (chosen from some set
+of supported rates), and produces a *detection key*.  The `Examine` algorithm
+uses a detection key to examine a clue and produce a detection result.
 
 This scheme should satisfy certain properties, formalizations of which can be
 found in the paper:
 
 ###### Correctness.
 
-Valid matches must always be detected by `Test`; i.e., there are no false negatives.
+Valid matches must always be detected by `Examine`; i.e., there are no false negatives.
 
 ###### Fuzziness.
 
 Invalid matches should produce false positives with probability approximately
-$p$, as long as the flag ciphertexts and detection keys were honestly generated.
+$p$, as long as the clues and detection keys were honestly generated.
 
 ###### Detection Ambiguity.
 
 An adversarial detector must be unable to distinguish between a true positive
-and a false positive, as long as the flag ciphertexts and detection keys were
+and a false positive, as long as the clues and detection keys were
 honestly generated.
 
 In this original definition, the receiver has control over how much detection
@@ -65,21 +64,21 @@ To address this problem, we generalize the original definition (now *Receiver
 FMD*) to *Sender FMD*, in which the false positive probability is chosen by the
 sender.
 
-Like R-FMD, S-FMD consists of a tuple of
-algorithms `(KeyGen, Flag, Extract, Test)`.  Like R-FMD, `KeyGen` generates a
-root key and a flag key, and `Test` takes a detection key and a flag ciphertext
-and produces a detection result.  Unlike R-FMD, `Extract` produces a detection
-key directly from the root key, and `Flag` takes the false positive rate $p$ and
-the receiver's flag key to produce a flag ciphertext.  As discussed below, S-FMD
-can be realized using tweaks to either of the R-FMD constructions in the
-original paper.
+S-FMD consists of a tuple of algorithms `(KeyGen, CreateClue, Examine)`.  Like
+R-FMD, `CreateClue` creates a clue and `Examine` takes a detection key and a
+clue and produces a detection result.  As discussed in the [next
+section](./construction.md), S-FMD can be realized using tweaks to either of the
+R-FMD constructions in the original paper.
+
+Unlike R-FMD, the false positive rate is set by the sender, so `CreateClue`
+takes both the false positive rate $p$ and the receiver's clue key.  Because the
+false postive rate is set by the sender, there is no separation of capability
+between the root key and a detection key, so `KeyGen` outputs a clue key and a
+detection key, and `Extract` disappears.
 
 In R-FMD, flag ciphertexts are universal with respect to the false positive
 rate, which is applied to the detection key; in S-FMD, the false positive rate
-is applied to the flag ciphertext and the detection key is universal.  (This
-means there is no meaningful difference in capability between the root key and
-the detection key, so the distinction is maintained just for ease of comparison
-between the two variants).
+is applied to the flag ciphertext and the detection key is universal.
 
 Unlike R-FMD, S-FMD allows detection precision to be adaptive, by having senders
 use a (consensus-determined) false positive parameter.  This parameter should
@@ -87,8 +86,12 @@ vary as the global message rates vary, so that filtered message streams have a
 bounded rate, and it should be the same for all users, so that messages cannot
 be distinguished by their false positive rate.
 
-[^1]: The paper calls these the secret and public keys respectively, but we
-avoid this in favor of capability-based terminology that names keys according to
-the precise capability they allow.
+[^1]: We change terminology from the FMD paper; the paper calls detection and
+clue keys the secret and public keys respectively, but we avoid this in favor of
+capability-based terminology that names keys according to the precise capability
+they allow.  The "clue" terminology is adopted from the [_Oblivious Message
+Retrieval_][omr] paper of Zeyu Liu and Eran Tromer; we `CreateClue` and `Examine` clues
+rather than `Flag` and `Test` flag ciphertexts.
 
 [macaroons]: https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/41892.pdf
+[omr]: https://eprint.iacr.org/2021/1256


### PR DESCRIPTION
- adds a addresses/keys diagram in the Concepts chapter that just has the user-visible keys, not the internal key components;
- updates the terminology in the FMD section to match the implementation (clues / clue keys).