### PR TITLE
proto: add stub of Wallet service protos.

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2018"
 
 [dependencies]
 bytes = "1"
-prost = "0.8"
+prost = "0.9"
+tonic = "0.6"
 
 [build-dependencies]
-prost-build = { version = "0.8" }
+prost-build = "0.9"
+tonic-build = "0.6"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -22,9 +22,16 @@ fn main() -> Result<()> {
         // into fixed-size byte arrays anyways, so there's no point allocating
         // into a temporary vector.
         ".penumbra.transaction",
+        // The byte fields in a state fragment will also be converted to fixed-size
+        // byte arrays and then discarded.
+        ".penumbra.wallet.StateFragment",
     ]);
 
     config.compile_protos(&["proto/transaction.proto"], &["proto/"])?;
     config.compile_protos(&["proto/transparent_proofs.proto"], &["proto/"])?;
+
+    // For the client code, we also want to generate RPC instances, so compile via tonic:
+    tonic_build::configure().compile_with_config(config, &["proto/wallet.proto"], &["proto/"])?;
+
     Ok(())
 }

--- a/proto/proto/transaction.proto
+++ b/proto/proto/transaction.proto
@@ -75,7 +75,8 @@ message OutputBody {
   bytes cm = 2;
   // The encoding of an ephemeral public key. 32 bytes.
   bytes ephemeral_key = 3;
-  // An encryption of the newly created note. 80 bytes.
+  // An encryption of the newly created note.
+  // 132 = 1(type) + 11(d) + 8(amount) + 32(asset_id) + 32(rcm) + 32(pk_d) + 16(MAC) bytes.
   bytes encrypted_note = 4;
   // The output proof. 192 bytes.
   bytes zkproof = 5;

--- a/proto/proto/wallet.proto
+++ b/proto/proto/wallet.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+package penumbra.wallet;
+
+import "transaction.proto";
+
+// A wallet service.
+service Wallet {
+  rpc CompactBlockRange(CompactBlockRangeRequest) returns (stream CompactBlock);
+  rpc TransactionByNote(TransactionByNoteRequest) returns (penumbra.transaction.Transaction);
+}
+
+// Requests a range of compact block data.
+message CompactBlockRangeRequest {
+  // The start height of the range.
+  uint32 start_height = 1;
+  // The end height of the range.
+  uint32 end_height = 2;
+}
+
+message CompactBlock {
+  uint32 height = 1;
+  repeated StateFragment fragment = 2;
+}
+
+// Contains the minimum data needed to update client state.
+message StateFragment {
+  // The note commitment for the output note. 32 bytes.
+  bytes cm = 2;
+  // The encoding of an ephemeral public key. 32 bytes.
+  bytes ephemeral_key = 3;
+  // An encryption of the newly created note.
+  // 132 = 1(type) + 11(d) + 8(amount) + 32(asset_id) + 32(rcm) + 32(pk_d) + 16(MAC) bytes.
+  bytes encrypted_note = 4;
+}
+
+// Requests the transaction containing a given output note commitment.
+// Note: this is bad for privacy, address private fetching later.
+message TransactionByNoteRequest {
+  // The note commitment we're interested in.
+  bytes cm = 1;
+}

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -15,16 +15,22 @@
 //! The [`Protobuf`] marker trait can be implemented on a domain type to ensure
 //! these conversions exist.
 
+/// Transaction structures.
 pub mod transaction {
     include!(concat!(env!("OUT_DIR"), "/penumbra.transaction.rs"));
 }
 
-/// Transparent proofs
+/// Transparent proofs.
 ///
 /// Note that these are protos for the "MVP" transparent version of Penumbra,
 /// i.e. not for production use and intentionally not private.
 pub mod transparent_proofs {
     include!(concat!(env!("OUT_DIR"), "/penumbra.transparent_proofs.rs"));
+}
+
+/// Wallet protocol structures.
+pub mod wallet {
+    tonic::include_proto!("penumbra.wallet");
 }
 
 mod protobuf;


### PR DESCRIPTION
Starts work on #33.

- [x] defines a `.proto` specification of the client protocol;
- [x] adds support for generating Rust proto types.

Instead of generating the protos using `prost` directly, the wallet protos are
generated using `tonic`, but using the same `prost` config as the other
protos. The reason is that we define a GRPC service for the wallet protocol,
and we want to derive the implementation using `tonic`, but this requires using the protos.  The alternative would be to somehow expose the protos to other crates, and use `tonic` there, but that's not as nice.

For the moment, the stub protocol places full trust in the endpoint for
integrity and privacy, but engineering away this trust is a future design
goal.

Currently, there are only two RPC methods:

- `CompactBlockRange` returns a stream of `CompactBlocks`, containing a height
  and a list of `StateFragments`, which have just the information needed to do
client-side scanning.

- `TransactionByNote` allows querying for a full transaction body by note
  commitment.  This allows a client to get full information on a transaction
once they've identified it through scanning.  This is quite bad for privacy if
the server weren't trusted, as it precisely identifies the notes the client is
interested in. In the future, it should be replaced with something that leaks
less information.