### PR TITLE
feat: Note, memo, ovk encryption/decryption

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -30,5 +30,6 @@ blake2b_simd = "0.5"
 once_cell = "1.8"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand = "0.8"
+chacha20poly1305 = "0.9.0"
 # only needed because ark-ff doesn't display correctly
 num-bigint = "0.4"

--- a/crypto/src/action.rs
+++ b/crypto/src/action.rs
@@ -1,7 +1,6 @@
 use penumbra_proto::{transaction, Protobuf};
 use std::convert::{TryFrom, TryInto};
 
-pub mod constants;
 pub mod error;
 pub mod output;
 pub mod spend;

--- a/crypto/src/action/constants.rs
+++ b/crypto/src/action/constants.rs
@@ -1,2 +1,1 @@
 pub const OVK_WRAPPED_LEN_BYTES: usize = 80;
-pub const NOTE_ENCRYPTION_BYTES: usize = 80;

--- a/crypto/src/action/constants.rs
+++ b/crypto/src/action/constants.rs
@@ -1,1 +1,0 @@
-pub const OVK_WRAPPED_LEN_BYTES: usize = 80;

--- a/crypto/src/action/output.rs
+++ b/crypto/src/action/output.rs
@@ -71,7 +71,7 @@ impl Body {
         let note_commitment = note.commit();
 
         let ephemeral_key = esk.diversified_public(&note.diversified_generator());
-        let encrypted_note = note.encrypt(&esk).expect("note encrypted successfully");
+        let encrypted_note = note.encrypt(&esk);
 
         let proof = OutputProof {
             g_d: *dest.diversified_generator(),

--- a/crypto/src/action/output.rs
+++ b/crypto/src/action/output.rs
@@ -1,5 +1,4 @@
 use bytes::Bytes;
-use rand_core::{CryptoRng, RngCore};
 use std::convert::{TryFrom, TryInto};
 
 use penumbra_proto::{transaction, Protobuf};
@@ -66,13 +65,7 @@ pub struct Body {
 }
 
 impl Body {
-    pub fn new<R: RngCore + CryptoRng>(
-        rng: &mut R,
-        note: Note,
-        v_blinding: Fr,
-        dest: &Address,
-        esk: &ka::Secret,
-    ) -> Body {
+    pub fn new(note: Note, v_blinding: Fr, dest: &Address, esk: &ka::Secret) -> Body {
         // TODO: p. 43 Spec. Decide whether to do leadByte 0x01 method or 0x02 or other.
         let value_commitment = note.value().commit(v_blinding);
         let note_commitment = note.commit();
@@ -86,7 +79,7 @@ impl Body {
             value: note.value(),
             v_blinding,
             note_blinding: note.note_blinding(),
-            esk: *esk,
+            esk: esk.clone(),
         };
 
         Self {

--- a/crypto/src/action/output.rs
+++ b/crypto/src/action/output.rs
@@ -71,7 +71,7 @@ impl Body {
         let note_commitment = note.commit();
 
         let ephemeral_key = esk.diversified_public(&note.diversified_generator());
-        let encrypted_note = note.encrypt(&esk);
+        let encrypted_note = note.encrypt(&esk).expect("note encrypted successfully");
 
         let proof = OutputProof {
             g_d: *dest.diversified_generator(),

--- a/crypto/src/keys/diversifier.rs
+++ b/crypto/src/keys/diversifier.rs
@@ -9,7 +9,7 @@ use crate::Fq;
 
 pub const DIVERSIFIER_LEN_BYTES: usize = 11;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Diversifier(pub [u8; DIVERSIFIER_LEN_BYTES]);
 
 /// The domain separator used to generate diversified generators.

--- a/crypto/src/keys/ivk.rs
+++ b/crypto/src/keys/ivk.rs
@@ -38,6 +38,11 @@ impl IncomingViewingKey {
         )
     }
 
+    /// Perform key agreement with a given public key.
+    pub fn key_agreement_with(&self, pk: &ka::Public) -> Result<ka::SharedSecret, ka::Error> {
+        self.ivk.key_agreement_with(pk)
+    }
+
     /// Derive a transmission key from the given diversified base.
     pub fn diversified_public(&self, diversified_generator: &decaf377::Element) -> ka::Public {
         self.ivk.diversified_public(diversified_generator)

--- a/crypto/src/keys/ovk.rs
+++ b/crypto/src/keys/ovk.rs
@@ -3,4 +3,4 @@ pub const OVK_LEN_BYTES: usize = 32;
 /// Allows viewing outgoing notes, i.e., notes sent from the spending key this
 /// key is derived from.
 #[derive(Clone)]
-pub struct OutgoingViewingKey(pub(super) [u8; OVK_LEN_BYTES]);
+pub struct OutgoingViewingKey(pub(crate) [u8; OVK_LEN_BYTES]);

--- a/crypto/src/memo.rs
+++ b/crypto/src/memo.rs
@@ -45,7 +45,7 @@ impl MemoPlaintext {
         let key = Key::from_slice(kdf_output.as_bytes());
 
         let cipher = ChaCha20Poly1305::new(key);
-        let nonce = Nonce::from_slice(&[0u8; 12]);
+        let nonce = Nonce::from_slice(&[1u8; 12]);
 
         let encryption_result = cipher
             .encrypt(nonce, self.0.as_ref())
@@ -78,7 +78,7 @@ impl MemoPlaintext {
         let key = Key::from_slice(kdf_output.as_bytes());
 
         let cipher = ChaCha20Poly1305::new(key);
-        let nonce = Nonce::from_slice(&[0u8; 12]);
+        let nonce = Nonce::from_slice(&[1u8; 12]);
         let plaintext = cipher
             .decrypt(nonce, ciphertext.0.as_ref())
             .map_err(|_| anyhow!("decryption error"))?;

--- a/crypto/src/memo.rs
+++ b/crypto/src/memo.rs
@@ -1,4 +1,10 @@
-use crate::Address;
+use chacha20poly1305::{
+    aead::{Aead, NewAead},
+    ChaCha20Poly1305, Key, Nonce,
+};
+use std::convert::TryInto;
+
+use crate::ka;
 
 pub const MEMO_CIPHERTEXT_LEN_BYTES: usize = 528;
 
@@ -16,10 +22,36 @@ impl Default for MemoPlaintext {
 }
 
 impl MemoPlaintext {
-    pub fn encrypt(&self, _key: &Address) -> MemoCiphertext {
-        // TODO!
-        let memo_bytes = [0u8; MEMO_CIPHERTEXT_LEN_BYTES];
-        MemoCiphertext(memo_bytes)
+    // Encrypt a memo, returning its ciphertext.
+    pub fn encrypt(
+        &self,
+        esk: &ka::Secret,
+        transmission_key: &ka::Public,
+        diversified_generator: &decaf377::Element,
+    ) -> MemoCiphertext {
+        let epk = esk.diversified_public(diversified_generator);
+        let shared_secret = esk
+            .key_agreement_with(&transmission_key)
+            .expect("key agreement success");
+
+        let mut kdf_input = Vec::new();
+        kdf_input.copy_from_slice(&shared_secret.0);
+        kdf_input.copy_from_slice(&epk.0);
+        let kdf_output = blake2b_simd::blake2b(&kdf_input);
+        let key = Key::from_slice(kdf_output.as_bytes());
+
+        let cipher = ChaCha20Poly1305::new(key);
+        let nonce = Nonce::from_slice(&[0u8; 12]);
+
+        let encryption_result = cipher
+            .encrypt(nonce, self.0.as_ref())
+            .expect("encryption failure!");
+
+        let ciphertext: [u8; MEMO_CIPHERTEXT_LEN_BYTES] = encryption_result
+            .try_into()
+            .expect("can fit in ciphertext len");
+
+        MemoCiphertext(ciphertext)
     }
 }
 

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -1,6 +1,8 @@
 use ark_ff::PrimeField;
-use chacha20poly1305::aead::{Aead, NewAead};
-use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
+use chacha20poly1305::{
+    aead::{Aead, NewAead},
+    ChaCha20Poly1305, Key, Nonce,
+};
 use decaf377::FieldExt;
 use once_cell::sync::Lazy;
 use std::convert::{TryFrom, TryInto};

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -476,7 +476,7 @@ mod tests {
             note_blinding,
         )
         .expect("transmission key is valid");
-        let esk = ka::Secret::new(rng);
+        let esk = ka::Secret::new(&mut rng);
         let epk = esk.diversified_public(&note.diversified_generator());
 
         let proof = OutputProof {
@@ -513,7 +513,7 @@ mod tests {
             note_blinding,
         )
         .expect("transmission key is valid");
-        let esk = ka::Secret::new(rng);
+        let esk = ka::Secret::new(&mut rng);
         let epk = esk.diversified_public(&note.diversified_generator());
 
         let proof = OutputProof {
@@ -561,7 +561,7 @@ mod tests {
             note_blinding,
         )
         .expect("transmission key is valid");
-        let esk = ka::Secret::new(rng);
+        let esk = ka::Secret::new(&mut rng);
         let correct_epk = esk.diversified_public(&note.diversified_generator());
 
         let proof = OutputProof {
@@ -599,7 +599,7 @@ mod tests {
             note_blinding,
         )
         .expect("transmission key is valid");
-        let esk = ka::Secret::new(rng);
+        let esk = ka::Secret::new(&mut rng);
 
         let proof = OutputProof {
             g_d: *dest.diversified_generator(),
@@ -609,7 +609,7 @@ mod tests {
             note_blinding,
             esk,
         };
-        let incorrect_esk = ka::Secret::new(rng);
+        let incorrect_esk = ka::Secret::new(&mut rng);
         let incorrect_epk = incorrect_esk.diversified_public(&note.diversified_generator());
 
         assert!(!proof.verify(
@@ -641,7 +641,7 @@ mod tests {
             note_blinding,
         )
         .expect("transmission key is valid");
-        let esk = ka::Secret::new(rng);
+        let esk = ka::Secret::new(&mut rng);
         let epk = esk.diversified_public(&note.diversified_generator());
 
         let proof = OutputProof {

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -116,16 +116,8 @@ impl Builder {
         let body = output::Body::new(note.clone(), v_blinding, dest, &esk);
         self.value_commitments -= body.value_commitment.0;
 
-        let encrypted_memo = memo
-            .encrypt(
-                &esk,
-                &note.transmission_key(),
-                &note.diversified_generator(),
-            )
-            .expect("memo was successfully encrypted");
-        let ovk_wrapped_key = note
-            .encrypt_key(&esk, &ovk, body.value_commitment)
-            .expect("ovk wrapped key was successfully encrypted");
+        let encrypted_memo = memo.encrypt(&esk, &dest);
+        let ovk_wrapped_key = note.encrypt_key(&esk, &ovk, body.value_commitment);
 
         let output = Action::Output(Output {
             body,

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -116,7 +116,11 @@ impl Builder {
         let body = output::Body::new(rng, note, v_blinding, dest, &esk);
         self.value_commitments -= body.value_commitment.0;
 
-        let encrypted_memo = memo.encrypt(dest);
+        let encrypted_memo = memo.encrypt(
+            &esk,
+            &note.transmission_key(),
+            &note.diversified_generator(),
+        );
         let ovk_wrapped_key = note.encrypt_key(&esk, &ovk, body.value_commitment);
 
         let output = Action::Output(Output {

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -113,7 +113,7 @@ impl Builder {
             note_blinding,
         )
         .expect("transmission key is valid");
-        let body = output::Body::new(rng, note, v_blinding, dest, &esk);
+        let body = output::Body::new(note.clone(), v_blinding, dest, &esk);
         self.value_commitments -= body.value_commitment.0;
 
         let encrypted_memo = memo.encrypt(

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -116,12 +116,16 @@ impl Builder {
         let body = output::Body::new(note.clone(), v_blinding, dest, &esk);
         self.value_commitments -= body.value_commitment.0;
 
-        let encrypted_memo = memo.encrypt(
-            &esk,
-            &note.transmission_key(),
-            &note.diversified_generator(),
-        );
-        let ovk_wrapped_key = note.encrypt_key(&esk, &ovk, body.value_commitment);
+        let encrypted_memo = memo
+            .encrypt(
+                &esk,
+                &note.transmission_key(),
+                &note.diversified_generator(),
+            )
+            .expect("memo was successfully encrypted");
+        let ovk_wrapped_key = note
+            .encrypt_key(&esk, &ovk, body.value_commitment)
+            .expect("ovk wrapped key was successfully encrypted");
 
         let output = Action::Output(Output {
             body,

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -6,8 +6,8 @@ use thiserror;
 
 use crate::rdsa::{Binding, Signature, SigningKey};
 use crate::{
-    action::constants::OVK_WRAPPED_LEN_BYTES,
     action::{output, spend, Action},
+    ka,
     keys::{OutgoingViewingKey, SpendKey},
     memo::MemoPlaintext,
     merkle,
@@ -95,7 +95,7 @@ impl Builder {
         dest: &Address,
         value_to_send: Value,
         memo: MemoPlaintext,
-        _ovk: &OutgoingViewingKey,
+        ovk: &OutgoingViewingKey,
     ) -> Self {
         let v_blinding = Fr::rand(rng);
         // We subtract from the transaction's value balance.
@@ -104,6 +104,7 @@ impl Builder {
             Fr::from(value_to_send.amount) * value_to_send.asset_id.value_generator();
 
         let note_blinding = Fq::rand(rng);
+        let esk = ka::Secret::new(rng);
 
         let note = Note::new(
             *dest.diversifier(),
@@ -112,14 +113,11 @@ impl Builder {
             note_blinding,
         )
         .expect("transmission key is valid");
-        let body = output::Body::new(rng, note, v_blinding, dest);
+        let body = output::Body::new(rng, note, v_blinding, dest, &esk);
         self.value_commitments -= body.value_commitment.0;
 
-        // TODO!
         let encrypted_memo = memo.encrypt(dest);
-
-        // TODO!
-        let ovk_wrapped_key = [0u8; OVK_WRAPPED_LEN_BYTES];
+        let ovk_wrapped_key = note.encrypt_key(&esk, &ovk, body.value_commitment);
 
         let output = Action::Output(Output {
             body,

--- a/decaf377-ka/src/lib.rs
+++ b/decaf377-ka/src/lib.rs
@@ -36,8 +36,8 @@ pub enum Error {
 
 impl Secret {
     /// Generate a new secret key using `rng`.
-    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> Self {
-        Self(decaf377::Fr::rand(&mut rng))
+    pub fn new<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        Self(decaf377::Fr::rand(rng))
     }
 
     /// Use the supplied field element as the secret key directly.

--- a/decaf377-ka/src/lib.rs
+++ b/decaf377-ka/src/lib.rs
@@ -10,7 +10,7 @@ use decaf377::{self, FieldExt};
 /// This is a refinement type around `[u8; 32]` that marks the bytes as being a
 /// public key.  Not all 32-byte arrays are valid public keys; invalid public
 /// keys will error during key agreement.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Public(pub [u8; 32]);
 
 /// A secret key used to perform key agreement using the counterparty's public key.


### PR DESCRIPTION
Closes #99 

This is using `AEAD_CHACHA20_POLY1305` as in Sapling/Orchard note encryption (ref: p.64-65 spec). One difference for Penumbra is since our memos are separated from the note, the memo is encrypted separately, but using the same method (i.e. same key, symmetric cipher). I'm using a unique nonce from the Note encryption (notes use `[0u8; 12]`, memos are using `[1u8; 12]`) but let me know if this is not the best choice. Another option could be to make further modifications to the Memo encryption/decryption. 