### PR TITLE
Stub Postgres Scaffolding 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# editor
+.swp
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM rust:1.54.0 as build
+FROM rust:1.56 as build
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --default-toolchain none -y
+RUN rustup component add rustfmt
 
 WORKDIR /usr/src
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN cargo build --bin pd --release --frozen && \
 # with a statically linked libc (read: musl), and musl's malloc exhibits
 # pathologically poor performance for Tokio applications...
 FROM debian:buster-slim as runtime
+ARG DATABASE_URL
+ENV DATABASE_URL=$DATABASE_URL
 WORKDIR /penumbra
 COPY --from=build /out/pd /usr/bin/pd
 ENV RUST_LOG=warn,pd=info,penumbra=info

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,6 +10,11 @@ services:
     environment:
       - RUST_LOG=${RUST_LOG:-info,pd=debug,penumbra=debug}
 
+  # expose database on a port so it is easy to play with
+  db:
+    ports:
+      - "5432:5432"
+
   # add prometheus and grafana
   #
   # in production, users will want to bring their own monitoring stack, rather

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,9 +11,9 @@ services:
       - RUST_LOG=${RUST_LOG:-info,pd=debug,penumbra=debug}
 
   # expose database on a port so it is easy to play with
-  db:
-    ports:
-      - "5432:5432"
+#  db:
+#    ports:
+#      - "5432:5432"
 
   # add prometheus and grafana
   #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,36 @@ services:
   # The Penumbra daemon
   pd:
     container_name: penumbra
-    build: "."
+    build:
+      context: .
+      args:
+        DATABASE_URL: postgres://postgres:postgres@db/penumbra
     environment:
       - RUST_LOG=${RUST_LOG:-warn,pd=info,penumbra=info}
     command:
       pd --host 0.0.0.0
+    restart: on-failure
+    depends_on:
+      - db
+    links:
+      - db:db
     networks:
       localnet:
         ipv4_address: 192.167.10.6
+
+  # database - postgres
+  db:
+    image: postgres:14.0
+    container_name: db
+    volumes:
+      - "db_data:/var/lib/postgresql/data"
+    environment:
+      - POSTGRES_DB=penumbra
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    networks:
+      localnet:
+        ipv4_address: 192.167.10.12
 
   # The Tendermint node
   tendermint:
@@ -40,3 +62,4 @@ networks:
 
 volumes:
   tendermint_data: {}
+  db_data: {}

--- a/penumbra/Cargo.toml
+++ b/penumbra/Cargo.toml
@@ -17,6 +17,7 @@ penumbra-proto = { path = "../proto" }
 penumbra-crypto = { path = "../crypto" }
 
 # Penumbra dependencies
+decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
 tower-abci = { git = "https://github.com/penumbra-zone/tower-abci/" }
 tendermint-proto = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "abci-domain-types" }
 tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "abci-domain-types" }

--- a/penumbra/Cargo.toml
+++ b/penumbra/Cargo.toml
@@ -34,6 +34,7 @@ reqwest = { version = "0.11", features = ["json"] }
 anyhow = "1"
 hex = "0.4"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
+sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres" ] }
 
 [build-dependencies]
 vergen = "5"

--- a/penumbra/src/bin/pd.rs
+++ b/penumbra/src/bin/pd.rs
@@ -1,3 +1,4 @@
+use penumbra::db::db_bootstrap;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -20,6 +21,9 @@ struct Opt {
 async fn main() {
     tracing_subscriber::fmt::init();
     let opt = Opt::from_args();
+
+    // bootstrap database
+    let _db_bootstrap_on_load = db_bootstrap().await.unwrap();
 
     let app = penumbra::App::default();
 

--- a/penumbra/src/bin/pd.rs
+++ b/penumbra/src/bin/pd.rs
@@ -1,5 +1,7 @@
-use penumbra::db::{db_bootstrap, db_connection, db_insert, db_read, NoteCommitmentTreeAnchor};
 use structopt::StructOpt;
+
+use penumbra::dbschema::{NoteCommitmentTreeAnchor, PenumbraNoteCommitmentTreeAnchor};
+use penumbra::dbutils::{db_bootstrap, db_connection, db_insert, db_read};
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -22,29 +24,26 @@ async fn main() {
     tracing_subscriber::fmt::init();
     let opt = Opt::from_args();
 
-    // get the pool, so it looks cool
+    // get the pool, cool
     let pool = db_connection().await.expect("");
 
-    // bootstrap database, for general malaise
+    // bootstrap database, malaise
     let _db_bootstrap_on_load = db_bootstrap(pool.clone()).await.unwrap();
 
-    // insert dummy, get chummy
-    let mut v: Vec<u8> = Vec::new();
-    v.push(1);
-    v.push(2);
-    v.push(3);
+    // insert dummy, chummy
+    let v: Vec<u8> = vec![6; 32];
     let _db_insert_dummy_row = db_insert(
-        NoteCommitmentTreeAnchor {
-            id: 0 as i32,
-            height: 23123122 as i64,
-            anchor: v.clone(),
-        },
+        PenumbraNoteCommitmentTreeAnchor::from(NoteCommitmentTreeAnchor {
+            id: 0,
+            height: 1337 as i64,
+            anchor: v,
+        }),
         pool.clone(),
     )
     .await
     .unwrap();
 
-    // read stuff, hope its not rough
+    // read stuff, rough
     let _db_read_dummy_row = db_read(pool.clone()).await.unwrap();
     println!(
         "raw height {} raw anchor {:?}",

--- a/penumbra/src/bin/pd.rs
+++ b/penumbra/src/bin/pd.rs
@@ -1,4 +1,4 @@
-use penumbra::db::db_bootstrap;
+use penumbra::db::{db_bootstrap, db_connection, db_insert, NoteCommitmentTreeAnchor};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -22,8 +22,29 @@ async fn main() {
     tracing_subscriber::fmt::init();
     let opt = Opt::from_args();
 
-    // bootstrap database
-    let _db_bootstrap_on_load = db_bootstrap().await.unwrap();
+    // get the pool, so it looks cool
+    let pool = db_connection().await.expect("");
+
+    // bootstrap database, for general malaise
+    let _db_bootstrap_on_load = db_bootstrap(pool.clone()).await.unwrap();
+
+    // insert dummy, get chummy
+    let mut v: Vec<u8> = Vec::new();
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    let _db_insert_dummy_row = db_insert(
+        NoteCommitmentTreeAnchor {
+            id: 0 as i64,
+            height: 2312312312312 as i64,
+            anchor: v.clone(),
+        },
+        pool.clone(),
+    )
+    .await
+    .unwrap();
+
+    // read stuff, hope its not rough
 
     let app = penumbra::App::default();
 

--- a/penumbra/src/bin/pd.rs
+++ b/penumbra/src/bin/pd.rs
@@ -1,4 +1,4 @@
-use penumbra::db::{db_bootstrap, db_connection, db_insert, NoteCommitmentTreeAnchor};
+use penumbra::db::{db_bootstrap, db_connection, db_insert, db_read, NoteCommitmentTreeAnchor};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -35,8 +35,8 @@ async fn main() {
     v.push(3);
     let _db_insert_dummy_row = db_insert(
         NoteCommitmentTreeAnchor {
-            id: 0 as i64,
-            height: 2312312312312 as i64,
+            id: 0 as i32,
+            height: 23123122 as i64,
             anchor: v.clone(),
         },
         pool.clone(),
@@ -45,7 +45,13 @@ async fn main() {
     .unwrap();
 
     // read stuff, hope its not rough
+    let _db_read_dummy_row = db_read(pool.clone()).await.unwrap();
+    println!(
+        "raw height {} raw anchor {:?}",
+        _db_read_dummy_row[0].height, _db_read_dummy_row[0].anchor
+    );
 
+    // app
     let app = penumbra::App::default();
 
     use tower_abci::{split, Server};

--- a/penumbra/src/db.rs
+++ b/penumbra/src/db.rs
@@ -1,0 +1,40 @@
+use sqlx::postgres::{PgPoolOptions, PgQueryResult};
+use sqlx::{query, Error};
+use sqlx::{Pool, Postgres};
+use std::env;
+
+fn db_get_connection_string() -> String {
+    let mut db_connection_string = "".to_string();
+
+    match env::var("DATABASE_URL") {
+        Ok(val) => db_connection_string = val,
+        Err(_e) => {}
+    }
+
+    db_connection_string
+}
+
+pub async fn db_connection() -> Result<Pool<Postgres>, sqlx::Error> {
+    let pool = PgPoolOptions::new()
+        .max_connections(3)
+        .connect(db_get_connection_string().as_str())
+        .await;
+
+    pool
+}
+
+pub async fn db_bootstrap() -> Result<PgQueryResult, Error> {
+    let mut conn = db_connection().await?;
+    let bootstrap_sql = query(
+        "
+CREATE TABLE IF NOT EXISTS note_commitment_tree_anchors (
+    id SERIAL PRIMARY KEY, 
+    height bigint NOT NULL, 
+    anchor bytea NOT NULL
+)",
+    )
+    .execute(&conn)
+    .await;
+
+    bootstrap_sql
+}

--- a/penumbra/src/db.rs
+++ b/penumbra/src/db.rs
@@ -1,13 +1,11 @@
-use sqlx::postgres::{PgPoolOptions, PgQueryResult, PgRow};
-use sqlx::FromRow;
-use sqlx::Row;
+use sqlx::postgres::{PgPoolOptions, PgQueryResult};
 use sqlx::{query, query_as, Error};
 use sqlx::{Pool, Postgres};
 use std::env;
 
 #[derive(Debug, sqlx::FromRow)]
 pub struct NoteCommitmentTreeAnchor {
-    pub id: i64,
+    pub id: i32,
     pub height: i64,
     pub anchor: Vec<u8>,
 }
@@ -60,4 +58,16 @@ pub async fn db_insert(
         .rows_affected();
 
     Ok(id)
+}
+
+pub async fn db_read(pool: Pool<Postgres>) -> Result<Vec<NoteCommitmentTreeAnchor>, Error> {
+    let mut p = pool.acquire().await?;
+    let rows = query_as::<_, NoteCommitmentTreeAnchor>(
+        "SELECT id, height, anchor FROM note_commitment_tree_anchors where id = 3;",
+    )
+    .fetch_one(&mut p)
+    .await?;
+
+    let x = rows;
+    Ok(vec![x])
 }

--- a/penumbra/src/dbschema.rs
+++ b/penumbra/src/dbschema.rs
@@ -1,0 +1,59 @@
+use std::convert::TryInto;
+use std::str::FromStr;
+
+use decaf377::FieldExt;
+use tendermint::block::Height;
+
+use penumbra_crypto::merkle::Root;
+use penumbra_crypto::Fq;
+
+/// Bridge type between Postgres and Penumbra
+#[derive(Debug, sqlx::FromRow)]
+pub struct NoteCommitmentTreeAnchor {
+    pub id: i32,
+    pub height: i64,
+    pub anchor: Vec<u8>,
+}
+
+/// Type for Penumbra for its representation
+/// this type is not conduvcive with the database as-is
+/// or at least the author could not find an easier way and
+/// hence the bridge type is used above `NoteCommitmentTreeAnchor`
+#[derive(Debug, sqlx::FromRow)]
+pub struct PenumbraNoteCommitmentTreeAnchor {
+    pub id: i32,
+    pub height: Height,
+    pub anchor: Root,
+}
+
+/// Convert between Penumbra and bridge type for DB
+impl From<PenumbraNoteCommitmentTreeAnchor> for NoteCommitmentTreeAnchor {
+    fn from(p: PenumbraNoteCommitmentTreeAnchor) -> Self {
+        NoteCommitmentTreeAnchor {
+            id: p.id,
+            height: i64::from(p.height),
+            // anchor.0 because it is Root(Fq), so we need inner type
+            anchor: FieldExt::to_bytes(&p.anchor.0).to_vec(),
+        }
+    }
+}
+
+/// Convert between bridge and Penumbra type for DB
+/// We need both because the conversion each way is through
+/// a different (read HACKY) route
+impl From<NoteCommitmentTreeAnchor> for PenumbraNoteCommitmentTreeAnchor {
+    fn from(n: NoteCommitmentTreeAnchor) -> Self {
+        let anchor = vec_to_array(n.anchor);
+        PenumbraNoteCommitmentTreeAnchor {
+            id: n.id,
+            height: Height::from_str(n.height.to_string().as_str()).unwrap(), // WARN: they did not have From<i64> but had FromStr so yolo
+            anchor: Root(Fq::from_bytes(anchor).unwrap()),
+        }
+    }
+}
+
+// Shamelessly copied from https://stackoverflow.com/questions/29570607/is-there-a-good-way-to-convert-a-vect-to-an-array
+fn vec_to_array<T, const N: usize>(v: Vec<T>) -> [T; N] {
+    v.try_into()
+        .unwrap_or_else(|v: Vec<T>| panic!("Expected a Vec of length {} but it was {}", N, v.len()))
+}

--- a/penumbra/src/dbutils.rs
+++ b/penumbra/src/dbutils.rs
@@ -1,14 +1,11 @@
+use std::env;
+
 use sqlx::postgres::{PgPoolOptions, PgQueryResult};
 use sqlx::{query, query_as, Error};
 use sqlx::{Pool, Postgres};
-use std::env;
 
-#[derive(Debug, sqlx::FromRow)]
-pub struct NoteCommitmentTreeAnchor {
-    pub id: i32,
-    pub height: i64,
-    pub anchor: Vec<u8>,
-}
+use crate::dbschema::NoteCommitmentTreeAnchor;
+use crate::dbschema::PenumbraNoteCommitmentTreeAnchor;
 
 fn db_get_connection_string() -> String {
     let mut db_connection_string = "".to_string();
@@ -45,10 +42,12 @@ CREATE TABLE IF NOT EXISTS note_commitment_tree_anchors (
     bootstrap_sql
 }
 
+/// Hardcoded query for inserting one row
 pub async fn db_insert(
-    record: NoteCommitmentTreeAnchor,
+    records: PenumbraNoteCommitmentTreeAnchor,
     pool: Pool<Postgres>,
 ) -> Result<u64, Error> {
+    let record: NoteCommitmentTreeAnchor = records.into();
     let mut p = pool.acquire().await?;
     let id = query("INSERT INTO note_commitment_tree_anchors (height, anchor) VALUES ($1, $2)")
         .bind(record.height)
@@ -60,14 +59,15 @@ pub async fn db_insert(
     Ok(id)
 }
 
-pub async fn db_read(pool: Pool<Postgres>) -> Result<Vec<NoteCommitmentTreeAnchor>, Error> {
+/// Hardcoded query for reading the first record
+pub async fn db_read(pool: Pool<Postgres>) -> Result<Vec<PenumbraNoteCommitmentTreeAnchor>, Error> {
     let mut p = pool.acquire().await?;
     let rows = query_as::<_, NoteCommitmentTreeAnchor>(
-        "SELECT id, height, anchor FROM note_commitment_tree_anchors where id = 3;",
+        "SELECT id, height, anchor FROM note_commitment_tree_anchors where id = 1;",
     )
     .fetch_one(&mut p)
     .await?;
 
-    let x = rows;
-    Ok(vec![x])
+    let res = rows.into();
+    Ok(vec![res])
 }

--- a/penumbra/src/lib.rs
+++ b/penumbra/src/lib.rs
@@ -1,6 +1,7 @@
 //! Source code for the Penumbra node software.
 
 mod app;
-pub mod db;
+pub mod dbschema;
+pub mod dbutils;
 
 pub use app::App;

--- a/penumbra/src/lib.rs
+++ b/penumbra/src/lib.rs
@@ -1,5 +1,6 @@
 //! Source code for the Penumbra node software.
 
 mod app;
+pub mod db;
 
 pub use app::App;


### PR DESCRIPTION
This is the proof of concept for adding a database, bootstrapping it with one table, and doing dummy transactions.

This work is not ideal but is a quick PR to add the feature.
Also, there are no tests. 

To check this out - 

1. Checkout this branch
2. Kill all previous docker containers and delete docker volumes and images
3. Re-run `docker-compose up -d`
4. In another terminal see `docker-compose logs -f`
5. You will see log of the `println`

Alternatively, 

1. Checkout this branch
2. Kill all previous docker containers and delete docker volumes and images
3. Re-run `docker-compose up -d`
4. `exec` into docker container `db` - `docker exec -it db bash`
5. Run psql to see database and single row  
    - `psql -U postgres`
    - `\c penumbra`
    - `select * from note_commitment_tree_anchors;`

Closes #109 