### PR TITLE
feat: Bech32m encoding/decoding, set first testnet ID

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -20,6 +20,7 @@ incrementalmerkletree = { git = "https://github.com/penumbra-zone/incrementalmer
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377" }
 
 # Crates.io deps
+bech32 = "0.8.1"
 fpe = "0.5"
 aes = "0.7"
 anyhow = "1"

--- a/spec/protocol/addresses_keys/addresses.md
+++ b/spec/protocol/addresses_keys/addresses.md
@@ -19,3 +19,8 @@ $pk_d = [ivk]B_d$
 The *compact flag key* is derived from a (diversified) *compact detection key* $cdtk_d$ using a non-diversified `decaf377` basepoint [$B$](../primitives/decaf377/test_vectors.md):
 
 $cfk_d = [cdtk_d]B$
+
+The diversifier, transmission key, and compact flag key are [Bech32m](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki) encoded with a human readable prefix that is:
+
+* `penumbra` for mainnet, and
+* `penumbra_tn00X_` for testnets, where X is the current testnet number.


### PR DESCRIPTION
Addresses now encode like: `penumbra_tn001_1kpgdhlzws6kyk2cf580wtt76t9nn2vf7em3pn05y3h8ym5a6aevdxshjgsnxecv94rzsxdhng6cjp8kgchqxud06p9xka0yxv99rty3njetqqnx2hrzz4tc03956e0`

Closes #63
