### PR TITLE
feat(pcli): add `generate` command, save/load wallet data in/from `penumbra_wallet.dat`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-wallet.dat
+*wallet.dat
 
 book
 .firebase/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+wallet.dat
+
 book
 .firebase/
 # For some reason mdbook dumps this here because the main page is ../README.md

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ cargo run --bin pcli -- --help
 Generate keys using:
 
 ```
-$ cargo run --bin pcli -- --wallet-location penumbra_wallet.dat generate
-Wallet generated, stored in penumbra_wallet.dat. WARNING: This file contains your private keys. BACK UP THIS FILE!
+$ cargo run --bin pcli -- generate
+Wallet generated, stored in /Users/Alice/Library/Application Support/zone.penumbra.pcli/penumbra_wallet.dat. WARNING: This file contains your private keys. BACK UP THIS FILE!
 Your first address is penumbra_tn001_10ftlcft6c8n95cc5lpwdupt2d86n0td2t55xjwkgnte9jgzlqfp7xlqfnssljygq6fxspvnj5xuc5j0qtd6j398elyhrqugs07r7s8v5n0dpkgweytjqm2gv6hmdef
 ```
 
-Keys will be stored in the location you provide via `--wallet-location <path>` or if you specify no location, in `pcli`'s data directory:
+Keys will be stored in `pcli`'s data directory:
 
 * Linux: `/home/alice/.config/pcli/penumbra_wallet.dat`
 * macOS: `/Users/Alice/Library/Application Support/zone.penumbra.pcli/penumbra_wallet.dat`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Now you can interact with Penumbra using `pcli`:
 cargo run --bin pcli -- --help
 ```
 
+Generate keys using:
+
+```
+cargo run --bin pcli -- generate
+```
+
 ### Running `pd` manually
 
 You'll need to [install Tendermint][tm-install].  Be sure to install `v0.35.0`,

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ cargo run --bin pcli -- --help
 Generate keys using:
 
 ```
-cargo run --bin pcli -- generate
+$ cargo run --bin pcli -- generate
+Wallet generated, stored in ./wallet.dat. WARNING: This file contains your private keys. BACK UP THIS FILE!
+Your first address is penumbra_tn001_10ftlcft6c8n95cc5lpwdupt2d86n0td2t55xjwkgnte9jgzlqfp7xlqfnssljygq6fxspvnj5xuc5j0qtd6j398elyhrqugs07r7s8v5n0dpkgweytjqm2gv6hmdef
 ```
 
 Keys will be stored in `wallet.dat` in the current working directory. To customize the location, use the `--key-location <file>` option.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Generate keys using:
 cargo run --bin pcli -- generate
 ```
 
+Keys will be stored in `wallet.dat` in the current working directory. To customize the location, use the `--key-location <file>` option.
+
 ### Running `pd` manually
 
 You'll need to [install Tendermint][tm-install].  Be sure to install `v0.35.0`,

--- a/README.md
+++ b/README.md
@@ -33,17 +33,34 @@ docker-compose up -d
 
 ### Running `pcli`
 
-Now you can interact with Penumbra using `pcli`:
-```
+Now you can interact with Penumbra using `pcli`, for instance
+```bash
+# Run this first in case the interface changed
+# from the sample commands below
 cargo run --bin pcli -- --help
 ```
-
-Generate keys using:
-
+to get
 ```
-$ cargo run --bin pcli -- generate
-Wallet generated, stored in /Users/Alice/Library/Application Support/zone.penumbra.pcli/penumbra_wallet.dat. WARNING: This file contains your private keys. BACK UP THIS FILE!
-Your first address is penumbra_tn001_10ftlcft6c8n95cc5lpwdupt2d86n0td2t55xjwkgnte9jgzlqfp7xlqfnssljygq6fxspvnj5xuc5j0qtd6j398elyhrqugs07r7s8v5n0dpkgweytjqm2gv6hmdef
+pcli 0.1.0
+The Penumbra command-line interface.
+
+USAGE:
+    pcli [OPTIONS] <SUBCOMMAND>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -a, --addr <addr>                          The address of the Tendermint node [default: 127.0.0.1:26657]
+    -w, --wallet-location <wallet-location>    The location of the wallet file [default: platform appdata directory]
+
+SUBCOMMANDS:
+    addr      Manages addresses
+    help      Prints this message or the help of the given subcommand(s)
+    query     Queries the Penumbra state
+    tx        Creates a transaction
+    wallet    Manages the wallet state
 ```
 
 Keys will be stored in `pcli`'s data directory:

--- a/README.md
+++ b/README.md
@@ -41,12 +41,16 @@ cargo run --bin pcli -- --help
 Generate keys using:
 
 ```
-$ cargo run --bin pcli -- generate
-Wallet generated, stored in ./wallet.dat. WARNING: This file contains your private keys. BACK UP THIS FILE!
+$ cargo run --bin pcli -- --wallet-location wallet.dat generate
+Wallet generated, stored in wallet.dat. WARNING: This file contains your private keys. BACK UP THIS FILE!
 Your first address is penumbra_tn001_10ftlcft6c8n95cc5lpwdupt2d86n0td2t55xjwkgnte9jgzlqfp7xlqfnssljygq6fxspvnj5xuc5j0qtd6j398elyhrqugs07r7s8v5n0dpkgweytjqm2gv6hmdef
 ```
 
-Keys will be stored in `wallet.dat` in the current working directory. To customize the location, use the `--key-location <file>` option.
+Keys will be stored in the location you provide via `--wallet-location <path>` or if you specify no location, in `pcli`'s data directory:
+
+* Linux: `/home/alice/.config/pcli/wallet.dat`
+* macOS: `/Users/Alice/Library/Application Support/zone.penumbra.pcli/wallet.dat`
+* Windows: `C:\Users\Alice\AppData\Roaming\penumbra\pcli\wallet.dat`
 
 ### Running `pd` manually
 

--- a/README.md
+++ b/README.md
@@ -41,16 +41,16 @@ cargo run --bin pcli -- --help
 Generate keys using:
 
 ```
-$ cargo run --bin pcli -- --wallet-location wallet.dat generate
-Wallet generated, stored in wallet.dat. WARNING: This file contains your private keys. BACK UP THIS FILE!
+$ cargo run --bin pcli -- --wallet-location penumbra_wallet.dat generate
+Wallet generated, stored in penumbra_wallet.dat. WARNING: This file contains your private keys. BACK UP THIS FILE!
 Your first address is penumbra_tn001_10ftlcft6c8n95cc5lpwdupt2d86n0td2t55xjwkgnte9jgzlqfp7xlqfnssljygq6fxspvnj5xuc5j0qtd6j398elyhrqugs07r7s8v5n0dpkgweytjqm2gv6hmdef
 ```
 
 Keys will be stored in the location you provide via `--wallet-location <path>` or if you specify no location, in `pcli`'s data directory:
 
-* Linux: `/home/alice/.config/pcli/wallet.dat`
-* macOS: `/Users/Alice/Library/Application Support/zone.penumbra.pcli/wallet.dat`
-* Windows: `C:\Users\Alice\AppData\Roaming\penumbra\pcli\wallet.dat`
+* Linux: `/home/alice/.config/pcli/penumbra_wallet.dat`
+* macOS: `/Users/Alice/Library/Application Support/zone.penumbra.pcli/penumbra_wallet.dat`
+* Windows: `C:\Users\Alice\AppData\Roaming\penumbra\pcli\penumbra_wallet.dat`
 
 ### Running `pd` manually
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -28,6 +28,9 @@ thiserror = "1"
 bytes = "1"
 hex = "0.4"
 blake2b_simd = "0.5"
+serde_json = "1"
+serde = { version = "1", features = ["derive"] }
+serde_with = { version = "1.11", features = ["hex"] }
 once_cell = "1.8"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand = "0.8"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -28,9 +28,7 @@ thiserror = "1"
 bytes = "1"
 hex = "0.4"
 blake2b_simd = "0.5"
-serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-serde_with = { version = "1.11", features = ["hex"] }
 once_cell = "1.8"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand = "0.8"

--- a/crypto/src/keys/diversifier.rs
+++ b/crypto/src/keys/diversifier.rs
@@ -102,6 +102,12 @@ impl From<u64> for DiversifierIndex {
     }
 }
 
+impl From<usize> for DiversifierIndex {
+    fn from(x: usize) -> Self {
+        (x as u64).into()
+    }
+}
+
 impl From<DiversifierIndex> for u64 {
     fn from(diversifier_index: DiversifierIndex) -> Self {
         u64::from_le_bytes(

--- a/crypto/src/keys/diversifier.rs
+++ b/crypto/src/keys/diversifier.rs
@@ -3,7 +3,8 @@ use anyhow::anyhow;
 use ark_ff::PrimeField;
 use fpe::ff1;
 use once_cell::sync::Lazy;
-use std::convert::TryFrom;
+use serde::{Deserialize, Serialize};
+use std::convert::{TryFrom, TryInto};
 
 use crate::Fq;
 
@@ -66,7 +67,7 @@ impl DiversifierKey {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct DiversifierIndex(pub [u8; 11]);
 
 impl From<u8> for DiversifierIndex {
@@ -98,5 +99,15 @@ impl From<u64> for DiversifierIndex {
         let mut bytes = [0; 11];
         bytes[0..8].copy_from_slice(&x.to_le_bytes());
         Self(bytes)
+    }
+}
+
+impl From<DiversifierIndex> for u64 {
+    fn from(diversifier_index: DiversifierIndex) -> Self {
+        u64::from_le_bytes(
+            diversifier_index.0[0..8]
+                .try_into()
+                .expect("can take first 8 bytes of diversifier index"),
+        )
     }
 }

--- a/crypto/src/keys/spend.rs
+++ b/crypto/src/keys/spend.rs
@@ -1,7 +1,6 @@
 use ark_ff::PrimeField;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
 
 use crate::{
     rdsa::{SigningKey, SpendAuth},
@@ -13,12 +12,8 @@ use super::{FullViewingKey, IncomingViewingKey, NullifierKey, OutgoingViewingKey
 pub const SPENDSEED_LEN_BYTES: usize = 32;
 
 /// The root key material for a [`SpendKey`].
-#[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct SpendSeed {
-    #[serde_as(as = "serde_with::hex::Hex")]
-    pub inner: [u8; SPENDSEED_LEN_BYTES],
-}
+pub struct SpendSeed(pub [u8; SPENDSEED_LEN_BYTES]);
 
 /// A key representing a single spending authority.
 pub struct SpendKey {
@@ -32,7 +27,7 @@ impl SpendKey {
     pub fn generate<R: RngCore + CryptoRng>(mut rng: R) -> Self {
         let mut seed_bytes = [0u8; SPENDSEED_LEN_BYTES];
         rng.fill_bytes(&mut seed_bytes);
-        Self::from_seed(SpendSeed { inner: seed_bytes })
+        Self::from_seed(SpendSeed(seed_bytes))
     }
 
     /// Loads a [`SpendKey`] from the provided [`SpendSeed`].
@@ -40,7 +35,7 @@ impl SpendKey {
         let ask = {
             let mut hasher = blake2b_simd::State::new();
             hasher.update(b"Penumbra_ExpndSd");
-            hasher.update(&seed.inner);
+            hasher.update(&seed.0);
             hasher.update(&[0; 1]);
             let hash_result = hasher.finalize();
 
@@ -50,7 +45,7 @@ impl SpendKey {
         let nk = {
             let mut hasher = blake2b_simd::State::new();
             hasher.update(b"Penumbra_ExpndSd");
-            hasher.update(&seed.inner);
+            hasher.update(&seed.0);
             hasher.update(&[1; 1]);
             let hash_result = hasher.finalize();
 

--- a/penumbra/Cargo.toml
+++ b/penumbra/Cargo.toml
@@ -27,6 +27,7 @@ tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branc
 bincode = "1.3.3"
 blake2b_simd = "0.5"
 bytes = "1"
+comfy-table = "5"
 directories = "4.0.1"
 tokio = { version = "1", features = ["full"]}
 tower = { version = "0.4", features = ["full"]}
@@ -48,4 +49,3 @@ sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres" ] }
 
 [build-dependencies]
 vergen = "5"
-

--- a/penumbra/Cargo.toml
+++ b/penumbra/Cargo.toml
@@ -24,6 +24,7 @@ tower-abci = { git = "https://github.com/penumbra-zone/tower-abci/" }
 tendermint-proto = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "abci-domain-types" }
 tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "abci-domain-types" }
 # External dependencies
+bincode = "1.3.3"
 blake2b_simd = "0.5"
 bytes = "1"
 tokio = { version = "1", features = ["full"]}

--- a/penumbra/Cargo.toml
+++ b/penumbra/Cargo.toml
@@ -27,6 +27,7 @@ tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branc
 bincode = "1.3.3"
 blake2b_simd = "0.5"
 bytes = "1"
+directories = "4.0.1"
 tokio = { version = "1", features = ["full"]}
 tower = { version = "0.4", features = ["full"]}
 tracing = "0.1"

--- a/penumbra/src/bin/pcli.rs
+++ b/penumbra/src/bin/pcli.rs
@@ -81,10 +81,8 @@ async fn main() -> Result<()> {
 
 /// Load existing keys from wallet file, printing an error if the file doesn't exist.
 fn load_existing_keys(wallet_path: &Path) -> keys::SpendKey {
-    let key_data = match fs::read(wallet_path) {
-        Ok(data) => keys::SpendSeed {
-            inner: data.try_into().expect("key is correct length"),
-        },
+    let key_data: keys::SpendSeed = match fs::read(wallet_path) {
+        Ok(data) => bincode::deserialize(&data).expect("can deserialize wallet file"),
         Err(err) => match err.kind() {
             io::ErrorKind::NotFound => {
                 eprintln!(
@@ -124,9 +122,8 @@ fn create_wallet(wallet_path: &Path) {
             }
         },
     };
-    let seed_json = serde_json::to_string_pretty(spend_key.seed()).expect("can serialize");
-    file.write_all(seed_json.as_bytes())
-        .expect("Unable to write file");
+    let seed_data = bincode::serialize(spend_key.seed()).expect("can serialize");
+    file.write_all(&seed_data).expect("Unable to write file");
     println!(
         "Spending key generated, seed stored in {}",
         wallet_path.display()

--- a/penumbra/src/bin/pcli.rs
+++ b/penumbra/src/bin/pcli.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<()> {
     // Currently we use just the data directory. Create it if it is missing.
     fs::create_dir_all(project_dir.data_dir()).expect("can create penumbra data directory");
 
-    // We store wallet data in `wallet.dat` in the state directory, unless
+    // We store wallet data in `penumbra_wallet.dat` in the state directory, unless
     // the user provides another location.
     let wallet_path: PathBuf;
     match opt.wallet_location {
@@ -54,7 +54,7 @@ async fn main() -> Result<()> {
             wallet_path = Path::new(&path).to_path_buf();
         }
         None => {
-            wallet_path = project_dir.data_dir().join("wallet.dat");
+            wallet_path = project_dir.data_dir().join("penumbra_wallet.dat");
         }
     }
 

--- a/penumbra/src/bin/pcli.rs
+++ b/penumbra/src/bin/pcli.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 use std::{fs, io, process};
 use structopt::StructOpt;
 
-use penumbra_crypto::keys;
 use penumbra_wallet::{state, storage};
 
 #[derive(Debug, StructOpt)]
@@ -91,8 +90,7 @@ async fn main() -> Result<()> {
         Command::Generate => {
             let wallet = create_wallet(&wallet_path);
             let client = state::ClientState::new(wallet);
-            let addr = client.address_by_index(0u64.into());
-            println!("Your first address is {}", addr);
+            println!("Your first address is {}", client.wallet.addresses[0]);
         }
     }
 
@@ -121,12 +119,7 @@ fn load_existing_keys(wallet_path: &Path) -> storage::Wallet {
 
 /// Create wallet file, ensuring existing wallets are not overwritten.
 fn create_wallet(wallet_path: &Path) -> storage::Wallet {
-    let spend_key = keys::SpendKey::generate(OsRng);
-    let wallet = storage::Wallet {
-        spend_seed: spend_key.seed().clone(),
-        last_used_diversifier_index: 0u64.into(),
-    };
-
+    let wallet = storage::Wallet::generate(&mut OsRng);
     let mut file = match fs::OpenOptions::new()
         .write(true)
         .create_new(true)

--- a/penumbra/src/bin/pcli.rs
+++ b/penumbra/src/bin/pcli.rs
@@ -20,7 +20,7 @@ struct Opt {
     addr: std::net::SocketAddr,
     #[structopt(subcommand)]
     cmd: Command,
-    /// The location of the wallet file.
+    /// The location of the wallet file [default: platform appdata directory]
     #[structopt(short, long)]
     wallet_location: Option<String>,
 }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -26,6 +26,7 @@ tracing-subscriber = "0.2"
 pin-project = "1"
 futures = "0.3"
 serde_json = "1"
+serde = { version = "1", features = ["derive"] }
 reqwest = { version = "0.11", features = ["json"] }
 anyhow = "1"
 hex = "0.4"

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod state;
+pub mod storage;

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, HashSet};
 
-use penumbra_crypto::{keys, memo::MemoPlaintext, merkle, note, Note, Nullifier};
+use penumbra_crypto::{fmd, keys, memo::MemoPlaintext, merkle, note, Address, Note, Nullifier};
+
+use crate::storage::Wallet;
 
 const MAX_MERKLE_CHECKPOINTS_CLIENT: usize = 10;
 
@@ -19,11 +21,11 @@ pub struct ClientState {
     // Map of transaction ID to full transaction data for transactions we have visibility into.
     pub transactions: BTreeMap<[u8; 32], Vec<u8>>,
     // Key material.
-    pub spend_key: keys::SpendKey,
+    pub wallet: Wallet,
 }
 
 impl ClientState {
-    pub fn new(spend_key: keys::SpendKey) -> Self {
+    pub fn new(wallet: Wallet) -> Self {
         Self {
             last_block_height: 0,
             note_commitment_tree: merkle::BridgeTree::new(MAX_MERKLE_CHECKPOINTS_CLIENT),
@@ -31,8 +33,29 @@ impl ClientState {
             received_set: HashSet::new(),
             spent_set: HashSet::new(),
             transactions: BTreeMap::new(),
-            spend_key,
+            wallet,
         }
+    }
+
+    /// Get an address by its diversifier index.
+    pub fn address_by_index(&self, diversifier_index: keys::DiversifierIndex) -> Address {
+        let spend_key = keys::SpendKey::from_seed(self.wallet.spend_seed.clone());
+        let fvk = spend_key.full_viewing_key();
+        let ivk = fvk.incoming();
+        ivk.payment_address(diversifier_index).0
+    }
+
+    /// Generate a new diversified `Address` and its corresponding `DetectionKey`.
+    pub fn new_address(&mut self) -> (Address, fmd::DetectionKey) {
+        self.wallet.last_used_diversifier_index =
+            (u64::from(self.wallet.last_used_diversifier_index) + 1).into();
+
+        // xx Store ivk on `ClientState` to prevent recomputing it? We don't want it on `Wallet` as wallet should
+        // be minimal.
+        let spend_key = keys::SpendKey::from_seed(self.wallet.spend_seed.clone());
+        let fvk = spend_key.full_viewing_key();
+        let ivk = fvk.incoming();
+        ivk.payment_address(self.wallet.last_used_diversifier_index)
     }
 
     // TODO: For each output in scanned transactions, try to decrypt the note ciphertext.

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 
-use penumbra_crypto::{fmd, keys, memo::MemoPlaintext, merkle, note, Address, Note, Nullifier};
+use penumbra_crypto::{fmd, memo::MemoPlaintext, merkle, note, Address, Note, Nullifier};
 
 use crate::storage::Wallet;
 
@@ -37,25 +37,9 @@ impl ClientState {
         }
     }
 
-    /// Get an address by its diversifier index.
-    pub fn address_by_index(&self, diversifier_index: keys::DiversifierIndex) -> Address {
-        let spend_key = keys::SpendKey::from_seed(self.wallet.spend_seed.clone());
-        let fvk = spend_key.full_viewing_key();
-        let ivk = fvk.incoming();
-        ivk.payment_address(diversifier_index).0
-    }
-
     /// Generate a new diversified `Address` and its corresponding `DetectionKey`.
     pub fn new_address(&mut self) -> (Address, fmd::DetectionKey) {
-        self.wallet.last_used_diversifier_index =
-            (u64::from(self.wallet.last_used_diversifier_index) + 1).into();
-
-        // xx Store ivk on `ClientState` to prevent recomputing it? We don't want it on `Wallet` as wallet should
-        // be minimal.
-        let spend_key = keys::SpendKey::from_seed(self.wallet.spend_seed.clone());
-        let fvk = spend_key.full_viewing_key();
-        let ivk = fvk.incoming();
-        ivk.payment_address(self.wallet.last_used_diversifier_index)
+        self.wallet.new_address()
     }
 
     // TODO: For each output in scanned transactions, try to decrypt the note ciphertext.

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -38,8 +38,8 @@ impl ClientState {
     }
 
     /// Generate a new diversified `Address` and its corresponding `DetectionKey`.
-    pub fn new_address(&mut self) -> (Address, fmd::DetectionKey) {
-        self.wallet.new_address()
+    pub fn new_address(&mut self, label: String) -> (usize, Address, fmd::DetectionKey) {
+        self.wallet.new_address(label)
     }
 
     // TODO: For each output in scanned transactions, try to decrypt the note ciphertext.

--- a/wallet/src/storage.rs
+++ b/wallet/src/storage.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+use penumbra_crypto::keys;
+
+/// The contents of the wallet file that share a spend authority.
+#[derive(Serialize, Deserialize)]
+pub struct Wallet {
+    pub spend_seed: keys::SpendSeed,
+    // Store the last diversifier index in use.
+    pub last_used_diversifier_index: keys::DiversifierIndex,
+}

--- a/wallet/src/storage.rs
+++ b/wallet/src/storage.rs
@@ -1,11 +1,44 @@
+use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use penumbra_crypto::keys;
+use penumbra_crypto::{fmd, keys, Address};
 
 /// The contents of the wallet file that share a spend authority.
 #[derive(Serialize, Deserialize)]
 pub struct Wallet {
     pub spend_seed: keys::SpendSeed,
-    // Store the last diversifier index in use.
-    pub last_used_diversifier_index: keys::DiversifierIndex,
+    // Store addresses in use, indexed by their `DiversifierIndex`
+    pub addresses: Vec<String>,
+}
+
+impl Wallet {
+    pub fn generate<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+        let spend_key = keys::SpendKey::generate(rng);
+        let fvk = spend_key.full_viewing_key();
+        let ivk = fvk.incoming();
+        let (address, _dtdk) = ivk.payment_address(0u64.into());
+        Self {
+            spend_seed: spend_key.seed().clone(),
+            addresses: vec![address.to_string()],
+        }
+    }
+
+    /// Incoming viewing key from this spend seed.
+    pub fn incoming(&self) -> keys::IncomingViewingKey {
+        let spend_key = keys::SpendKey::from_seed(self.spend_seed.clone());
+        let fvk = spend_key.full_viewing_key();
+        fvk.incoming().clone()
+    }
+
+    /// Generate a new diversified `Address` and its corresponding `DetectionKey`.
+    pub fn new_address(&mut self) -> (Address, fmd::DetectionKey) {
+        // The index of the `self.addresses` vector is the diversifier index.
+        let new_diversifier_index: keys::DiversifierIndex =
+            (self.addresses.len() as u64 + 1u64).into();
+
+        let (new_addr, new_dtdk) = self.incoming().payment_address(new_diversifier_index);
+        self.addresses.push(new_addr.to_string());
+
+        (new_addr, new_dtdk)
+    }
 }


### PR DESCRIPTION
This PR:
* Adds a `generate` command for generating keys
* Stores key material once generated in `penumbra_wallet.dat` (or alternatively a custom location)
* Loads and saves key material using a minimal (minimal bc this is what we serialize) `Wallet` struct that has a spend key seed and the last diversifier index in use
* Integrates https://docs.rs/directories/4.0.1/directories/ 