### PR TITLE
fix pd start command

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,3 +1,4 @@
+version: "3.9"
 # docker-compose oerrides for local development.
 #
 # this modifies the docker-compose configuration for locally testing and

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       - RUST_LOG=${RUST_LOG:-warn,pd=info,penumbra=info}
     command:
-      pd --host 0.0.0.0
+      pd start --host 0.0.0.0
     restart: on-failure
     depends_on:
       - db


### PR DESCRIPTION
The docker command will just loop fail, since the proper command is `pd start --host <ip>`. I also had to add a version entry to the override yaml in order to start it.

I personally had to change it to version 3.7, since that's the latest my Docker package supports (Ubuntu), but I wasn't sure if you cared about supporting that or were using 3.9 for a specific reason, so I didn't include that in this.