### PR TITLE
fix: create wallet if it doesn't exist

### DIFF
--- a/penumbra/src/bin/pcli.rs
+++ b/penumbra/src/bin/pcli.rs
@@ -177,7 +177,10 @@ fn load_wallet(wallet_path: &Path) -> storage::Wallet {
 }
 
 fn save_wallet(wallet: &storage::Wallet, wallet_path: &Path) -> Result<(), anyhow::Error> {
-    let mut file = fs::OpenOptions::new().write(true).open(wallet_path)?;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(wallet_path)?;
 
     let seed_data = bincode::serialize(&wallet)?;
     file.write_all(&seed_data)?;


### PR DESCRIPTION
We need `create(true)` to allow `save_wallet` to create the wallet