### PR TITLE
feat: genesis, wallet service, tx serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Initialize Tendermint:
 tendermint init validator
 ```
 
-This will create a default genesis file stored in `$TMHOME` (if set, else `~/.tendermint`) named `genesis.json`.
+This will create a default genesis file stored in `$TMHOME/config` (if set, else `~/.tendermint/config`) named `genesis.json`.
 
 You probably want to set a log level:
 ```bash

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $ cargo run --bin pd -- create-genesis penumbra-tn001 \
 }
 ```
 
-To perform genesis for a testnet, edit the `genesis.json` file stored in `$TMHOME` or `~/.tendermint` (see an example in `testnets/genesis_tn001.json`). You should edit the following fields:
+To perform genesis for a testnet, edit the `genesis.json` file stored in `$TMHOME/config/` or `~/.tendermint/config/` (see an example in `testnets/genesis_tn001.json`). You should edit the following fields:
 * `validators` key: add the other validators and their voting power,
 * `app_state` key: add the generated genesis notes,
 * `chain_id` update the `chain_id` for the testnet.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Initialize Tendermint:
 tendermint init validator
 ```
 
+This will create a default genesis file stored in `$TMHOME` (if set, else `~/.tendermint`) named `genesis.json`.
+
 You probably want to set a log level:
 ```bash
 export RUST_LOG=debug  # bash
@@ -124,7 +126,12 @@ $ cargo run --bin pd -- create-genesis penumbra-tn001 \
 }
 ```
 
+To perform genesis for a testnet, edit the `genesis.json` file stored in `$TMHOME` or `~/.tendermint` (see an example in `testnets/genesis_tn001.json`). You should edit the following fields:
+* `validators` key: add the other validators and their voting power,
+* `app_state` key: add the generated genesis notes,
+* `chain_id` update the `chain_id` for the testnet.
 
+Now when you start `pd` and tendermint as described above, you will see a message at the `INFO` level indicating genesis has been performed: `consensus: penumbra::app: performing genesis for chain_id: penumbra_tn001`.
 
 [Discord]: https://discord.gg/hKvkrqa3zC
 [Penumbra]: https://penumbra.zone

--- a/crypto/src/action/output.rs
+++ b/crypto/src/action/output.rs
@@ -65,7 +65,13 @@ pub struct Body {
 }
 
 impl Body {
-    pub fn new(note: Note, v_blinding: Fr, dest: &Address, esk: &ka::Secret) -> Body {
+    pub fn new(
+        note: Note,
+        v_blinding: Fr,
+        diversified_generator: decaf377::Element,
+        transmission_key: ka::Public,
+        esk: &ka::Secret,
+    ) -> Body {
         // TODO: p. 43 Spec. Decide whether to do leadByte 0x01 method or 0x02 or other.
         let value_commitment = note.value().commit(v_blinding);
         let note_commitment = note.commit();
@@ -74,8 +80,8 @@ impl Body {
         let encrypted_note = note.encrypt(esk);
 
         let proof = OutputProof {
-            g_d: *dest.diversified_generator(),
-            pk_d: *dest.transmission_key(),
+            g_d: diversified_generator,
+            pk_d: transmission_key,
             value: note.value(),
             v_blinding,
             note_blinding: note.note_blinding(),

--- a/crypto/src/action/output.rs
+++ b/crypto/src/action/output.rs
@@ -4,9 +4,7 @@ use std::convert::{TryFrom, TryInto};
 use penumbra_proto::{transaction, Protobuf};
 
 use super::error::ProtoError;
-use crate::{
-    ka, memo::MemoCiphertext, note, proofs::transparent::OutputProof, value, Address, Fr, Note,
-};
+use crate::{ka, memo::MemoCiphertext, note, proofs::transparent::OutputProof, value, Fr, Note};
 
 #[derive(Clone)]
 pub struct Output {

--- a/crypto/src/merkle.rs
+++ b/crypto/src/merkle.rs
@@ -37,6 +37,12 @@ impl TryFrom<&[u8]> for Root {
     }
 }
 
+impl Root {
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0.to_bytes()
+    }
+}
+
 pub trait TreeExt {
     fn root2(&self) -> Root;
 }

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -324,6 +324,12 @@ impl From<Commitment> for [u8; 32] {
     }
 }
 
+impl Into<Vec<u8>> for Commitment {
+    fn into(self) -> Vec<u8> {
+        self.0.to_bytes().to_vec()
+    }
+}
+
 impl TryFrom<[u8; 32]> for Commitment {
     type Error = Error;
 

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -104,6 +104,14 @@ impl Note {
         self.value
     }
 
+    pub fn asset_id(&self) -> asset::Id {
+        self.value.asset_id
+    }
+
+    pub fn amount(&self) -> u64 {
+        self.value.amount
+    }
+
     /// Encrypt a note, returning its ciphertext.
     pub fn encrypt(&self, esk: &ka::Secret) -> [u8; NOTE_CIPHERTEXT_BYTES] {
         let epk = esk.diversified_public(&self.diversified_generator());

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -14,8 +14,14 @@ use crate::{
     Fr,
 };
 
+mod error;
+pub use error::Error;
+
 mod builder;
 pub use builder::Builder;
+
+mod genesis;
+pub use genesis::GenesisBuilder;
 
 #[derive(Clone)]
 pub struct TransactionBody {
@@ -198,7 +204,7 @@ mod tests {
 
     use crate::keys::SpendKey;
     use crate::memo::MemoPlaintext;
-    use crate::transaction::builder::Error;
+    use crate::transaction::Error;
     use crate::{note, Fq, Note, Value};
 
     #[test]

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -194,6 +194,13 @@ impl TryFrom<transaction::Transaction> for Transaction {
     }
 }
 
+impl Into<Vec<u8>> for Transaction {
+    fn into(self) -> Vec<u8> {
+        let protobuf_serialized: transaction::Transaction = self.into();
+        protobuf_serialized.encode_to_vec()
+    }
+}
+
 impl Protobuf<transaction::Fee> for Fee {}
 
 impl From<Fee> for transaction::Fee {

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -92,8 +92,6 @@ impl TryFrom<transaction::TransactionBody> for TransactionBody {
 #[derive(Clone, Debug)]
 pub struct Fee(pub u64);
 
-// temp: remove dead code when Transaction fields are read
-#[allow(dead_code)]
 pub struct Transaction {
     transaction_body: TransactionBody,
     binding_sig: Signature<Binding>,
@@ -103,6 +101,20 @@ impl Transaction {
     /// Start building a transaction relative to a given [`merkle::Root`].
     pub fn build_with_root(merkle_root: merkle::Root) -> Builder {
         Builder {
+            actions: Vec::new(),
+            fee: None,
+            synthetic_blinding_factor: Fr::zero(),
+            value_balance: decaf377::Element::default(),
+            value_commitments: decaf377::Element::default(),
+            merkle_root,
+            expiry_height: None,
+            chain_id: None,
+        }
+    }
+
+    /// Build the genesis transactions.
+    pub fn genesis_build_with_root(merkle_root: merkle::Root) -> GenesisBuilder {
+        GenesisBuilder {
             actions: Vec::new(),
             fee: None,
             synthetic_blinding_factor: Fr::zero(),

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -194,6 +194,18 @@ impl TryFrom<transaction::Transaction> for Transaction {
     }
 }
 
+impl TryFrom<&[u8]> for Transaction {
+    type Error = ProtoError;
+
+    fn try_from(bytes: &[u8]) -> Result<Transaction, Self::Error> {
+        let protobuf_serialized_proof = transaction::Transaction::decode(bytes)
+            .map_err(|_| ProtoError::TransactionMalformed)?;
+        Ok(protobuf_serialized_proof
+            .try_into()
+            .map_err(|_| ProtoError::TransactionMalformed)?)
+    }
+}
+
 impl Into<Vec<u8>> for Transaction {
     fn into(self) -> Vec<u8> {
         let protobuf_serialized: transaction::Transaction = self.into();

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -103,7 +103,13 @@ impl Builder {
             note_blinding,
         )
         .expect("transmission key is valid");
-        let body = output::Body::new(note.clone(), v_blinding, dest, &esk);
+        let body = output::Body::new(
+            note.clone(),
+            v_blinding,
+            *dest.diversified_generator(),
+            *dest.transmission_key(),
+            &esk,
+        );
         self.value_commitments -= body.value_commitment.0;
 
         let encrypted_memo = memo.encrypt(&esk, dest);

--- a/crypto/src/transaction/error.rs
+++ b/crypto/src/transaction/error.rs
@@ -1,0 +1,9 @@
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum Error {
+    #[error("Chain ID not set")]
+    NoChainID,
+    #[error("Fee not set")]
+    FeeNotSet,
+    #[error("Value balance of this transaction is not zero")]
+    NonZeroValueBalance,
+}

--- a/penumbra/Cargo.toml
+++ b/penumbra/Cargo.toml
@@ -24,15 +24,18 @@ tower-abci = { git = "https://github.com/penumbra-zone/tower-abci/" }
 tendermint-proto = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "abci-domain-types" }
 tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "abci-domain-types" }
 # External dependencies
+async-stream = "0.2"
 bincode = "1.3.3"
 blake2b_simd = "0.5"
 bytes = "1"
 comfy-table = "5"
 directories = "4.0.1"
 tokio = { version = "1", features = ["full"]}
+tokio-stream = "0.1"
 tower = { version = "0.4", features = ["full"]}
 tracing = "0.1"
 structopt = "0.3"
+tonic = "0.6.1"
 tracing-subscriber = "0.2"
 pin-project = "1"
 futures = "0.3"

--- a/penumbra/src/app.rs
+++ b/penumbra/src/app.rs
@@ -34,6 +34,9 @@ pub struct App {
     nullifier_set: BTreeSet<Nullifier>,
 }
 
+/// The Penumbra wallet service.
+pub struct WalletApp {}
+
 impl Service<Request> for App {
     type Response = Response;
     type Error = BoxError;
@@ -211,8 +214,14 @@ impl App {
     }
 }
 
+impl WalletApp {
+    pub fn new() -> WalletApp {
+        WalletApp {}
+    }
+}
+
 #[tonic::async_trait]
-impl Wallet for App {
+impl Wallet for WalletApp {
     type CompactBlockRangeStream =
         Pin<Box<dyn Stream<Item = Result<CompactBlock, Status>> + Send + Sync + 'static>>;
 

--- a/penumbra/src/app.rs
+++ b/penumbra/src/app.rs
@@ -10,7 +10,8 @@ use futures::{executor::block_on, future::FutureExt};
 use rand_core::OsRng;
 use sqlx::{query_as, Pool, Postgres};
 use tendermint::abci::{request, response, Event, EventAttributeIndexExt, Request, Response};
-use tokio_stream::Stream;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 use tonic::Status;
 use tower::Service;
 
@@ -24,7 +25,7 @@ use penumbra_proto::wallet::{
 use tower_abci::BoxError;
 
 use crate::{
-    dbschema::PenumbraTransaction,
+    dbschema::{PenumbraStateFragment, PenumbraTransaction},
     dbutils::{db_commit_block, db_connection},
     genesis::GenesisNotes,
     state::PendingBlock,
@@ -316,8 +317,7 @@ impl WalletApp {
 
 #[tonic::async_trait]
 impl Wallet for WalletApp {
-    type CompactBlockRangeStream =
-        Pin<Box<dyn Stream<Item = Result<CompactBlock, Status>> + Send + Sync + 'static>>;
+    type CompactBlockRangeStream = ReceiverStream<Result<CompactBlock, Status>>;
 
     async fn compact_block_range(
         &self,
@@ -328,11 +328,43 @@ impl Wallet for WalletApp {
             .acquire()
             .await
             .map_err(|_| tonic::Status::unavailable("server error"))?;
+        let request = request.into_inner();
+        let start_height = request.start_height;
+        let end_height = request.end_height;
 
-        // select * from blocks where height between start_block and end_block;
-        // note_commitment, ephemeral_key, encrypted_note
+        if end_height < start_height {
+            return Err(tonic::Status::failed_precondition(
+                "end height must be greater than start height",
+            ));
+        }
 
-        todo!()
+        let (tx, rx) = mpsc::channel(100);
+
+        tokio::spawn(async move {
+            for block_height in start_height..=end_height {
+                let rows = query_as::<_, PenumbraStateFragment>(
+                    r#"
+SELECT note_commitment, ephemeral_key, note_ciphertext FROM notes
+WHERE transaction_id IN (select id from transactions where block_id IN
+(SELECT id FROM blocks WHERE height = $1)
+)
+"#,
+                )
+                .bind(block_height)
+                .fetch_all(&mut p)
+                .await
+                .expect("if no results will return empty state fragments");
+
+                let block = CompactBlock {
+                    height: block_height,
+                    fragment: rows.into_iter().map(|x| x.into()).collect::<Vec<_>>(),
+                };
+                tracing::info!("sending block response: {:?}", block);
+                tx.send(Ok(block.clone())).await.unwrap();
+            }
+        });
+
+        Ok(tonic::Response::new(Self::CompactBlockRangeStream::new(rx)))
     }
 
     async fn transaction_by_note(
@@ -345,14 +377,18 @@ impl Wallet for WalletApp {
             .await
             .map_err(|_| tonic::Status::unavailable("server error"))?;
 
-        // Check the database to see if we have a matching note commitment.
         let note_commitment = request.into_inner().cm;
-        let rows = query_as::<_,PenumbraTransaction>(
-            "SELECT transactions.transaction FROM transactions JOIN notes ON transactions.id = (SELECT transaction_id FROM notes WHERE note_commitment=$1);"
+        let rows = query_as::<_, PenumbraTransaction>(
+            r#"
+SELECT transactions.transaction FROM transactions
+JOIN notes ON transactions.id = (SELECT transaction_id FROM notes WHERE note_commitment=$1
+)
+"#,
         )
         .bind(note_commitment)
         .fetch_one(&mut p)
-        .await.map_err(|_| tonic::Status::not_found("transaction not found"))?;
+        .await
+        .map_err(|_| tonic::Status::not_found("transaction not found"))?;
 
         let transaction = penumbra_crypto::Transaction::try_from(&rows.transaction[..])
             .map_err(|_| tonic::Status::data_loss("transaction not well formed"))?;

--- a/penumbra/src/app.rs
+++ b/penumbra/src/app.rs
@@ -7,12 +7,17 @@ use std::{
 
 use bytes::Bytes;
 use futures::future::FutureExt;
-use tower::Service;
-
 use tendermint::abci::{response, Event, EventAttributeIndexExt, Request, Response};
+use tokio_stream::Stream;
+use tonic::Status;
+use tower::Service;
 
 use penumbra_crypto::{
     merkle, merkle::Frontier, merkle::TreeExt, note, Action, Nullifier, Transaction,
+};
+use penumbra_proto::transaction;
+use penumbra_proto::wallet::{
+    wallet_server::Wallet, CompactBlock, CompactBlockRangeRequest, TransactionByNoteRequest,
 };
 use tower_abci::BoxError;
 
@@ -203,6 +208,26 @@ impl App {
         }
 
         true
+    }
+}
+
+#[tonic::async_trait]
+impl Wallet for App {
+    type CompactBlockRangeStream =
+        Pin<Box<dyn Stream<Item = Result<CompactBlock, Status>> + Send + Sync + 'static>>;
+
+    async fn compact_block_range(
+        &self,
+        request: tonic::Request<CompactBlockRangeRequest>,
+    ) -> Result<tonic::Response<Self::CompactBlockRangeStream>, Status> {
+        todo!()
+    }
+
+    async fn transaction_by_note(
+        &self,
+        request: tonic::Request<TransactionByNoteRequest>,
+    ) -> Result<tonic::Response<transaction::Transaction>, Status> {
+        todo!()
     }
 }
 

--- a/penumbra/src/bin/pcli.rs
+++ b/penumbra/src/bin/pcli.rs
@@ -40,6 +40,8 @@ enum Command {
     Wallet(Wallet),
     /// Manages addresses.
     Addr(Addr),
+    /// Fetch transaction by note commitment - TEMP (not gonna be exposed to user)
+    FetchByNoteCommitment,
 }
 
 #[derive(Debug, StructOpt)]
@@ -95,7 +97,7 @@ async fn main() -> Result<()> {
 
     match opt.cmd {
         Command::Tx { key, value } => {
-            let spend_key = load_existing_keys(&wallet_path);
+            let spend_key = load_wallet(&wallet_path);
             let local_storage = state::ClientState::new(spend_key);
 
             let rsp = reqwest::get(format!(
@@ -109,7 +111,7 @@ async fn main() -> Result<()> {
             tracing::info!("{}", rsp);
         }
         Command::Query { key } => {
-            let spend_key = load_existing_keys(&wallet_path);
+            let spend_key = load_wallet(&wallet_path);
             let local_storage = state::ClientState::new(spend_key);
 
             let rsp: serde_json::Value = reqwest::get(format!(
@@ -175,9 +177,9 @@ async fn main() -> Result<()> {
             println!("{}", table);
         }
         Command::FetchByNoteCommitment => {
-            let spend_key = load_existing_keys(&wallet_path);
+            let spend_key = load_wallet(&wallet_path);
             let local_storage = state::ClientState::new(spend_key);
-            let mut client = WalletClient::connect("http://127.0.0.1:2323").await?;
+            let mut client = WalletClient::connect("http://127.0.0.1:3232").await?;
 
             let cm = vec![0, 0, 0u8];
             let request = tonic::Request::new(TransactionByNoteRequest { cm: cm.clone() });

--- a/penumbra/src/bin/pcli.rs
+++ b/penumbra/src/bin/pcli.rs
@@ -179,7 +179,7 @@ async fn main() -> Result<()> {
         Command::FetchByNoteCommitment => {
             let spend_key = load_wallet(&wallet_path);
             let local_storage = state::ClientState::new(spend_key);
-            let mut client = WalletClient::connect("http://127.0.0.1:3232").await?;
+            let mut client = WalletClient::connect("http://127.0.0.1:26666").await?;
 
             let cm = vec![0, 0, 0u8];
             let request = tonic::Request::new(TransactionByNoteRequest { cm: cm.clone() });

--- a/penumbra/src/bin/pcli.rs
+++ b/penumbra/src/bin/pcli.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 use std::{fs, io, process};
 use structopt::StructOpt;
 
-use penumbra_crypto::keys;
 use penumbra_proto::wallet::{
     wallet_client::WalletClient, CompactBlock, CompactBlockRangeRequest, TransactionByNoteRequest,
 };
@@ -40,8 +39,10 @@ enum Command {
     Wallet(Wallet),
     /// Manages addresses.
     Addr(Addr),
-    /// Fetch transaction by note commitment - TEMP (not gonna be exposed to user)
+    /// Fetch transaction by note commitment - TEMP (ultimately not gonna be exposed to user)
     FetchByNoteCommitment,
+    /// Block request - TEMP (ultimately not gonna be exposed to user)
+    BlockRequest { end_block_height: u64 },
 }
 
 #[derive(Debug, StructOpt)]
@@ -98,7 +99,7 @@ async fn main() -> Result<()> {
     match opt.cmd {
         Command::Tx { key, value } => {
             let spend_key = load_wallet(&wallet_path);
-            let local_storage = state::ClientState::new(spend_key);
+            let _local_storage = state::ClientState::new(spend_key);
 
             let rsp = reqwest::get(format!(
                 r#"http://{}/broadcast_tx_async?tx="{}={}""#,
@@ -112,7 +113,7 @@ async fn main() -> Result<()> {
         }
         Command::Query { key } => {
             let spend_key = load_wallet(&wallet_path);
-            let local_storage = state::ClientState::new(spend_key);
+            let _local_storage = state::ClientState::new(spend_key);
 
             let rsp: serde_json::Value = reqwest::get(format!(
                 r#"http://{}/abci_query?data=0x{}"#,
@@ -178,7 +179,7 @@ async fn main() -> Result<()> {
         }
         Command::FetchByNoteCommitment => {
             let spend_key = load_wallet(&wallet_path);
-            let local_storage = state::ClientState::new(spend_key);
+            let _local_storage = state::ClientState::new(spend_key);
             let mut client = WalletClient::connect("http://127.0.0.1:26666").await?;
 
             let cm = vec![0, 0, 0u8];
@@ -186,7 +187,7 @@ async fn main() -> Result<()> {
 
             tracing::info!("requesting tx by note commitment: {:?}", cm);
 
-            let response = client.transaction_by_note(request).await?;
+            let _response = client.transaction_by_note(request).await?;
 
             tracing::info!("got tx");
             // TODO: Add to local store

--- a/penumbra/src/bin/pcli.rs
+++ b/penumbra/src/bin/pcli.rs
@@ -206,8 +206,11 @@ async fn main() -> Result<()> {
                 start_height,
                 end_height
             );
-            let response = client.compact_block_range(request).await?;
-            tracing::info!("got response: {:?}", response);
+            let mut stream = client.compact_block_range(request).await?.into_inner();
+
+            while let Some(block) = stream.message().await? {
+                tracing::info!("got fragment: {:?}", block);
+            }
         }
         _ => todo!(),
     }

--- a/penumbra/src/bin/pd.rs
+++ b/penumbra/src/bin/pd.rs
@@ -4,7 +4,6 @@ use rand_chacha::ChaCha20Rng;
 use structopt::StructOpt;
 use tonic::transport::Server;
 
-use penumbra::dbschema::{NoteCommitmentTreeAnchor, PenumbraNoteCommitmentTreeAnchor};
 use penumbra::dbutils::{db_bootstrap, db_connection};
 use penumbra::genesis::{generate_genesis_notes, GenesisAddr};
 use penumbra_proto::wallet::wallet_server;

--- a/penumbra/src/bin/pd.rs
+++ b/penumbra/src/bin/pd.rs
@@ -80,7 +80,7 @@ async fn main() {
                 .serve(wallet_service_addr);
 
             // xx better way to serve both?
-            join!(
+            let _result = join!(
                 wallet_server,
                 abci_server.listen(format!("{}:{}", host, abci_port))
             );

--- a/penumbra/src/bin/pd.rs
+++ b/penumbra/src/bin/pd.rs
@@ -48,52 +48,54 @@ async fn main() {
     match opt.cmd {
         Command::Start { host, port } => {
             // get the pool, cool
-            // let pool = db_connection().await.expect("");
+            let pool = db_connection().await.expect("");
 
-            // // bootstrap database, malaise
-            // let _db_bootstrap_on_load = db_bootstrap(pool.clone()).await.unwrap();
+            // bootstrap database, malaise
+            let _db_bootstrap_on_load = db_bootstrap(pool.clone()).await.unwrap();
 
-            // // insert dummy, chummy
-            // let v: Vec<u8> = vec![6; 32];
-            // let _db_insert_dummy_row = db_insert(
-            //     PenumbraNoteCommitmentTreeAnchor::from(NoteCommitmentTreeAnchor {
-            //         id: 0,
-            //         height: 1337 as i64,
-            //         anchor: v,
-            //     }),
-            //     pool.clone(),
-            // )
-            // .await
-            // .unwrap();
+            // insert dummy, chummy
+            let v: Vec<u8> = vec![6; 32];
+            let _db_insert_dummy_row = db_insert(
+                PenumbraNoteCommitmentTreeAnchor::from(NoteCommitmentTreeAnchor {
+                    id: 0,
+                    height: 1337 as i64,
+                    anchor: v,
+                }),
+                pool.clone(),
+            )
+            .await
+            .unwrap();
 
-            // // read stuff, rough
-            // let _db_read_dummy_row = db_read(pool.clone()).await.unwrap();
-            // println!(
-            //     "raw height {} raw anchor {:?}",
-            //     _db_read_dummy_row[0].height, _db_read_dummy_row[0].anchor
-            // );
+            // read stuff, rough
+            let _db_read_dummy_row = db_read(pool.clone()).await.unwrap();
+            println!(
+                "raw height {} raw anchor {:?}",
+                _db_read_dummy_row[0].height, _db_read_dummy_row[0].anchor
+            );
 
             // app
             let app = penumbra::App::default();
+            let wallet_app = penumbra::WalletApp::new();
 
             use tower_abci::split;
 
-            // let (consensus, mempool, snapshot, info) = split::service(app, 1);
+            let (consensus, mempool, snapshot, info) = split::service(app, 1);
 
-            // let server = tower_abci::Server::builder()
-            //     .consensus(consensus)
-            //     .snapshot(snapshot)
-            //     .mempool(mempool)
-            //     .info(info)
-            //     .finish()
-            //     .unwrap();
+            let server = tower_abci::Server::builder()
+                .consensus(consensus)
+                .snapshot(snapshot)
+                .mempool(mempool)
+                .info(info)
+                .finish()
+                .unwrap();
 
             // Run the ABCI server.
-            //server.listen(format!("{}:{}", host, port)).await.unwrap();
+            server.listen(format!("{}:{}", host, port)).await.unwrap();
 
-            let wallet_service_addr = "127.0.0.1:2323".parse().expect("this is a valid address");
+            // xx Move the below
+            let wallet_service_addr = "127.0.0.1:3232".parse().expect("this is a valid address");
             let wallet_server = Server::builder()
-                .add_service(wallet_server::WalletServer::new(app))
+                .add_service(wallet_server::WalletServer::new(wallet_app))
                 .serve(wallet_service_addr)
                 .await
                 .unwrap();

--- a/penumbra/src/bin/pd.rs
+++ b/penumbra/src/bin/pd.rs
@@ -5,7 +5,7 @@ use structopt::StructOpt;
 use tonic::transport::Server;
 
 use penumbra::dbschema::{NoteCommitmentTreeAnchor, PenumbraNoteCommitmentTreeAnchor};
-use penumbra::dbutils::{db_bootstrap, db_connection, db_insert, db_read};
+use penumbra::dbutils::{db_bootstrap, db_connection};
 use penumbra::genesis::{generate_genesis_notes, GenesisAddr};
 use penumbra_proto::wallet::wallet_server;
 
@@ -54,31 +54,9 @@ async fn main() {
             abci_port,
             wallet_port,
         } => {
-            // get the pool, cool
+            // Create database tables
             let pool = db_connection().await.expect("");
-
-            // bootstrap database, malaise
             let _db_bootstrap_on_load = db_bootstrap(pool.clone()).await.unwrap();
-
-            // insert dummy, chummy
-            let v: Vec<u8> = vec![6; 32];
-            let _db_insert_dummy_row = db_insert(
-                PenumbraNoteCommitmentTreeAnchor::from(NoteCommitmentTreeAnchor {
-                    id: 0,
-                    height: 1337 as i64,
-                    anchor: v,
-                }),
-                pool.clone(),
-            )
-            .await
-            .unwrap();
-
-            // read stuff, rough
-            let _db_read_dummy_row = db_read(pool.clone()).await.unwrap();
-            println!(
-                "raw height {} raw anchor {:?}",
-                _db_read_dummy_row[0].height, _db_read_dummy_row[0].anchor
-            );
 
             let abci_app = penumbra::App::default();
             let wallet_app = penumbra::WalletApp::new();

--- a/penumbra/src/bin/pd.rs
+++ b/penumbra/src/bin/pd.rs
@@ -7,7 +7,7 @@ use tonic::transport::Server;
 use penumbra::dbschema::{NoteCommitmentTreeAnchor, PenumbraNoteCommitmentTreeAnchor};
 use penumbra::dbutils::{db_bootstrap, db_connection, db_insert, db_read};
 use penumbra::genesis::{generate_genesis_notes, GenesisAddr};
-use penumbra_proto::wallet::{wallet_server, wallet_server::Wallet};
+use penumbra_proto::wallet::wallet_server;
 
 #[derive(Debug, StructOpt)]
 #[structopt(

--- a/penumbra/src/bin/pd.rs
+++ b/penumbra/src/bin/pd.rs
@@ -1,10 +1,13 @@
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
+use std::net::SocketAddr;
 use structopt::StructOpt;
+use tonic::transport::Server;
 
 use penumbra::dbschema::{NoteCommitmentTreeAnchor, PenumbraNoteCommitmentTreeAnchor};
 use penumbra::dbutils::{db_bootstrap, db_connection, db_insert, db_read};
 use penumbra::genesis::{generate_genesis_notes, GenesisAddr};
+use penumbra_proto::wallet::{wallet_server, wallet_server::Wallet};
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -45,48 +48,55 @@ async fn main() {
     match opt.cmd {
         Command::Start { host, port } => {
             // get the pool, cool
-            let pool = db_connection().await.expect("");
+            // let pool = db_connection().await.expect("");
 
-            // bootstrap database, malaise
-            let _db_bootstrap_on_load = db_bootstrap(pool.clone()).await.unwrap();
+            // // bootstrap database, malaise
+            // let _db_bootstrap_on_load = db_bootstrap(pool.clone()).await.unwrap();
 
-            // insert dummy, chummy
-            let v: Vec<u8> = vec![6; 32];
-            let _db_insert_dummy_row = db_insert(
-                PenumbraNoteCommitmentTreeAnchor::from(NoteCommitmentTreeAnchor {
-                    id: 0,
-                    height: 1337_i64,
-                    anchor: v,
-                }),
-                pool.clone(),
-            )
-            .await
-            .unwrap();
+            // // insert dummy, chummy
+            // let v: Vec<u8> = vec![6; 32];
+            // let _db_insert_dummy_row = db_insert(
+            //     PenumbraNoteCommitmentTreeAnchor::from(NoteCommitmentTreeAnchor {
+            //         id: 0,
+            //         height: 1337 as i64,
+            //         anchor: v,
+            //     }),
+            //     pool.clone(),
+            // )
+            // .await
+            // .unwrap();
 
-            // read stuff, rough
-            let _db_read_dummy_row = db_read(pool.clone()).await.unwrap();
-            println!(
-                "raw height {} raw anchor {:?}",
-                _db_read_dummy_row[0].height, _db_read_dummy_row[0].anchor
-            );
+            // // read stuff, rough
+            // let _db_read_dummy_row = db_read(pool.clone()).await.unwrap();
+            // println!(
+            //     "raw height {} raw anchor {:?}",
+            //     _db_read_dummy_row[0].height, _db_read_dummy_row[0].anchor
+            // );
 
             // app
             let app = penumbra::App::default();
 
-            use tower_abci::{split, Server};
+            use tower_abci::split;
 
-            let (consensus, mempool, snapshot, info) = split::service(app, 1);
+            // let (consensus, mempool, snapshot, info) = split::service(app, 1);
 
-            let server = Server::builder()
-                .consensus(consensus)
-                .snapshot(snapshot)
-                .mempool(mempool)
-                .info(info)
-                .finish()
-                .unwrap();
+            // let server = tower_abci::Server::builder()
+            //     .consensus(consensus)
+            //     .snapshot(snapshot)
+            //     .mempool(mempool)
+            //     .info(info)
+            //     .finish()
+            //     .unwrap();
 
             // Run the ABCI server.
-            server.listen(format!("{}:{}", host, port)).await.unwrap();
+            //server.listen(format!("{}:{}", host, port)).await.unwrap();
+
+            let wallet_service_addr = "127.0.0.1:2323".parse().expect("this is a valid address");
+            let wallet_server = Server::builder()
+                .add_service(wallet_server::WalletServer::new(app))
+                .serve(wallet_service_addr)
+                .await
+                .unwrap();
         }
         Command::CreateGenesis {
             chain_id,

--- a/penumbra/src/bin/pd.rs
+++ b/penumbra/src/bin/pd.rs
@@ -1,11 +1,7 @@
-use std::time::Duration;
-
 use futures::join;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
-use std::net::SocketAddr;
 use structopt::StructOpt;
-use tokio::{net::TcpListener, runtime::Runtime};
 use tonic::transport::Server;
 
 use penumbra::dbschema::{NoteCommitmentTreeAnchor, PenumbraNoteCommitmentTreeAnchor};

--- a/penumbra/src/bin/pd.rs
+++ b/penumbra/src/bin/pd.rs
@@ -29,7 +29,7 @@ struct Opt {
 enum Command {
     /// Start running the ABCI and wallet services.
     Start {
-        /// Bind the server to this host.
+        /// Bind the services to this host.
         #[structopt(short, long, default_value = "127.0.0.1")]
         host: String,
         /// Bind the ABCI server to this port.

--- a/penumbra/src/dbschema.rs
+++ b/penumbra/src/dbschema.rs
@@ -6,6 +6,7 @@ use tendermint::block::Height;
 
 use penumbra_crypto::merkle::Root;
 use penumbra_crypto::Fq;
+use penumbra_proto::wallet::StateFragment;
 
 /// Bridge type between Postgres and Penumbra
 #[derive(Debug, sqlx::FromRow)]
@@ -30,6 +31,14 @@ pub struct PenumbraNoteCommitmentTreeAnchor {
 #[derive(Debug, sqlx::FromRow)]
 pub struct PenumbraTransaction {
     pub transaction: Vec<u8>,
+}
+
+/// Bridge type between Postgres and Penumbra for state fragments
+#[derive(Debug, sqlx::FromRow)]
+pub struct PenumbraStateFragment {
+    pub note_commitment: Vec<u8>,
+    pub ephemeral_key: Vec<u8>,
+    pub note_ciphertext: Vec<u8>,
 }
 
 /// Convert between Penumbra and bridge type for DB
@@ -62,4 +71,15 @@ impl From<NoteCommitmentTreeAnchor> for PenumbraNoteCommitmentTreeAnchor {
 fn vec_to_array<T, const N: usize>(v: Vec<T>) -> [T; N] {
     v.try_into()
         .unwrap_or_else(|v: Vec<T>| panic!("Expected a Vec of length {} but it was {}", N, v.len()))
+}
+
+/// Convert between db and proto for state fragments
+impl From<PenumbraStateFragment> for StateFragment {
+    fn from(p: PenumbraStateFragment) -> Self {
+        StateFragment {
+            cm: p.note_commitment.into(),
+            ephemeral_key: p.ephemeral_key.into(),
+            encrypted_note: p.note_ciphertext.into(),
+        }
+    }
 }

--- a/penumbra/src/dbschema.rs
+++ b/penumbra/src/dbschema.rs
@@ -26,6 +26,12 @@ pub struct PenumbraNoteCommitmentTreeAnchor {
     pub anchor: Root,
 }
 
+/// Bridge type between Postgres and Penumbra for transactions
+#[derive(Debug, sqlx::FromRow)]
+pub struct PenumbraTransaction {
+    pub transaction: Vec<u8>,
+}
+
 /// Convert between Penumbra and bridge type for DB
 impl From<PenumbraNoteCommitmentTreeAnchor> for NoteCommitmentTreeAnchor {
     fn from(p: PenumbraNoteCommitmentTreeAnchor) -> Self {

--- a/penumbra/src/dbutils.rs
+++ b/penumbra/src/dbutils.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use sqlx::postgres::{PgPoolOptions, PgQueryResult};
+use sqlx::postgres::PgPoolOptions;
 use sqlx::{query, query_as, Error};
 use sqlx::{Pool, Postgres};
 
@@ -30,8 +30,8 @@ pub async fn db_connection() -> Result<Pool<Postgres>, sqlx::Error> {
 }
 
 /// Bootstrap the database, creating tables if they do not exist.
-pub async fn db_bootstrap(pool: Pool<Postgres>) -> Result<PgQueryResult, Error> {
-    let bootstrap_sql_blocks = query(
+pub async fn db_bootstrap(pool: Pool<Postgres>) -> Result<(), Error> {
+    query(
         r#"
 CREATE TABLE IF NOT EXISTS blocks (
     id SERIAL PRIMARY KEY, 
@@ -41,9 +41,9 @@ CREATE TABLE IF NOT EXISTS blocks (
 "#,
     )
     .execute(&pool)
-    .await;
+    .await?;
 
-    let bootstrap_sql_transactions = query(
+    query(
         r#"
 CREATE TABLE IF NOT EXISTS transactions (
     id SERIAL PRIMARY KEY,
@@ -53,9 +53,9 @@ CREATE TABLE IF NOT EXISTS transactions (
 "#,
     )
     .execute(&pool)
-    .await;
+    .await?;
 
-    let bootstrap_sql_notes = query(
+    query(
         r#"
 CREATE TABLE IF NOT EXISTS notes (
     id SERIAL PRIMARY KEY,
@@ -67,10 +67,9 @@ CREATE TABLE IF NOT EXISTS notes (
 "#,
     )
     .execute(&pool)
-    .await;
+    .await?;
 
-    // xx combine with bootstrap_sql_blocks, bootstrap_sql_notes
-    bootstrap_sql_transactions
+    Ok(())
 }
 
 /// Hardcoded query for inserting one row into `blocks` given an active database transaction.

--- a/penumbra/src/dbutils.rs
+++ b/penumbra/src/dbutils.rs
@@ -46,6 +46,9 @@ CREATE TABLE IF NOT EXISTS transactions (
     id SERIAL PRIMARY KEY,
     transaction_id bytea NOT NULL,
     note_commitment bytea NOT NULL,
+    note_ciphertext bytea NOT NULL,
+    ephemeral_key bytea NOT NULL,
+    transaction bytea NOT NULL,
     block_id bigint REFERENCES blocks (id)
 )
 "#,

--- a/penumbra/src/dbutils.rs
+++ b/penumbra/src/dbutils.rs
@@ -40,14 +40,26 @@ CREATE TABLE IF NOT EXISTS blocks (
     )
     .execute(&pool)
     .await;
+
+    let bootstrap_sql_notes = query(
+        r#"
+CREATE TABLE IF NOT EXISTS notes (
+    id SERIAL PRIMARY KEY,
+    note_commitment bytea NOT NULL,
+    note_ciphertext bytea NOT NULL,
+    ephemeral_key bytea NOT NULL,
+    transaction_id bigint REFERENCES transactions (id),
+)
+"#,
+    )
+    .execute(&pool)
+    .await;
+
     let bootstrap_sql_transactions = query(
         r#"
 CREATE TABLE IF NOT EXISTS transactions (
     id SERIAL PRIMARY KEY,
     transaction_id bytea NOT NULL,
-    note_commitment bytea NOT NULL,
-    note_ciphertext bytea NOT NULL,
-    ephemeral_key bytea NOT NULL,
     transaction bytea NOT NULL,
     block_id bigint REFERENCES blocks (id)
 )
@@ -56,7 +68,7 @@ CREATE TABLE IF NOT EXISTS transactions (
     .execute(&pool)
     .await;
 
-    // xx combine with bootstrap_sql_blocks
+    // xx combine with bootstrap_sql_blocks, bootstrap_sql_notes
     bootstrap_sql_transactions
 }
 

--- a/penumbra/src/genesis.rs
+++ b/penumbra/src/genesis.rs
@@ -5,7 +5,7 @@ use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use penumbra_crypto::{asset, keys, Address, Fq, Note, Value};
+use penumbra_crypto::{asset, Address, Fq, Note, Value};
 
 pub fn generate_genesis_notes(
     rng: &mut ChaCha20Rng,

--- a/penumbra/src/genesis.rs
+++ b/penumbra/src/genesis.rs
@@ -5,7 +5,7 @@ use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use penumbra_crypto::{asset, Address, Fq, Note, Value};
+use penumbra_crypto::{asset, keys, Address, Fq, Note, Value};
 
 pub fn generate_genesis_notes(
     rng: &mut ChaCha20Rng,

--- a/penumbra/src/genesis.rs
+++ b/penumbra/src/genesis.rs
@@ -37,6 +37,12 @@ pub struct GenesisNotes {
     notes: Vec<Note>,
 }
 
+impl GenesisNotes {
+    pub fn notes(&self) -> Vec<Note> {
+        self.notes.clone()
+    }
+}
+
 #[derive(Debug)]
 pub struct GenesisAddr {
     pub amount: u64,

--- a/penumbra/src/lib.rs
+++ b/penumbra/src/lib.rs
@@ -4,6 +4,7 @@ mod app;
 pub mod dbschema;
 pub mod dbutils;
 pub mod genesis;
+pub mod state;
 
 pub use app::App;
 pub use app::WalletApp;

--- a/penumbra/src/lib.rs
+++ b/penumbra/src/lib.rs
@@ -6,3 +6,4 @@ pub mod dbutils;
 pub mod genesis;
 
 pub use app::App;
+pub use app::WalletApp;

--- a/penumbra/src/state.rs
+++ b/penumbra/src/state.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::convert::TryInto;
 
-use penumbra_crypto::{ka, note, Action, Note, Transaction};
+use penumbra_crypto::{ka, note, Action, Transaction};
 
 /// Stores pending state changes from transactions.
 #[derive(Debug)]

--- a/penumbra/src/state.rs
+++ b/penumbra/src/state.rs
@@ -1,0 +1,60 @@
+use std::collections::HashMap;
+use std::convert::TryInto;
+
+use penumbra_crypto::{ka, note, Action, Note, Transaction};
+
+/// Stores pending state changes from transactions.
+#[derive(Debug)]
+pub struct PendingBlock {
+    // Stores note commitments for convienience when updating the NCT.
+    pub note_commitments: Vec<note::Commitment>,
+    // A map of serialized transactions (what we store) to its notes.
+    pub transactions: HashMap<Vec<u8>, Vec<NoteFragment>>,
+}
+
+impl Default for PendingBlock {
+    fn default() -> Self {
+        PendingBlock {
+            note_commitments: Vec::new(),
+            transactions: HashMap::new(),
+        }
+    }
+}
+
+impl PendingBlock {
+    /// Adds the changes from a transaction.
+    pub fn add_transaction(&mut self, transaction: Transaction) {
+        let mut note_fragments = Vec::<NoteFragment>::new();
+        for action in transaction.transaction_body().actions {
+            match action {
+                Action::Output(output) => {
+                    // Unpack new notes from outputs, save here.
+                    note_fragments.push(NoteFragment {
+                        note_commitment: output.body.note_commitment,
+                        ephemeral_key: output.body.ephemeral_key,
+                        note_ciphertext: output.body.encrypted_note,
+                    });
+                    self.note_commitments.push(output.body.note_commitment);
+                }
+                Action::Spend(_spend) => {
+                    // This should be done when implementing `DeliverTx`
+                    todo!("add nullifiers from spends to the database!")
+                }
+            }
+        }
+
+        let serialized_transaction: Vec<u8> = transaction
+            .try_into()
+            .expect("can serialize genesis transaction");
+
+        self.transactions
+            .insert(serialized_transaction, note_fragments);
+    }
+}
+
+#[derive(Debug)]
+pub struct NoteFragment {
+    pub note_commitment: note::Commitment,
+    pub ephemeral_key: ka::Public,
+    pub note_ciphertext: [u8; note::NOTE_CIPHERTEXT_BYTES],
+}

--- a/testnets/genesis_tn001.json
+++ b/testnets/genesis_tn001.json
@@ -1,0 +1,37 @@
+{
+    "genesis_time": "2021-10-28T16:46:17.085763Z",
+    "chain_id": "penumbra_tn001",
+    "initial_height": "0",
+    "consensus_params": {
+        "block": {
+            "max_bytes": "22020096",
+            "max_gas": "-1"
+        },
+        "evidence": {
+            "max_age_num_blocks": "100000",
+            "max_age_duration": "172800000000000",
+            "max_bytes": "1048576"
+        },
+        "validator": {
+            "pub_key_types": [
+                "ed25519"
+            ]
+        },
+        "version": {
+            "app_version": "0"
+        }
+    },
+    "validators": [
+        {
+            "address": "YOURDEETSHERE",
+            "pub_key": {
+                "type": "tendermint/PubKeyEd25519",
+                "value": "YOURDEETSHERE"
+            },
+            "power": "10",
+            "name": ""
+        }
+    ],
+    "app_hash": "",
+    "app_state": ""
+}


### PR DESCRIPTION
This PR closes #33 (and implements the necessary pre-reqs). 

## Genesis

This PR handles `InitChain` for genesis and describes how to setup genesis JSON files for development or testnets. If you follow the documentation you should see for block 0:

```
Nov 11 13:14:09.290  INFO abci{addr=127.0.0.1:49932}:consensus: penumbra::app: performing genesis for chain_id: penumbra_tn001
Nov 11 13:14:09.517  INFO abci{addr=127.0.0.1:49932}:consensus: penumbra::app: successfully loaded all genesis notes
Nov 11 13:14:09.517  INFO abci{addr=127.0.0.1:49932}:consensus: penumbra::app: committing pending changes to database
Nov 11 13:14:12.497  INFO abci{addr=127.0.0.1:49932}:consensus: sqlx::query: /* SQLx ping */; rows: 0, elapsed: 268.625µs
Nov 11 13:14:12.498  INFO abci{addr=127.0.0.1:49932}:consensus: sqlx::query: BEGIN; rows: 0, elapsed: 682.625µs
Nov 11 13:14:12.512  INFO abci{addr=127.0.0.1:49932}:consensus: sqlx::query: INSERT INTO blocks (height, …; rows: 0, elapsed: 13.494ms

INSERT INTO
  blocks (height, anchor)
VALUES
  ($1, $2)

Nov 11 13:14:12.520  INFO abci{addr=127.0.0.1:49932}:consensus: sqlx::query: INSERT INTO transactions (transaction, …; rows: 0, elapsed: 6.893ms

INSERT INTO
  transactions (transaction, block_id)
VALUES
  ($1, $2)

saving notes
Nov 11 13:14:12.523  INFO abci{addr=127.0.0.1:49932}:consensus: sqlx::query: INSERT INTO notes (note_commitment, …; rows: 0, elapsed: 1.560ms

INSERT INTO
  notes (
    note_commitment,
    ephemeral_key,
    note_ciphertext,
    transaction_id
  )
VALUES
  ($1, $2, $3, $4)

Nov 11 13:14:12.523  INFO abci{addr=127.0.0.1:49932}:consensus: sqlx::query: COMMIT; rows: 0, elapsed: 395.375µs
Nov 11 13:14:12.523  INFO abci{addr=127.0.0.1:49932}:consensus: penumbra::app: initial app_hash at genesis: b"@[\xf4<.\x9d3\xdc\xee.\xbc\xa1\xa8\xe2 \xd1\x98\x87\xa6NqJ+NY\xc7\x0b\xab\xcd\x87:\x05"
```

A single transaction is created with the genesis notes as outputs, this is added to the database table called `transactions`, and the notes are added to the local NCT and to a database table called `notes`. Data about each block is added to the `blocks` table. Data during a block is kept in a pending state on a new struct called `PendingBlock`. As transactions are processed they can be added to this struct and the pending state changes are committed to the database and local state during the Tendermint `Commit` phase. 

This does _not_ yet update the nullifier set or update the database for spends (there's a `todo!()` inline to capture where this should be done). This will require adding another database table (I've created a ticket for this, as part of `DeliverTx` implementation in ticket #135). 

## Wallet service

The gRPC wallet service is implemented & runs alongside the ABCI server. There are two temporary commands added to `pcli` which exercise the wallet service and should be removed as part of implementing sync in issue #35 (which is what will actually use the wallet service). For now, these allow a developer to query the genesis data.

### Getting a transaction by one of the associated note commitments

```
     Running `target/debug/pcli fetch-by-note-commitment b26ed92e5016a6b8d21bf0c5c0d3b2095487b1ba9a6ea883829e946afb59430b`
Nov 10 14:45:28.571  INFO pcli: requesting tx by note commitment: [178, 110, 217, 46, 80, 22, 166, 184, 210, 27, 240, 197, 192, 211, 178, 9, 84, 135, 177, 186, 154, 110, 168, 131, 130, 158, 148, 106, 251, 89, 67, 11]
Nov 10 14:45:28.581  INFO pcli: got response: Response { metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Wed, 10 Nov 2021 19:45:28 GMT", "grpc-status": "0"} }, message: Transaction { body: Some(TransactionBody { actions: [Action { action: Some(Output(Output { body: Some(OutputBody { cv: b"\x168#YK\xfbhJa;\x0f(B@\xdc\xe4\x98`\xbe\xcd\xbd\xe0\xe6z\x19\xe12\x91W\xfaD\x08", cm: b"\xb2n\xd9.P\x16\xa6\xb8\xd2\x1b\xf0\xc5\xc0\xd3\xb2\tT\x87\xb1\xba\x9an\xa8\x83\x82\x9e\x94j\xfbYC\x0b", ephemeral_key: b"nB\x98\xff\xc5\xf1\xc1\xeb\x1b\xe4\x07\x1c\x926\xf7\xfdVq\x91\xccL\xb3t\xba:z #\xca\x9e \x11", encrypted_note: b"\x8a\x18\xd1u.\xcd\xcb\x9eX\x14\xf6q9\x0f\xd1\x9b\xbb\xcc\x1dNd\"i\xf0\xb9F\x81\xad \xbbr\xd8<c\x16\xa0\xd8\xce\x94x\x84PG\x97\xb4\xf5\x1f\xd4\x1fY\xa2\xaeR\x1aK\x0b)\xcd\xc9I*+\xda\x96\xacO\xe9\xd4\x16*\xa0\xb3z=\xd8\x8f\xf5\x91\x10~LB\x92\x03\xba0\xc3\x92`Fn1\xf3\xfa\x91Q`=\xbe-\xdc\xa8{:\xa5\xde\xf7\x90m!\xf5\x17\x8dv\xffe\x1c\xfa\x05\x0e\xfa'\x05\xa3\xf5\xae\"\x81\x8bu\x87j", zkproof: b"\n \xee\xa4{\x17\xe0\xee\x8c\xd6\xec\x8ce\xf8\xf5nB}\x99_Cr\xcc\x0cX\xc3O\xd6c\x99\xc3\x84\x06\x05\x12 \n\xd0F\x8d\xb1\x12\xd5[\xceR\xd5\x9f\xda\xbe\xbe)\xcb\x0c\x97^\xd3\x0e6\x98\xa6;|<Q\x95\xd1\x01\x18d\" 2\x13gMt\xc0\xf0\xa1\x0bxh8\"T`(\x880\x94\x01G\xedof\xbb\xaez\xf1\xedu\x91\x01* \xb1\xfc\x0em2\"V\xd0\x9994\x03\x1d\x12?\xe5\xd4\xfbh\x1d\xf4{\xbedn\xc2hE\xb8\xd8u\x032 \x93\xf7$\\\x0e\x02e3\x8e\xd5M\xb5tF-\x16\xa3f\x18}?/\xf3a\xaa\x94\xec\xdd\xad\xfb\xb1\x03: \x0e@\xb9\xcd\x86\x102A\x88b559\x13\xf6@R\xb8X#\x16X\xc3D\x92\x12\xf5\x02+Kd\x03" }), encrypted_memo: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", ovk_wrapped_key: b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0" })) }], anchor: b"\x8b@ks\x8e[\x12c)\xc7N\xf2F\xdbf\xd4\xb8) 2\0. \xea\xa4\x9c/\\\x9bO\x9a\x07", expiry_height: 0, chain_id: "penumbra_tn001", fee: Some(Fee { amount: 0 }) }), binding_sig: b"bN\x17\x14\xb9\xa1\x10\n\xca\x03(\x1a\xfe\x1a\xb4\x84K\x1e6\xfd?G\xee[\xb9\x05i%ci\xc6\x0e\xf0HH\x92\xf7^&|<*\xf5\xcdv\x95K\xb2_v\xd4\xe7\xd8{\xdaR\xf4\xfb>\xaboB\x8f\x01" }, extensions: Extensions }
```

### Getting state updates given a range of block heights

```
     Running `target/debug/pcli block-request 0 1`
Nov 11 13:00:13.789  INFO pcli: requesting state fragments from: 0 to 1
Nov 11 13:00:13.801  INFO pcli: got fragment: CompactBlock { height: 0, fragment: [StateFragment { cm: b"\xb2n\xd9.P\x16\xa6\xb8\xd2\x1b\xf0\xc5\xc0\xd3\xb2\tT\x87\xb1\xba\x9an\xa8\x83\x82\x9e\x94j\xfbYC\x0b", ephemeral_key: b"\xdayyn/\x8c\xd9\x8b\xc3\xc2\xb4\xa0\xfbc\x7f~l\x0f\xffI\xf1\x0e$\xb2v\x99\x8a%\x8cIB\t", encrypted_note: b"\x98\xe7&NM\xd6\xff\xf0\rn\xf8\xe2\x93\x940\x1a,\xc7\xb8\xb2\xf9.\xc0r\xc4\xa4\x8e\xba\xb7\tV9\x13\xa4\x88\xb5\xa2\xe3\xef\xfe\xb8\xab\x08\xbc\xae;^Z/p\xafmH\xf7\xe5\xae\x13i\rS\xecup\xc6\xe4I\xd9\xe4\x19\x97\xd9\xc0\x88[\xb8(\xf0\xd2\r\xfa\x8a\xf4\x12\x1c\xc8\t\xefW\x8a\x10X\xf1\xcd\xe9?=\x7f\x0b1\xf7\xbe\xcd\x8eN\x0b?t\xe2a\xf6\x99jO\x12\x17tF\xbfY\xd0\xe3\x8dh\x10&U\xf2\xeb\x84\xaa\x93`" }] }
Nov 11 13:00:13.803  INFO pcli: got fragment: CompactBlock { height: 1, fragment: [] }
```