### PR TITLE
deps: pin tendermint libraries to stable branch

### DIFF
--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -21,8 +21,8 @@ penumbra-wallet = { path = "../wallet" }
 ark-ff = { git = "https://github.com/penumbra-zone/algebra", branch = "ours" }
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
 tower-abci = { git = "https://github.com/penumbra-zone/tower-abci/" }
-tendermint-proto = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "abci-domain-types" }
-tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "abci-domain-types" }
+tendermint-proto = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "abci-domain-types_r12" }
+tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "abci-domain-types_r12" }
 # External dependencies
 async-stream = "0.2"
 bincode = "1.3.3"


### PR DESCRIPTION
Should close #149 (might need to kick off CI again due to having just merged the associated fix in tower-abci: https://github.com/penumbra-zone/tower-abci/pull/9)
h/t to @hdevalence for keeping this branch around