### PR TITLE
feat: send dummy tx using pcli to pd, log for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ To perform genesis for a testnet, edit the `genesis.json` file stored in `$TMHOM
 * `app_state` key: add the generated genesis notes,
 * `chain_id` update the `chain_id` for the testnet.
 
-Now when you start `pd` and tendermint as described above, you will see a message at the `INFO` level indicating genesis has been performed: `consensus: penumbra::app: performing genesis for chain_id: penumbra_tn001`.
+Now when you start `pd` and tendermint as described above, you will see a message at the `INFO` level indicating genesis has been performed: `consensus: penumbra::app: performing genesis for chain_id: penumbra-tn001`.
 
 [Discord]: https://discord.gg/hKvkrqa3zC
 [Penumbra]: https://penumbra.zone

--- a/crypto/src/address.rs
+++ b/crypto/src/address.rs
@@ -6,6 +6,8 @@ use bech32::{FromBase32, ToBase32, Variant};
 
 use crate::{fmd, ka, keys::Diversifier, Fq};
 
+pub const CURRENT_CHAIN_ID: &str = "penumbra_tn001";
+/// Human-readable prefix in the address.
 pub const CURRENT_NETWORK_ID: &str = "penumbra_tn001_";
 
 /// A valid payment address.

--- a/crypto/src/address.rs
+++ b/crypto/src/address.rs
@@ -6,7 +6,7 @@ use bech32::{FromBase32, ToBase32, Variant};
 
 use crate::{fmd, ka, keys::Diversifier, Fq};
 
-pub const CURRENT_CHAIN_ID: &str = "penumbra_tn001";
+pub const CURRENT_CHAIN_ID: &str = "penumbra-tn001";
 /// Human-readable prefix in the address.
 pub const CURRENT_NETWORK_ID: &str = "penumbra_tn001_";
 

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -17,6 +17,8 @@ pub mod proofs;
 pub mod transaction;
 pub mod value;
 
+pub use address::CURRENT_CHAIN_ID;
+
 pub use action::output::Output;
 pub use action::spend::Spend;
 pub use action::Action;

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -184,6 +184,12 @@ impl From<Transaction> for transaction::Transaction {
     }
 }
 
+impl From<&Transaction> for transaction::Transaction {
+    fn from(msg: &Transaction) -> Self {
+        msg.into()
+    }
+}
+
 impl TryFrom<transaction::Transaction> for Transaction {
     type Error = ProtoError;
 
@@ -217,7 +223,22 @@ impl TryFrom<&[u8]> for Transaction {
     }
 }
 
+impl TryFrom<Vec<u8>> for Transaction {
+    type Error = ProtoError;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Transaction, Self::Error> {
+        Ok(Self::try_from(&bytes[..])?)
+    }
+}
+
 impl Into<Vec<u8>> for Transaction {
+    fn into(self) -> Vec<u8> {
+        let protobuf_serialized: transaction::Transaction = self.into();
+        protobuf_serialized.encode_to_vec()
+    }
+}
+
+impl Into<Vec<u8>> for &Transaction {
     fn into(self) -> Vec<u8> {
         let protobuf_serialized: transaction::Transaction = self.into();
         protobuf_serialized.encode_to_vec()

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
             let serialized_tx: Vec<u8> = dummy_tx.into();
 
             let rsp = reqwest::get(format!(
-                r#"http://{}:{}/broadcast_tx_async?tx="{}""#,
+                r#"http://{}:{}/broadcast_tx_async?tx=0x{}"#,
                 opt.node,
                 opt.abci_port,
                 hex::encode(serialized_tx)

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -81,7 +81,16 @@ enum Addr {
 #[derive(Debug, StructOpt)]
 enum Tx {
     /// Send transaction to the node.
-    Send,
+    Send {
+        /// Amount to send.
+        amount: u64,
+        /// Denomination.
+        denomination: String,
+        /// Destination address.
+        address: String,
+        /// Fee.
+        fee: u64,
+    },
 }
 
 #[tokio::main]
@@ -107,12 +116,15 @@ async fn main() -> Result<()> {
     }
 
     match opt.cmd {
-        Command::Tx(Tx::Send) => {
+        Command::Tx(Tx::Send {
+            amount: _,
+            denomination: _,
+            address: _,
+            fee,
+        }) => {
             let spend_key = load_wallet(&wallet_path);
             let mut local_storage = state::ClientState::new(spend_key);
 
-            // TODO: Set fee on CLI (part of issue #138)
-            let fee = 0;
             let dummy_tx = local_storage.new_transaction(&mut OsRng, fee)?;
             let serialized_tx: Vec<u8> = dummy_tx.into();
 

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -155,20 +155,11 @@ impl App {
     }
 
     #[instrument(skip(self))]
-    fn deliver_tx(&mut self, hex_encoded_bytes: Bytes) -> response::DeliverTx {
+    fn deliver_tx(&mut self, txbytes: Bytes) -> response::DeliverTx {
         // TODO: implement (#135)
 
         // Transactions that cannot be deserialized should return a non-zero `DeliverTx` code.
-        let txbytes = match hex::decode(hex_encoded_bytes.as_ref()) {
-            Ok(transaction) => transaction,
-            Err(_) => {
-                return response::DeliverTx {
-                    code: 1,
-                    ..Default::default()
-                }
-            }
-        };
-        let _transaction = match Transaction::try_from(txbytes) {
+        let _transaction = match Transaction::try_from(txbytes.as_ref()) {
             Ok(transaction) => transaction,
             Err(_) => {
                 return response::DeliverTx {

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -144,7 +144,7 @@ impl App {
 
     #[instrument(skip(self))]
     fn query(&self, query: Bytes) -> response::Query {
-        // TODO: implement (#23)
+        // TODO: implement (#22)
         Default::default()
     }
 
@@ -155,10 +155,30 @@ impl App {
     }
 
     #[instrument(skip(self))]
-    fn deliver_tx(&mut self, tx: Bytes) -> response::DeliverTx {
+    fn deliver_tx(&mut self, hex_encoded_bytes: Bytes) -> response::DeliverTx {
         // TODO: implement (#135)
 
-        // This should accumulate data from `tx` into `self.pending_block`
+        // Transactions that cannot be deserialized should return a non-zero `DeliverTx` code.
+        let txbytes = match hex::decode(hex_encoded_bytes.as_ref()) {
+            Ok(transaction) => transaction,
+            Err(_) => {
+                return response::DeliverTx {
+                    code: 1,
+                    ..Default::default()
+                }
+            }
+        };
+        let _transaction = match Transaction::try_from(txbytes) {
+            Ok(transaction) => transaction,
+            Err(_) => {
+                return response::DeliverTx {
+                    code: 1,
+                    ..Default::default()
+                }
+            }
+        };
+
+        // This should accumulate data from `_transaction` into `self.pending_block`
 
         Default::default()
     }


### PR DESCRIPTION
This connects the transaction sending functionality of `pcli` with its receipt on the `pd` side (using hex-encoded protobuf serialization). The transaction is just a dummy transaction pending the functionality described in #138 (which in turn requires client sync in #35). When the dummy transaction is sent by the client via `pcli tx send`, one will see a `DeliverTx` request be handled by `pd`, and if deserialized correctly, a zero code in the `DeliverTx` response:

```
Nov 16 15:46:45.592  INFO abci{addr=127.0.0.1:52232}:consensus: pd::app: req=DeliverTx(DeliverTx { tx: b"0a3412208b406b738e5b126329c74ef246db66d4b8292032002e20eaa49c2f5c9b4f9a07220e70656e756d6272615f746e3030312a00124072f32a44611108830a035d4818cf1d4b5a920a70b376f064f601728a1ebb2f0e2ec3d0eadfecf0e023c4b39c1edb403bce22b1705337053d911eccf2e5159003" })
Nov 16 15:46:45.592  INFO abci{addr=127.0.0.1:52232}:consensus: pd::app: rsp=DeliverTx(DeliverTx { code: 0, data: b"", log: "", info: "", gas_wanted: 0, gas_used: 0, events: [], codespace: "" })
```

The other `DeliverTx` response fields are unpopulated (for #135). 

Closes #133