### PR TITLE
Add scary warning to pcli

### DIFF
--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -93,6 +93,26 @@ enum Tx {
     },
 }
 
+fn display_usage_warning() {
+    println!(
+        "
+                               \x1b[1;31m⛔️WARNING️️⛔️:
+        
+                        you are about to lose money!\x1b[0m
+
+🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
+This message ... is part of a system of messages...
+... we considered ourselves to be a fault-tolerant distributed system...
+This message is a warning about danger.
+The danger is in a particular location... the center of danger is the \x1b[1;92mpcli\x1b[0m binary...
+The danger is to your \x1b[1;92mfunds\x1b[0m, and it can \x1b[1;31mdestroy\x1b[0m them.
+The danger is unleashed only if you execute this software.
+🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
+
+                           \x1b[1;31mUSE AT YOUR OWN RISK\x1b[0m"
+    )
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
@@ -114,6 +134,9 @@ async fn main() -> Result<()> {
             wallet_path = project_dir.data_dir().join("penumbra_wallet.dat");
         }
     }
+
+    // Display a warning message to the user so they don't get upset when all their money is stolen.
+    display_usage_warning();
 
     match opt.cmd {
         Command::Tx(Tx::Send {


### PR DESCRIPTION
Adds a big scary message with colors and emoji when running `pcli` so nobody is surprised if all their money in the testnet goes away.

Closes #32 