### PR TITLE
feat: add pcli balance command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,19 +124,19 @@ $ cargo run --bin pd -- create-genesis penumbra-tn001 \
 "(1, tungsten_cube, penumbra_tn001_1kpgdhlzws6kyk2cf580wtt76t9nn2vf7em3pn05y3h8ym5a6aevdxshjgsnxecv94rzsxdhng6cjp8kgchqxud06p9xka0yxv99rty3njetqqnx2hrzz4tc03956e0)"
 
 {
-  "notes": [
+  [
     {
       "diversifier": "b050dbfc4e86ac4b2b09a1",
       "amount": 100,
-      "note_blinding": "fb5b430096940592704c911b0fdef6ae324f054ddc6ea8cb13555373af81a00b",
-      "asset_id": "3213674d74c0f0a10b786838225460288830940147ed6f66bbae7af1ed759101",
+      "note_blinding": "93f7245c0e0265338ed54db574462d16a366187d3f2ff361aa94ecddadfbb103",
+      "asset_denom": "pen",
       "transmission_key": "dee5afda596735313ecee219be848dce4dd3baee58d342f244266ce185a8c503"
     },
     {
       "diversifier": "b050dbfc4e86ac4b2b09a1",
       "amount": 1,
-      "note_blinding": "2ca0a10d8f76a24f11e72ca1d21e18a16b112d98acdaeb62f6dde519297d080f",
-      "asset_id": "7bcfef24592b30affe8f1970d719ad4a2c5930570477e5e29be80d97816edf0f",
+      "note_blinding": "7793daf7ac4ef421d6ad138675180b37b866cc5ca0297a846fb9301d9deb2c0d",
+      "asset_denom": "tungsten_cube",
       "transmission_key": "dee5afda596735313ecee219be848dce4dd3baee58d342f244266ce185a8c503"
     }
   ]

--- a/crypto/src/asset.rs
+++ b/crypto/src/asset.rs
@@ -1,4 +1,6 @@
 //! Asset types and identifiers.
+use std::convert::{TryFrom, TryInto};
+
 use ark_ff::fields::PrimeField;
 use decaf377::FieldExt;
 use once_cell::sync::Lazy;
@@ -36,6 +38,7 @@ impl std::fmt::Debug for Id {
 
 // XXX define a DenomTrace structure ?
 
+// xx rename this derive?
 impl From<&[u8]> for Id {
     fn from(slice: &[u8]) -> Id {
         // Convert an asset name to an asset ID by hashing to a scalar
@@ -46,6 +49,18 @@ impl From<&[u8]> for Id {
                 .hash(slice)
                 .as_bytes(),
         ))
+    }
+}
+
+impl TryFrom<Vec<u8>> for Id {
+    type Error = anyhow::Error;
+
+    fn try_from(vec: Vec<u8>) -> Result<Id, Self::Error> {
+        let bytes: [u8; 32] = vec
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("vec not long enough to construct Asset ID"))?;
+        let inner = Fq::from_bytes(bytes)?;
+        Ok(Id(inner))
     }
 }
 

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -175,6 +175,20 @@ async fn main() -> Result<()> {
                 tracing::info!("got asset: {:?}", asset);
             }
         }
+        Command::Balance => {
+            let state = ClientStateFile::load(wallet_path)?;
+            let notes_by_asset = state.notes_by_asset_denomination();
+
+            let mut table = Table::new();
+            table.load_preset(presets::NOTHING);
+            table.set_header(vec!["Asset denomination", "Balance"]);
+            for (denom, notes) in notes_by_asset {
+                let note_amounts: Vec<u64> = notes.iter().map(|note| note.amount()).collect();
+                let balance: u64 = note_amounts.iter().sum();
+                table.add_row(vec![denom, balance.to_string()]);
+            }
+            println!("{}", table);
+        }
         _ => todo!(),
     }
 

--- a/pcli/src/opt.rs
+++ b/pcli/src/opt.rs
@@ -57,6 +57,8 @@ pub enum Command {
     },
     /// List every asset in the Asset Registry
     AssetList {},
+    /// Displays current balance by asset.
+    Balance,
 }
 
 #[derive(Debug, StructOpt)]


### PR DESCRIPTION
Closes #137, adding a command that lists balance by asset. In that ticket another idea is proposed, adding balance by address (could be part of the address command perhaps?), I propose we do in a followup such that the `notes_by_asset_denomination` method and asset registry syncing can be used for #138 

Output looks like:
```
 Asset denomination  Balance
 pen                 100
```