### PR TITLE
Implement `pcli tx send`

### DIFF
--- a/crypto/src/action/spend.rs
+++ b/crypto/src/action/spend.rs
@@ -14,7 +14,7 @@ use crate::{
     value, Fr, Note, Nullifier,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Spend {
     pub body: Body,
     pub auth_sig: Signature<SpendAuth>,
@@ -64,7 +64,7 @@ impl TryFrom<transaction::Spend> for Spend {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Body {
     pub value_commitment: value::Commitment,
     pub nullifier: Nullifier,

--- a/crypto/src/action/spend.rs
+++ b/crypto/src/action/spend.rs
@@ -86,9 +86,8 @@ impl Body {
         v_blinding: Fr,
         nk: keys::NullifierKey,
     ) -> Body {
-        let a = Fr::rand(rng);
-        let rsk: SigningKey<SpendAuth> = ask.randomize(&a);
-        let rk: VerificationKey<SpendAuth> = rsk.into();
+        let rsk = ask.randomize(&spend_auth_randomizer);
+        let rk = rsk.into();
         let note_commitment = note.commit();
         let proof = SpendProof {
             merkle_path,

--- a/crypto/src/action/spend.rs
+++ b/crypto/src/action/spend.rs
@@ -87,7 +87,8 @@ impl Body {
         nk: keys::NullifierKey,
     ) -> Body {
         let a = Fr::rand(rng);
-        let rk = ask.randomize(&a).into();
+        let rsk: SigningKey<SpendAuth> = ask.randomize(&a);
+        let rk: VerificationKey<SpendAuth> = rsk.into();
         let note_commitment = note.commit();
         let proof = SpendProof {
             merkle_path,

--- a/crypto/src/keys/diversifier.rs
+++ b/crypto/src/keys/diversifier.rs
@@ -9,7 +9,7 @@ use crate::Fq;
 
 pub const DIVERSIFIER_LEN_BYTES: usize = 11;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Diversifier(pub [u8; DIVERSIFIER_LEN_BYTES]);
 
 impl Diversifier {
@@ -20,6 +20,14 @@ impl Diversifier {
             .hash(&self.0);
 
         decaf377::Element::map_to_group_cdh(&Fq::from_le_bytes_mod_order(hash.as_bytes()))
+    }
+}
+
+impl std::fmt::Debug for Diversifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Diversifier")
+            .field(&hex::encode(&self.0))
+            .finish()
     }
 }
 
@@ -46,7 +54,7 @@ impl TryFrom<&[u8]> for Diversifier {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct DiversifierKey(pub(super) [u8; 32]);
 
 impl DiversifierKey {
@@ -62,8 +70,24 @@ impl DiversifierKey {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+impl std::fmt::Debug for DiversifierKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("DiversifierKey")
+            .field(&hex::encode(&self.0))
+            .finish()
+    }
+}
+
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub struct DiversifierIndex(pub [u8; 11]);
+
+impl std::fmt::Debug for DiversifierIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("DiversifierIndex")
+            .field(&hex::encode(&self.0))
+            .finish()
+    }
+}
 
 impl From<u8> for DiversifierIndex {
     fn from(x: u8) -> Self {

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -21,7 +21,7 @@ pub enum Error {
 /// Transparent proof for spending existing notes.
 ///
 /// This structure keeps track of the auxiliary (private) inputs.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SpendProof {
     // Path to the note being spent in the note commitment merkle tree.
     pub merkle_path: merkle::Path,

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -130,7 +130,8 @@ impl SpendProof {
 
         // Spend authority.
         let rk_bytes: [u8; 32] = rk.into();
-        let rk_test_bytes: [u8; 32] = self.ak.randomize(&self.spend_auth_randomizer).into();
+        let rk_test = self.ak.randomize(&self.spend_auth_randomizer);
+        let rk_test_bytes: [u8; 32] = rk_test.into();
         if rk_bytes != rk_test_bytes {
             proof_verifies = false;
         }

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -326,6 +326,7 @@ mod tests {
         let sk_sender = SpendKey::generate(&mut rng);
         let fvk_sender = sk_sender.full_viewing_key();
         let ovk_sender = fvk_sender.outgoing();
+        let (send_addr, _) = fvk_sender.incoming().payment_address(0u64.into());
 
         let sk_recipient = SpendKey::generate(&mut rng);
         let fvk_recipient = sk_recipient.full_viewing_key();
@@ -340,9 +341,10 @@ mod tests {
             amount: 20,
             asset_id: b"pen".as_ref().into(),
         };
+        // The note was previously sent to the sender.
         let note = Note::new(
-            *dest.diversifier(),
-            *dest.transmission_key(),
+            *send_addr.diversifier(),
+            *send_addr.transmission_key(),
             spend_value,
             Fq::zero(),
         )

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -162,7 +162,7 @@ impl Transaction {
             }
         }
 
-        // Add fee into binding signature computation.
+        // Add fee into binding verification key computation.
         let pen_trace = b"pen";
         let pen_id = asset::Id::from(&pen_trace[..]);
         let fee_value = Value {

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -328,11 +328,11 @@ mod tests {
         let dummy_merkle_path: merkle::Path = (merkle::DEPTH, merkle_siblings);
 
         let output_value = Value {
-            amount: 20,
+            amount: 10,
             asset_id: b"pen".as_ref().into(),
         };
         let spend_value = Value {
-            amount: 10,
+            amount: 20,
             asset_id: b"pen".as_ref().into(),
         };
         let dummy_note = Note::new(

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -1,4 +1,4 @@
-use ark_ff::UniformRand;
+use ark_ff::{UniformRand, Zero};
 use rand::seq::SliceRandom;
 use rand_core::{CryptoRng, RngCore};
 use std::ops::Deref;
@@ -128,7 +128,7 @@ impl Builder {
     /// Set the transaction fee in PEN.
     ///
     /// Note that we're using the lower case `pen` in the code.
-    pub fn set_fee<R: RngCore + CryptoRng>(mut self, mut rng: R, fee: u64) -> Self {
+    pub fn set_fee(mut self, fee: u64) -> Self {
         let pen_trace = b"pen";
         let pen_id = asset::Id::from(&pen_trace[..]);
 
@@ -137,12 +137,12 @@ impl Builder {
             asset_id: pen_id,
         };
 
-        let v_blinding = Fr::rand(&mut rng);
-        let value_commitment = fee_value.commit(v_blinding);
+        let fee_v_blinding = Fr::zero();
+        let value_commitment = fee_value.commit(fee_v_blinding);
 
         // The fee is effectively an additional output, so we
         // add to the transaction's value balance.
-        self.synthetic_blinding_factor -= v_blinding;
+        self.synthetic_blinding_factor -= fee_v_blinding;
         self.value_balance -= Fr::from(fee) * pen_id.value_generator();
         self.value_commitments -= value_commitment.0;
 

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -140,11 +140,11 @@ impl Builder {
         let v_blinding = Fr::rand(&mut rng);
         let value_commitment = fee_value.commit(v_blinding);
 
-        // The fee is effectively an additional spend, so we
+        // The fee is effectively an additional output, so we
         // add to the transaction's value balance.
-        self.synthetic_blinding_factor += v_blinding;
-        self.value_balance += Fr::from(fee) * pen_id.value_generator();
-        self.value_commitments += value_commitment.0;
+        self.synthetic_blinding_factor -= v_blinding;
+        self.value_balance -= Fr::from(fee) * pen_id.value_generator();
+        self.value_commitments -= value_commitment.0;
 
         self.fee = Some(Fee(fee));
         self

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -70,10 +70,7 @@ impl Builder {
 
         let body_serialized: Vec<u8> = body.clone().into();
         let auth_sig = rsk.sign(rng, &body_serialized);
-
-        let spend = Action::Spend(Spend { body, auth_sig });
-
-        self.actions.push(spend);
+        self.actions.push(Action::Spend(Spend { body, auth_sig }));
 
         self
     }

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -55,9 +55,9 @@ async fn main() -> Result<()> {
             .await?;
         }
         Command::Tx(TxCmd::Send {
-            amount: _,
-            denomination: _,
-            address: _,
+            amount,
+            denomination,
+            address,
             fee,
         }) => {
             let mut state = ClientStateFile::load(wallet_path)?;
@@ -66,8 +66,8 @@ async fn main() -> Result<()> {
                 format!("http://{}:{}", opt.node, opt.wallet_port),
             )
             .await?;
-            let dummy_tx = state.new_transaction(&mut OsRng, fee)?;
-            let serialized_tx: Vec<u8> = dummy_tx.into();
+            let tx = state.new_transaction(&mut OsRng, amount, denomination, address, fee)?;
+            let serialized_tx: Vec<u8> = tx.into();
 
             let rsp = reqwest::get(format!(
                 r#"http://{}:{}/broadcast_tx_async?tx=0x{}"#,

--- a/pd/src/verify.rs
+++ b/pd/src/verify.rs
@@ -111,6 +111,7 @@ impl StatelessTransactionExt for Transaction {
 
 impl StatefulTransactionExt for PendingTransaction {
     fn verify_stateful(&self, nct_root: merkle::Root) -> Result<VerifiedTransaction, Error> {
+        // xx the nct from the client could be behind the node
         if nct_root != self.root {
             return Err(anyhow::anyhow!("invalid note commitment tree root"));
         }

--- a/pd/src/verify.rs
+++ b/pd/src/verify.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use anyhow::Error;
 
@@ -38,7 +38,10 @@ pub trait StatelessTransactionExt {
 }
 
 pub trait StatefulTransactionExt {
-    fn verify_stateful(&self, nct_root: merkle::Root) -> Result<VerifiedTransaction, Error>;
+    fn verify_stateful(
+        &self,
+        valid_anchors: &VecDeque<merkle::Root>,
+    ) -> Result<VerifiedTransaction, Error>;
 }
 
 impl StatelessTransactionExt for Transaction {
@@ -110,9 +113,11 @@ impl StatelessTransactionExt for Transaction {
 }
 
 impl StatefulTransactionExt for PendingTransaction {
-    fn verify_stateful(&self, nct_root: merkle::Root) -> Result<VerifiedTransaction, Error> {
-        // xx the nct from the client could be behind the node
-        if nct_root != self.root {
+    fn verify_stateful(
+        &self,
+        valid_anchors: &VecDeque<merkle::Root>,
+    ) -> Result<VerifiedTransaction, Error> {
+        if !valid_anchors.contains(&self.root) {
             return Err(anyhow::anyhow!("invalid note commitment tree root"));
         }
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -33,3 +33,4 @@ reqwest = { version = "0.11", features = ["json"] }
 anyhow = "1"
 hex = "0.4"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
+rand = "0.8"

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -70,7 +70,7 @@ impl ClientState {
     /// Generate a new transaction.
     pub fn new_transaction<R: RngCore + CryptoRng>(
         &mut self,
-        mut rng: &mut R,
+        rng: &mut R,
         amount: u64,
         denomination: String,
         address: String,
@@ -83,7 +83,7 @@ impl ClientState {
             Address::from_str(&address).map_err(|_| anyhow::anyhow!("address is invalid"))?;
 
         let mut tx_builder = Transaction::build_with_root(self.note_commitment_tree.root2())
-            .set_fee(&mut rng, fee)
+            .set_fee(fee)
             .set_chain_id(CURRENT_CHAIN_ID.to_string());
 
         let mut notes_by_asset_denom = self.notes_by_asset_denomination();

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -1,15 +1,17 @@
 use anyhow::Context;
 use hex;
 use penumbra_proto::wallet::{CompactBlock, StateFragment};
+use rand::seq::SliceRandom;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
+use std::str::FromStr;
 use tracing::instrument;
 
 use penumbra_crypto::{
-    asset,
+    asset, memo,
     merkle::{Frontier, NoteCommitmentTree, Tree, TreeExt},
-    note, FieldExt, Note, Nullifier, Transaction, CURRENT_CHAIN_ID,
+    note, Address, FieldExt, Note, Nullifier, Transaction, Value, CURRENT_CHAIN_ID,
 };
 
 use crate::Wallet;
@@ -69,15 +71,102 @@ impl ClientState {
     pub fn new_transaction<R: RngCore + CryptoRng>(
         &mut self,
         mut rng: &mut R,
+        amount: u64,
+        denomination: String,
+        address: String,
         fee: u64,
-    ) -> Result<Transaction, penumbra_crypto::transaction::Error> {
+    ) -> Result<Transaction, anyhow::Error> {
         // xx Could populate chain_id from the info endpoint on the node, or at least
         // error if there is an inconsistency
 
-        Transaction::build_with_root(self.note_commitment_tree.root2())
+        let dest_address: Address =
+            Address::from_str(&address).map_err(|_| anyhow::anyhow!("address is invalid"))?;
+
+        let mut tx_builder = Transaction::build_with_root(self.note_commitment_tree.root2())
             .set_fee(&mut rng, fee)
-            .set_chain_id(CURRENT_CHAIN_ID.to_string())
+            .set_chain_id(CURRENT_CHAIN_ID.to_string());
+
+        let mut notes_by_asset_denom = self.notes_by_asset_denomination();
+        let notes_of_denom = match notes_by_asset_denom.get_mut(&denomination) {
+            Some(notes) => notes,
+            None => {
+                return Err(anyhow::anyhow!(
+                    "no notes of denomination found: {}",
+                    denomination
+                ))
+            }
+        };
+        notes_of_denom.shuffle(rng);
+
+        let mut notes_to_spend: Vec<Note> = Vec::new();
+        let mut total_spend_value = 0u64;
+        for note in notes_of_denom {
+            notes_to_spend.push(note.clone());
+            total_spend_value += note.amount();
+
+            if total_spend_value >= amount + fee {
+                break;
+            }
+        }
+
+        if total_spend_value < amount + fee {
+            return Err(anyhow::anyhow!(
+                "insufficient balance: you need {}, you have {}",
+                amount + fee,
+                total_spend_value
+            ));
+        }
+
+        let value_to_send = Value {
+            amount,
+            asset_id: notes_to_spend[0].asset_id(),
+        };
+
+        for note in notes_to_spend {
+            let auth_path = self
+                .note_commitment_tree
+                .authentication_path(&note.commit())
+                .unwrap();
+            let merkle_path = (u64::from(auth_path.0) as usize, auth_path.1);
+            let merkle_position = auth_path.0;
+            tx_builder = tx_builder.add_spend(
+                rng,
+                self.wallet.spend_key(),
+                merkle_path,
+                note,
+                merkle_position,
+            );
+        }
+
+        // xx: add memo handling
+        let memo = memo::MemoPlaintext([0u8; 512]);
+        tx_builder = tx_builder.add_output(
+            rng,
+            &dest_address,
+            value_to_send,
+            memo,
+            self.wallet.outgoing_viewing_key(),
+        );
+
+        // xx let user specify change address
+        let return_address = self.wallet.address_by_index(0)?;
+        let change = Value {
+            amount: total_spend_value - amount - fee,
+            asset_id: value_to_send.asset_id,
+        };
+        // xx Builder::add_output could take Option<MemoPlaintext>
+        let change_memo = memo::MemoPlaintext([0u8; 512]);
+        tx_builder = tx_builder.add_output(
+            rng,
+            &return_address,
+            change,
+            change_memo,
+            self.wallet.outgoing_viewing_key(),
+        );
+
+        tx_builder
             .finalize(rng)
+            .map_err(|err| anyhow::anyhow!("error during transaction finalization: {}", err))
     }
 
     /// Get a mapping of asset denominations to unspent notes.

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -92,18 +92,10 @@ impl ClientState {
                 .get(&note.asset_id())
                 .expect("all asset IDs should have denominations stored locally");
 
-            let new_notes = match notemap.get(asset_denom) {
-                Some(current_notes) => {
-                    let mut new_notes: Vec<Note> =
-                        current_notes.iter().map(|note| note.clone()).collect();
-                    new_notes.push(note.clone());
-                    new_notes.to_vec()
-                }
-                None => {
-                    vec![note.clone()]
-                }
-            };
-            notemap.insert(asset_denom.clone(), new_notes);
+            notemap
+                .entry(asset_denom.clone())
+                .or_insert(Vec::new())
+                .push(note.clone());
         }
 
         notemap

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use penumbra_crypto::{
     fmd,
-    keys::{FullViewingKey, IncomingViewingKey, SpendKey},
+    keys::{FullViewingKey, IncomingViewingKey, OutgoingViewingKey, SpendKey},
     Address,
 };
 
@@ -33,6 +33,16 @@ impl Wallet {
         self.spend_key.full_viewing_key().incoming()
     }
 
+    /// Outgoing viewing key from this spend seed.
+    pub fn outgoing_viewing_key(&self) -> &OutgoingViewingKey {
+        self.spend_key.full_viewing_key().outgoing()
+    }
+
+    /// Spend key from this spend seed.
+    pub fn spend_key(&self) -> SpendKey {
+        self.spend_key.clone()
+    }
+
     /// Get the full viewing key for this wallet.
     pub fn full_viewing_key(&self) -> &FullViewingKey {
         self.spend_key.full_viewing_key()
@@ -46,6 +56,15 @@ impl Wallet {
             .incoming_viewing_key()
             .payment_address(next_index.into());
         (next_index, address, dtk)
+    }
+
+    /// Get address by index.
+    pub fn address_by_index(&self, index: usize) -> Result<Address, anyhow::Error> {
+        if self.address_labels.get(index).is_none() {
+            return Err(anyhow::anyhow!("no address with this index!"));
+        }
+        let (address, _dtk) = self.incoming_viewing_key().payment_address(index.into());
+        Ok(address)
     }
 
     /// Iterate through the addresses in this wallet.


### PR DESCRIPTION
Closes #138

This draft PR implements the basic functionality for constructing a transaction in `pcli`. Other thoughts (also listed as comments inline) are:
* We could specify the memo in an optional arg on the command line for `tx send`
* It would be cleaner when we have no memo to let `Builder::add_output` take an `Option<MemoPlaintext>`
* It may be nice to let the user specify the change address - currently it's just the Default index 0 address

Not ready for merge as currently the spend auth sig is failing to verify in CheckTx: you will see this if you try to submit a transaction with debug level logging. I've added a regression test to display the problem in https://github.com/penumbra-zone/penumbra/pull/180/commits/5956d77ec5733956f77f92d79e1a70bd21827d3e (the test currently will fail during the spend auth verification as there is no fix yet)