### PR TITLE
Spend detection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.server.extraEnv": {"DATABASE_URL": "postgres://postgres:postgres@localhost/penumbra" },
+}

--- a/crypto/src/action/spend.rs
+++ b/crypto/src/action/spend.rs
@@ -1,6 +1,5 @@
 use std::convert::{TryFrom, TryInto};
 
-use ark_ff::UniformRand;
 use bytes::Bytes;
 use rand_core::{CryptoRng, RngCore};
 
@@ -76,7 +75,7 @@ pub struct Body {
 impl Body {
     #[allow(clippy::too_many_arguments)]
     pub fn new<R: RngCore + CryptoRng>(
-        rng: &mut R,
+        _rng: &mut R,
         value_commitment: value::Commitment,
         ask: SigningKey<SpendAuth>,
         spend_auth_randomizer: Fr,

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -346,9 +346,9 @@ impl From<Commitment> for [u8; 32] {
     }
 }
 
-impl Into<Vec<u8>> for Commitment {
-    fn into(self) -> Vec<u8> {
-        self.0.to_bytes().to_vec()
+impl From<Commitment> for Vec<u8> {
+    fn from(commitment: Commitment) -> Vec<u8> {
+        commitment.0.to_bytes().to_vec()
     }
 }
 

--- a/crypto/src/nullifier.rs
+++ b/crypto/src/nullifier.rs
@@ -29,3 +29,11 @@ impl TryFrom<&[u8]> for Nullifier {
         Ok(Nullifier(inner))
     }
 }
+
+impl TryFrom<Vec<u8>> for Nullifier {
+    type Error = anyhow::Error;
+
+    fn try_from(vec: Vec<u8>) -> Result<Nullifier, Self::Error> {
+        Self::try_from(&vec[..])
+    }
+}

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -237,16 +237,16 @@ impl TryFrom<Vec<u8>> for Transaction {
     }
 }
 
-impl Into<Vec<u8>> for Transaction {
-    fn into(self) -> Vec<u8> {
-        let protobuf_serialized: ProtoTransaction = self.into();
+impl From<Transaction> for Vec<u8> {
+    fn from(transaction: Transaction) -> Vec<u8> {
+        let protobuf_serialized: ProtoTransaction = transaction.into();
         protobuf_serialized.encode_to_vec()
     }
 }
 
-impl Into<Vec<u8>> for &Transaction {
-    fn into(self) -> Vec<u8> {
-        let protobuf_serialized: ProtoTransaction = self.into();
+impl From<&Transaction> for Vec<u8> {
+    fn from(transaction: &Transaction) -> Vec<u8> {
+        let protobuf_serialized: ProtoTransaction = transaction.into();
         protobuf_serialized.encode_to_vec()
     }
 }

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -223,9 +223,9 @@ impl TryFrom<&[u8]> for Transaction {
     fn try_from(bytes: &[u8]) -> Result<Transaction, Self::Error> {
         let protobuf_serialized_proof =
             ProtoTransaction::decode(bytes).map_err(|_| ProtoError::TransactionMalformed)?;
-        Ok(protobuf_serialized_proof
+        protobuf_serialized_proof
             .try_into()
-            .map_err(|_| ProtoError::TransactionMalformed)?)
+            .map_err(|_| ProtoError::TransactionMalformed)
     }
 }
 
@@ -233,7 +233,7 @@ impl TryFrom<Vec<u8>> for Transaction {
     type Error = ProtoError;
 
     fn try_from(bytes: Vec<u8>) -> Result<Transaction, Self::Error> {
-        Ok(Self::try_from(&bytes[..])?)
+        Self::try_from(&bytes[..])
     }
 }
 

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -372,8 +372,8 @@ mod tests {
             .finalize(&mut rng)
             .expect("transaction created ok");
 
-        let merkle_root = transaction.clone().transaction_body().merkle_root;
-        for action in transaction.clone().transaction_body().actions {
+        let merkle_root = transaction.transaction_body().merkle_root;
+        for action in transaction.transaction_body().actions {
             match action {
                 Action::Output(inner) => {
                     assert!(inner.body.proof.verify(

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -50,7 +50,7 @@ hex = "0.4"
 rand = "0.8"
 rand_chacha = "0.3.1"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
-sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres" ] }
+sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres", "offline" ] }
 
 [build-dependencies]
 vergen = "5"

--- a/pd/build.rs
+++ b/pd/build.rs
@@ -2,5 +2,4 @@ use vergen::{vergen, Config};
 
 fn main() {
     vergen(Config::default()).unwrap();
-    println!("cargo:rerun-if-changed=migrations");
 }

--- a/pd/build.rs
+++ b/pd/build.rs
@@ -1,5 +1,6 @@
 use vergen::{vergen, Config};
 
 fn main() {
-    vergen(Config::default()).unwrap()
+    vergen(Config::default()).unwrap();
+    println!("cargo:rerun-if-changed=migrations");
 }

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -1,0 +1,317 @@
+{
+  "db": "PostgreSQL",
+  "05347961996a6bff00aaf099676e07fb19c13d7de456cd5395852883608cb330": {
+    "query": "\nCREATE TABLE IF NOT EXISTS notes (\n    note_commitment bytea PRIMARY KEY,\n    ephemeral_key bytea NOT NULL,\n    encrypted_note bytea NOT NULL,\n    transaction_id bytea NOT NULL,\n    height bigint REFERENCES blocks (height)\n)\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
+  "0c6a89db4de3642914e3cddf6e08a042eac9b140a03118943170433527ef5cc3": {
+    "query": "INSERT INTO nullifiers VALUES ($1, $2)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "1abc3c48b127eee2761f3385541e195f9aca35269e6db0c41e3f67a0e04f280b": {
+    "query": "SELECT denom, asset_id FROM assets WHERE asset_id = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "denom",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 1,
+          "name": "asset_id",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Bytea"
+        ]
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
+  "3cbb441b10f4a068c16dd3a40accd689be26f2a6619b363fd966ee10e740f07b": {
+    "query": " INSERT INTO assets ( asset_id, denom) VALUES ($1, $2)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Varchar"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "51f515cc43458854df653c298142e6c77b2905b453f85c31ae1a0f56fbce1c2a": {
+    "query": "\nINSERT INTO blobs (id, data) VALUES ('nct', $1)\nON CONFLICT (id) DO UPDATE SET data = $1\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "68ecee6442fbca8293efe210d7b798e0a070f2be083b074583048ac513c3dc96": {
+    "query": "INSERT INTO blocks (height, nct_anchor, app_hash) VALUES ($1, $2, $3)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Bytea",
+          "Bytea"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "73e0b933842ff451654acd14f7a681c505aed832f9158fd800bf32b21916625e": {
+    "query": "SELECT transaction_id FROM notes WHERE note_commitment = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "transaction_id",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Bytea"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
+  "7542a4b3510cb47b2eec584ef77e8dc1d86ca90ba4143eff091fa35e90277007": {
+    "query": "\nINSERT INTO notes (\n    note_commitment,\n    ephemeral_key,\n    encrypted_note,\n    transaction_id,\n    height\n) VALUES ($1, $2, $3, $4, $5)\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Bytea",
+          "Bytea",
+          "Bytea",
+          "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "8195450f9f1cedf05eebd974adbdc42dc70a8e2abb7753d7b02cba03786bee0d": {
+    "query": "SELECT denom, asset_id FROM assets",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "denom",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 1,
+          "name": "asset_id",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
+  "9024aaa179b92038a276abd92a8f20b3a28133ea8435c1d4d9ae4bc3ec31158a": {
+    "query": "SELECT height, nct_anchor AS \"nct_anchor: merkle::Root\", app_hash FROM blocks ORDER BY height DESC LIMIT 1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "height",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
+          "name": "nct_anchor: merkle::Root",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 2,
+          "name": "app_hash",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "aed57af72fe55a40c7fe24c06ff908821372686522783850b2db72fbed2aa9e4": {
+    "query": "SELECT id, data FROM blobs WHERE id = 'nct';",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 1,
+          "name": "data",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
+  "c084268c7bb93cb72a3fa5a45330ba54225e53d5adf2ea30016ff4b901ba9036": {
+    "query": "SELECT nullifier FROM nullifiers WHERE height = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "nullifier",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
+  "d722736210a88c571e5aef441591d017bef03e21f663ca7a6df8f54b3b1c27ea": {
+    "query": "\nCREATE TABLE IF NOT EXISTS assets (\n    asset_id bytea PRIMARY KEY NOT NULL,\n    denom varchar NOT NULL\n)\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
+  "ddf4fcde7ed7cdeb7ed5c9ec15de33489df033e943fd4caa90d828a58c521b00": {
+    "query": "\nCREATE TABLE IF NOT EXISTS blobs (\n    id varchar(64) PRIMARY KEY,\n    data bytea NOT NULL\n)\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
+  "eabcbfa47724faa05cbd3445cc0e20f17177281eefb6b58ced9760fd1cd9fc4f": {
+    "query": "\nCREATE TABLE IF NOT EXISTS blocks (\n    height bigint PRIMARY KEY,\n    nct_anchor bytea NOT NULL,\n    app_hash bytea NOT NULL\n)\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
+  "f2a471a0953f4bd441bfba26e56e5558eca1f72e5fc8250124157975654a2c73": {
+    "query": "SELECT note_commitment, ephemeral_key, encrypted_note FROM notes WHERE height = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "note_commitment",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 1,
+          "name": "ephemeral_key",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 2,
+          "name": "encrypted_note",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "fa3bb4acdebf33999d5428378b544df3655e44bc57056abac2babb5bf9ec3e6d": {
+    "query": "\nCREATE TABLE IF NOT EXISTS nullifiers (\n    nullifier bytea PRIMARY KEY,\n    height bigint NOT NULL REFERENCES blocks (height)\n)\n",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
+  "feb219cf82779306d199c5f733359b2cafd5ab51fca03922a9e73c3a4ff44bf7": {
+    "query": "SELECT height FROM nullifiers WHERE nullifier = $1 LIMIT 1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "height",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Bytea"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  }
+}

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -1,15 +1,5 @@
 {
   "db": "PostgreSQL",
-  "05347961996a6bff00aaf099676e07fb19c13d7de456cd5395852883608cb330": {
-    "query": "\nCREATE TABLE IF NOT EXISTS notes (\n    note_commitment bytea PRIMARY KEY,\n    ephemeral_key bytea NOT NULL,\n    encrypted_note bytea NOT NULL,\n    transaction_id bytea NOT NULL,\n    height bigint REFERENCES blocks (height)\n)\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": []
-    }
-  },
   "0c6a89db4de3642914e3cddf6e08a042eac9b140a03118943170433527ef5cc3": {
     "query": "INSERT INTO nullifiers VALUES ($1, $2)",
     "describe": {
@@ -70,6 +60,36 @@
         "Left": [
           "Bytea"
         ]
+      },
+      "nullable": []
+    }
+  },
+  "56ac73fb90a557deadc0ced8c798a1a39ea01fafe58f940528e53836cfdaf986": {
+    "query": "CREATE TABLE IF NOT EXISTS assets (\n    asset_id bytea PRIMARY KEY NOT NULL,\n    denom varchar NOT NULL\n)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
+  "6608d5e9a28ac8f0864c4e9c08937e3a49dff68ef3202f4dcc2e0c2443d68968": {
+    "query": "CREATE TABLE IF NOT EXISTS blocks (\n    height bigint PRIMARY KEY,\n    nct_anchor bytea NOT NULL,\n    app_hash bytea NOT NULL\n)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
+  "673a8ddb83336e82fe43107119f7768381063102e0aff3a24dcc9fa7195ebadb": {
+    "query": "CREATE TABLE IF NOT EXISTS nullifiers (\n    nullifier bytea PRIMARY KEY,\n    height bigint NOT NULL REFERENCES blocks (height)\n)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
       },
       "nullable": []
     }
@@ -178,6 +198,16 @@
       ]
     }
   },
+  "a0a83fb42dc6ec8a9af35a29a492ad1651c13e047af85a25ebc41fdbd1909da7": {
+    "query": "CREATE TABLE IF NOT EXISTS notes (\n    note_commitment bytea PRIMARY KEY,\n    ephemeral_key bytea NOT NULL,\n    encrypted_note bytea NOT NULL,\n    transaction_id bytea NOT NULL,\n    height bigint REFERENCES blocks (height)\n)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
   "aed57af72fe55a40c7fe24c06ff908821372686522783850b2db72fbed2aa9e4": {
     "query": "SELECT id, data FROM blobs WHERE id = 'nct';",
     "describe": {
@@ -222,28 +252,8 @@
       ]
     }
   },
-  "d722736210a88c571e5aef441591d017bef03e21f663ca7a6df8f54b3b1c27ea": {
-    "query": "\nCREATE TABLE IF NOT EXISTS assets (\n    asset_id bytea PRIMARY KEY NOT NULL,\n    denom varchar NOT NULL\n)\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": []
-    }
-  },
-  "ddf4fcde7ed7cdeb7ed5c9ec15de33489df033e943fd4caa90d828a58c521b00": {
-    "query": "\nCREATE TABLE IF NOT EXISTS blobs (\n    id varchar(64) PRIMARY KEY,\n    data bytea NOT NULL\n)\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": []
-    }
-  },
-  "eabcbfa47724faa05cbd3445cc0e20f17177281eefb6b58ced9760fd1cd9fc4f": {
-    "query": "\nCREATE TABLE IF NOT EXISTS blocks (\n    height bigint PRIMARY KEY,\n    nct_anchor bytea NOT NULL,\n    app_hash bytea NOT NULL\n)\n",
+  "cd248ce18bd666c96bcf98dab23b66cfd807dcda482411d67be301a914b68b59": {
+    "query": "CREATE TABLE IF NOT EXISTS blobs (\n    id varchar(64) PRIMARY KEY,\n    data bytea NOT NULL\n)",
     "describe": {
       "columns": [],
       "parameters": {
@@ -282,16 +292,6 @@
         false,
         false
       ]
-    }
-  },
-  "fa3bb4acdebf33999d5428378b544df3655e44bc57056abac2babb5bf9ec3e6d": {
-    "query": "\nCREATE TABLE IF NOT EXISTS nullifiers (\n    nullifier bytea PRIMARY KEY,\n    height bigint NOT NULL REFERENCES blocks (height)\n)\n",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": []
     }
   },
   "feb219cf82779306d199c5f733359b2cafd5ab51fca03922a9e73c3a4ff44bf7": {

--- a/pd/src/db.rs
+++ b/pd/src/db.rs
@@ -1,6 +1,6 @@
 pub mod schema;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use sqlx::{query_file, Pool, Postgres};
 use tracing::instrument;
 
@@ -17,7 +17,10 @@ pub async fn init_tables(db: &Pool<Postgres>) -> Result<()> {
 
     let mut tx = db.begin().await?;
     for query in tables.into_iter() {
-        query.execute(&mut tx).await?;
+        query
+            .execute(&mut tx)
+            .await
+            .context("could not initialize database")?;
     }
     tx.commit().await?;
 

--- a/pd/src/db.rs
+++ b/pd/src/db.rs
@@ -1,70 +1,25 @@
 pub mod schema;
 
 use anyhow::Result;
-use sqlx::{query, Pool, Postgres};
+use sqlx::{query_file, Pool, Postgres};
 use tracing::instrument;
 
 /// Create database tables if they do not already exist.
 #[instrument]
 pub async fn init_tables(db: &Pool<Postgres>) -> Result<()> {
-    query!(
-        r#"
-CREATE TABLE IF NOT EXISTS blobs (
-    id varchar(64) PRIMARY KEY,
-    data bytea NOT NULL
-)
-"#,
-    )
-    .execute(db)
-    .await?;
+    let tables = [
+        query_file!("src/db/assets.sql"),
+        query_file!("src/db/blobs.sql"),
+        query_file!("src/db/blocks.sql"),
+        query_file!("src/db/notes.sql"),
+        query_file!("src/db/nullifiers.sql"),
+    ];
 
-    query!(
-        r#"
-CREATE TABLE IF NOT EXISTS blocks (
-    height bigint PRIMARY KEY,
-    nct_anchor bytea NOT NULL,
-    app_hash bytea NOT NULL
-)
-"#,
-    )
-    .execute(db)
-    .await?;
-
-    query!(
-        r#"
-CREATE TABLE IF NOT EXISTS notes (
-    note_commitment bytea PRIMARY KEY,
-    ephemeral_key bytea NOT NULL,
-    encrypted_note bytea NOT NULL,
-    transaction_id bytea NOT NULL,
-    height bigint REFERENCES blocks (height)
-)
-"#,
-    )
-    .execute(db)
-    .await?;
-
-    query!(
-        r#"
-CREATE TABLE IF NOT EXISTS nullifiers (
-    nullifier bytea PRIMARY KEY,
-    height bigint NOT NULL REFERENCES blocks (height)
-)
-"#,
-    )
-    .execute(db)
-    .await?;
-
-    query!(
-        r#"
-CREATE TABLE IF NOT EXISTS assets (
-    asset_id bytea PRIMARY KEY NOT NULL,
-    denom varchar NOT NULL
-)
-"#,
-    )
-    .execute(db)
-    .await?;
+    let mut tx = db.begin().await?;
+    for query in tables.into_iter() {
+        query.execute(&mut tx).await?;
+    }
+    tx.commit().await?;
 
     Ok(())
 }

--- a/pd/src/db.rs
+++ b/pd/src/db.rs
@@ -7,7 +7,7 @@ use tracing::instrument;
 /// Create database tables if they do not already exist.
 #[instrument]
 pub async fn init_tables(db: &Pool<Postgres>) -> Result<()> {
-    query(
+    query!(
         r#"
 CREATE TABLE IF NOT EXISTS blobs (
     id varchar(64) PRIMARY KEY,
@@ -18,10 +18,10 @@ CREATE TABLE IF NOT EXISTS blobs (
     .execute(db)
     .await?;
 
-    query(
+    query!(
         r#"
 CREATE TABLE IF NOT EXISTS blocks (
-    height bigint PRIMARY KEY, 
+    height bigint PRIMARY KEY,
     nct_anchor bytea NOT NULL,
     app_hash bytea NOT NULL
 )
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS blocks (
     .execute(db)
     .await?;
 
-    query(
+    query!(
         r#"
 CREATE TABLE IF NOT EXISTS notes (
     note_commitment bytea PRIMARY KEY,
@@ -44,21 +44,22 @@ CREATE TABLE IF NOT EXISTS notes (
     .execute(db)
     .await?;
 
-    query(
+    query!(
         r#"
 CREATE TABLE IF NOT EXISTS nullifiers (
-    nullifier bytea PRIMARY KEY
+    nullifier bytea PRIMARY KEY,
+    height bigint NOT NULL REFERENCES blocks (height)
 )
 "#,
     )
     .execute(db)
     .await?;
 
-    query(
+    query!(
         r#"
 CREATE TABLE IF NOT EXISTS assets (
-    asset_id bytea PRIMARY KEY,
-    denom varchar
+    asset_id bytea PRIMARY KEY NOT NULL,
+    denom varchar NOT NULL
 )
 "#,
     )

--- a/pd/src/db/assets.sql
+++ b/pd/src/db/assets.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS assets (
+    asset_id bytea PRIMARY KEY NOT NULL,
+    denom varchar NOT NULL
+)

--- a/pd/src/db/blobs.sql
+++ b/pd/src/db/blobs.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS blobs (
+    id varchar(64) PRIMARY KEY,
+    data bytea NOT NULL
+)

--- a/pd/src/db/blocks.sql
+++ b/pd/src/db/blocks.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS blocks (
+    height bigint PRIMARY KEY,
+    nct_anchor bytea NOT NULL,
+    app_hash bytea NOT NULL
+)

--- a/pd/src/db/notes.sql
+++ b/pd/src/db/notes.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS notes (
+    note_commitment bytea PRIMARY KEY,
+    ephemeral_key bytea NOT NULL,
+    encrypted_note bytea NOT NULL,
+    transaction_id bytea NOT NULL,
+    height bigint REFERENCES blocks (height)
+)

--- a/pd/src/db/nullifiers.sql
+++ b/pd/src/db/nullifiers.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS nullifiers (
+    nullifier bytea PRIMARY KEY,
+    height bigint NOT NULL REFERENCES blocks (height)
+)

--- a/pd/src/db/schema.rs
+++ b/pd/src/db/schema.rs
@@ -25,4 +25,5 @@ pub struct NotesRow {
 #[derive(Debug, sqlx::FromRow)]
 pub struct NullifiersRow {
     pub nullifier: Nullifier,
+    pub height: i64,
 }

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -13,7 +13,7 @@ use pd::{
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "pd",
-    about = "The Penumbra daemon.", 
+    about = "The Penumbra daemon.",
     version = env!("VERGEN_GIT_SEMVER"),
 )]
 struct Opt {
@@ -100,11 +100,9 @@ async fn main() {
             tokio::select! {
                 x = abci_server => {
                     let _ = dbg!(x);
-                    return;
                 }
                 x = wallet_server => {
                     let _ = dbg!(x);
-                    return;
                 }
             };
         }

--- a/proto/proto/wallet.proto
+++ b/proto/proto/wallet.proto
@@ -22,6 +22,7 @@ message CompactBlockRangeRequest {
 message CompactBlock {
   uint32 height = 1;
   repeated StateFragment fragments = 2;
+  repeated bytes nullifiers = 3;
 }
 
 // Requests an asset denom given an asset ID

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use hex;
 use penumbra_proto::wallet::{CompactBlock, StateFragment};
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -94,10 +93,9 @@ impl ClientState {
 
             let new_notes = match notemap.get(asset_denom) {
                 Some(current_notes) => {
-                    let mut new_notes: Vec<Note> =
-                        current_notes.iter().map(|note| note.clone()).collect();
+                    let mut new_notes: Vec<Note> = current_notes.to_vec();
                     new_notes.push(note.clone());
-                    new_notes.to_vec()
+                    new_notes
                 }
                 None => {
                     vec![note.clone()]
@@ -163,7 +161,7 @@ impl ClientState {
             // viewing key
             if let Ok(note) = Note::decrypt(
                 encrypted_note.as_ref(),
-                &self.wallet.incoming_viewing_key(),
+                self.wallet.incoming_viewing_key(),
                 &ephemeral_key
                     .as_ref()
                     .try_into()

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -131,7 +131,11 @@ impl ClientState {
     #[instrument(skip(self, fragments))]
     pub fn scan_block(
         &mut self,
-        CompactBlock { height, fragments }: CompactBlock,
+        CompactBlock {
+            height,
+            fragments,
+            nullifiers,
+        }: CompactBlock,
     ) -> Result<(), anyhow::Error> {
         // We have to do a bit of a dance to use None as "-1" and handle genesis notes.
         match (height, self.last_block_height()) {


### PR DESCRIPTION
Fixes #175 by extending the wallet protocol to send nullifier sets in `CompactBlock`s and using them to detect spends on the set of known unspent notes kept by the client.

Included in this PR are some improvements to the way we handle the database, which fix #155.

Additionally, if using VS Code, one can get `sqlx` query macros properly verified by rust-analyzer by opening the project directory as a folder; this will pick up the `.vscode/settings.json` file added here which sets the `DATABASE_URL` for the project appropriately.