### PR TITLE
pcli: suppress warning message with undocumented env var

### DIFF
--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -23,7 +23,9 @@ pub use state::ClientStateFile;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Display a warning message to the user so they don't get upset when all their tokens are lost.
-    warning::display();
+    if std::env::var("PCLI_UNLEASH_DANGER").is_err() {
+        warning::display();
+    }
 
     tracing_subscriber::fmt::init();
     let opt = Opt::from_args();


### PR DESCRIPTION
This commit adds an (intentionally) undocumented environment variable that
suppresses the scary testnet warning text.  If someone can dig through the
source and/or git history to find it and then set it, they're good to go.