### PR TITLE
Print nullifiers in `hex::encode`d format

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -27,6 +27,7 @@ aes = "0.7"
 anyhow = "1"
 thiserror = "1"
 bytes = "1"
+derivative = "2.2"
 hex = "0.4"
 blake2b_simd = "0.5"
 serde = { version = "1", features = ["derive"] }

--- a/crypto/src/keys/diversifier.rs
+++ b/crypto/src/keys/diversifier.rs
@@ -1,6 +1,7 @@
 use aes::Aes256;
 use anyhow::anyhow;
 use ark_ff::PrimeField;
+use derivative::Derivative;
 use fpe::ff1;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
@@ -9,8 +10,11 @@ use crate::Fq;
 
 pub const DIVERSIFIER_LEN_BYTES: usize = 11;
 
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub struct Diversifier(pub [u8; DIVERSIFIER_LEN_BYTES]);
+#[derive(Copy, Clone, PartialEq, Eq, Derivative)]
+#[derivative(Debug)]
+pub struct Diversifier(
+    #[derivative(Debug(bound = "", format_with = "crate::fmt_hex"))] pub [u8; DIVERSIFIER_LEN_BYTES],
+);
 
 impl Diversifier {
     /// Generate the diversified basepoint associated to this diversifier.
@@ -20,14 +24,6 @@ impl Diversifier {
             .hash(&self.0);
 
         decaf377::Element::map_to_group_cdh(&Fq::from_le_bytes_mod_order(hash.as_bytes()))
-    }
-}
-
-impl std::fmt::Debug for Diversifier {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Diversifier")
-            .field(&hex::encode(&self.0))
-            .finish()
     }
 }
 
@@ -54,8 +50,11 @@ impl TryFrom<&[u8]> for Diversifier {
     }
 }
 
-#[derive(Clone)]
-pub struct DiversifierKey(pub(super) [u8; 32]);
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
+pub struct DiversifierKey(
+    #[derivative(Debug(bound = "", format_with = "crate::fmt_hex"))] pub(super) [u8; 32],
+);
 
 impl DiversifierKey {
     pub fn diversifier_for_index(&self, index: &DiversifierIndex) -> Diversifier {
@@ -70,24 +69,11 @@ impl DiversifierKey {
     }
 }
 
-impl std::fmt::Debug for DiversifierKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("DiversifierKey")
-            .field(&hex::encode(&self.0))
-            .finish()
-    }
-}
-
-#[derive(Copy, Clone, Deserialize, Serialize)]
-pub struct DiversifierIndex(pub [u8; 11]);
-
-impl std::fmt::Debug for DiversifierIndex {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("DiversifierIndex")
-            .field(&hex::encode(&self.0))
-            .finish()
-    }
-}
+#[derive(Copy, Clone, Deserialize, Serialize, Derivative)]
+#[derivative(Debug)]
+pub struct DiversifierIndex(
+    #[derivative(Debug(bound = "", format_with = "crate::fmt_hex"))] pub [u8; 11],
+);
 
 impl From<u8> for DiversifierIndex {
     fn from(x: u8) -> Self {

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -27,3 +27,11 @@ pub use note::Note;
 pub use nullifier::Nullifier;
 pub use transaction::Transaction;
 pub use value::Value;
+
+fn fmt_hex<T: AsRef<[u8]>>(data: T, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    write!(f, "{}", hex::encode(data))
+}
+
+fn fmt_fq(data: &Fq, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fmt_hex(&data.to_bytes(), f)
+}

--- a/crypto/src/nullifier.rs
+++ b/crypto/src/nullifier.rs
@@ -2,12 +2,14 @@ use std::convert::{TryFrom, TryInto};
 
 use ark_ff::PrimeField;
 use decaf377::FieldExt;
+use derivative::Derivative;
 use once_cell::sync::Lazy;
 
 use crate::Fq;
 
-#[derive(PartialEq, Eq, Debug, Clone, Hash, PartialOrd, Ord)]
-pub struct Nullifier(pub Fq);
+#[derive(PartialEq, Eq, Derivative, Clone, Hash, PartialOrd, Ord)]
+#[derivative(Debug)]
+pub struct Nullifier(#[derivative(Debug(format_with = "crate::fmt_fq"))] pub Fq);
 
 /// The domain separator used to derive nullifiers.
 pub static NULLIFIER_DOMAIN_SEP: Lazy<Fq> = Lazy::new(|| {

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -176,7 +176,12 @@ async fn main() -> Result<()> {
             }
         }
         Command::Balance => {
-            let state = ClientStateFile::load(wallet_path)?;
+            let mut state = ClientStateFile::load(wallet_path)?;
+            sync(
+                &mut state,
+                format!("http://{}:{}", opt.node, opt.wallet_port),
+            )
+            .await?;
             let notes_by_asset = state.notes_by_asset_denomination();
 
             let mut table = Table::new();

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -23,7 +23,9 @@ pub use state::ClientStateFile;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Display a warning message to the user so they don't get upset when all their tokens are lost.
-    warning::display();
+    if std::env::var("PCLI_UNLEASH_DANGER").is_err() {
+        warning::display();
+    }
 
     tracing_subscriber::fmt::init();
     let opt = Opt::from_args();

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -208,7 +208,7 @@ impl ClientState {
     /// Scan the provided block and update the client state.
     ///
     /// The provided block must be the one immediately following [`Self::last_block_height`].
-    #[instrument(skip(self, fragments))]
+    #[instrument(skip(self, fragments, nullifiers))]
     pub fn scan_block(
         &mut self,
         CompactBlock {


### PR DESCRIPTION
This also pulls in a `derivative` dependency to make other hex-encoded things easier to derive `Debug` impls for; we should use this pattern going forwards.

This also implements a quick fix to omit the nullifiers list from the `scan_block` instrumentation span.