### PR TITLE
`pcli` tweaks

### DIFF
--- a/crypto/src/keys/spend.rs
+++ b/crypto/src/keys/spend.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
@@ -68,5 +70,21 @@ impl SpendKey {
 
     pub fn incoming_viewing_key(&self) -> &IncomingViewingKey {
         self.fvk.incoming()
+    }
+}
+
+impl TryFrom<&[u8]> for SpendSeed {
+    type Error = anyhow::Error;
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        if slice.len() != SPENDSEED_LEN_BYTES {
+            return Err(anyhow::anyhow!(
+                "spendseed must be 32 bytes, got {:?}",
+                slice.len()
+            ));
+        }
+
+        let mut bytes = [0u8; SPENDSEED_LEN_BYTES];
+        bytes.copy_from_slice(&slice[0..32]);
+        Ok(SpendSeed(bytes))
     }
 }

--- a/pcli/src/state.rs
+++ b/pcli/src/state.rs
@@ -55,6 +55,7 @@ impl ClientStateFile {
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
+            .truncate(true)
             .open(&self.path)?;
 
         serde_json::to_writer_pretty(&mut file, &self.state)?;

--- a/pcli/src/sync.rs
+++ b/pcli/src/sync.rs
@@ -9,6 +9,7 @@ use crate::ClientStateFile;
 
 #[instrument(skip(state), fields(start_height = state.last_block_height()))]
 pub async fn sync(state: &mut ClientStateFile, wallet_uri: String) -> Result<()> {
+    tracing::info!("starting client sync");
     let mut client = WalletClient::connect(wallet_uri).await?;
 
     let start_height = state.last_block_height().map(|h| h + 1).unwrap_or(0);
@@ -27,6 +28,7 @@ pub async fn sync(state: &mut ClientStateFile, wallet_uri: String) -> Result<()>
         count += 1;
         if count % 1000 == 0 {
             state.commit()?;
+            tracing::info!(height = ?state.last_block_height().unwrap(), "syncing...");
         }
     }
 
@@ -42,7 +44,7 @@ pub async fn sync(state: &mut ClientStateFile, wallet_uri: String) -> Result<()>
         );
     }
 
-    tracing::info!("finished sync");
     state.commit()?;
+    tracing::info!(end_height = ?state.last_block_height().unwrap(), "finished sync");
     Ok(())
 }

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -148,7 +148,7 @@ impl ClientState {
         );
 
         // xx let user specify change address
-        let return_address = self.wallet.address_by_index(0)?;
+        let (_label, return_address) = self.wallet.address_by_index(0)?;
         let change = Value {
             amount: total_spend_value - amount - fee,
             asset_id: value_to_send.asset_id,


### PR DESCRIPTION
This removes stub and testing commands, and fleshes out the wallet-* commands
to include a reset command (keeps the seed, but resets the rest of the state),
and import and export commands.