### PR TITLE
crypto: implement basic sighash

### DIFF
--- a/crypto/src/action/spend.rs
+++ b/crypto/src/action/spend.rs
@@ -19,17 +19,6 @@ pub struct Spend {
     pub auth_sig: Signature<SpendAuth>,
 }
 
-impl Spend {
-    /// Verify an auth sig using the provided randomized verification key.
-    pub fn verify_auth_sig(&self) -> bool {
-        let body_serialized: Vec<u8> = self.body.clone().into();
-        self.body
-            .rk
-            .verify(&body_serialized, &self.auth_sig)
-            .is_ok()
-    }
-}
-
 impl Protobuf<transaction::Spend> for Spend {}
 
 impl From<Spend> for transaction::Spend {

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -28,6 +28,7 @@ fn main() -> Result<()> {
 
     config.compile_protos(&["proto/transaction.proto"], &["proto/"])?;
     config.compile_protos(&["proto/transparent_proofs.proto"], &["proto/"])?;
+    config.compile_protos(&["proto/sighash.proto"], &["proto/"])?;
 
     // For the client code, we also want to generate RPC instances, so compile via tonic:
     tonic_build::configure().compile_with_config(config, &["proto/wallet.proto"], &["proto/"])?;

--- a/proto/proto/sighash.proto
+++ b/proto/proto/sighash.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+package penumbra.sighash;
+
+import "transaction.proto";
+
+// The content of a transaction, except for authorization signatures, for use
+// as a sighash input.
+//
+// Analogue of TransactionBody.
+message SigHashTransaction {
+  // A list of actions (state changes) performed by this transaction.
+  repeated SigHashAction actions = 1;
+  // The root of some previous state of the note commitment tree.
+  bytes anchor = 2;
+  // The maximum height that this transaction can be included in the chain.
+  uint32 expiry_height = 3;
+  // The chain this transaction is intended for.  Including this prevents
+  // replaying a transaction on one chain onto a different chain.
+  string chain_id = 4;
+  // The transaction fee.
+  transaction.Fee fee = 5;
+}
+
+// Analogue of Action
+message SigHashAction {
+  oneof action {
+    transaction.SpendBody spend = 1;
+    transaction.Output output = 2;
+  }
+}


### PR DESCRIPTION
This implements basic sighash functionality in the following way:

- Adds a new `SigHashTransaction` proto type that mirrors the `Transaction`
  proto but skips all of the signatures;

- Defines a `TransactionBody` -> `SigHashTransaction` conversion and a
  `TransactionBody::sighash()` function that hashes the serialization of the
  `SigHashTransaction`;

- Changes the transaction builder to defer creation of spend auth signatures
  until finalization is complete and the sighash is available;

- Changes transaction verification to verify signatures against the sighash
  value.

The effect of these changes is to ensure that spend authorizations are bound to
the entire transaction, not just the single spend description, so that spend
descriptions cannot be replayed into different transactions than the one they
were intended for.