### PR TITLE
add asset denom type

### DIFF
--- a/crypto/src/asset.rs
+++ b/crypto/src/asset.rs
@@ -28,6 +28,8 @@ use crate::Fq;
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Id(pub Fq);
 
+pub struct Denom(pub String);
+
 impl std::fmt::Debug for Id {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use ark_ff::BigInteger;
@@ -36,17 +38,20 @@ impl std::fmt::Debug for Id {
     }
 }
 
-// XXX define a DenomTrace structure ?
+impl From<&str> for Denom {
+    fn from(strin: &str) -> Denom {
+        Denom(strin.to_string())
+    }
+}
 
-// xx rename this derive?
-impl From<&[u8]> for Id {
-    fn from(slice: &[u8]) -> Id {
+impl From<Denom> for Id {
+    fn from(denom: Denom) -> Id {
         // Convert an asset name to an asset ID by hashing to a scalar
         Id(Fq::from_le_bytes_mod_order(
             // XXX choice of hash function?
             blake2b_simd::Params::default()
                 .personal(b"Penumbra_AssetID")
-                .hash(slice)
+                .hash(denom.0.as_ref())
                 .as_bytes(),
         ))
     }
@@ -56,9 +61,9 @@ impl TryFrom<Vec<u8>> for Id {
     type Error = anyhow::Error;
 
     fn try_from(vec: Vec<u8>) -> Result<Id, Self::Error> {
-        let bytes: [u8; 32] = vec
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("vec not long enough to construct Asset ID"))?;
+        let bytes: [u8; 32] = vec.try_into().map_err(|_| {
+            anyhow::anyhow!("could not deserialize Asset ID: input vec is not 32 bytes")
+        })?;
         let inner = Fq::from_bytes(bytes)?;
         Ok(Id(inner))
     }
@@ -93,11 +98,11 @@ mod tests {
         // marked for future deletion
         // not really a test, just a way to exercise the code
 
-        let pen_trace = b"pen";
-        let atom_trace = b"HubPort/HubChannel/atom";
+        let pen_trace = Denom("pen".to_string());
+        let atom_trace = Denom("HubPort/HubChannel/atom".to_string());
 
-        let pen_id = Id::from(&pen_trace[..]);
-        let atom_id = Id::from(&atom_trace[..]);
+        let pen_id = Id::from(pen_trace);
+        let atom_id = Id::from(atom_trace);
 
         dbg!(pen_id);
         dbg!(atom_id);

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -427,7 +427,7 @@ mod tests {
 
         let value = Value {
             amount: 10,
-            asset_id: b"pen".as_ref().into(),
+            asset_id: asset::Denom::from("pen").into(),
         };
         let note = Note::new(
             *dest.diversifier(),

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -462,7 +462,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: b"pen".as_ref().into(),
+            asset_id: asset::Denom::from("pen").into(),
         };
         let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
@@ -499,7 +499,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: b"pen".as_ref().into(),
+            asset_id: asset::Denom::from("pen").into(),
         };
         let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
@@ -547,7 +547,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: b"pen".as_ref().into(),
+            asset_id: asset::Denom::from("pen").into(),
         };
         let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
@@ -585,7 +585,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: b"pen".as_ref().into(),
+            asset_id: asset::Denom::from("pen").into(),
         };
         let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
@@ -627,7 +627,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: b"pen".as_ref().into(),
+            asset_id: asset::Denom::from("pen").into(),
         };
         let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
@@ -663,7 +663,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: b"pen".as_ref().into(),
+            asset_id: asset::Denom::from("pen").into(),
         };
         let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
@@ -715,7 +715,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: b"pen".as_ref().into(),
+            asset_id: asset::Denom::from("pen").into(),
         };
         let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
@@ -767,7 +767,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: b"pen".as_ref().into(),
+            asset_id: asset::Denom::from("pen").into(),
         };
         let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
@@ -819,7 +819,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: b"pen".as_ref().into(),
+            asset_id: asset::Denom::from("pen").into(),
         };
         let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -178,8 +178,8 @@ impl Transaction {
         }
 
         // Add fee into binding verification key computation.
-        let pen_trace = b"pen";
-        let pen_id = asset::Id::from(&pen_trace[..]);
+        let pen_trace = asset::Denom::from("pen");
+        let pen_id = asset::Id::from(pen_trace);
         let fee_value = Value {
             amount: self.transaction_body.fee.0,
             asset_id: pen_id,
@@ -320,7 +320,7 @@ mod tests {
                 &dest,
                 Value {
                     amount: 10,
-                    asset_id: b"pen".as_ref().into(),
+                    asset_id: asset::Denom::from("pen").into(),
                 },
                 MemoPlaintext::default(),
                 ovk_sender,
@@ -346,11 +346,11 @@ mod tests {
 
         let output_value = Value {
             amount: 10,
-            asset_id: b"pen".as_ref().into(),
+            asset_id: asset::Denom::from("pen").into(),
         };
         let spend_value = Value {
             amount: 20,
-            asset_id: b"pen".as_ref().into(),
+            asset_id: asset::Denom::from("pen").into(),
         };
         // The note was previously sent to the sender.
         let note = Note::new(

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -126,8 +126,8 @@ impl Builder {
     ///
     /// Note that we're using the lower case `pen` in the code.
     pub fn set_fee(mut self, fee: u64) -> Self {
-        let pen_trace = b"pen";
-        let pen_id = asset::Id::from(&pen_trace[..]);
+        let pen_trace = asset::Denom::from("pen");
+        let pen_id = asset::Id::from(pen_trace);
 
         let fee_value = Value {
             amount: fee,

--- a/crypto/src/value.rs
+++ b/crypto/src/value.rs
@@ -99,11 +99,11 @@ mod tests {
     fn sum_value_commitments() {
         use ark_ff::Field;
 
-        let pen_trace = b"pen";
-        let atom_trace = b"HubPort/HubChannel/atom";
+        let pen_trace = asset::Denom::from("pen");
+        let atom_trace = asset::Denom::from("HubPort/HubChannel/atom");
 
-        let pen_id = asset::Id::from(&pen_trace[..]);
-        let atom_id = asset::Id::from(&atom_trace[..]);
+        let pen_id = asset::Id::from(pen_trace);
+        let atom_id = asset::Id::from(atom_trace);
 
         // some values of different types
         let v1 = Value {

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -113,7 +113,7 @@ impl App {
             tracing::info!(?note);
             // Add all assets found in the genesis transaction to the asset registry
             genesis_block.new_assets.insert(
-                asset::Id::from(note.asset_denom.as_bytes()),
+                asset::Denom(note.asset_denom.clone()).into(),
                 note.asset_denom.clone(),
             );
 

--- a/pd/src/genesis.rs
+++ b/pd/src/genesis.rs
@@ -112,7 +112,7 @@ impl TryFrom<GenesisNote> for Note {
             transmission_key,
             Value {
                 amount,
-                asset_id: asset::Id::from(asset_denom.as_bytes()),
+                asset_id: asset::Denom(asset_denom.clone()).into(),
             },
             note_blinding,
         )?;

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -150,7 +150,7 @@ impl ClientState {
                 &dest_address,
                 Value {
                     amount: *amount,
-                    asset_id: denom.as_bytes().into(),
+                    asset_id: asset::Denom(denom.to_string()).into(),
                 },
                 memo,
                 self.wallet.outgoing_viewing_key(),
@@ -196,7 +196,7 @@ impl ClientState {
                     &change_address,
                     Value {
                         amount: change,
-                        asset_id: denom.as_bytes().into(),
+                        asset_id: asset::Denom(denom.to_string()).into(),
                     },
                     memo,
                     self.wallet.outgoing_viewing_key(),


### PR DESCRIPTION
This PR adds the asset::Denom type, which wraps a `String` and adds a `From<Denom>` implementation for `asset::Id`.

Closes #179 