### PR TITLE
pcli: truncate archive directory hash

### DIFF
--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -116,7 +116,7 @@ async fn main() -> Result<()> {
             let wallet_archive_dir = archive_dir
                 .data_dir()
                 .join(CURRENT_CHAIN_ID)
-                .join(format!("{:X}", result));
+                .join(hex::encode(&result[0..8]));
             std::fs::create_dir_all(&wallet_archive_dir)
                 .expect("can create penumbra wallet archive directory");
             archive_path = wallet_archive_dir.join("penumbra_wallet.json");


### PR DESCRIPTION
This is mostly cosmetic, just means directories like `zone.penumbra.testnet-archive/penumbra-tn001/81b6f2200a5aef30/` instead of `zone.penumbra.testnet-archive/penumbra-tn001/12C0ADDC7808DDE714548B8366E09D06261CCED0BF00DC694A9084B964A6F6F1/`