### PR TITLE
load latest note commitment tree anchors from database on startup

### DIFF
--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -108,6 +108,26 @@
       "nullable": []
     }
   },
+  "6ad227b21367ed03f7a27a5ec65a3499e5edecd8f94ed786751ee5a16321acaa": {
+    "query": "SELECT nct_anchor AS \"nct_anchor: merkle::Root\" FROM blocks ORDER BY height DESC LIMIT $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "nct_anchor: merkle::Root",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false
+      ]
+    }
+  },
   "73e0b933842ff451654acd14f7a681c505aed832f9158fd800bf32b21916625e": {
     "query": "SELECT transaction_id FROM notes WHERE note_commitment = $1",
     "describe": {

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -80,12 +80,11 @@ impl App {
     #[instrument(skip(state))]
     pub async fn new(state: State) -> Result<Self, anyhow::Error> {
         let note_commitment_tree = state.note_commitment_tree().await?;
-
+        let recent_anchors = state.recent_anchors(NUM_RECENT_ANCHORS).await?;
         Ok(Self {
             state,
             note_commitment_tree,
-            // TODO: load from DB
-            recent_anchors: Default::default(),
+            recent_anchors: recent_anchors,
             mempool_nullifiers: Arc::new(Default::default()),
             pending_block: None,
             completion_tracker: Default::default(),

--- a/pd/src/state.rs
+++ b/pd/src/state.rs
@@ -167,10 +167,9 @@ INSERT INTO notes (
     // retrieve the `last` latest node commitment tree anchors from the database
     pub async fn recent_anchors(&self, last: usize) -> Result<VecDeque<merkle::Root>> {
         let mut conn = self.pool.acquire().await?;
-        let anchor_rows = query_as!(
-            schema::BlocksRow,
-            r#"SELECT height, nct_anchor AS "nct_anchor: merkle::Root", app_hash FROM blocks ORDER BY height DESC LIMIT $1"#,
-             last as i64,
+        let anchor_rows = query!(
+            r#"SELECT nct_anchor AS "nct_anchor: merkle::Root" FROM blocks ORDER BY height DESC LIMIT $1"#,
+            last as i64,
         )
         .fetch_all(&mut conn)
         .await?;


### PR DESCRIPTION
This PR introduces a getter to `pd/src/state.rs` that retrieves the `last` most recent NCT anchors, and changes `app.rs` to use the getter to populate the initial App state.

Closes #192 