### PR TITLE
add tx memo support to pcli

### DIFF
--- a/crypto/src/memo.rs
+++ b/crypto/src/memo.rs
@@ -4,7 +4,7 @@ use chacha20poly1305::{
     ChaCha20Poly1305, Key, Nonce,
 };
 use once_cell::sync::Lazy;
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 
 use crate::{ka, keys::IncomingViewingKey, note::derive_symmetric_key, Address};
 
@@ -26,6 +26,20 @@ pub struct MemoPlaintext(pub [u8; MEMO_LEN_BYTES]);
 impl Default for MemoPlaintext {
     fn default() -> MemoPlaintext {
         MemoPlaintext([0u8; MEMO_LEN_BYTES])
+    }
+}
+
+impl TryFrom<String> for MemoPlaintext {
+    type Error = anyhow::Error;
+
+    fn try_from(input: String) -> Result<MemoPlaintext, Self::Error> {
+        if input.len() > MEMO_LEN_BYTES {
+            return Err(anyhow::anyhow!("provided memo exceeds maximum memo size"));
+        }
+        let mut mp = [0u8; MEMO_LEN_BYTES];
+        mp.copy_from_slice(input.as_bytes());
+
+        Ok(MemoPlaintext(mp))
     }
 }
 

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -66,6 +66,7 @@ async fn main() -> Result<()> {
             address,
             fee,
             source_address_id,
+            memo,
         }) => {
             let mut state = ClientStateFile::load(wallet_path)?;
             sync(
@@ -80,6 +81,7 @@ async fn main() -> Result<()> {
                 address,
                 fee,
                 source_address_id,
+                memo,
             )?;
             let serialized_tx: Vec<u8> = tx.into();
 

--- a/pcli/src/opt.rs
+++ b/pcli/src/opt.rs
@@ -97,5 +97,8 @@ pub enum TxCmd {
         /// If set, spend funds originally sent to the specified address.
         #[structopt(short, long)]
         source_address_id: Option<u64>,
+        /// If set, set the transaction's memo field to the provided text.
+        #[structopt(short, long)]
+        memo: Option<String>,
     },
 }

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -146,7 +146,7 @@ impl ClientState {
         for (denom, amount) in &output_value {
             let memo: memo::MemoPlaintext = match tx_memo {
                 Some(ref input_memo) => input_memo.clone().try_into()?,
-                None => memo::MemoPlaintext([0u8; memo::MEMO_LEN_BYTES])
+                None => memo::MemoPlaintext([0u8; memo::MEMO_LEN_BYTES]),
             };
             tx_builder = tx_builder.add_output(
                 rng,

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -128,6 +128,7 @@ impl ClientState {
         address: String,
         fee: u64,
         source_address: Option<u64>,
+        tx_memo: Option<String>,
     ) -> Result<Transaction, anyhow::Error> {
         // xx Could populate chain_id from the info endpoint on the node, or at least
         // error if there is an inconsistency
@@ -143,8 +144,10 @@ impl ClientState {
         output_value.insert(denomination, amount);
 
         for (denom, amount) in &output_value {
-            // xx: add memo handling
-            let memo = memo::MemoPlaintext([0u8; 512]);
+            let memo: memo::MemoPlaintext = match tx_memo {
+                Some(ref input_memo) => input_memo.clone().try_into()?,
+                None => memo::MemoPlaintext([0u8; memo::MEMO_LEN_BYTES])
+            };
             tx_builder = tx_builder.add_output(
                 rng,
                 &dest_address,


### PR DESCRIPTION
This PR adds support for users to set their transaction's `memo` field using pcli.

Closes #214 