### PR TITLE
fix panic on setting tx memo field from pcli

### DIFF
--- a/crypto/src/memo.rs
+++ b/crypto/src/memo.rs
@@ -37,7 +37,7 @@ impl TryFrom<String> for MemoPlaintext {
             return Err(anyhow::anyhow!("provided memo exceeds maximum memo size"));
         }
         let mut mp = [0u8; MEMO_LEN_BYTES];
-        mp.copy_from_slice(input.as_bytes());
+        mp[..input.len()].copy_from_slice(input.as_bytes());
 
         Ok(MemoPlaintext(mp))
     }


### PR DESCRIPTION
`copy_from_slice` requires the source and dest to be the same size, or else it will panic at runtime as discovered during testnet testing.