### PR TITLE
pcli: wait for checktx response

### DIFF
--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<()> {
             let serialized_tx: Vec<u8> = tx.into();
 
             let rsp = reqwest::get(format!(
-                r#"http://{}:{}/broadcast_tx_async?tx=0x{}"#,
+                r#"http://{}:{}/broadcast_tx_sync?tx=0x{}"#,
                 opt.node,
                 opt.rpc_port,
                 hex::encode(serialized_tx)


### PR DESCRIPTION
Using https://docs.tendermint.com/master/rpc/#/Tx/broadcast_tx_sync instead waits for the `CheckTx` response. Thanks to @avahowell for pointing this out.