### PR TITLE
pd: refactor check_tx, deliver_tx to have better instrumentation

### DIFF
--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -444,7 +444,7 @@ impl Service<Request> for App {
                 return async move {
                     tracing::debug!("starting check_tx");
                     let rsp = rsp.await;
-                    tracing::debug!(?rsp);
+                    tracing::info!(?rsp);
                     let _ = finished_signal.send(());
                     match rsp {
                         Ok(()) => Ok(Response::CheckTx(response::CheckTx::default())),
@@ -470,7 +470,7 @@ impl Service<Request> for App {
                 return async move {
                     tracing::debug!("starting deliver_tx");
                     let rsp = rsp.await;
-                    tracing::debug!(?rsp);
+                    tracing::info!(?rsp);
                     let _ = finished_signal.send(());
                     match rsp {
                         Ok(()) => Ok(Response::DeliverTx(response::DeliverTx::default())),


### PR DESCRIPTION
This refactors the check_tx and deliver_tx methods to return a `Result<(),
Error>` rather than an ABCI response, and then wraps those methods in an
invocation that transforms the result into an ABCI response, so that:

* we can return any errors that occur in the ABCI `log` field;
* we have one place where we send the completion signal, so we don't forget it;
* the implementation of the functions is simpler;
* we can instrument the processing with a span with the transaction hash.