### PR TITLE
add `App.validators`, staking module, Validator type and track initial validator set

### DIFF
--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -1,5 +1,29 @@
 {
   "db": "PostgreSQL",
+  "04f479f64381a7ea02bd9ae155d4ef6bf31e44f64705c7b36f6ad74aca2f115b": {
+    "query": "SELECT tm_pubkey, voting_power FROM validators",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "tm_pubkey",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 1,
+          "name": "voting_power",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
   "0c6a89db4de3642914e3cddf6e08a042eac9b140a03118943170433527ef5cc3": {
     "query": "INSERT INTO nullifiers VALUES ($1, $2)",
     "describe": {
@@ -48,6 +72,16 @@
           "Bytea",
           "Varchar"
         ]
+      },
+      "nullable": []
+    }
+  },
+  "51084a18f15226a89dfdfb35e5de7172b4053d495d728934a20528ab4dcf713b": {
+    "query": "CREATE TABLE IF NOT EXISTS validators (\n    tm_pubkey bytea NOT NULL PRIMARY KEY,\n    voting_power bigint NOT NULL\n)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
       },
       "nullable": []
     }

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -76,6 +76,19 @@
       "nullable": []
     }
   },
+  "3d56b7352d39010ff9e047b71268c26d00e9629870f21a98971ffd1b4f81a231": {
+    "query": "INSERT INTO validators (tm_pubkey, voting_power) VALUES ($1, $2)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "51084a18f15226a89dfdfb35e5de7172b4053d495d728934a20528ab4dcf713b": {
     "query": "CREATE TABLE IF NOT EXISTS validators (\n    tm_pubkey bytea NOT NULL PRIMARY KEY,\n    voting_power bigint NOT NULL\n)",
     "describe": {

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -90,12 +90,13 @@ impl App {
         let note_commitment_tree = state.note_commitment_tree().await?;
         let genesis_config = state.genesis_configuration().await?;
         let recent_anchors = state.recent_anchors(NUM_RECENT_ANCHORS).await?;
+        let validators = state.validators().await?;
         Ok(Self {
             state,
             note_commitment_tree,
             recent_anchors: recent_anchors,
             mempool_nullifiers: Arc::new(Default::default()),
-            validators: Arc::new(Default::default()),
+            validators: Arc::new(Mutex::new(validators)),
             pending_block: None,
             completion_tracker: Default::default(),
             epoch_duration: genesis_config.epoch_duration,

--- a/pd/src/db.rs
+++ b/pd/src/db.rs
@@ -13,6 +13,7 @@ pub async fn init_tables(db: &Pool<Postgres>) -> Result<()> {
         query_file!("src/db/blocks.sql"),
         query_file!("src/db/notes.sql"),
         query_file!("src/db/nullifiers.sql"),
+        query_file!("src/db/validators.sql"),
     ];
 
     let mut tx = db.begin().await?;

--- a/pd/src/db/validators.sql
+++ b/pd/src/db/validators.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS validators (
+    tm_pubkey bytea NOT NULL PRIMARY KEY,
+    voting_power bigint NOT NULL
+)

--- a/pd/src/lib.rs
+++ b/pd/src/lib.rs
@@ -5,6 +5,7 @@ mod db;
 mod pd_metrics;
 mod pending_block;
 mod request_ext;
+mod staking;
 mod state;
 mod verify;
 mod wallet;

--- a/pd/src/staking.rs
+++ b/pd/src/staking.rs
@@ -3,10 +3,10 @@ use tendermint::{vote, PublicKey};
 const PENUMBRA_BECH32_VALIDATOR_PREFIX: &str = "penumbravalpub";
 /// Validator tracks the Penumbra validator's long-term consensus key (tm_pubkey), as well as their
 /// voting power.
-#[derive(Debug, Eq, PartialOrd, Ord)]
+#[derive(Debug, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct Validator {
     tm_pubkey: PublicKey,
-    voting_power: vote::Power,
+    pub voting_power: vote::Power,
 }
 
 impl PartialEq for Validator {
@@ -17,7 +17,6 @@ impl PartialEq for Validator {
 
 impl Validator {
     pub fn new(pubkey: PublicKey, voting_power: vote::Power) -> Validator {
-        pubkey.to_bech32(PENUMBRA_BECH32_VALIDATOR_PREFIX);
         Validator {
             tm_pubkey: pubkey,
             voting_power,

--- a/pd/src/staking.rs
+++ b/pd/src/staking.rs
@@ -1,0 +1,29 @@
+use tendermint::{vote, PublicKey};
+
+/// Validator tracks the Penumbra validator's long-term consensus key (tm_pubkey), as well as their
+/// voting power.
+#[derive(Debug, Eq, PartialOrd, Ord)]
+pub struct Validator {
+    tm_pubkey: PublicKey,
+    voting_power: vote::Power,
+}
+
+impl PartialEq for Validator {
+    fn eq(&self, other: &Self) -> bool {
+        self.tm_pubkey == other.tm_pubkey
+    }
+}
+
+impl Validator {
+    pub fn new(pubkey: PublicKey, voting_power: vote::Power) -> Validator {
+        Validator {
+            tm_pubkey: pubkey,
+            voting_power,
+        }
+    }
+    /*
+    fn consensus_address() -> Address {
+        // todo - bech32 encoding of tm_pubkey?
+    }
+    */
+}

--- a/pd/src/staking.rs
+++ b/pd/src/staking.rs
@@ -1,5 +1,6 @@
 use tendermint::{vote, PublicKey};
 
+const PENUMBRA_BECH32_VALIDATOR_PREFIX: &str = "penumbravalpub";
 /// Validator tracks the Penumbra validator's long-term consensus key (tm_pubkey), as well as their
 /// voting power.
 #[derive(Debug, Eq, PartialOrd, Ord)]
@@ -16,14 +17,18 @@ impl PartialEq for Validator {
 
 impl Validator {
     pub fn new(pubkey: PublicKey, voting_power: vote::Power) -> Validator {
+        pubkey.to_bech32(PENUMBRA_BECH32_VALIDATOR_PREFIX);
         Validator {
             tm_pubkey: pubkey,
             voting_power,
         }
     }
-    /*
-    fn consensus_address() -> Address {
-        // todo - bech32 encoding of tm_pubkey?
+
+    /// consensus_address returns the bech32-encoded address of the validator's primary consensus
+    /// public key.
+    ///
+    /// TKTK: should this return an address type?
+    pub fn consensus_address(&self) -> String {
+        self.tm_pubkey.to_bech32(PENUMBRA_BECH32_VALIDATOR_PREFIX)
     }
-    */
 }

--- a/pd/src/state.rs
+++ b/pd/src/state.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use sqlx::postgres::PgPoolOptions;
 use sqlx::{query, query_as, Pool, Postgres};
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, VecDeque};
 use tendermint::block;
 use tracing::instrument;
 
@@ -14,6 +14,7 @@ use penumbra_proto::{
     thin_wallet::{Asset, TransactionDetail},
 };
 
+use crate::staking::Validator;
 use crate::{
     db::{self, schema},
     genesis::GenesisAppState,
@@ -276,6 +277,35 @@ INSERT INTO blobs (id, data) VALUES ('gc', $1)
             )
             .collect(),
         })
+    }
+
+    /// Retreive the current validator set.
+    ///
+    pub async fn validators(&self) -> Result<BTreeMap<tendermint::PublicKey, Validator>> {
+        let mut conn = self.pool.acquire().await?;
+
+        let mut validators: BTreeMap<tendermint::PublicKey, Validator> = BTreeMap::new();
+
+        let stored_validators = query!(r#"SELECT tm_pubkey, voting_power FROM validators"#)
+            .fetch_all(&mut conn)
+            .await?;
+        for row in stored_validators.iter() {
+            // NOTE: we store the validator's public key in the database as a json-encoded string,
+            // because Tendermint pubkeys can be either ed25519 or secp256k1, and we want a
+            // non-ambiguous encoding for the public key.
+            let decoded_pubkey: tendermint::PublicKey = serde_json::from_slice(&row.tm_pubkey)?;
+
+            // NOTE: voting_power is stored in the psql database as a `bigint`, which maps to an
+            // `i64` in sqlx. try_into uses the `TryFrom<i64>` implementation for voting power from
+            // Tendermint, so will return an error if voting power is negative (and not silently
+            // overflow).
+            validators.insert(
+                decoded_pubkey,
+                Validator::new(decoded_pubkey, row.voting_power.try_into()?),
+            );
+        }
+
+        Ok(validators)
     }
 
     /// Retrieve the [`TransactionDetail`] for a given note commitment.


### PR DESCRIPTION
This PR adds the `validators` field to `App`, which is a `BTreeMap<tendermint::PublicKey, Validator>` that will track the validator set. Note that this just pulls the initial validator state from the tendermint genesis state, we will need to add additional logic to the ABCI app once undelegations, slashing/evidence handling, etc, are implemented.

Closes #36