### PR TITLE
Pcli cleanup

### DIFF
--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -4,7 +4,7 @@ use directories::ProjectDirs;
 use penumbra_crypto::keys::SpendSeed;
 use rand_core::OsRng;
 use sha2::{Digest, Sha256};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 use penumbra_crypto::CURRENT_CHAIN_ID;

--- a/pcli/src/opt.rs
+++ b/pcli/src/opt.rs
@@ -44,6 +44,19 @@ pub enum Command {
     },
 }
 
+impl Command {
+    /// Determine if this command requires a network sync before it executes.
+    pub fn needs_sync(&self) -> bool {
+        match self {
+            Command::Tx(cmd) => cmd.needs_sync(),
+            Command::Wallet(cmd) => cmd.needs_sync(),
+            Command::Addr(cmd) => cmd.needs_sync(),
+            Command::Sync => true,
+            Command::Balance { .. } => true,
+        }
+    }
+}
+
 #[derive(Debug, StructOpt)]
 pub enum WalletCmd {
     /// Import an existing spend seed.
@@ -59,6 +72,19 @@ pub enum WalletCmd {
     Reset,
     /// Delete the entire wallet permanently.
     Delete,
+}
+
+impl WalletCmd {
+    /// Determine if this command requires a network sync before it executes.
+    pub fn needs_sync(&self) -> bool {
+        match self {
+            WalletCmd::Import { .. } => false,
+            WalletCmd::Export => false,
+            WalletCmd::Generate => false,
+            WalletCmd::Reset => false,
+            WalletCmd::Delete => false,
+        }
+    }
 }
 
 #[derive(Debug, StructOpt)]
@@ -81,6 +107,17 @@ pub enum AddrCmd {
     },
 }
 
+impl AddrCmd {
+    /// Determine if this command requires a network sync before it executes.
+    pub fn needs_sync(&self) -> bool {
+        match self {
+            AddrCmd::List => false,
+            AddrCmd::Show { .. } => false,
+            AddrCmd::New { .. } => false,
+        }
+    }
+}
+
 #[derive(Debug, StructOpt)]
 pub enum TxCmd {
     /// Send transaction to the node.
@@ -101,4 +138,13 @@ pub enum TxCmd {
         #[structopt(short, long)]
         memo: Option<String>,
     },
+}
+
+impl TxCmd {
+    /// Determine if this command requires a network sync before it executes.
+    pub fn needs_sync(&self) -> bool {
+        match self {
+            TxCmd::Send { .. } => true,
+        }
+    }
 }

--- a/pcli/src/sync.rs
+++ b/pcli/src/sync.rs
@@ -26,7 +26,7 @@ pub async fn sync(state: &mut ClientStateFile, wallet_uri: String) -> Result<()>
         state.scan_block(block)?;
         // very basic form of intermediate checkpointing
         count += 1;
-        if count % 1000 == 0 {
+        if count % 1000 == 1 {
             state.commit()?;
             tracing::info!(height = ?state.last_block_height().unwrap(), "syncing...");
         }


### PR DESCRIPTION
This PR does a few pieces of cleanup to `pcli` and implements one bug fix:
- sychronization is called in one place in the main function, eliminating multiple duplicate code blocks
- the determination of whether a command requires pre-synchronization is done in a separate function
- if starting from height zero, the INFO messages will use round 1000s rather than X999s
- refactor the `addr` subcommands to eliminate code duplication
- *bug fix*: wallets were not archived when imported, only when generated locally; this is now resolved