### PR TITLE
Track pending spends and change in `pcli`

### DIFF
--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -84,15 +84,12 @@ impl Note {
 
     /// Generate a fresh note representing the given value for the given destination address, with a
     /// random blinding factor.
-    pub fn fresh(
-        rng: &mut impl Rng,
-        address: &crate::Address,
-        value: Value,
-    ) -> Result<Self, Error> {
+    pub fn generate(rng: &mut impl Rng, address: &crate::Address, value: Value) -> Self {
         let diversifier = *address.diversifier();
         let transmission_key = *address.transmission_key();
         let note_blinding = Fq::rand(rng);
         Note::from_parts(diversifier, transmission_key, value, note_blinding)
+            .expect("transmission key in address is always valid")
     }
 
     pub fn diversified_generator(&self) -> decaf377::Element {
@@ -442,7 +439,7 @@ mod tests {
             amount: 10,
             asset_id: asset::Denom::from("penumbra").into(),
         };
-        let note = Note::fresh(&mut rng, &dest, value).expect("can create note");
+        let note = Note::generate(&mut rng, &dest, value);
         let esk = ka::Secret::new(&mut rng);
 
         let ciphertext = note.encrypt(&esk);

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -478,15 +478,8 @@ mod tests {
             amount: 10,
             asset_id: asset::Denom::from("penumbra").into(),
         };
-        let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::new(
-            *dest.diversifier(),
-            *dest.transmission_key(),
-            value_to_send,
-            note_blinding,
-        )
-        .expect("transmission key is valid");
+        let note = Note::fresh(&mut rng, &dest, value_to_send).expect("transmission key is valid");
         let esk = ka::Secret::new(&mut rng);
         let epk = esk.diversified_public(&note.diversified_generator());
 
@@ -495,7 +488,7 @@ mod tests {
             pk_d: *dest.transmission_key(),
             value: value_to_send,
             v_blinding,
-            note_blinding,
+            note_blinding: note.note_blinding(),
             esk,
         };
 
@@ -517,15 +510,8 @@ mod tests {
             amount: 10,
             asset_id: asset::Denom::from("penumbra").into(),
         };
-        let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::new(
-            *dest.diversifier(),
-            *dest.transmission_key(),
-            value_to_send,
-            note_blinding,
-        )
-        .expect("transmission key is valid");
+        let note = Note::fresh(&mut rng, &dest, value_to_send).expect("transmission key is valid");
         let esk = ka::Secret::new(&mut rng);
         let epk = esk.diversified_public(&note.diversified_generator());
 
@@ -534,7 +520,7 @@ mod tests {
             pk_d: *dest.transmission_key(),
             value: value_to_send,
             v_blinding,
-            note_blinding,
+            note_blinding: note.note_blinding(),
             esk,
         };
 
@@ -567,15 +553,8 @@ mod tests {
             amount: 10,
             asset_id: asset::Denom::from("penumbra").into(),
         };
-        let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::new(
-            *dest.diversifier(),
-            *dest.transmission_key(),
-            value_to_send,
-            note_blinding,
-        )
-        .expect("transmission key is valid");
+        let note = Note::fresh(&mut rng, &dest, value_to_send).expect("transmission key is valid");
         let esk = ka::Secret::new(&mut rng);
         let correct_epk = esk.diversified_public(&note.diversified_generator());
 
@@ -584,7 +563,7 @@ mod tests {
             pk_d: *dest.transmission_key(),
             value: value_to_send,
             v_blinding,
-            note_blinding,
+            note_blinding: note.note_blinding(),
             esk,
         };
         let incorrect_value_commitment = value_to_send.commit(Fr::rand(&mut rng));
@@ -607,15 +586,8 @@ mod tests {
             amount: 10,
             asset_id: asset::Denom::from("penumbra").into(),
         };
-        let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::new(
-            *dest.diversifier(),
-            *dest.transmission_key(),
-            value_to_send,
-            note_blinding,
-        )
-        .expect("transmission key is valid");
+        let note = Note::fresh(&mut rng, &dest, value_to_send).expect("transmission key is valid");
         let esk = ka::Secret::new(&mut rng);
 
         let proof = OutputProof {
@@ -623,7 +595,7 @@ mod tests {
             pk_d: *dest.transmission_key(),
             value: value_to_send,
             v_blinding,
-            note_blinding,
+            note_blinding: note.note_blinding(),
             esk,
         };
         let incorrect_esk = ka::Secret::new(&mut rng);
@@ -651,15 +623,8 @@ mod tests {
             amount: 10,
             asset_id: asset::Denom::from("penumbra").into(),
         };
-        let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::new(
-            *dest.diversifier(),
-            *dest.transmission_key(),
-            value_to_send,
-            note_blinding,
-        )
-        .expect("transmission key is valid");
+        let note = Note::fresh(&mut rng, &dest, value_to_send).expect("transmission key is valid");
         let esk = ka::Secret::new(&mut rng);
         let epk = esk.diversified_public(&note.diversified_generator());
 
@@ -668,7 +633,7 @@ mod tests {
             pk_d: *dest.transmission_key(),
             value: value_to_send,
             v_blinding,
-            note_blinding,
+            note_blinding: note.note_blinding(),
             esk,
         };
 
@@ -689,15 +654,10 @@ mod tests {
             amount: 10,
             asset_id: asset::Denom::from("penumbra").into(),
         };
-        let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::new(
-            *sender.diversifier(),
-            *sender.transmission_key(),
-            value_to_send,
-            note_blinding,
-        )
-        .expect("transmission key is valid");
+
+        let note =
+            Note::fresh(&mut rng, &sender, value_to_send).expect("transmission key is valid");
         let note_commitment = note.commit();
         let spend_auth_randomizer = Fr::rand(&mut rng);
         let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -718,7 +678,7 @@ mod tests {
             value: value_to_send,
             v_blinding,
             note_commitment,
-            note_blinding,
+            note_blinding: note.note_blinding(),
             spend_auth_randomizer,
             ak,
             nk,
@@ -743,15 +703,10 @@ mod tests {
             amount: 10,
             asset_id: asset::Denom::from("penumbra").into(),
         };
-        let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::new(
-            *sender.diversifier(),
-            *sender.transmission_key(),
-            value_to_send,
-            note_blinding,
-        )
-        .expect("transmission key is valid");
+
+        let note =
+            Note::fresh(&mut rng, &sender, value_to_send).expect("transmission key is valid");
         let note_commitment = note.commit();
         let spend_auth_randomizer = Fr::rand(&mut rng);
         let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -772,7 +727,7 @@ mod tests {
             value: value_to_send,
             v_blinding,
             note_commitment,
-            note_blinding,
+            note_blinding: note.note_blinding(),
             spend_auth_randomizer,
             ak,
             nk,
@@ -797,15 +752,9 @@ mod tests {
             amount: 10,
             asset_id: asset::Denom::from("penumbra").into(),
         };
-        let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::new(
-            *sender.diversifier(),
-            *sender.transmission_key(),
-            value_to_send,
-            note_blinding,
-        )
-        .expect("transmission key is valid");
+        let note =
+            Note::fresh(&mut rng, &sender, value_to_send).expect("transmission key is valid");
         let note_commitment = note.commit();
         let spend_auth_randomizer = Fr::rand(&mut rng);
         let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -826,7 +775,7 @@ mod tests {
             value: value_to_send,
             v_blinding,
             note_commitment,
-            note_blinding,
+            note_blinding: note.note_blinding(),
             spend_auth_randomizer,
             ak,
             nk,
@@ -851,15 +800,9 @@ mod tests {
             amount: 10,
             asset_id: asset::Denom::from("penumbra").into(),
         };
-        let note_blinding = Fq::rand(&mut rng);
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::new(
-            *sender.diversifier(),
-            *sender.transmission_key(),
-            value_to_send,
-            note_blinding,
-        )
-        .expect("transmission key is valid");
+        let note =
+            Note::fresh(&mut rng, &sender, value_to_send).expect("transmission key is valid");
         let note_commitment = note.commit();
         let spend_auth_randomizer = Fr::rand(&mut rng);
         let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -880,7 +823,7 @@ mod tests {
             value: value_to_send,
             v_blinding,
             note_commitment,
-            note_blinding,
+            note_blinding: note.note_blinding(),
             spend_auth_randomizer,
             ak,
             nk,

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -479,7 +479,7 @@ mod tests {
             asset_id: asset::Denom::from("penumbra").into(),
         };
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::fresh(&mut rng, &dest, value_to_send).expect("transmission key is valid");
+        let note = Note::generate(&mut rng, &dest, value_to_send);
         let esk = ka::Secret::new(&mut rng);
         let epk = esk.diversified_public(&note.diversified_generator());
 
@@ -511,7 +511,7 @@ mod tests {
             asset_id: asset::Denom::from("penumbra").into(),
         };
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::fresh(&mut rng, &dest, value_to_send).expect("transmission key is valid");
+        let note = Note::generate(&mut rng, &dest, value_to_send);
         let esk = ka::Secret::new(&mut rng);
         let epk = esk.diversified_public(&note.diversified_generator());
 
@@ -554,7 +554,7 @@ mod tests {
             asset_id: asset::Denom::from("penumbra").into(),
         };
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::fresh(&mut rng, &dest, value_to_send).expect("transmission key is valid");
+        let note = Note::generate(&mut rng, &dest, value_to_send);
         let esk = ka::Secret::new(&mut rng);
         let correct_epk = esk.diversified_public(&note.diversified_generator());
 
@@ -587,7 +587,7 @@ mod tests {
             asset_id: asset::Denom::from("penumbra").into(),
         };
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::fresh(&mut rng, &dest, value_to_send).expect("transmission key is valid");
+        let note = Note::generate(&mut rng, &dest, value_to_send);
         let esk = ka::Secret::new(&mut rng);
 
         let proof = OutputProof {
@@ -624,7 +624,7 @@ mod tests {
             asset_id: asset::Denom::from("penumbra").into(),
         };
         let v_blinding = Fr::rand(&mut rng);
-        let note = Note::fresh(&mut rng, &dest, value_to_send).expect("transmission key is valid");
+        let note = Note::generate(&mut rng, &dest, value_to_send);
         let esk = ka::Secret::new(&mut rng);
         let epk = esk.diversified_public(&note.diversified_generator());
 
@@ -656,8 +656,7 @@ mod tests {
         };
         let v_blinding = Fr::rand(&mut rng);
 
-        let note =
-            Note::fresh(&mut rng, &sender, value_to_send).expect("transmission key is valid");
+        let note = Note::generate(&mut rng, &sender, value_to_send);
         let note_commitment = note.commit();
         let spend_auth_randomizer = Fr::rand(&mut rng);
         let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -705,8 +704,7 @@ mod tests {
         };
         let v_blinding = Fr::rand(&mut rng);
 
-        let note =
-            Note::fresh(&mut rng, &sender, value_to_send).expect("transmission key is valid");
+        let note = Note::generate(&mut rng, &sender, value_to_send);
         let note_commitment = note.commit();
         let spend_auth_randomizer = Fr::rand(&mut rng);
         let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -753,8 +751,7 @@ mod tests {
             asset_id: asset::Denom::from("penumbra").into(),
         };
         let v_blinding = Fr::rand(&mut rng);
-        let note =
-            Note::fresh(&mut rng, &sender, value_to_send).expect("transmission key is valid");
+        let note = Note::generate(&mut rng, &sender, value_to_send);
         let note_commitment = note.commit();
         let spend_auth_randomizer = Fr::rand(&mut rng);
         let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
@@ -801,8 +798,7 @@ mod tests {
             asset_id: asset::Denom::from("penumbra").into(),
         };
         let v_blinding = Fr::rand(&mut rng);
-        let note =
-            Note::fresh(&mut rng, &sender, value_to_send).expect("transmission key is valid");
+        let note = Note::generate(&mut rng, &sender, value_to_send);
         let note_commitment = note.commit();
         let spend_auth_randomizer = Fr::rand(&mut rng);
         let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -76,7 +76,9 @@ impl Builder {
         self
     }
 
-    /// Add a new note to the output
+    /// Generate a new note and add it to the output, returning a clone of the generated note.
+    ///
+    /// For chaining output, use [`Builder::add_output`].
     pub fn add_output_producing_note<R: RngCore + CryptoRng>(
         mut self,
         rng: &mut R,
@@ -122,6 +124,8 @@ impl Builder {
 
     /// Create a new `Output`, implicitly creating a new note for it and encrypting the provided
     /// [`MemoPlaintext`] with a fresh ephemeral secret key.
+    ///
+    /// To return the generated note, use [`Builder::add_output_producing_note`].
     pub fn add_output<R: RngCore + CryptoRng>(
         self,
         rng: &mut R,

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -77,7 +77,7 @@ impl Builder {
     }
 
     /// Add a new note to the output
-    pub fn add_output_getting_note<R: RngCore + CryptoRng>(
+    pub fn add_output_producing_note<R: RngCore + CryptoRng>(
         mut self,
         rng: &mut R,
         dest: &Address,
@@ -130,7 +130,7 @@ impl Builder {
         memo: MemoPlaintext,
         ovk: &OutgoingViewingKey,
     ) -> Self {
-        self.add_output_getting_note(rng, dest, value_to_send, memo, ovk)
+        self.add_output_producing_note(rng, dest, value_to_send, memo, ovk)
             .1
     }
 

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -85,7 +85,7 @@ impl Builder {
         memo: MemoPlaintext,
         ovk: &OutgoingViewingKey,
     ) -> (Note, Self) {
-        let note = Note::fresh(rng, dest, value_to_send).expect("transmission key is valid");
+        let note = Note::generate(rng, dest, value_to_send);
         let diversified_generator = note.diversified_generator();
         let transmission_key = note.transmission_key();
         let value_to_send = note.value();

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -223,13 +223,13 @@ async fn main() -> Result<()> {
 
                 // Format a string describing the pending balance updates
                 let pending_string = if pending > 0 && pending_change > 0 {
-                    format!("+{} change, -{} spent", pending, pending_change)
+                    format!("+{} (change), -{} (spent)", pending, pending_change)
                 } else if pending == 0 {
-                    format!("+{} change", pending_change)
+                    format!("+{} (change)", pending_change)
                 } else if pending_change == 0 {
-                    format!("-{} spent", pending)
+                    format!("-{} (spent)", pending)
                 } else {
-                    "".to_string()
+                    String::new()
                 };
 
                 (unspent.to_string(), pending_string)

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -224,9 +224,9 @@ async fn main() -> Result<()> {
                 // Format a string describing the pending balance updates
                 let pending_string = if pending > 0 && pending_change > 0 {
                     format!("+{} (change), -{} (spent)", pending, pending_change)
-                } else if pending == 0 {
+                } else if pending == 0 && pending_change > 0 {
                     format!("+{} (change)", pending_change)
-                } else if pending_change == 0 {
+                } else if pending > 0 && pending_change == 0 {
                     format!("-{} (spent)", pending)
                 } else {
                     String::new()

--- a/pcli/src/sync.rs
+++ b/pcli/src/sync.rs
@@ -33,6 +33,7 @@ pub async fn sync(state: &mut ClientStateFile, wallet_uri: String) -> Result<()>
         }
     }
 
+    state.prune_timeouts();
     state.commit()?;
     tracing::info!(end_height = ?state.last_block_height().unwrap(), "finished sync");
     Ok(())

--- a/pd/src/genesis.rs
+++ b/pd/src/genesis.rs
@@ -116,7 +116,7 @@ impl TryFrom<&GenesisNote> for Note {
         let transmission_key = ka::Public(genesis_note.transmission_key);
         let diversifier = Diversifier(genesis_note.diversifier);
 
-        let note = Note::new(
+        let note = Note::from_parts(
             diversifier,
             transmission_key,
             Value {

--- a/pd/src/verify.rs
+++ b/pd/src/verify.rs
@@ -209,7 +209,7 @@ mod tests {
             asset_id: asset::Denom::from("penumbra").into(),
         };
         // The note was previously sent to the sender.
-        let note = Note::new(
+        let note = Note::from_parts(
             *send_addr.diversifier(),
             *send_addr.transmission_key(),
             spend_value,

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -1,5 +1,5 @@
 mod state;
 mod wallet;
 
-pub use state::ClientState;
+pub use state::{ClientState, UnspentNote};
 pub use wallet::Wallet;

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -144,8 +144,9 @@ impl ClientState {
         let mut notes_to_spend = Vec::new();
         let mut total_spend_value = 0u64;
         for note in notes.into_iter() {
-            // A note is spendable if it is unspent, or anticipated to be received as change
-            if let UnspentNote::Unspent(note) | UnspentNote::PendingChange(note) = note {
+            // A note is only spendable if it has been confirmed on chain to us (change outputs
+            // cannot be spent yet because they do not have a position):
+            if let UnspentNote::Unspent(note) = note {
                 notes_to_spend.push(note);
                 total_spend_value += note.amount();
 

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -579,24 +579,22 @@ mod serde_helpers {
                     .pending_timeouts
                     .into_iter()
                     .map(|(timeout, commitments)| {
-                        (
-                            timeout,
-                            commitments
-                                .into_iter()
-                                .map(|commitment| match commitment {
-                                    PendingCommitment::Change(commitment) => {
-                                        PendingCommitmentHelper::Change(hex::encode(
-                                            commitment.0.to_bytes(),
-                                        ))
-                                    }
-                                    PendingCommitment::Spend(commitment) => {
-                                        PendingCommitmentHelper::Spend(hex::encode(
-                                            commitment.0.to_bytes(),
-                                        ))
-                                    }
-                                })
-                                .collect(),
-                        )
+                        let commitments = commitments
+                            .into_iter()
+                            .map(|commitment| match commitment {
+                                PendingCommitment::Change(commitment) => {
+                                    PendingCommitmentHelper::Change(hex::encode(
+                                        commitment.0.to_bytes(),
+                                    ))
+                                }
+                                PendingCommitment::Spend(commitment) => {
+                                    PendingCommitmentHelper::Spend(hex::encode(
+                                        commitment.0.to_bytes(),
+                                    ))
+                                }
+                            })
+                            .collect();
+                        (timeout, commitments)
                     })
                     .collect(),
                 pending_set: state

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -1,6 +1,4 @@
 use anyhow::Context;
-use penumbra_crypto::action::{output, spend};
-use penumbra_crypto::Action;
 use penumbra_proto::light_wallet::{CompactBlock, StateFragment};
 use rand::seq::SliceRandom;
 use rand_core::{CryptoRng, RngCore};

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -367,6 +367,9 @@ impl ClientState {
                     note_commitment,
                 );
 
+                // If the note was a pending change note, remove it from the pending change set
+                self.pending_change_set.remove(&note_commitment);
+
                 // Insert the note into the received set
                 self.unspent_set.insert(note_commitment, note.clone());
             }

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use penumbra_crypto::action::output;
+use penumbra_crypto::action::{output, spend};
 use penumbra_crypto::Action;
 use penumbra_proto::light_wallet::{CompactBlock, StateFragment};
 use rand::seq::SliceRandom;
@@ -238,6 +238,8 @@ impl ClientState {
                 ) {
                     self.pending_change_set.insert(body.note_commitment, note);
                 }
+            } else if let Action::Spend(spend::Spend { body, .. }) = action {
+                // FIXME: track this spent output somehow
             }
         }
 

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -579,8 +579,11 @@ mod serde_helpers {
         note_commitment_tree: Vec<u8>,
         nullifier_map: Vec<(String, String)>,
         unspent_set: Vec<(String, String)>,
+        #[serde(default)]
         pending_set: Vec<(String, String)>,
+        #[serde(default)]
         pending_change_set: Vec<(String, String)>,
+        #[serde(default)]
         pending_timeouts: Vec<(SystemTime, Vec<PendingCommitmentHelper>)>,
         spent_set: Vec<(String, String)>,
         transactions: Vec<(String, String)>,

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -362,7 +362,7 @@ impl ClientState {
                         // Drop this pending change note -- this is permissible, because dropping a
                         // pending change note just means we forget about an output, not an input
                         if self.pending_change_set.remove(&commitment).is_none() {
-                            tracing::warn!(
+                            tracing::debug!(
                                 ?timeout,
                                 ?commitment,
                                 "attempted to drop a pending change note, but found that it did not exist",
@@ -376,7 +376,7 @@ impl ClientState {
                         if let Some(note) = self.pending_set.remove(&commitment) {
                             self.unspent_set.insert(commitment, note);
                         } else {
-                            tracing::warn!(
+                            tracing::debug!(
                                 ?timeout,
                                 ?commitment,
                                 "attempted to move a pending spend back to the unspent set, but found that it did not exist",
@@ -478,6 +478,13 @@ impl ClientState {
                         tracing::debug!(
                             ?nullifier,
                             "found nullifier for pending note: marking it as spent"
+                        )
+                    } else if let Some(note) = self.pending_change_set.remove(&note_commitment) {
+                        // Insert the note into the spent set
+                        self.spent_set.insert(note_commitment, note);
+                        tracing::debug!(
+                            ?nullifier,
+                            "found nullifier for pending change note: marking it as spent"
                         )
                     } else if self.spent_set.contains_key(&note_commitment) {
                         // If the nullifier is already in the spent set, it means we've already


### PR DESCRIPTION
This PR implements pending-spend and pending-change tracking in `pcli`, along the way cleaning up a couple APIs in the crypto crate. High level changes:

- `Note::new` is now `Note::from_parts`
- `Note::generate` is a new function to create a freshly random note given a destination address and a typed value (this should be preferred over `Note::from_parts` where possible, because it is infallible since addresses are always well-formed)
- A new method on the transaction builder allows adding an output while getting the internally-generated note back as a clone. This is useful for implementing change-tracking, because when we add change outputs, we need to keep track of those notes.
- Sets of pending spends and pending change have been added to the wallet state, with backwards-compatible serialization that fills in the empty set if they are not present
- Pending spends and change are pruned based on their timeout whenever they are read from disk, and additionally after every wallet sync:
  + pending spends return to the unspent set (the transaction failed, so we should be allowed to try again with those inputs)
  + pending change is dropped on the floor (the outputs of the transaction never happened, so we should forget them)
- Every pending spend or change is associated with an expiry time set 60 seconds in the future from when the transaction which generated those spends/change was created. The same timestamp for expiry is used for every pending piece of any given transaction, which means that both the pending spend and pending change from a transaction will drop from view atomically in the case of a transaction failure, preventing weird transient observations in `pcli balance`
- Internally, to implement the balance display functionality of this PR, a new `UnspentNote` enum has been added, which wraps a `&Note` with a descriptor of whether it is `Ready`, `PendingSpend`, or `PendingChange`. This type is used in the output of the various functions that ask for lists of notes in the wallet, and because it is only holding a reference to a note, this decreases cloning. Only `Ready` notes are used when forming transactions, because even though we can predict the change for a pending transaction, we can't predict its position in the note commitment tree, which means we can't spend change until the transaction clears.
- **`pcli balance` has been updated to display an additional "Pending" column (which only appears when there is anything to show) that gives pending transactions in the format "+N (change) / -M (spent)"**