### PR TITLE
pd: move remote_addr to server-level span

### DIFF
--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -54,6 +54,7 @@ rand_core = { version = "0.6.3", features = ["getrandom"] }
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres", "offline" ] }
 metrics = "0.17.0"
 metrics-exporter-prometheus = "0.6.1"
+http = "0.2"
 
 [build-dependencies]
 vergen = "5"


### PR DESCRIPTION
This cleans up the changes in #236 but required inlining some helper functionality from tonic.