### PR TITLE
feat: support coin metadata including minimum denomination

### DIFF
--- a/crypto/src/asset.rs
+++ b/crypto/src/asset.rs
@@ -118,6 +118,7 @@ pub struct Metadata {
     /// The base unit of the asset, e.g. `upenumbra`. Calculations should be done with the base.
     pub base: String,
     /// The unit that should be used in displaying e.g. balances, e.g. `penumbra`.
+    /// The `Denom` (and thus the `Id`) for the asset is derived from the `display`.
     pub display: String,
 }
 

--- a/crypto/src/asset.rs
+++ b/crypto/src/asset.rs
@@ -4,6 +4,7 @@ use std::convert::{TryFrom, TryInto};
 use ark_ff::fields::PrimeField;
 use decaf377::FieldExt;
 use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
 
 use crate::Fq;
 
@@ -87,6 +88,31 @@ impl Id {
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.to_bytes()
     }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DenomUnit {
+    /// The name of this denomination, e.g. `upenumbra`.
+    pub denom: String,
+    /// The exponent of this denomination, if the minimum denomination, `0`.
+    pub exponent: u8,
+    /// A list of alternative aliases for the denomination.
+    pub aliases: Vec<String>,
+}
+
+/// Metadata about each asset including the minimum denomination.
+///
+/// Based on [ADR-024](https://docs.cosmos.network/master/architecture/adr-024-coin-metadata.html).
+#[derive(Serialize, Deserialize)]
+pub struct AssetList {
+    /// The description of this asset, e.g. `The native token for the Penumbra zone.`
+    pub description: String,
+    /// A list of alternative denominations that can be used, e.g. `upenumbra`, `penumbra`.
+    pub denom_unit: Vec<DenomUnit>,
+    /// The base unit of the asset, e.g. `upenumbra`. Calculations should be done with the base.
+    pub base: String,
+    /// The unit that should be used in displaying e.g. balances, e.g. `penumbra`.
+    pub display: String,
 }
 
 #[cfg(test)]

--- a/crypto/src/asset.rs
+++ b/crypto/src/asset.rs
@@ -70,6 +70,12 @@ impl TryFrom<Vec<u8>> for Id {
     }
 }
 
+impl From<Id> for [u8; 32] {
+    fn from(asset_id: Id) -> [u8; 32] {
+        asset_id.0.to_bytes()
+    }
+}
+
 /// The domain separator used to hash asset ids to value generators.
 static VALUE_GENERATOR_DOMAIN_SEP: Lazy<Fq> = Lazy::new(|| {
     Fq::from_le_bytes_mod_order(blake2b_simd::blake2b(b"penumbra.value.generator").as_bytes())
@@ -90,7 +96,7 @@ impl Id {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct DenomUnit {
     /// The name of this denomination, e.g. `upenumbra`.
     pub denom: String,
@@ -103,12 +109,12 @@ pub struct DenomUnit {
 /// Metadata about each asset including the minimum denomination.
 ///
 /// Based on [ADR-024](https://docs.cosmos.network/master/architecture/adr-024-coin-metadata.html).
-#[derive(Serialize, Deserialize)]
-pub struct AssetList {
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct Metadata {
     /// The description of this asset, e.g. `The native token for the Penumbra zone.`
     pub description: String,
     /// A list of alternative denominations that can be used, e.g. `upenumbra`, `penumbra`.
-    pub denom_unit: Vec<DenomUnit>,
+    pub denom_units: Vec<DenomUnit>,
     /// The base unit of the asset, e.g. `upenumbra`. Calculations should be done with the base.
     pub base: String,
     /// The unit that should be used in displaying e.g. balances, e.g. `penumbra`.

--- a/pcli/src/fetch.rs
+++ b/pcli/src/fetch.rs
@@ -15,10 +15,16 @@ pub async fn assets(state: &mut ClientStateFile, wallet_uri: String) -> Result<(
     let mut stream = client.asset_list(request).await?.into_inner();
     while let Some(asset) = stream.message().await? {
         state.add_asset_to_registry(
-            asset.asset_id.try_into().map_err(|_| {
-                anyhow::anyhow!("could not parse asset ID for denom {}", asset.asset_denom)
+            asset
+                .asset_id
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("could not parse asset ID for assetlist"))?,
+            serde_json::from_str(&asset.metadata).map_err(|_| {
+                anyhow::anyhow!(
+                    "could not parse asset metadata for assetlist {}",
+                    asset.metadata
+                )
             })?,
-            asset.asset_denom.clone(),
         );
     }
 

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -37,13 +37,26 @@
       "nullable": []
     }
   },
-  "1abc3c48b127eee2761f3385541e195f9aca35269e6db0c41e3f67a0e04f280b": {
-    "query": "SELECT denom, asset_id FROM assets WHERE asset_id = $1",
+  "3d56b7352d39010ff9e047b71268c26d00e9629870f21a98971ffd1b4f81a231": {
+    "query": "INSERT INTO validators (tm_pubkey, voting_power) VALUES ($1, $2)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "3e53068704ac0d77a57c8600d4f767a6d5f240e835dfd54b98b241840c4bbc4d": {
+    "query": "SELECT metadata, asset_id FROM assets WHERE asset_id = $1",
     "describe": {
       "columns": [
         {
           "ordinal": 0,
-          "name": "denom",
+          "name": "metadata",
           "type_info": "Varchar"
         },
         {
@@ -61,32 +74,6 @@
         false,
         false
       ]
-    }
-  },
-  "3cbb441b10f4a068c16dd3a40accd689be26f2a6619b363fd966ee10e740f07b": {
-    "query": " INSERT INTO assets ( asset_id, denom) VALUES ($1, $2)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Varchar"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "3d56b7352d39010ff9e047b71268c26d00e9629870f21a98971ffd1b4f81a231": {
-    "query": "INSERT INTO validators (tm_pubkey, voting_power) VALUES ($1, $2)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Int8"
-        ]
-      },
-      "nullable": []
     }
   },
   "51084a18f15226a89dfdfb35e5de7172b4053d495d728934a20528ab4dcf713b": {
@@ -107,16 +94,6 @@
         "Left": [
           "Bytea"
         ]
-      },
-      "nullable": []
-    }
-  },
-  "56ac73fb90a557deadc0ced8c798a1a39ea01fafe58f940528e53836cfdaf986": {
-    "query": "CREATE TABLE IF NOT EXISTS assets (\n    asset_id bytea PRIMARY KEY NOT NULL,\n    denom varchar NOT NULL\n)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": []
       },
       "nullable": []
     }
@@ -175,6 +152,30 @@
       ]
     }
   },
+  "6b5a2ec3264138bfc685b064584743e34afb1c8cfad23e3510c6734da2137d5f": {
+    "query": "SELECT metadata, asset_id FROM assets",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "metadata",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 1,
+          "name": "asset_id",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
   "73e0b933842ff451654acd14f7a681c505aed832f9158fd800bf32b21916625e": {
     "query": "SELECT transaction_id FROM notes WHERE note_commitment = $1",
     "describe": {
@@ -211,28 +212,17 @@
       "nullable": []
     }
   },
-  "8195450f9f1cedf05eebd974adbdc42dc70a8e2abb7753d7b02cba03786bee0d": {
-    "query": "SELECT denom, asset_id FROM assets",
+  "79b631e733000749a11c7ba7132f3da59cd0dba88228accf8ac1b678e26d0f8c": {
+    "query": "INSERT INTO assets VALUES ($1, $2)",
     "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "denom",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 1,
-          "name": "asset_id",
-          "type_info": "Bytea"
-        }
-      ],
+      "columns": [],
       "parameters": {
-        "Left": []
+        "Left": [
+          "Bytea",
+          "Varchar"
+        ]
       },
-      "nullable": [
-        false,
-        false
-      ]
+      "nullable": []
     }
   },
   "9024aaa179b92038a276abd92a8f20b3a28133ea8435c1d4d9ae4bc3ec31158a": {
@@ -267,6 +257,16 @@
   },
   "a0a83fb42dc6ec8a9af35a29a492ad1651c13e047af85a25ebc41fdbd1909da7": {
     "query": "CREATE TABLE IF NOT EXISTS notes (\n    note_commitment bytea PRIMARY KEY,\n    ephemeral_key bytea NOT NULL,\n    encrypted_note bytea NOT NULL,\n    transaction_id bytea NOT NULL,\n    height bigint REFERENCES blocks (height)\n)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
+  "a5c1499f47cea6a6afa633bbb890de31c75e5a3e99327ae1982a3cd98c79d219": {
+    "query": "CREATE TABLE IF NOT EXISTS assets (\n    asset_id bytea PRIMARY KEY NOT NULL,\n    metadata varchar NOT NULL\n)",
     "describe": {
       "columns": [],
       "parameters": {

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -122,6 +122,8 @@ impl App {
         for note in &genesis.notes {
             tracing::info!(?note);
             // Add all assets found in the genesis transaction to the asset registry
+            // xx Instead of per-note, here we'll inspect each entry in the `assets` genesis key
+            // and add their assetlist to the registry.
             genesis_block.new_assets.insert(
                 asset::Denom(note.asset_denom.clone()).into(),
                 note.asset_denom.clone(),

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -130,11 +130,11 @@ impl App {
         // xx todo: Warn on genesis notes that do not correspond to any known asset.
 
         for asset in &genesis.assets {
-            // The base is used to derive the asset_id
+            // The display is used to derive the asset_id
             tracing::info!(?asset);
             genesis_block
                 .new_assets
-                .insert(asset::Denom(asset.base.clone()).into(), asset.clone());
+                .insert(asset::Denom(asset.display.clone()).into(), asset.clone());
         }
 
         let genesis_tx = genesis_tx_builder

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -121,18 +121,20 @@ impl App {
 
         for note in &genesis.notes {
             tracing::info!(?note);
-            // Add all assets found in the genesis transaction to the asset registry
-            // xx Instead of per-note, here we'll inspect each entry in the `assets` genesis key
-            // and add their assetlist to the registry.
-            genesis_block.new_assets.insert(
-                asset::Denom(note.asset_denom.clone()).into(),
-                note.asset_denom.clone(),
-            );
-
             genesis_tx_builder.add_output(
                 &mut OsRng,
                 note::Note::try_from(note).expect("GenesisNote can be converted into regular Note"),
             );
+        }
+
+        // xx todo: Warn on genesis notes that do not correspond to any known asset.
+
+        for asset in &genesis.assets {
+            // The base is used to derive the asset_id
+            tracing::info!(?asset);
+            genesis_block
+                .new_assets
+                .insert(asset::Denom(asset.base.clone()).into(), asset.clone());
         }
 
         let genesis_tx = genesis_tx_builder

--- a/pd/src/db/assets.sql
+++ b/pd/src/db/assets.sql
@@ -1,4 +1,4 @@
 CREATE TABLE IF NOT EXISTS assets (
     asset_id bytea PRIMARY KEY NOT NULL,
-    denom varchar NOT NULL
+    metadata varchar NOT NULL
 )

--- a/pd/src/genesis.rs
+++ b/pd/src/genesis.rs
@@ -74,6 +74,8 @@ pub struct GenesisAppState {
     pub notes: Vec<GenesisNote>,
     /// Epoch duration in terms of blocks
     pub epoch_duration: u64,
+    /// Initial assets.
+    pub assets: Vec<asset::Metadata>,
 }
 
 #[serde_as]

--- a/pd/src/pending_block.rs
+++ b/pd/src/pending_block.rs
@@ -18,6 +18,7 @@ pub struct PendingBlock {
     /// Nullifiers that were spent in this block.
     pub spent_nullifiers: BTreeSet<Nullifier>,
     /// Stores new asset types found in this block that need to be added to the asset registry.
+    /// xxx Needs to map to AssetList
     pub new_assets: BTreeMap<asset::Id, String>,
 }
 

--- a/pd/src/pending_block.rs
+++ b/pd/src/pending_block.rs
@@ -18,8 +18,7 @@ pub struct PendingBlock {
     /// Nullifiers that were spent in this block.
     pub spent_nullifiers: BTreeSet<Nullifier>,
     /// Stores new asset types found in this block that need to be added to the asset registry.
-    /// xxx Needs to map to AssetList
-    pub new_assets: BTreeMap<asset::Id, String>,
+    pub new_assets: BTreeMap<asset::Id, asset::Metadata>,
 }
 
 impl PendingBlock {

--- a/pd/src/wallet.rs
+++ b/pd/src/wallet.rs
@@ -124,7 +124,7 @@ impl ThinWallet for State {
                     .map_err(|_| tonic::Status::unavailable("database error"))
                     .unwrap();
                 for asset in &assets[..] {
-                    tracing::debug!(asset_id = ?hex::encode(&asset.asset_id), asset_denom = ?asset.asset_denom, "sending asset");
+                    tracing::debug!(asset_id = ?hex::encode(&asset.asset_id), metadata = ?asset.metadata, "sending asset");
                     tx.send(Ok(asset.clone())).await.unwrap();
                 }
             }

--- a/proto/proto/thin_wallet.proto
+++ b/proto/proto/thin_wallet.proto
@@ -13,7 +13,7 @@ service ThinWallet {
   rpc AssetList(AssetListRequest) returns (stream Asset);
 }
 
-// Requests an asset denom given an asset ID
+// Requests an assetlist given an asset ID
 message AssetLookupRequest {
   // The asset ID
   bytes asset_id = 1;
@@ -25,7 +25,7 @@ message AssetListRequest {
 
 message Asset {
   bytes asset_id = 1;
-  string asset_denom = 2;
+  string assetlist = 2;
 }
 
 // Requests the transaction containing a given output note commitment.

--- a/proto/proto/thin_wallet.proto
+++ b/proto/proto/thin_wallet.proto
@@ -13,7 +13,7 @@ service ThinWallet {
   rpc AssetList(AssetListRequest) returns (stream Asset);
 }
 
-// Requests an assetlist given an asset ID
+// Requests full asset metadata given an asset ID
 message AssetLookupRequest {
   // The asset ID
   bytes asset_id = 1;
@@ -25,7 +25,7 @@ message AssetListRequest {
 
 message Asset {
   bytes asset_id = 1;
-  string assetlist = 2;
+  string metadata = 2;
 }
 
 // Requests the transaction containing a given output note commitment.

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -230,8 +230,9 @@ impl ClientState {
                 .expect("all asset IDs should have denominations stored locally")
                 .display
                 .clone();
-            // TODO: Currently we're using the display field, but we should in pcli be using
-            // the base denomination for computations and the display denomination only for the UI.
+            // We're using the display field to derive the `Denom`, but we should in pcli be using
+            // the base denomination for computations and the display denomination only for the UI
+            // and deriving the trace. See issue #244.
 
             let index: u64 = self
                 .wallet()


### PR DESCRIPTION
Closes #178
Related to #57 

* Adds a new required key to the genesis file that specifies assets and their metadata, including alternative denominations:

```
"assets": [
      {
        "description": "The native staking token of the Penumbra zone.",
        "denom_units": [
          {
            "denom": "upenumbra",
            "exponent": 0,
            "aliases": [
              "micropenumbra"
            ]
          },
          {
            "denom": "mpenumbra",
            "exponent": 3,
            "aliases": [
              "millipenumbra"
            ]
          },
          {
            "denom": "penumbra",
            "exponent": 6,
            "aliases": []
          }
        ],
        "base": "upenumbra",
        "display": "penumbra"
      }
    ]
```

* Adds an `asset::Metadata` struct to the crypto crate, this is based on [ADR-024](https://docs.cosmos.network/master/architecture/adr-024-coin-metadata.html).
* Modifies the thin wallet protocol to return the full asset metadata instead of the `asset::Denom`.
* pcli now stores in its asset registry the full asset metadata (so heads up if testing you'll need to blow away the contents of the `asset_registry` key in the wallet state file, or the whole wallet state file if you prefer) 

Made two followups so far: #244 #243