### PR TITLE
Remove zero outputs

### DIFF
--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -167,45 +167,48 @@ impl ClientState {
         }
 
         for (denom, amount) in value_to_spend {
-            // Select a list of notes that provides at least the required amount.
-            let notes = self.notes_to_spend(rng, amount, denom.clone(), source_address)?;
-            let change_address = self
-                .wallet
-                .change_address(notes.last().expect("spent at least one note"))?;
-            let spent: u64 = notes.iter().map(|note| note.amount()).sum();
+            // Only produce an output if the amount is greater than zero
+            if amount > 0 {
+                // Select a list of notes that provides at least the required amount.
+                let notes = self.notes_to_spend(rng, amount, denom.clone(), source_address)?;
+                let change_address = self
+                    .wallet
+                    .change_address(notes.last().expect("spent at least one note"))?;
+                let spent: u64 = notes.iter().map(|note| note.amount()).sum();
 
-            // Spend each of the notes we selected.
-            for note in notes {
-                let auth_path = self
-                    .note_commitment_tree
-                    .authentication_path(&note.commit())
-                    .unwrap();
-                let merkle_path = (u64::from(auth_path.0) as usize, auth_path.1);
-                let merkle_position = auth_path.0;
-                tx_builder = tx_builder.add_spend(
-                    rng,
-                    self.wallet.spend_key(),
-                    merkle_path,
-                    note,
-                    merkle_position,
-                );
-            }
+                // Spend each of the notes we selected.
+                for note in notes {
+                    let auth_path = self
+                        .note_commitment_tree
+                        .authentication_path(&note.commit())
+                        .unwrap();
+                    let merkle_path = (u64::from(auth_path.0) as usize, auth_path.1);
+                    let merkle_position = auth_path.0;
+                    tx_builder = tx_builder.add_spend(
+                        rng,
+                        self.wallet.spend_key(),
+                        merkle_path,
+                        note,
+                        merkle_position,
+                    );
+                }
 
-            // Find out how much change we have and whether to add a change output.
-            let change = spent - amount;
-            if change > 0 {
-                // xx: add memo handling
-                let memo = memo::MemoPlaintext([0u8; 512]);
-                tx_builder = tx_builder.add_output(
-                    rng,
-                    &change_address,
-                    Value {
-                        amount: change,
-                        asset_id: asset::Denom(denom.to_string()).into(),
-                    },
-                    memo,
-                    self.wallet.outgoing_viewing_key(),
-                );
+                // Find out how much change we have and whether to add a change output.
+                let change = spent - amount;
+                if change > 0 {
+                    // xx: add memo handling
+                    let memo = memo::MemoPlaintext([0u8; 512]);
+                    tx_builder = tx_builder.add_output(
+                        rng,
+                        &change_address,
+                        Value {
+                            amount: change,
+                            asset_id: asset::Denom(denom.to_string()).into(),
+                        },
+                        memo,
+                        self.wallet.outgoing_viewing_key(),
+                    );
+                }
             }
         }
 

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -162,7 +162,9 @@ impl ClientState {
 
         // The value we need to spend is the output value, plus fees.
         let mut value_to_spend = output_value;
-        *value_to_spend.entry("penumbra".into()).or_default() += fee;
+        if fee > 0 {
+            *value_to_spend.entry("penumbra".into()).or_default() += fee;
+        }
 
         for (denom, amount) in value_to_spend {
             // Select a list of notes that provides at least the required amount.


### PR DESCRIPTION
Now, the transaction builder does not produce an output if that particular output would be equal to zero.

This prevents silliness like requiring you to have at least one penumbra-denominated note in hand in order to send a zero-fee transaction, because that note needs to be split into shares of (0% fee, 100% change) in order to create the (zero!) fee output.