### PR TITLE
track validator commission rate, commission address, and unclaimed reward

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -31,6 +31,7 @@ derivative = "2.2"
 hex = "0.4"
 blake2b_simd = "0.5"
 serde = { version = "1", features = ["derive"] }
+serde_with = { version = "1.11", features = ["hex"] }
 once_cell = "1.8"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand = "0.8"

--- a/crypto/src/asset.rs
+++ b/crypto/src/asset.rs
@@ -38,6 +38,26 @@ impl std::fmt::Debug for Id {
     }
 }
 
+impl std::fmt::Display for Id {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        use ark_ff::BigInteger;
+        let bytes = self.0.into_repr().to_bytes_le();
+        f.write_fmt(format_args!("asset::Id({})", hex::encode(&bytes)))
+    }
+}
+
+impl std::str::FromStr for Id {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes: [u8; 32] = s.as_bytes().try_into().map_err(|_| {
+            anyhow::anyhow!("could not deserialize Asset ID: input vec is not 32 bytes")
+        })?;
+        let inner = Fq::from_bytes(bytes)?;
+        Ok(Id(inner))
+    }
+}
+
 impl From<&str> for Denom {
     fn from(strin: &str) -> Denom {
         Denom(strin.to_string())

--- a/crypto/src/value.rs
+++ b/crypto/src/value.rs
@@ -1,5 +1,6 @@
 //! Values (?)
 
+use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::ops::Deref;
 use thiserror;
@@ -9,10 +10,11 @@ use once_cell::sync::Lazy;
 
 use crate::{asset, Fq, Fr};
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Value {
     pub amount: u64,
     // The asset ID. 256 bits.
+    #[serde(with = "serde_with::rust::display_fromstr")]
     pub asset_id: asset::Id,
 }
 

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -55,7 +55,7 @@ sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres", "offl
 metrics = "0.17.0"
 metrics-exporter-prometheus = "0.6.1"
 http = "0.2"
-num = "0.4"
+num = { version = "0.4", features = ["serde"] } 
 
 [build-dependencies]
 vergen = "5"

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -55,6 +55,7 @@ sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres", "offl
 metrics = "0.17.0"
 metrics-exporter-prometheus = "0.6.1"
 http = "0.2"
+num = "0.4"
 
 [build-dependencies]
 vergen = "5"

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -91,6 +91,22 @@
       ]
     }
   },
+  "328fa59e7194fccb9894d123e299d0cddadd5f4d3dda1ff6a06d94a1eabd5be9": {
+    "query": "INSERT INTO validators (tm_pubkey, voting_power, commission_address, commission_rate, unclaimed_reward) VALUES ($1, $2, $3, $4, $5)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Int8",
+          "Varchar",
+          "Bytea",
+          "Bytea"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "3cbb441b10f4a068c16dd3a40accd689be26f2a6619b363fd966ee10e740f07b": {
     "query": " INSERT INTO assets ( asset_id, denom) VALUES ($1, $2)",
     "describe": {
@@ -99,19 +115,6 @@
         "Left": [
           "Bytea",
           "Varchar"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "3d56b7352d39010ff9e047b71268c26d00e9629870f21a98971ffd1b4f81a231": {
-    "query": "INSERT INTO validators (tm_pubkey, voting_power) VALUES ($1, $2)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Int8"
         ]
       },
       "nullable": []

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -75,6 +75,16 @@
       ]
     }
   },
+  "25bd791f06a593a77395aa005a9abba0cfc3374be8c392cbf6b744100302b541": {
+    "query": "CREATE INDEX ON notes (position)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
   "3cbb441b10f4a068c16dd3a40accd689be26f2a6619b363fd966ee10e740f07b": {
     "query": " INSERT INTO assets ( asset_id, denom) VALUES ($1, $2)",
     "describe": {
@@ -86,6 +96,36 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "48100a65ab8914f275b9c9b7fbcb66ce951952813b8a24fe2659169421825eb1": {
+    "query": "CREATE INDEX ON nullifiers (height)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
+  "4a4a307127c44e3a2ecd637e405d1be56f8854aa4089704a1d2018ac168ad881": {
+    "query": "SELECT nullifier \n                FROM nullifiers \n                WHERE height = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "nullifier",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false
+      ]
     }
   },
   "51f515cc43458854df653c298142e6c77b2905b453f85c31ae1a0f56fbce1c2a": {
@@ -112,6 +152,16 @@
   },
   "59d92c68ee186e0565595bba405f32e2bba39806c4e78c42e87f77dd903d7455": {
     "query": "CREATE TABLE IF NOT EXISTS notes (\n    note_commitment bytea PRIMARY KEY,\n    ephemeral_key bytea NOT NULL,\n    encrypted_note bytea NOT NULL,\n    transaction_id bytea NOT NULL,\n    position bigint NOT NULL,\n    height bigint REFERENCES blocks (height)\n)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": []
+    }
+  },
+  "5c7b1cae63842279e1f2268c7215de7f2251b2f645060b0c6e4bdd406d717ae6": {
+    "query": "CREATE TABLE IF NOT EXISTS validators (\n    tm_pubkey bytea NOT NULL PRIMARY KEY,\n    voting_power bigint NOT NULL,\n    commission_address varchar NOT NULL,\n    commission_rate bigint NOT NULL,\n    unclaimed_reward bytea NOT NULL\n)",
     "describe": {
       "columns": [],
       "parameters": {

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -39,8 +39,8 @@
       ]
     }
   },
-  "25e3fa1252e6befbef555c506e6e1296df4cb89da7ec99238bc928767adc64ca": {
-    "query": "SELECT tm_pubkey, voting_power, commission_address, commission_rate, unclaimed_reward FROM validators",
+  "1b342fe294468358875e2ed0b3108462f3434b8412817505c2d42b5bb4423c90": {
+    "query": "SELECT tm_pubkey, voting_power, commission_address, commission_rate FROM validators",
     "describe": {
       "columns": [
         {
@@ -62,11 +62,6 @@
           "ordinal": 3,
           "name": "commission_rate",
           "type_info": "Int8"
-        },
-        {
-          "ordinal": 4,
-          "name": "unclaimed_reward",
-          "type_info": "Bytea"
         }
       ],
       "parameters": {
@@ -76,25 +71,8 @@
         false,
         false,
         false,
-        false,
         false
       ]
-    }
-  },
-  "328fa59e7194fccb9894d123e299d0cddadd5f4d3dda1ff6a06d94a1eabd5be9": {
-    "query": "INSERT INTO validators (tm_pubkey, voting_power, commission_address, commission_rate, unclaimed_reward) VALUES ($1, $2, $3, $4, $5)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Int8",
-          "Varchar",
-          "Int8",
-          "Bytea"
-        ]
-      },
-      "nullable": []
     }
   },
   "3cbb441b10f4a068c16dd3a40accd689be26f2a6619b363fd966ee10e740f07b": {
@@ -194,6 +172,21 @@
       "nullable": [
         false
       ]
+    }
+  },
+  "6c1203738db6f9a244389dc721f40c628bff216460ad769ba971d96c1f51b3f2": {
+    "query": "INSERT INTO validators (tm_pubkey, voting_power, commission_address, commission_rate) VALUES ($1, $2, $3, $4)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Int8",
+          "Varchar",
+          "Int8"
+        ]
+      },
+      "nullable": []
     }
   },
   "73e0b933842ff451654acd14f7a681c505aed832f9158fd800bf32b21916625e": {

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -13,16 +13,6 @@
       "nullable": []
     }
   },
-  "12c4a79f3395421bf16fe2a02d94bdb78948112e0dac9fcba45de6dce47a5b6a": {
-    "query": "CREATE TABLE IF NOT EXISTS validators (\n    tm_pubkey bytea NOT NULL PRIMARY KEY,\n    voting_power bigint NOT NULL,\n    commission_address varchar NOT NULL,\n    commission_rate bytea NOT NULL,\n    unclaimed_reward bytea NOT NULL\n)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": []
-    }
-  },
   "1abc3c48b127eee2761f3385541e195f9aca35269e6db0c41e3f67a0e04f280b": {
     "query": "SELECT denom, asset_id FROM assets WHERE asset_id = $1",
     "describe": {
@@ -71,7 +61,7 @@
         {
           "ordinal": 3,
           "name": "commission_rate",
-          "type_info": "Bytea"
+          "type_info": "Int8"
         },
         {
           "ordinal": 4,
@@ -100,7 +90,7 @@
           "Bytea",
           "Int8",
           "Varchar",
-          "Bytea",
+          "Int8",
           "Bytea"
         ]
       },

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -1,29 +1,5 @@
 {
   "db": "PostgreSQL",
-  "04f479f64381a7ea02bd9ae155d4ef6bf31e44f64705c7b36f6ad74aca2f115b": {
-    "query": "SELECT tm_pubkey, voting_power FROM validators",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "tm_pubkey",
-          "type_info": "Bytea"
-        },
-        {
-          "ordinal": 1,
-          "name": "voting_power",
-          "type_info": "Int8"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
-  },
   "0c6a89db4de3642914e3cddf6e08a042eac9b140a03118943170433527ef5cc3": {
     "query": "INSERT INTO nullifiers VALUES ($1, $2)",
     "describe": {
@@ -33,6 +9,16 @@
           "Bytea",
           "Int8"
         ]
+      },
+      "nullable": []
+    }
+  },
+  "12c4a79f3395421bf16fe2a02d94bdb78948112e0dac9fcba45de6dce47a5b6a": {
+    "query": "CREATE TABLE IF NOT EXISTS validators (\n    tm_pubkey bytea NOT NULL PRIMARY KEY,\n    voting_power bigint NOT NULL,\n    commission_address varchar NOT NULL,\n    commission_rate bytea NOT NULL,\n    unclaimed_reward bytea NOT NULL\n)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": []
       },
       "nullable": []
     }
@@ -63,14 +49,46 @@
       ]
     }
   },
-  "25bd791f06a593a77395aa005a9abba0cfc3374be8c392cbf6b744100302b541": {
-    "query": "CREATE INDEX ON notes (position)",
+  "25e3fa1252e6befbef555c506e6e1296df4cb89da7ec99238bc928767adc64ca": {
+    "query": "SELECT tm_pubkey, voting_power, commission_address, commission_rate, unclaimed_reward FROM validators",
     "describe": {
-      "columns": [],
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "tm_pubkey",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 1,
+          "name": "voting_power",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 2,
+          "name": "commission_address",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 3,
+          "name": "commission_rate",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 4,
+          "name": "unclaimed_reward",
+          "type_info": "Bytea"
+        }
+      ],
       "parameters": {
         "Left": []
       },
-      "nullable": []
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
     }
   },
   "3cbb441b10f4a068c16dd3a40accd689be26f2a6619b363fd966ee10e740f07b": {
@@ -95,46 +113,6 @@
           "Bytea",
           "Int8"
         ]
-      },
-      "nullable": []
-    }
-  },
-  "48100a65ab8914f275b9c9b7fbcb66ce951952813b8a24fe2659169421825eb1": {
-    "query": "CREATE INDEX ON nullifiers (height)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": []
-    }
-  },
-  "4a4a307127c44e3a2ecd637e405d1be56f8854aa4089704a1d2018ac168ad881": {
-    "query": "SELECT nullifier \n                FROM nullifiers \n                WHERE height = $1",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "nullifier",
-          "type_info": "Bytea"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
-      "nullable": [
-        false
-      ]
-    }
-  },
-  "51084a18f15226a89dfdfb35e5de7172b4053d495d728934a20528ab4dcf713b": {
-    "query": "CREATE TABLE IF NOT EXISTS validators (\n    tm_pubkey bytea NOT NULL PRIMARY KEY,\n    voting_power bigint NOT NULL\n)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": []
       },
       "nullable": []
     }

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -144,6 +144,11 @@ impl App {
         tracing::info!("loaded all genesis notes");
 
         // load the validators from the genesis app state
+        //
+        // NOTE: we ignore the validators passed to InitChain.validators, and instead expect them
+        // to be provided inside the initial app genesis state (`GenesisAppState`). Returning those
+        // validators in InitChain::Response tells Tendermint that they are the initial validator
+        // set. See https://docs.tendermint.com/master/spec/abci/abci.html#initchain
         let genesis_validators = genesis.validators.clone();
         let mut tm_validators: Vec<tendermint::abci::types::ValidatorUpdate> = Vec::new();
         for (pubkey, val) in genesis.validators.iter() {

--- a/pd/src/db/validators.sql
+++ b/pd/src/db/validators.sql
@@ -2,6 +2,6 @@ CREATE TABLE IF NOT EXISTS validators (
     tm_pubkey bytea NOT NULL PRIMARY KEY,
     voting_power bigint NOT NULL,
     commission_address varchar NOT NULL,
-    commission_rate bytea NOT NULL,
+    commission_rate bigint NOT NULL,
     unclaimed_reward bytea NOT NULL
 )

--- a/pd/src/db/validators.sql
+++ b/pd/src/db/validators.sql
@@ -1,4 +1,7 @@
 CREATE TABLE IF NOT EXISTS validators (
     tm_pubkey bytea NOT NULL PRIMARY KEY,
-    voting_power bigint NOT NULL
+    voting_power bigint NOT NULL,
+    commission_address varchar NOT NULL,
+    commission_rate bytea NOT NULL,
+    unclaimed_reward bytea NOT NULL
 )

--- a/pd/src/genesis.rs
+++ b/pd/src/genesis.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{collections::BTreeMap, str::FromStr};
 
 use ark_ff::UniformRand;
 use decaf377::{FieldExt, Fq};
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
 use penumbra_crypto::{asset, ka, keys::Diversifier, note, Address, Note, Value};
+
+use crate::staking::Validator;
 
 pub fn generate_genesis_notes(
     rng: &mut ChaCha20Rng,
@@ -74,6 +76,8 @@ pub struct GenesisAppState {
     pub notes: Vec<GenesisNote>,
     /// Epoch duration in terms of blocks
     pub epoch_duration: u64,
+    /// Initial validator set
+    pub validators: BTreeMap<tendermint::PublicKey, Validator>,
 }
 
 #[serde_as]

--- a/pd/src/staking.rs
+++ b/pd/src/staking.rs
@@ -1,5 +1,3 @@
-use num::bigint;
-use num::rational;
 use penumbra_crypto::{Address, Value};
 use serde::{Deserialize, Serialize};
 use tendermint::{vote, PublicKey};
@@ -23,7 +21,7 @@ pub struct Validator {
 
     /// commission_rate is the portion of staking rewards that go to the validator (as opposed to
     /// the delegators).
-    pub commission_rate: rational::Ratio<bigint::BigInt>,
+    pub commission_rate_bps: u16,
 
     /// unclaimed_reward is the amount of commission that the validator has yet to claim.
     pub unclaimed_reward: Value,
@@ -40,14 +38,14 @@ impl Validator {
         pubkey: PublicKey,
         voting_power: vote::Power,
         commission_address: Address,
-        commission_rate: rational::Ratio<bigint::BigInt>,
+        commission_rate_bps: u16,
         unclaimed_reward: Value,
     ) -> Validator {
         Validator {
             tm_pubkey: pubkey,
             voting_power,
             commission_address,
-            commission_rate,
+            commission_rate_bps,
             unclaimed_reward,
         }
     }

--- a/pd/src/staking.rs
+++ b/pd/src/staking.rs
@@ -36,10 +36,19 @@ impl PartialEq for Validator {
 }
 
 impl Validator {
-    pub fn new(pubkey: PublicKey, voting_power: vote::Power) -> Validator {
+    pub fn new(
+        pubkey: PublicKey,
+        voting_power: vote::Power,
+        commission_address: Address,
+        commission_rate: rational::Ratio<bigint::BigInt>,
+        unclaimed_reward: Value,
+    ) -> Validator {
         Validator {
             tm_pubkey: pubkey,
             voting_power,
+            commission_address,
+            commission_rate,
+            unclaimed_reward,
         }
     }
 

--- a/pd/src/staking.rs
+++ b/pd/src/staking.rs
@@ -21,7 +21,8 @@ pub struct Validator {
 
     /// The portion of staking rewards that go to the validator (as opposed to the delegators).
     pub commission_rate_bps: u16,
-    // TODO: track unclaimed reward
+    // NOTE: unclaimed rewards are tracked by inserting reward notes for the last epoch into the
+    // NCT at the beginning of each epoch
 }
 
 impl PartialEq for Validator {

--- a/pd/src/staking.rs
+++ b/pd/src/staking.rs
@@ -7,20 +7,19 @@ const PENUMBRA_BECH32_VALIDATOR_PREFIX: &str = "penumbravalpub";
 /// voting power.
 #[derive(Deserialize, Serialize, Debug, Eq, Clone)]
 pub struct Validator {
-    /// tm_pubkey is the validator's long-term Tendermint public key, where the private component
+    /// The validator's long-term Tendermint public key, where the private component
     /// is used to sign blocks.
     tm_pubkey: PublicKey,
 
-    /// voting_power is the validator's current voting power.
+    /// The validator's current voting power.
     pub voting_power: vote::Power,
 
-    /// commission_address is the validator's shielded commission address, where they receive their
-    /// portion of the staking rewards.
+    /// The validator's shielded commission address, where they receive their portion of the
+    /// staking rewards.
     #[serde(with = "serde_with::rust::display_fromstr")]
     pub commission_address: Address,
 
-    /// commission_rate is the portion of staking rewards that go to the validator (as opposed to
-    /// the delegators).
+    /// The portion of staking rewards that go to the validator (as opposed to the delegators).
     pub commission_rate_bps: u16,
     // TODO: track unclaimed reward
 }

--- a/pd/src/staking.rs
+++ b/pd/src/staking.rs
@@ -1,12 +1,13 @@
 use num::bigint;
 use num::rational;
 use penumbra_crypto::{Address, Value};
+use serde::{Deserialize, Serialize};
 use tendermint::{vote, PublicKey};
 
 const PENUMBRA_BECH32_VALIDATOR_PREFIX: &str = "penumbravalpub";
 /// Validator tracks the Penumbra validator's long-term consensus key (tm_pubkey), as well as their
 /// voting power.
-#[derive(Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, Clone)]
 pub struct Validator {
     /// tm_pubkey is the validator's long-term Tendermint public key, where the private component
     /// is used to sign blocks.
@@ -17,11 +18,12 @@ pub struct Validator {
 
     /// commission_address is the validator's shielded commission address, where they receive their
     /// portion of the staking rewards.
+    #[serde(with = "serde_with::rust::display_fromstr")]
     pub commission_address: Address,
 
     /// commission_rate is the portion of staking rewards that go to the validator (as opposed to
     /// the delegators).
-    pub commision_rate: rational::Ratio<bigint::BigInt>,
+    pub commission_rate: rational::Ratio<bigint::BigInt>,
 
     /// unclaimed_reward is the amount of commission that the validator has yet to claim.
     pub unclaimed_reward: Value,

--- a/pd/src/staking.rs
+++ b/pd/src/staking.rs
@@ -1,4 +1,4 @@
-use penumbra_crypto::{Address, Value};
+use penumbra_crypto::Address;
 use serde::{Deserialize, Serialize};
 use tendermint::{vote, PublicKey};
 
@@ -22,9 +22,7 @@ pub struct Validator {
     /// commission_rate is the portion of staking rewards that go to the validator (as opposed to
     /// the delegators).
     pub commission_rate_bps: u16,
-
-    /// unclaimed_reward is the amount of commission that the validator has yet to claim.
-    pub unclaimed_reward: Value,
+    // TODO: track unclaimed reward
 }
 
 impl PartialEq for Validator {
@@ -39,14 +37,12 @@ impl Validator {
         voting_power: vote::Power,
         commission_address: Address,
         commission_rate_bps: u16,
-        unclaimed_reward: Value,
     ) -> Validator {
         Validator {
             tm_pubkey: pubkey,
             voting_power,
             commission_address,
             commission_rate_bps,
-            unclaimed_reward,
         }
     }
 

--- a/pd/src/staking.rs
+++ b/pd/src/staking.rs
@@ -1,12 +1,30 @@
+use num::bigint;
+use num::rational;
+use penumbra_crypto::{Address, Value};
 use tendermint::{vote, PublicKey};
 
 const PENUMBRA_BECH32_VALIDATOR_PREFIX: &str = "penumbravalpub";
 /// Validator tracks the Penumbra validator's long-term consensus key (tm_pubkey), as well as their
 /// voting power.
-#[derive(Debug, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Validator {
+    /// tm_pubkey is the validator's long-term Tendermint public key, where the private component
+    /// is used to sign blocks.
     tm_pubkey: PublicKey,
+
+    /// voting_power is the validator's current voting power.
     pub voting_power: vote::Power,
+
+    /// commission_address is the validator's shielded commission address, where they receive their
+    /// portion of the staking rewards.
+    pub commission_address: Address,
+
+    /// commission_rate is the portion of staking rewards that go to the validator (as opposed to
+    /// the delegators).
+    pub commision_rate: rational::Ratio<bigint::BigInt>,
+
+    /// unclaimed_reward is the amount of commission that the validator has yet to claim.
+    pub unclaimed_reward: Value,
 }
 
 impl PartialEq for Validator {

--- a/pd/src/state.rs
+++ b/pd/src/state.rs
@@ -333,12 +333,17 @@ INSERT INTO blobs (id, data) VALUES ('gc', $1)
         // TODO: batching optimization
         for (tm_pubkey, val) in validators.iter() {
             let pubkey_str = serde_json::to_string(tm_pubkey)?;
+            let comm_rate = serde_json::to_string(&val.commission_rate)?;
+            let unclaimed_reward = serde_json::to_string(&val.unclaimed_reward)?;
 
             // TODO: commission address, rate, unclaimed reward
             query!(
-                "INSERT INTO validators (tm_pubkey, voting_power) VALUES ($1, $2)",
+                "INSERT INTO validators (tm_pubkey, voting_power, commission_address, commission_rate, unclaimed_reward) VALUES ($1, $2, $3, $4, $5)",
                 pubkey_str.as_bytes(),
                 i64::try_from(val.voting_power)?,
+                val.commission_address.to_string(),
+                comm_rate.as_bytes(),
+                unclaimed_reward.as_bytes(),
             )
             .execute(&mut conn)
             .await?;


### PR DESCRIPTION
This PR adds support for loading initial validator state from initial application state, and extends our `Validator` struct to include the commission address, commission rate, and unclaimed reward.

Closes #40 