### PR TITLE
Fixes #250 by adding --offline option to `pcli balance`

### DIFF
--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -201,8 +201,15 @@ async fn main() -> Result<()> {
             // Print the table (we don't get here if `show --addr-only`)
             println!("{}", table);
         }
-        Command::Balance { by_address } => {
-            let state = state.expect("state must be synchronized");
+        Command::Balance {
+            by_address,
+            offline,
+        } => {
+            let state = if !offline {
+                state.expect("state must be synchronized")
+            } else {
+                ClientStateFile::load(wallet_path)?
+            };
 
             let mut table = Table::new();
             table.load_preset(presets::NOTHING);

--- a/pcli/src/opt.rs
+++ b/pcli/src/opt.rs
@@ -44,6 +44,9 @@ pub enum Command {
         /// If set, breaks down balances by address.
         #[structopt(short, long)]
         by_address: bool,
+        #[structopt(long)]
+        /// If set, does not attempt to synchronize the wallet before printing the balance.
+        offline: bool,
     },
 }
 
@@ -55,7 +58,7 @@ impl Command {
             Command::Wallet(cmd) => cmd.needs_sync(),
             Command::Addr(cmd) => cmd.needs_sync(),
             Command::Sync => true,
-            Command::Balance { .. } => true,
+            Command::Balance { offline, .. } => !offline,
         }
     }
 }


### PR DESCRIPTION
Now we can check what the balance is in the currently cached wallet.