### PR TITLE
pd: rework and rename `create-genesis` to `create-genesis-template`

### DIFF
--- a/crypto/src/address.rs
+++ b/crypto/src/address.rs
@@ -3,6 +3,7 @@ use std::io::{Cursor, Read, Write};
 use anyhow::anyhow;
 use ark_serialize::CanonicalDeserialize;
 use bech32::{FromBase32, ToBase32, Variant};
+use serde_with::{DeserializeFromStr, SerializeDisplay};
 
 use crate::{fmd, ka, keys::Diversifier, Fq};
 
@@ -11,7 +12,7 @@ pub const CURRENT_CHAIN_ID: &str = "penumbra-valetudo";
 pub const CURRENT_ADDRESS_VERSION: u32 = 0;
 
 /// A valid payment address.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, SerializeDisplay, DeserializeFromStr)]
 pub struct Address {
     d: Diversifier,
     /// cached copy of the diversified base

--- a/crypto/src/asset.rs
+++ b/crypto/src/asset.rs
@@ -64,16 +64,25 @@ impl From<&str> for Denom {
     }
 }
 
-impl From<Denom> for Id {
-    fn from(denom: Denom) -> Id {
+impl Denom {
+    /// Returns the asset ID corresponding to this denomination.
+    pub fn id(&self) -> Id {
         // Convert an asset name to an asset ID by hashing to a scalar
         Id(Fq::from_le_bytes_mod_order(
             // XXX choice of hash function?
             blake2b_simd::Params::default()
                 .personal(b"Penumbra_AssetID")
-                .hash(denom.0.as_ref())
+                .hash(self.0.as_ref())
                 .as_bytes(),
         ))
+    }
+}
+
+impl From<Denom> for Id {
+    fn from(denom: Denom) -> Id {
+        // Putting the impl in id() rather than here means
+        // id() doesn't need to clone the string
+        denom.id()
     }
 }
 

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -12,7 +12,8 @@ use penumbra_proto::{
 
 use crate::{
     action::{error::ProtoError, Action},
-    asset, merkle,
+    asset,
+    merkle::{self, NoteCommitmentTree, TreeExt},
     rdsa::{Binding, Signature, VerificationKey, VerificationKeyBytes},
     Fr, Value,
 };
@@ -132,7 +133,8 @@ impl Transaction {
     }
 
     /// Build the genesis transactions.
-    pub fn genesis_build_with_root(merkle_root: merkle::Root) -> GenesisBuilder {
+    pub fn genesis_builder() -> GenesisBuilder {
+        let merkle_root = NoteCommitmentTree::new(0).root2();
         GenesisBuilder {
             actions: Vec::new(),
             fee: None,

--- a/crypto/src/transaction/genesis.rs
+++ b/crypto/src/transaction/genesis.rs
@@ -1,17 +1,14 @@
-use ark_ff::UniformRand;
-use rand_core::{CryptoRng, RngCore};
-use std::ops::Deref;
+use ark_ff::{One, Zero};
 
 use super::Error;
 use crate::note::OVK_WRAPPED_LEN_BYTES;
-use crate::rdsa::{Binding, Signature, SigningKey};
 use crate::{
     action::{output, Action},
     ka,
     memo::{MemoCiphertext, MEMO_CIPHERTEXT_LEN_BYTES},
     merkle,
     transaction::{Fee, Transaction, TransactionBody},
-    value, Fr, Note, Output,
+    Fr, Note, Output,
 };
 
 /// Used to construct a Penumbra transaction from genesis notes.
@@ -22,6 +19,10 @@ use crate::{
 ///
 /// The `GenesisBuilder` has no way to create spends, only outputs, and
 /// allows for a non-zero value balance.
+///
+/// While the genesis transaction has the same form as normal transactions,
+/// its outputs are not private, and the `GenesisBuilder` uses constant values
+/// instead of RNG outputs.
 pub struct GenesisBuilder {
     // Actions we'll perform in this transaction.
     pub actions: Vec<Action>,
@@ -43,13 +44,17 @@ pub struct GenesisBuilder {
 
 impl GenesisBuilder {
     /// Create a new `Output` for the genesis note.
-    pub fn add_output<R: RngCore + CryptoRng>(&mut self, rng: &mut R, note: Note) {
-        let v_blinding = Fr::rand(rng);
+    ///
+    /// This output is not private!
+    pub fn add_output(&mut self, note: Note) {
+        let v_blinding = Fr::zero();
         // We subtract from the transaction's value balance.
         self.synthetic_blinding_factor -= v_blinding;
         self.value_balance -= Fr::from(note.amount()) * note.asset_id().value_generator();
 
-        let esk = ka::Secret::new(rng);
+        // Use the secret key "1" in case we decide we want contributory
+        // behaviour for `decaf377-ka` later
+        let esk = ka::Secret::new_from_field(Fr::one());
         let body = output::Body::new(
             note.clone(),
             v_blinding,
@@ -81,28 +86,7 @@ impl GenesisBuilder {
         self
     }
 
-    /// Add the binding signature based on the current sum of synthetic blinding factors.
-    #[allow(non_snake_case)]
-    pub fn compute_binding_sig<R: CryptoRng + RngCore>(
-        &self,
-        rng: &mut R,
-        transaction_body: TransactionBody,
-    ) -> Signature<Binding> {
-        let binding_signing_key: SigningKey<Binding> = self.synthetic_blinding_factor.into();
-
-        // Check that the derived verification key corresponds to the signing key to be used.
-        let H = value::VALUE_BLINDING_GENERATOR.deref();
-        let binding_verification_key_raw = (self.synthetic_blinding_factor * H).compress().0;
-
-        // For the genesis transaction there will be a non-zero value balance since we are creating value.
-        let computed_verification_key = (self.value_commitments - self.value_balance).compress().0;
-        assert_eq!(binding_verification_key_raw, computed_verification_key);
-
-        let transaction_body_serialized: Vec<u8> = transaction_body.into();
-        binding_signing_key.sign(rng, &transaction_body_serialized)
-    }
-
-    pub fn finalize<R: CryptoRng + RngCore>(self, rng: &mut R) -> Result<Transaction, Error> {
+    pub fn finalize(self) -> Result<Transaction, Error> {
         if self.chain_id.is_none() {
             return Err(Error::NoChainID);
         }
@@ -115,7 +99,7 @@ impl GenesisBuilder {
             fee: Fee(0),
         };
 
-        let binding_sig = self.compute_binding_sig(rng, transaction_body.clone());
+        let binding_sig = [0u8; 64].into();
 
         Ok(Transaction {
             transaction_body,

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -56,6 +56,7 @@ metrics = "0.17.0"
 metrics-exporter-prometheus = "0.6.1"
 http = "0.2"
 num = { version = "0.4", features = ["serde"] } 
+ed25519-consensus = "1.2"
 
 [build-dependencies]
 vergen = "5"

--- a/pd/src/genesis.rs
+++ b/pd/src/genesis.rs
@@ -1,205 +1,56 @@
-use std::{collections::BTreeMap, str::FromStr};
-
-use ark_ff::UniformRand;
-use decaf377::{FieldExt, Fq};
-use rand_chacha::ChaCha20Rng;
+use ark_ff::Zero;
+use decaf377::Fq;
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
 
-use penumbra_crypto::{asset, ka, keys::Diversifier, note, Address, Note, Value};
+use penumbra_crypto::{asset::Denom, Address, Note, Value};
 
 use crate::staking::Validator;
 
-pub fn generate_genesis_notes(
-    rng: &mut ChaCha20Rng,
-    genesis_allocations: Vec<GenesisAddr>,
-) -> Vec<GenesisNote> {
-    let mut notes = Vec::<GenesisNote>::new();
-    for genesis_addr in genesis_allocations {
-        let note = GenesisNote::new(
-            *genesis_addr.address.diversifier(),
-            *genesis_addr.address.transmission_key(),
-            GenesisValue {
-                amount: genesis_addr.amount,
-                asset_denom: genesis_addr.denom,
-            },
-            Fq::rand(rng),
-        )
-        .expect("note created successfully");
-        notes.push(note);
-    }
-    notes
-}
-
-/// Value used only during genesis. The difference from [`Value`] is that
-/// the human-readable asset denomination is stored rather than the hashed
-/// asset ID.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct GenesisValue {
-    pub amount: u64,
-    /// The asset's human-readable denomination.
-    pub asset_denom: String,
-}
-
-#[derive(Debug)]
-pub struct GenesisAddr {
+/// A (transparent) genesis allocation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Allocation {
     pub amount: u64,
     pub denom: String,
     pub address: Address,
 }
 
-impl FromStr for GenesisAddr {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let fields: Vec<&str> = s
-            .trim_matches(|p| p == '(' || p == ')')
-            .split(',')
-            .collect();
-
-        let amount_fromstr = fields[0].parse::<u64>()?;
-        let denom_fromstr = fields[1].trim().to_string();
-        let address_fromstr = Address::from_str(fields[2].trim())?;
-
-        Ok(GenesisAddr {
-            amount: amount_fromstr,
-            denom: denom_fromstr,
-            address: address_fromstr,
-        })
-    }
-}
-
-#[serde_as]
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
-pub struct GenesisAppState {
-    /// Initial notes
-    pub notes: Vec<GenesisNote>,
-    /// Epoch duration in terms of blocks
-    pub epoch_duration: u64,
-    /// Initial validator set
-    pub validators: BTreeMap<tendermint::PublicKey, Validator>,
-}
-
-#[serde_as]
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone)]
-pub struct GenesisNote {
-    #[serde_as(as = "serde_with::hex::Hex")]
-    pub diversifier: [u8; 11],
-    pub amount: u64,
-    #[serde_as(as = "serde_with::hex::Hex")]
-    pub note_blinding: [u8; 32],
-    pub asset_denom: String,
-    #[serde_as(as = "serde_with::hex::Hex")]
-    pub transmission_key: [u8; 32],
-}
-
-impl GenesisNote {
-    pub fn new(
-        diversifier: Diversifier,
-        transmission_key: ka::Public,
-        value: GenesisValue,
-        note_blinding: Fq,
-    ) -> Result<Self, note::Error> {
-        Ok(GenesisNote {
-            diversifier: diversifier.0,
-            amount: value.amount,
-            note_blinding: note_blinding.to_bytes(),
-            asset_denom: value.asset_denom,
-            transmission_key: transmission_key.0,
-        })
-    }
-}
-
-impl TryFrom<&GenesisNote> for Note {
-    type Error = anyhow::Error;
-
-    fn try_from(genesis_note: &GenesisNote) -> Result<Self, Self::Error> {
-        let amount = genesis_note.amount;
-        let asset_denom = &genesis_note.asset_denom;
-        let note_blinding = Fq::from_bytes(genesis_note.note_blinding)?;
-        let transmission_key = ka::Public(genesis_note.transmission_key);
-        let diversifier = Diversifier(genesis_note.diversifier);
-
-        let note = Note::from_parts(
-            diversifier,
-            transmission_key,
+impl Allocation {
+    /// Obtain a note corresponding to this allocation.
+    ///
+    /// Note: to ensure determinism, this uses a zero blinding factor when
+    /// creating the note. This is fine, because the genesis allocations are
+    /// already public.
+    pub fn note(&self) -> Result<Note, anyhow::Error> {
+        Note::from_parts(
+            *self.address.diversifier(),
+            *self.address.transmission_key(),
             Value {
-                amount,
-                asset_id: asset::Denom(asset_denom.clone()).into(),
+                amount: self.amount,
+                asset_id: Denom(self.denom.clone()).id(),
             },
-            note_blinding,
-        )?;
-
-        Ok(note)
+            Fq::zero(),
+        )
+        .map_err(Into::into)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// The application state at genesis.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct AppState {
+    /// The initial token allocations.
+    pub allocations: Vec<Allocation>,
+    /// The number of blocks in each epoch.
+    pub epoch_duration: u64,
+    /// The initial validator set.
+    pub validators: Vec<Validator>,
+}
 
-    use penumbra_crypto::keys::SpendKey;
-    use rand_core::OsRng;
-
-    #[test]
-    fn genesis_notes_json() {
-        let sk = SpendKey::generate(OsRng);
-        let (dest0, _) = sk
-            .full_viewing_key()
-            .incoming()
-            .payment_address(0u64.into());
-        let (dest1, _) = sk
-            .full_viewing_key()
-            .incoming()
-            .payment_address(1u64.into());
-        let (dest2, _) = sk
-            .full_viewing_key()
-            .incoming()
-            .payment_address(2u64.into());
-
-        let value0 = GenesisValue {
-            amount: 100,
-            asset_denom: "penumbra".to_string(),
-        };
-        let value1 = GenesisValue {
-            amount: 1,
-            asset_denom: "tungsten_cube".to_string(),
-        };
-        let value2 = GenesisValue {
-            amount: 1000,
-            asset_denom: "penumbra".to_string(),
-        };
-
-        let note0 = GenesisNote::new(
-            *dest0.diversifier(),
-            *dest0.transmission_key(),
-            value0,
-            Fq::rand(&mut OsRng),
-        )
-        .unwrap();
-        let note1 = GenesisNote::new(
-            *dest1.diversifier(),
-            *dest1.transmission_key(),
-            value1,
-            Fq::rand(&mut OsRng),
-        )
-        .unwrap();
-        let note2 = GenesisNote::new(
-            *dest2.diversifier(),
-            *dest2.transmission_key(),
-            value2,
-            Fq::rand(&mut OsRng),
-        )
-        .unwrap();
-
-        let genesis_notes = vec![note0, note1, note2];
-
-        let serialized = serde_json::to_string_pretty(&genesis_notes).unwrap();
-
-        println!("\n{}\n", serialized);
-
-        let genesis_notes2: Vec<GenesisNote> = serde_json::from_str(&serialized).unwrap();
-
-        assert_eq!(genesis_notes, genesis_notes2);
+impl Default for AppState {
+    fn default() -> Self {
+        AppState {
+            epoch_duration: 8640,
+            allocations: Vec::default(),
+            validators: Vec::default(),
+        }
     }
 }

--- a/pd/src/lib.rs
+++ b/pd/src/lib.rs
@@ -5,15 +5,14 @@ mod db;
 mod pd_metrics;
 mod pending_block;
 mod request_ext;
-mod staking;
 mod state;
 mod verify;
 mod wallet;
 
 pub mod genesis;
+pub mod staking;
 
 pub use app::App;
-pub use genesis::GenesisNote;
 pub use pd_metrics::register_all_metrics;
 pub use pending_block::PendingBlock;
 pub use request_ext::RequestExt;

--- a/pd/src/staking.rs
+++ b/pd/src/staking.rs
@@ -16,7 +16,6 @@ pub struct Validator {
 
     /// The validator's shielded commission address, where they receive their portion of the
     /// staking rewards.
-    #[serde(with = "serde_with::rust::display_fromstr")]
     pub commission_address: Address,
 
     /// The portion of staking rewards that go to the validator (as opposed to the delegators).
@@ -52,5 +51,10 @@ impl Validator {
     /// TKTK: should this return an address type?
     pub fn consensus_address(&self) -> String {
         self.tm_pubkey.to_bech32(PENUMBRA_BECH32_VALIDATOR_PREFIX)
+    }
+
+    // why isn't tm_pubkey public?
+    pub fn tm_pubkey(&self) -> &PublicKey {
+        &self.tm_pubkey
     }
 }


### PR DESCRIPTION
Our create-genesis subcommand was serving two roles:

1. using command line parameters to generate JSON output that could be put into
the `app_state` field of the Tendermint `genesis.json` file;
2. constructing genesis notes given an input of genesis allocations.

The second role was only necessary because we made the `app_state` record
notes, rather than recording allocations directly, even though they have the
same information.  Instead, we can record the allocations as part of the
genesis state, and compute the notes as needed.  (Digging into this revealed
that the genesis transaction was being created non-deterministically, which
would cause an instant consensus divergence on a multi-node system; that's
fixed along the way).

The first role is not tenable as the scope of the Penumbra configuration
increases.  For instance, we now need to specify details about the validator
set.  Currently, it's not possible to feed the output of `create-genesis`
directly into the `genesis.json` file, because not all the fields are included.
This makes running nodes difficult.

Adding more and more command line options to the tool that generates the
config data, and then having people record those options in a script or
something, is much less ergonomic than just editing the config data directly.

To edit the config data directly, though, it's helpful to have a complete
example of the format.  So, the `create-genesis` command is renamed to
`create-genesis-template`, and it generates an editable example file.

Now that we specify validator info in the `app_state` together with the genesis
allocations, we'll need to change our setup for deployments so that the
`genesis.json` file is specified in advance.  This means that we'll need to
change the setup so that validator identity keys are chosen in advance (and
written into the genesis file).