### PR TITLE
Fix pending spend display in `pcli`

### DIFF
--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -301,7 +301,7 @@ async fn main() -> Result<()> {
 
                 // Set up headers for the table (a "Pending" column will be added if there are any
                 // pending transactions)
-                headers = vec!["Asset", "Unspent"];
+                headers = vec!["Asset", "Total"];
             }
 
             // Add an "Available" and "Pending" column if there are any pending transactions

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -68,7 +68,8 @@ async fn main() -> Result<()> {
             source_address_id,
             memo,
         }) => {
-            let tx = state.expect("state must be synchronized").new_transaction(
+            let mut state = state.expect("state must be synchronized");
+            let tx = state.new_transaction(
                 &mut OsRng,
                 amount,
                 denomination,
@@ -77,6 +78,8 @@ async fn main() -> Result<()> {
                 source_address_id,
                 memo,
             )?;
+            state.commit()?;
+
             let serialized_tx: Vec<u8> = tx.into();
 
             let rsp = reqwest::get(format!(

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -227,13 +227,16 @@ async fn main() -> Result<()> {
                     } += note.as_ref().amount();
                 }
 
+                // The amount spent is the difference between pending and pending change:
+                let pending_spend = pending - pending_change;
+
                 // Format a string describing the pending balance updates
                 let pending_string = if pending > 0 && pending_change > 0 {
-                    format!("+{} (change), -{} (spent)", pending_change, pending)
+                    format!("+{} (change), -{} (spent)", pending_change, pending_spend)
                 } else if pending == 0 && pending_change > 0 {
                     format!("+{} (change)", pending_change)
                 } else if pending > 0 && pending_change == 0 {
-                    format!("-{} (spent)", pending)
+                    format!("-{} (spent)", pending_spend)
                 } else {
                     String::new()
                 };

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -229,7 +229,7 @@ async fn main() -> Result<()> {
 
                 // Format a string describing the pending balance updates
                 let pending_string = if pending > 0 && pending_change > 0 {
-                    format!("+{} (change), -{} (spent)", pending, pending_change)
+                    format!("+{} (change), -{} (spent)", pending_change, pending)
                 } else if pending == 0 && pending_change > 0 {
                     format!("+{} (change)", pending_change)
                 } else if pending > 0 && pending_change == 0 {

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -236,7 +236,8 @@ impl ClientState {
                 let note_commitment = note.commit();
 
                 // Add the note to the pending set
-                tracing::info!(value = ?note.value(), "adding note to pending set");
+                tracing::info!(value = ?note.value(), "moving note from unspent set to pending set");
+                self.unspent_set.remove(&note_commitment);
                 self.pending_set
                     .insert(note_commitment, (timeout, note.clone()));
 

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -165,6 +165,7 @@ impl ClientState {
     ///
     /// TODO: this function is too complicated, merge with
     /// builder API ?
+    #[instrument(skip(self, rng))]
     pub fn new_transaction<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -384,7 +385,7 @@ impl ClientState {
 
     /// Remove all pending spends and change whose timeouts have expired, dropping pending change
     /// and returning pending spends to the unspent set.
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(pending_set_size = self.pending_set.len(), pending_change_set_size = self.pending_change_set.len()))]
     pub fn prune_timeouts(&mut self) {
         let now = SystemTime::now();
 

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -334,13 +334,13 @@ impl ClientState {
     /// Returns unspent notes, grouped by address index and then by denomination.
     pub fn unspent_notes_by_address_and_denom(
         &self,
-    ) -> BTreeMap<u64, HashMap<String, Vec<UnspentNote>>> {
+    ) -> BTreeMap<u64, BTreeMap<String, Vec<UnspentNote>>> {
         let mut notemap = BTreeMap::default();
 
         for (index, denom, note) in self.unspent_notes() {
             notemap
                 .entry(index)
-                .or_insert_with(HashMap::default)
+                .or_insert_with(BTreeMap::default)
                 .entry(denom)
                 .or_insert_with(Vec::default)
                 .push(note.clone());
@@ -352,8 +352,8 @@ impl ClientState {
     /// Returns unspent notes, grouped by denomination and then by address index.
     pub fn unspent_notes_by_denom_and_address(
         &self,
-    ) -> HashMap<String, BTreeMap<u64, Vec<UnspentNote>>> {
-        let mut notemap = HashMap::default();
+    ) -> BTreeMap<String, BTreeMap<u64, Vec<UnspentNote>>> {
+        let mut notemap = BTreeMap::default();
 
         for (index, denom, note) in self.unspent_notes() {
             notemap

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -400,12 +400,12 @@ impl ClientState {
                 // IMPORTANT: we must recover the pending note or else we can't ever spend it
                 // without resetting and resyncing the wallet entirely
                 if self.spent_set.contains_key(&note_commitment) {
-                    tracing::info!(
+                    tracing::debug!(
                         value = ?note.value(),
                         "timeout expired for pending note already in spent set"
                     )
                 } else {
-                    tracing::info!(
+                    tracing::debug!(
                         value = ?note.value(),
                         "timeout expired for pending note, putting it back into the unspent set"
                     );
@@ -422,7 +422,7 @@ impl ClientState {
                 // We can drop pending change notes, because they are outputs of the transaction and
                 // therefore we can expect that either the transaction will fail, or we will receive
                 // them again later
-                tracing::info!(
+                tracing::debug!(
                     value = ?note.value(),
                     "timeout expired for pending change, dropping it"
                 );
@@ -496,7 +496,7 @@ impl ClientState {
 
                 // If the note was a pending change note, remove it from the pending change set
                 if self.pending_change_set.remove(&note_commitment).is_some() {
-                    tracing::info!(value = ?note.value(), "found pending change note while scanning, removing it from the pending change set");
+                    tracing::debug!(value = ?note.value(), "found pending change note while scanning, removing it from the pending change set");
                 }
 
                 // Insert the note into the received set
@@ -514,7 +514,7 @@ impl ClientState {
                     // Try to remove the nullifier from the unspent set
                     if let Some(note) = self.unspent_set.remove(&note_commitment) {
                         // Insert the note into the spent set
-                        tracing::info!(
+                        tracing::debug!(
                             value = ?note.value(),
                             ?nullifier,
                             "found nullifier for unspent note, marking it as spent"
@@ -523,7 +523,7 @@ impl ClientState {
                     }
                     if let Some((_, note)) = self.pending_set.remove(&note_commitment) {
                         // Insert the note into the spent set
-                        tracing::info!(
+                        tracing::debug!(
                             value = ?note.value(),
                             ?nullifier,
                             "found nullifier for pending note, marking it as spent"
@@ -532,7 +532,7 @@ impl ClientState {
                     }
                     if let Some((_, note)) = self.pending_change_set.remove(&note_commitment) {
                         // Insert the note into the spent set
-                        tracing::info!(
+                        tracing::debug!(
                             value = ?note.value(),
                             ?nullifier,
                             "found nullifier for pending change note, marking it as spent"
@@ -542,7 +542,7 @@ impl ClientState {
                     if self.spent_set.contains_key(&note_commitment) {
                         // If the nullifier is already in the spent set, it means we've already
                         // processed this note and it's spent
-                        tracing::debug!(?nullifier, "found nullifier for already-spent note")
+                        tracing::info!(?nullifier, "found nullifier for already-spent note")
                     }
                 } else {
                     // This happens all the time, but if you really want to see every nullifier,


### PR DESCRIPTION
This fixes several bugs with displaying pending spends and change in `pcli`:
- State is committed after a transaction is created, thus saving pending spends/change which were
  previously implicitly dropped
- Better tracing messages make it easier to understand the management of the pending sets
- Logic error corrected where pending set was not cleared if a transaction was confirmed on-chain,
  leading to confusing display for 60 seconds
- Logic error corrected where notes were simultaneously present in the unspent and pending set after a spend
- Use `BTreeMap`s to store the array of assets to print, which results in alphabetically sorted assets

It also improves the balance display, so that pending transactions are easier to understand:

```
 Asset          Total    Available  Pending                     
 gm             20010                                           
 gn             19970                                           
 penumbra       1199897  999973     +199924 (held), -29 (spent) 
 pizza          10000                                           
 tungsten_cube  100
```