### PR TITLE
Integrate create-genesis-template into validator setup script, groundwork for multi-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,14 @@ To load genesis state for a fresh Docker configuration:
 for pd/postgres/tendermint!
 
 ```bash
-./scripts/docker_compose_freshstart.sh
+./scripts/docker_compose_freshstart.sh /PATH/TO/DATA/DIRECTORY
 ```
 
-The script will handle generating genesis JSON data and copying it to the container volumes
-and restarting the containers. You should have a working setup with all containers running
+The script will handle generating genesis JSON data and building and starting the containers.
+
+The data directory provided to the script will contain the state of the tendermint node.
+
+You should have a working setup with all containers running
 after running the script:
 
 ```console

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,20 +19,77 @@ services:
       - "26667:26667"
 
   # The Tendermint node
-  tendermint:
+  tendermint-node0:
     image: "tendermint/tendermint:latest"
-    container_name: tendermint
+    container_name: tendermint-node0
     ports:
       - "26656:26656"
       - "26657:26657"
     volumes:
-      - "tendermint_data:/tendermint"
+      - ~/scratch/testnet_build/node0:/tendermint:Z
     command: start --proxy-app=tcp://pd:26658
+    environment:
+      - ID=0
+      - LOG=${LOG:-tendermint.log}
     depends_on:
       - pd
     networks:
       localnet:
         ipv4_address: 192.167.10.2
+
+  # The Tendermint node
+  # tendermint-node1:
+  #   image: "tendermint/tendermint:latest"
+  #   container_name: tendermint-node1
+  #   ports:
+  #     - "26659-26660:26656-26657"
+  #   volumes:
+  #     - ~/scratch/testnet_build/node1:/tendermint:Z
+  #   command: start --proxy-app=tcp://pd:26658
+  #   environment:
+  #     - ID=1
+  #     - LOG=${LOG:-tendermint.log}
+  #   depends_on:
+  #     - pd
+  #   networks:
+  #     localnet:
+  #       ipv4_address: 192.167.10.3
+
+  # # The Tendermint node
+  # tendermint-node2:
+  #   image: "tendermint/tendermint:latest"
+  #   container_name: tendermint-node2
+  #   ports:
+  #     - "26661-26662:26656-26657"
+  #   volumes:
+  #     - ~/scratch/testnet_build/node2:/tendermint:Z
+  #   command: start --proxy-app=tcp://pd:26658
+  #   environment:
+  #     - ID=2
+  #     - LOG=${LOG:-tendermint.log}
+  #   depends_on:
+  #     - pd
+  #   networks:
+  #     localnet:
+  #       ipv4_address: 192.167.10.4
+
+  # # The Tendermint node
+  # tendermint-node3:
+  #   image: "tendermint/tendermint:latest"
+  #   container_name: tendermint-node3
+  #   ports:
+  #     - "26663-26664:26656-26657"
+  #   volumes:
+  #     - ~/scratch/testnet_build/node3:/tendermint:Z
+  #   command: start --proxy-app=tcp://pd:26658
+  #   environment:
+  #     - ID=3
+  #     - LOG=${LOG:-tendermint.log}
+  #   depends_on:
+  #     - pd
+  #   networks:
+  #     localnet:
+  #       ipv4_address: 192.167.10.5
 
 networks:
   localnet:
@@ -41,6 +98,3 @@ networks:
       driver: default
       config:
         - subnet: 192.167.10.0/16
-
-volumes:
-  tendermint_data: {}

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -192,8 +192,10 @@ async fn main() -> anyhow::Result<()> {
                 )],
             };
 
-            println!("// Edit the following template according to your needs");
-            println!("\n{}\n", serde_json::to_string_pretty(&app_state)?);
+            // Print this comment to stderr so stdout can be redirected as
+            // syntactically valid JSON
+            eprintln!("// Edit the following template according to your needs\n");
+            println!("{}", serde_json::to_string_pretty(&app_state)?);
         }
     }
 

--- a/scripts/docker_compose_freshstart.sh
+++ b/scripts/docker_compose_freshstart.sh
@@ -1,12 +1,37 @@
 #!/usr/bin/env bash
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
+cd "${parent_path}/../"
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+[ "$#" -eq 1 ] || die "build path argument required"
+
+
+build_path="$1"
+if [ -d "${build_path}" ] 
+then
+    printf "Directory ${build_path} already exists. Please remove it if you really want to DELETE ALL YOUR VALIDATOR DATA AND START OVER." >&2
+    printf "\n\nIf you just want to rebuild the Docker containers to reflect code changes and maintain the tendermint and penumbra database state, try:\n" >&2
+    printf "\t\`docker-compose up --build -d\`" >&2
+    exit 1
+fi
+
+printf "\t\tA new genesis has occurred...\n\n"
+printf "Storing configs to ${build_path}/ ...\n\n\n"
+
+mkdir -p ${build_path}
 docker-compose stop
 docker container prune
 docker volume rm penumbra_tendermint_data
 docker volume rm penumbra_prometheus_data
 docker volume rm penumbra_db_data
-docker-compose up --build -d
 python3 -m venv scripts/.venv
 source scripts/.venv/bin/activate
 pip install -r scripts/requirements.txt
-python3 scripts/setup_validator.py testnets/001_valetudo.csv penumbra-valetudo
+python3 scripts/setup_validator.py penumbra-valetudo ${build_path}
+
+docker-compose up --build -d

--- a/scripts/setup_validator.py
+++ b/scripts/setup_validator.py
@@ -2,6 +2,8 @@
 
 import argparse
 import json
+import os
+import shutil
 import subprocess
 import tempfile
 
@@ -13,13 +15,109 @@ import docker
 EPOCH_DURATION_BLOCKS = 8640
 
 
+# Fetch the tendermint git repo and build the docker image.
+# This is necessary because every architecture (e.g. for our M1 Macs)
+# isn't available on DockerHub for this image. git and go build tools
+# are required on the host.
+def build_tendermint_localnode(testnet_config_dir):
+    temp_dir = tempfile.TemporaryDirectory()
+    result = subprocess.run(
+        [
+            "git",
+            "clone",
+            "git@github.com:tendermint/tendermint.git",
+            temp_dir.name,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    # build the executable
+    result = subprocess.run(
+        [
+            "make build-linux",
+        ],
+        capture_output=True,
+        text=True,
+        shell=True,
+        cwd=temp_dir.name,
+    )
+
+    tendermint_binary = os.path.join(temp_dir.name, "build", "tendermint")
+    if not os.path.exists(tendermint_binary):
+        raise Exception("error building tendermint binary")
+
+    # copy the executable into the directory used for the testnet configs
+    shutil.copy(tendermint_binary, os.path.join(testnet_config_dir, "tendermint"))
+
+    # now the docker image can be built
+    client = docker.from_env()
+    client.images.build(
+        path=os.path.join(temp_dir.name, "networks", "local", "localnode"),
+        tag="tendermint/localnode",
+    )
+    tendermint_localnode_images = client.images.list(name="tendermint/localnode")
+    if not tendermint_localnode_images:
+        raise Exception("Error building tendermint/localnode image")
+
+
 # This script will handle configuring a Penumbra docker-compose validator deployment
 # by initializing the Tendermint node and patching the genesis.json (stored in the
 # Docker volume).
-def main(genesis_csv_file, chain_id):
+def main(chain_id, testnet_config_dir):
     client = docker.from_env()
+    tendermint_localnode_images = client.images.list(name="tendermint/localnode")
+    tendermint_binary = os.path.join(testnet_config_dir, "tendermint")
+    if not tendermint_localnode_images or not os.path.exists(tendermint_binary):
+        # The design of the tendermint localnode image requires the binary to be built
+        # on the host and inserted inside, so there's potential for misconfiguration here
+        build_tendermint_localnode(testnet_config_dir)
 
-    # generate the JSON
+    # The tendermint/localnode image is present so we can create initial testnet
+    # configs
+    client.containers.run(
+        "tendermint/localnode",
+        "testnet --config /etc/tendermint/config-template.toml --populate-persistent-peers=false --o . --starting-ip-address 192.167.10.2",
+        volumes=[f"{testnet_config_dir}:/tendermint:Z"],
+    )
+
+    # Now the testnet_config_dir directory structure should look like:
+    #
+    # ├── node0
+    # │   ├── config
+    # │   │   ├── config.toml
+    # │   │   ├── genesis.json
+    # │   │   ├── node_key.json
+    # │   │   └── priv_validator_key.json
+    # │   └── data
+    # │       └── priv_validator_state.json
+    # ├── node1
+    # │   ├── config
+    # │   │   ├── config.toml
+    # │   │   ├── genesis.json
+    # │   │   ├── node_key.json
+    # │   │   └── priv_validator_key.json
+    # │   └── data
+    # │       └── priv_validator_state.json
+    # ├── node2
+    # │   ├── config
+    # │   │   ├── config.toml
+    # │   │   ├── genesis.json
+    # │   │   ├── node_key.json
+    # │   │   └── priv_validator_key.json
+    # │   └── data
+    # │       └── priv_validator_state.json
+    # ├── node3
+    # │   ├── config
+    # │   │   ├── config.toml
+    # │   │   ├── genesis.json
+    # │   │   ├── node_key.json
+    # │   │   └── priv_validator_key.json
+    # │   └── data
+    # │       └── priv_validator_state.json
+    # └── tendermint
+
+    # generate the JSON for the genesis template
     result = subprocess.run(
         [
             "cargo",
@@ -27,64 +125,49 @@ def main(genesis_csv_file, chain_id):
             "--bin",
             "pd",
             "--",
-            "create-genesis",
-            "penumbra-valetudo",
-            "--file",
-            genesis_csv_file,
+            "create-genesis-template",
         ],
         capture_output=True,
         text=True,
     )
 
     genesis_data = json.loads(result.stdout)
-    patch_genesis(client, chain_id, genesis_data)
+    for node in ["node0", "node1", "node2", "node3"]:
+        patch_genesis(client, chain_id, genesis_data, testnet_config_dir, node)
 
-    # restart the containers to pick up changes
-    subprocess.run(["docker-compose", "restart"])
+    print(
+        f"""Testnet configs have been generated and genesis app state injected!
+    
+    See the magic at: {testnet_config_dir}"""
+    )
 
 
 # This method will patch an existing genesis.json file
 # with hardcoded genesis notes for ease of spinning up nodes.
-def patch_genesis(client: docker.DockerClient, chain_id, genesis_data):
-    temp_dir = tempfile.TemporaryDirectory()
-
+def patch_genesis(
+    client: docker.DockerClient, chain_id, genesis_data, testnet_config_dir, node
+):
+    print(
+        "Patching genesis file:",
+        os.path.join(testnet_config_dir, node, "config", "genesis.json"),
+    )
     # Load the Genesis file as JSON
-    existing_genesis = json.loads(
-        client.containers.run(
-            "alpine",
-            "/source/config/genesis.json",
-            stderr=True,
-            remove=True,
-            entrypoint="cat",
-            volumes=[f"{temp_dir.name}:/dest", "penumbra_tendermint_data:/source"],
-        ).decode("utf-8")
+    existing_genesis = json.load(
+        open(os.path.join(testnet_config_dir, node, "config", "genesis.json"))
     )
 
     existing_genesis["chain_id"] = chain_id
 
     existing_genesis["app_state"] = {}
 
-    # patch the existing genesis data with our hardcoded notes
-    existing_genesis["app_state"]["notes"] = genesis_data
-
-    # add the epoch duration in blocks
-    existing_genesis["app_state"]["epoch_duration"] = EPOCH_DURATION_BLOCKS
+    # patch the existing genesis data with our hardcoded data
+    existing_genesis["app_state"] = genesis_data
 
     # write the modified genesis data back
-    with open(f"{temp_dir.name}/genesis.json", "w") as f:
-        f.write(json.dumps(existing_genesis))
-
-    # store the modified genesis file within the volume
-    client.containers.run(
-        "alpine",
-        "/source/genesis.json /dest/config/genesis.json",
-        stderr=True,
-        remove=True,
-        entrypoint="cp",
-        volumes=[f"{temp_dir.name}:/source", "penumbra_tendermint_data:/dest"],
-    ).decode("utf-8")
-
-    temp_dir.cleanup()
+    with open(
+        os.path.join(testnet_config_dir, node, "config", "genesis.json"), "w"
+    ) as f:
+        f.write(json.dumps(existing_genesis, sort_keys=True, indent=4))
 
 
 if __name__ == "__main__":
@@ -92,18 +175,18 @@ if __name__ == "__main__":
         description="Generate genesis JSON and load into a validator container."
     )
     parser.add_argument(
-        "genesis_file",
-        metavar="f",
-        nargs=1,
-        help="which file contains the CSV genesis data",
-    )
-    parser.add_argument(
         "chain_id",
         metavar="c",
         nargs=1,
         help="chain ID",
     )
+    parser.add_argument(
+        "testnet_config_dir",
+        metavar="t",
+        nargs=1,
+        help="directory to store testnet configs",
+    )
 
     args = parser.parse_args()
 
-    main(args.genesis_file[0], args.chain_id[0])
+    main(args.chain_id[0], args.testnet_config_dir[0])


### PR DESCRIPTION
The fresh start script now integrates the `create-genesis-template` command, uses a persistent directory mount for tendermint configs, and uses the tendermint testnet setup command.

Closes: #267 