### PR TITLE
pcli: add asset denom to error output when syncing asset registry

### DIFF
--- a/pcli/src/fetch.rs
+++ b/pcli/src/fetch.rs
@@ -19,7 +19,9 @@ pub async fn assets(state: &mut ClientStateFile, wallet_uri: String) -> Result<(
             })?,
             asset::REGISTRY
                 .parse_base(&asset.asset_denom)
-                .ok_or_else(|| anyhow::anyhow!("invalid asset denomination"))?,
+                .ok_or_else(|| {
+                    anyhow::anyhow!("invalid asset denomination: {}", asset.asset_denom)
+                })?,
         );
     }
 


### PR DESCRIPTION
After merge of #283, `penumbra` is no longer a valid base denomination (in favor of `upenumbra`). This causes an error when syncing (discovered by @plaidfinch):

```
Error: invalid asset denomination: penumbra
```

This PR just adds debug output for the future to display which asset denom is invalid