### PR TITLE
specify fixed-point arithmetic for rate calculations

### DIFF
--- a/spec/SUMMARY.md
+++ b/spec/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Delegation](./stake/delegation.md)
   - [Undelegation](./stake/undelegation.md)
   - [Example Staking Dynamics](./stake/example.md)
+  - [Arithmetic](./stake/arithmetic.md)
 - [IBC Integration]()
   - [Transfers into Penumbra](./ibc/in.md)
   - [Transfers out of Penumbra]()

--- a/spec/stake.md
+++ b/spec/stake.md
@@ -18,3 +18,4 @@ This section describes the staking and delegation mechanism in detail:
 - [Delegation](./stake/delegation.md) describes how users bond stake to validators;
 - [Undelegation](./stake/undelegation.md) describes how users unbond stake from validators;
 - [Example Staking Dynamics](./stake/example.md) contains a worked example illustrating the mechanism design.
+- [Arithmetic](./stake/arithmetic.md) contains the specification for computing staking rates with fixed-point arithmetic

--- a/spec/stake/arithmetic.md
+++ b/spec/stake/arithmetic.md
@@ -9,21 +9,49 @@ and plenty of headroom for additions.
 
 All integer values should be interpreted as unsigned 64-bit integers, with the
 exception of the validator's commission rate, which is a `u16` specified in
-terms of basis points.
+terms of basis points. All integer values, with the exception of the
+validator's commission rate, have an implicit denominator of $10^8$. 
+
+Throughout this spec *representations* are referred to as $\mathtt x$, where
+$\mathtt x = x \cdot 10^{8}$, and the *value* represented by representations is
+$x = \mathtt x \cdot 10^{-8}$.
+
+As an example, let's take a starting value $\mathtt x$ represented in our scheme (so,
+$x \cdot 10^8$) and compute its product with $y$, also represented by our fixed point
+scheme, so $y \cdot 10^8$. The product $\mathtt x \mathtt y$ is computed as 
+
+$$\left\lfloor \frac{(x 10^8)(y 10^8)}{10^{8}} \right\rfloor = \left\lfloor \frac{\mathtt x \mathtt y}{10^{8}} \right\rfloor$$
+
+Since both $x$ and $y$ are both representations and both have a factor of
+$10^8$, computing their product includes an extra factor of 10^8 which we
+divide out. All representations are `u64` in our scheme, and any fixed-point
+number or product of fixed point numbers with 8 digits fits well within 64
+bits.
+
+
+## Table of Contents
+
+* $\mathtt r_{e}$: the fixed-point representation of the base rate at epoch $e$.
+* $\mathtt \psi(e)$: the fixed-point representation of the base exchange rate at epoch $e$.
+* $s_{i, e}$: the $10^4$ denominated fixed-point representation of the funding rate of the validator's funding stream at index $i$ and epoch $e$.
+* $c_{v,e}$: the sum of the validator's commission rates, which are specified as a fixed point integer with an implicit $10^4$ denominator.
+* $\mathtt r_{v,e}$: the fixed-point representation of the validator-specific reward rate for validator $v$ at epoch $e$.
+* $\mathtt \psi_v(e)$: the fixed-point representation of the validator-specific exchange rate for validator $v$ at epoch $e$.
+* $\mathtt \theta_v(e)$: the fixed-point representation of the validator's voting power adjustment function for validator $v$ at epoch $e$.
+
 
 ## Base Reward Rate
 
 The base reward is an input to the protocol, and the exact details of how this
 base rate $r_{e}$ is determined is not yet decided. For now, we can assume it is
-derived from the block header. $r_{e}$ is a fixed-precision `u64` integer with
-8 digits of precision.
+derived from the block header.
 
 
 ## Base Exchange Rate
 
 The base exchange rate, $\psi(e)$, can be safely computed as follows:
 
-$$\psi(e) = \left\lfloor \frac {\psi(e-1) (10^8 + r_e)} {10^8} \right\rfloor$$
+$$\mathtt \psi(e) = \left\lfloor \frac {\mathtt \psi(e-1) (10^8 + \mathtt r_e)} {10^8} \right\rfloor$$
 
 ## Commission Rate from Funding Streams
 
@@ -32,27 +60,24 @@ To compute the validator's commission rate from its set of funding streams, the 
 $$c_{v,e} = \sum_{0 \leq i < n} (s_{i,e})$$
 
 Where $s$ is the set of rates defined by the funding streams, $s_{i,e}$ being
-the ith rate at epoch $e$.  $s_i$ should be a fixed-precision `u16` integer
-type, specified in terms of [basis
-points](https://en.wikipedia.org/wiki/Basis_point). The resulting $c_{v,e}$ is
-defined in terms of basis points (i.e., four digits of precision). 
+the ith rate at epoch $e$.
 
 
 ## Validator Reward Rate
 
 To compute the validator's base reward rate, we compute the following:
 
-$$r_{v,e} = \lfloor \frac{(1e8 - (c_{v,e}*1e4))r_e}{1e8} \rfloor$$
+$$\mathtt r_{v,e} = \left\lfloor \frac{(10^8 - (c_{v,e} \cdot 10^4))\mathtt r_e}{10^8} \right\rfloor$$
 
 ## Validator Exchange Rate
 
 To compute the validator's exchange rate, we adapt the formula from the staking
 specification for our fixed-point arithmetic scheme like so:
 
-$$\psi_v(e) = \left\lfloor \frac {\psi_v(e-1) (10^8 + r_{v,i})}{10^8} \right\rfloor$$
+$$\mathtt \psi_v(e) = \left\lfloor \frac {\psi_v(e-1) (10^8 + \mathtt r_{v,e})}{10^8} \right\rfloor$$
 
 ## Validator Voting Power Adjustment
 
 Finally, to compute the validator's voting power adjustment function, simply take:
 
-$$\theta_v(e) = \lfloor \frac{\psi_v{e}*1e8}{\psi{e}} \rfloor$$
+$$\theta_v(e) = \lfloor \frac{\psi_v{e}*10^8}{\psi{e}} \rfloor$$

--- a/spec/stake/arithmetic.md
+++ b/spec/stake/arithmetic.md
@@ -9,7 +9,8 @@ and plenty of headroom for additions.
 
 All integer values should be interpreted as unsigned 64-bit integers, with the
 exception of the validator's commission rate, which is a `u16` specified in
-terms of basis points. All integer values, with the exception of the
+terms of basis points (one one-hundredth of a percent, or in other words, an
+implicit denominator of $10^{4}$). All integer values, with the exception of the
 validator's commission rate, have an implicit denominator of $10^8$. 
 
 Throughout this spec *representations* are referred to as $\mathtt x$, where
@@ -29,15 +30,15 @@ number or product of fixed point numbers with 8 digits fits well within 64
 bits.
 
 
-## Table of Contents
+### Summary of Notation
 
 * $\mathtt r_{e}$: the fixed-point representation of the base rate at epoch $e$.
-* $\mathtt \psi(e)$: the fixed-point representation of the base exchange rate at epoch $e$.
-* $s_{i, e}$: the $10^4$ denominated fixed-point representation of the funding rate of the validator's funding stream at index $i$ and epoch $e$.
-* $c_{v,e}$: the sum of the validator's commission rates, which are specified as a fixed point integer with an implicit $10^4$ denominator.
+* $\mathtt {psi}(e)$: the fixed-point representation of the base exchange rate at epoch $e$.
+* $s_{i, e}$: the funding rate of the validator's funding stream at index $i$ and epoch $e$, in basis points.
+* $c_{v,e}$: the sum of the validator's commission rates, in basis points.
 * $\mathtt r_{v,e}$: the fixed-point representation of the validator-specific reward rate for validator $v$ at epoch $e$.
-* $\mathtt \psi_v(e)$: the fixed-point representation of the validator-specific exchange rate for validator $v$ at epoch $e$.
-* $\mathtt \theta_v(e)$: the fixed-point representation of the validator's voting power adjustment function for validator $v$ at epoch $e$.
+* $\mathtt {psi}_v(e)$: the fixed-point representation of the validator-specific exchange rate for validator $v$ at epoch $e$.
+* $\mathtt {theta}_v(e)$: the fixed-point representation of the validator's voting power adjustment function for validator $v$ at epoch $e$.
 
 
 ## Base Reward Rate
@@ -51,17 +52,13 @@ derived from the block header.
 
 The base exchange rate, $\psi(e)$, can be safely computed as follows:
 
-$$\mathtt \psi(e) = \left\lfloor \frac {\mathtt \psi(e-1) (10^8 + \mathtt r_e)} {10^8} \right\rfloor$$
+$$\mathtt {psi}(e) = \left\lfloor \frac {\mathtt {psi}(e-1) \cdot (10^8 + \mathtt r_e)} {10^8} \right\rfloor$$
 
 ## Commission Rate from Funding Streams
 
-To compute the validator's commission rate from its set of funding streams, the following calculation can be performed:
-
-$$c_{v,e} = \sum_{0 \leq i < n} (s_{i,e})$$
-
-Where $s$ is the set of rates defined by the funding streams, $s_{i,e}$ being
-the ith rate at epoch $e$.
-
+To compute the validator's commission rate from its set of funding streams, compute
+$$c_{v,e} = \sum_{i} s_{i,e}$$
+where $s_{i, e}$ is the rate of validator $v$'s $i$-th funding stream at epoch $e$.
 
 ## Validator Reward Rate
 
@@ -71,13 +68,14 @@ $$\mathtt r_{v,e} = \left\lfloor \frac{(10^8 - (c_{v,e} \cdot 10^4))\mathtt r_e}
 
 ## Validator Exchange Rate
 
-To compute the validator's exchange rate, we adapt the formula from the staking
-specification for our fixed-point arithmetic scheme like so:
+To compute the validator's exchange rate, we use the same formula as for the
+base exchange rate, but substitute the validator-specific reward rate in place
+of the base reward rate:
 
-$$\mathtt \psi_v(e) = \left\lfloor \frac {\psi_v(e-1) (10^8 + \mathtt r_{v,e})}{10^8} \right\rfloor$$
+$$\mathtt {psi}_v(e) = \left\lfloor \frac {\mathtt {psi}_v(e-1) \cdot (10^8 + \mathtt r_{v,e})}{10^8} \right\rfloor$$
 
 ## Validator Voting Power Adjustment
 
-Finally, to compute the validator's voting power adjustment function, simply take:
+Finally, to compute the validator's voting power adjustment function, compute:
 
-$$\theta_v(e) = \lfloor \frac{\psi_v{e}*10^8}{\psi{e}} \rfloor$$
+$$\mathtt {theta}_v(e) = \left\lfloor \frac{\mathtt {psi}_v(e) 10^8}{\mathtt {psi}(e)} \right\rfloor$$

--- a/spec/stake/arithmetic.md
+++ b/spec/stake/arithmetic.md
@@ -4,13 +4,18 @@ To compute base reward rate, base exchange rate, validator-specific exchange
 rates, and total validator voting power, we need to carefully perform
 arithmetic to avoid issues with precision and rounding. We use explicitly
 specified fixed-precision arithmetic for this, with a precision of 8 digits.
-This allows outputs to fit in a u32.
+This allows outputs to fit in a u64, with all products fitting in the output
+and plenty of headroom for additions.
+
+All integer values should be interpreted as unsigned 64-bit integers, with the
+exception of the validator's commission rate, which is a `u16` specified in
+terms of basis points.
 
 ## Base Reward Rate
 
 The base reward is an input to the protocol, and the exact details of how this
 base rate $r_{e}$ is determined is not yet decided. For now, we can assume it is
-derived from the block header. $r_{e}$ is a fixed-precision `u32` integer with
+derived from the block header. $r_{e}$ is a fixed-precision `u64` integer with
 8 digits of precision.
 
 

--- a/spec/stake/arithmetic.md
+++ b/spec/stake/arithmetic.md
@@ -1,0 +1,54 @@
+# Fixed-Point Arithmetic for Rate Computation
+
+To compute base reward rate, base exchange rate, validator-specific exchange
+rates, and total validator voting power, we need to carefully perform
+arithmetic to avoid issues with precision and rounding. We use explicitly
+specified fixed-precision arithmetic for this, with a precision of 8 digits.
+This allows outputs to fit in a u32.
+
+## Base Reward Rate
+
+The base reward is an input to the protocol, and the exact details of how this
+base rate $r_{e}$ is determined is not yet decided. For now, we can assume it is
+derived from the block header. $r_{e}$ is a fixed-precision `u32` integer with
+8 digits of precision.
+
+
+## Base Exchange Rate
+
+The base exchange rate, $\psi(e)$, can be safely computed as follows:
+
+$$\psi(e) = \prod_{0 \leq i < e} \lfloor \frac{(1e8 + r_i)}{1e8} \rfloor $$
+
+
+## Commission Rate from Funding Streams
+
+To compute the validator's commission rate from its set of funding streams, the following calculation can be performed:
+
+$$c_{v,e} = \sum_{0 \leq i < n} (s_{i,e})$$
+
+Where $s$ is the set of rates defined by the funding streams, $s_{i,e}$ being
+the ith rate at epoch $e$.  $s_i$ should be a fixed-precision `u16` integer
+type, specified in terms of [basis
+points](https://en.wikipedia.org/wiki/Basis_point). The resulting $c_{v,e}$ is
+defined in terms of basis points (i.e., four digits of precision). 
+
+
+## Validator Reward Rate
+
+To compute the validator's base reward rate, we compute the following:
+
+$$r_{v,e} = \lfloor \frac{(1e8 - (c_{v,e}*1e4))r_e}{1e8} \rfloor$$
+
+## Validator Exchange Rate
+
+To compute the validator's exchange rate, we adapt the formula from the staking
+specification for our fixed-point arithmetic scheme like so:
+
+$$\psi_v(e) = \prod_{0 \leq i < e} \lfloor \frac{(1e8 + r_{v,i})}{1e8} \rfloor$$
+
+## Validator Voting Power Adjustment
+
+Finally, to compute the validator's voting power adjustment function, simply take:
+
+$$\theta_v(e) = \lfloor \frac{\psi_v{e}*1e8}{\psi{e}} \rfloor$$

--- a/spec/stake/arithmetic.md
+++ b/spec/stake/arithmetic.md
@@ -23,8 +23,7 @@ derived from the block header. $r_{e}$ is a fixed-precision `u64` integer with
 
 The base exchange rate, $\psi(e)$, can be safely computed as follows:
 
-$$\psi(e) = \prod_{0 \leq i < e} \lfloor \frac{(1e8 + r_i)}{1e8} \rfloor $$
-
+$$\psi(e) = \left\lfloor \frac {\psi(e-1) (10^8 + r_e)} {10^8} \right\rfloor$$
 
 ## Commission Rate from Funding Streams
 
@@ -50,7 +49,7 @@ $$r_{v,e} = \lfloor \frac{(1e8 - (c_{v,e}*1e4))r_e}{1e8} \rfloor$$
 To compute the validator's exchange rate, we adapt the formula from the staking
 specification for our fixed-point arithmetic scheme like so:
 
-$$\psi_v(e) = \prod_{0 \leq i < e} \lfloor \frac{(1e8 + r_{v,i})}{1e8} \rfloor$$
+$$\psi_v(e) = \left\lfloor \frac {\psi_v(e-1) (10^8 + r_{v,i})}{10^8} \right\rfloor$$
 
 ## Validator Voting Power Adjustment
 

--- a/spec/stake/tokens.md
+++ b/spec/stake/tokens.md
@@ -29,9 +29,10 @@ and unbonded stake, increasing when there is relatively less bonded stake and
 decreasing when there is relatively more.  This formula should be decided and
 adjusted by governance.
 
-Each validator declares a commission percentage $c_{v,e} \in [0,1]$, also
-indexed by epoch, which is subtracted from the base reward rate to get a
-validator-specific reward rate $$r_{v,e} = (1 - c_{v,e})r_e.$$
+Each validator declares a set of funding streams, which comprise both the
+destinations of their commission and the total commission rate $c_{v,e} \in
+[0,1]$. $c{v,e}$ is subtracted from the base reward rate to get a
+validator-specific reward rate $$r_{v,e} = (1 - c_{v,e})r_e.$$.
 
 The base exchange rate between `PEN` and `dPEN` is given by the function
 $$\psi(e) = \prod_{0 \leq i < e} (1 + r_i),$$ which measures the cumulative


### PR DESCRIPTION
this PR specifies fixed-point arithmetic for computing:

* base exchange rate
* commission rate
* validator reward rate
* validator exchange rate
* validator voting power adjustment

by adding an extra section to the Staking and Delegation part of the spec called "arithmetic".

Closes #271 

