### PR TITLE
crypto,stake: change delegation token denoms to use underscores

### DIFF
--- a/crypto/src/asset/registry.rs
+++ b/crypto/src/asset/registry.rs
@@ -200,23 +200,23 @@ pub static REGISTRY: Lazy<Registry> = Lazy::new(|| {
         )
         .add_asset(
             // TODO: this doesn't restrict the length of the bech32 encoding
-            "^udelegation-(?P<data>penumbravaloper1[a-zA-HJ-NP-Z0-9]+)$",
+            "^udelegation_(?P<data>penumbravaloper1[a-zA-HJ-NP-Z0-9]+)$",
             &[
-                "^delegation-(?P<data>penumbravaloper1[a-zA-HJ-NP-Z0-9]+)$",
-                "^mdelegation-(?P<data>penumbravaloper1[a-zA-HJ-NP-Z0-9]+)$",
+                "^delegation_(?P<data>penumbravaloper1[a-zA-HJ-NP-Z0-9]+)$",
+                "^mdelegation_(?P<data>penumbravaloper1[a-zA-HJ-NP-Z0-9]+)$",
             ],
             (|data: &str| {
                 assert!(!data.is_empty());
                 denom::Inner::new(
-                    format!("udelegation-{}", data),
+                    format!("udelegation_{}", data),
                     vec![
                         denom::Unit {
                             exponent: 6,
-                            denom: format!("delegation-{}", data),
+                            denom: format!("delegation_{}", data),
                         },
                         denom::Unit {
                             exponent: 3,
-                            denom: format!("mdelegation-{}", data),
+                            denom: format!("mdelegation_{}", data),
                         },
                     ],
                 )

--- a/stake/src/token.rs
+++ b/stake/src/token.rs
@@ -17,7 +17,7 @@ impl DelegationToken {
         // This format string needs to be in sync with the asset registry
         let base_denom = asset::REGISTRY
             .parse_base(&format!(
-                "udelegation-{}",
+                "udelegation_{}",
                 pk.to_bech32(VALIDATOR_IDENTITY_BECH32_PREFIX)
             ))
             .expect("base denom format is valid");
@@ -57,7 +57,7 @@ impl TryFrom<asset::BaseDenom> for DelegationToken {
 
         let (hrp, data, variant) = bech32::decode(
             // Note: this regex must be in sync with asset::REGISTRY
-            Regex::new("udelegation-(?P<data>penumbravaloper1[a-zA-HJ-NP-Z0-9]+)")
+            Regex::new("udelegation_(?P<data>penumbravaloper1[a-zA-HJ-NP-Z0-9]+)")
                 .expect("regex is valid")
                 .captures(&value.to_string())
                 .ok_or_else(|| {


### PR DESCRIPTION
This prevents the denomination from being awkwardly line-wrapped by software that interprets a - as an opportunity for wrapping.