### PR TITLE
Rename `BaseDenom`->`Denom`, `DisplayDenom`->`Unit`.

### DIFF
--- a/crypto/src/asset.rs
+++ b/crypto/src/asset.rs
@@ -6,7 +6,7 @@ mod id;
 mod registry;
 
 pub use cache::Cache;
-pub use denom::{BaseDenom, DisplayDenom};
+pub use denom::{Denom, Unit};
 pub use id::Id;
 pub use registry::{Registry, REGISTRY};
 
@@ -19,18 +19,18 @@ mod tests {
     #[test]
     fn test_registry_native_token() {
         // We should be able to use `parse_base` with the valid base denomination.
-        let base_denom = REGISTRY.parse_base("upenumbra").unwrap();
+        let base_denom = REGISTRY.parse_denom("upenumbra").unwrap();
         assert_eq!(format!("{}", base_denom), "upenumbra".to_string());
 
         // If we try to use `parse_base` with a display denomination, we should get `None`.
         let display_denoms = vec!["mpenumbra", "penumbra"];
         for display_denom in &display_denoms {
-            assert!(REGISTRY.parse_base(display_denom).is_none());
+            assert!(REGISTRY.parse_denom(display_denom).is_none());
         }
 
         // We should be able to use the display denominations with `parse_display` however.
         for display_denom in display_denoms {
-            let parsed_display_denom = REGISTRY.parse_display(display_denom);
+            let parsed_display_denom = REGISTRY.parse_unit(display_denom);
 
             assert_eq!(
                 format!("{}", parsed_display_denom.base()),
@@ -41,7 +41,7 @@ mod tests {
         }
 
         // The base denomination (upenumbra) can also be used for display purposes.
-        let parsed_display_denom = REGISTRY.parse_display("upenumbra");
+        let parsed_display_denom = REGISTRY.parse_unit("upenumbra");
         assert_eq!(
             format!("{}", parsed_display_denom.base()),
             "upenumbra".to_string()
@@ -51,23 +51,23 @@ mod tests {
     #[test]
     fn test_displaydenom_format_value() {
         // with exponent 6, 1782000 formats to 1.782
-        let penumbra_display_denom = REGISTRY.parse_display("penumbra");
+        let penumbra_display_denom = REGISTRY.parse_unit("penumbra");
         assert_eq!(penumbra_display_denom.format_value(1782000), "1.782");
         assert_eq!(penumbra_display_denom.format_value(6700001), "6.700001");
         assert_eq!(penumbra_display_denom.format_value(1), "0.000001");
 
         // with exponent 3, 1782000 formats to 1782
-        let mpenumbra_display_denom = REGISTRY.parse_display("mpenumbra");
+        let mpenumbra_display_denom = REGISTRY.parse_unit("mpenumbra");
         assert_eq!(mpenumbra_display_denom.format_value(1782000), "1782");
 
         // with exponent 0, 1782000 formats to 1782000
-        let upenumbra_display_denom = REGISTRY.parse_display("upenumbra");
+        let upenumbra_display_denom = REGISTRY.parse_unit("upenumbra");
         assert_eq!(upenumbra_display_denom.format_value(1782000), "1782000");
     }
 
     #[test]
     fn best_unit_for() {
-        let base_denom = REGISTRY.parse_base("upenumbra").unwrap();
+        let base_denom = REGISTRY.parse_denom("upenumbra").unwrap();
 
         assert_eq!(base_denom.best_unit_for(0).to_string(), "upenumbra");
         assert_eq!(base_denom.best_unit_for(999).to_string(), "upenumbra");
@@ -78,7 +78,7 @@ mod tests {
 
     #[test]
     fn test_displaydenom_parse_value() {
-        let penumbra_display_denom = REGISTRY.parse_display("penumbra");
+        let penumbra_display_denom = REGISTRY.parse_unit("penumbra");
         assert!(penumbra_display_denom.parse_value("1.2.3").is_err());
 
         assert_eq!(
@@ -90,14 +90,14 @@ mod tests {
             6700001
         );
 
-        let mpenumbra_display_denom = REGISTRY.parse_display("mpenumbra");
+        let mpenumbra_display_denom = REGISTRY.parse_unit("mpenumbra");
         assert_eq!(
             mpenumbra_display_denom.parse_value("1782").unwrap(),
             1782000
         );
         assert!(mpenumbra_display_denom.parse_value("1782.0001").is_err());
 
-        let upenumbra_display_denom = REGISTRY.parse_display("upenumbra");
+        let upenumbra_display_denom = REGISTRY.parse_unit("upenumbra");
         assert_eq!(
             upenumbra_display_denom.parse_value("1782000").unwrap(),
             1782000
@@ -108,7 +108,7 @@ mod tests {
     fn test_registry_fallthrough() {
         // We should be able to use `parse_base` with a base denomination for assets
         // not included in the hardcoded registry.
-        let base_denom = REGISTRY.parse_base("cube").unwrap();
+        let base_denom = REGISTRY.parse_denom("cube").unwrap();
         assert_eq!(format!("{}", base_denom), "cube".to_string());
     }
 
@@ -117,12 +117,12 @@ mod tests {
         fn displaydenom_parsing_formatting_roundtrip(
             v: u32
         ) {
-            let penumbra_display_denom = REGISTRY.parse_display("penumbra");
+            let penumbra_display_denom = REGISTRY.parse_unit("penumbra");
             let formatted = penumbra_display_denom.format_value(v.into());
             let parsed = penumbra_display_denom.parse_value(&formatted);
             assert_eq!(v, parsed.unwrap() as u32);
 
-            let mpenumbra_display_denom = REGISTRY.parse_display("mpenumbra");
+            let mpenumbra_display_denom = REGISTRY.parse_unit("mpenumbra");
             let formatted = mpenumbra_display_denom.format_value(v.into());
             let parsed = mpenumbra_display_denom.parse_value(&formatted);
             assert_eq!(v, parsed.unwrap() as u32);

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -447,7 +447,7 @@ mod tests {
 
         let value = Value {
             amount: 10,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let note = Note::generate(&mut rng, &dest, value);
         let esk = ka::Secret::new(&mut rng);

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -476,7 +476,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let v_blinding = Fr::rand(&mut rng);
         let note = Note::generate(&mut rng, &dest, value_to_send);
@@ -508,7 +508,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let v_blinding = Fr::rand(&mut rng);
         let note = Note::generate(&mut rng, &dest, value_to_send);
@@ -551,7 +551,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let v_blinding = Fr::rand(&mut rng);
         let note = Note::generate(&mut rng, &dest, value_to_send);
@@ -584,7 +584,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let v_blinding = Fr::rand(&mut rng);
         let note = Note::generate(&mut rng, &dest, value_to_send);
@@ -621,7 +621,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let v_blinding = Fr::rand(&mut rng);
         let note = Note::generate(&mut rng, &dest, value_to_send);
@@ -652,7 +652,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let v_blinding = Fr::rand(&mut rng);
 
@@ -700,7 +700,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let v_blinding = Fr::rand(&mut rng);
 
@@ -748,7 +748,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let v_blinding = Fr::rand(&mut rng);
         let note = Note::generate(&mut rng, &sender, value_to_send);
@@ -795,7 +795,7 @@ mod tests {
 
         let value_to_send = Value {
             amount: 10,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let v_blinding = Fr::rand(&mut rng);
         let note = Note::generate(&mut rng, &sender, value_to_send);

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -182,7 +182,7 @@ impl Transaction {
         // Add fee into binding verification key computation.
         let fee_value = Value {
             amount: self.transaction_body.fee.0,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let fee_v_blinding = Fr::zero();
         let fee_value_commitment = fee_value.commit(fee_v_blinding);
@@ -315,7 +315,7 @@ mod tests {
                 &dest,
                 Value {
                     amount: 10,
-                    asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+                    asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
                 },
                 MemoPlaintext::default(),
                 ovk_sender,

--- a/crypto/src/transaction/builder.rs
+++ b/crypto/src/transaction/builder.rs
@@ -143,7 +143,7 @@ impl Builder {
     ///
     /// Note that we're using the lower case `pen` in the code.
     pub fn set_fee(mut self, fee: u64) -> Self {
-        let asset_id = asset::REGISTRY.parse_base("upenumbra").unwrap().id();
+        let asset_id = asset::REGISTRY.parse_denom("upenumbra").unwrap().id();
         let fee_value = Value {
             amount: fee,
             asset_id: asset_id.clone(),

--- a/crypto/src/value.rs
+++ b/crypto/src/value.rs
@@ -73,7 +73,7 @@ impl FromStr for Value {
             let numeric_str = captures.get(1).expect("matched regex").as_str();
             let denom_str = captures.get(2).expect("matched regex").as_str();
 
-            let display_denom = asset::REGISTRY.parse_display(denom_str);
+            let display_denom = asset::REGISTRY.parse_unit(denom_str);
             let amount = display_denom.parse_value(numeric_str)?;
             let asset_id = display_denom.base().id();
 
@@ -143,9 +143,9 @@ mod tests {
     fn sum_value_commitments() {
         use ark_ff::Field;
 
-        let pen_denom = asset::REGISTRY.parse_base("upenumbra").unwrap();
+        let pen_denom = asset::REGISTRY.parse_denom("upenumbra").unwrap();
         let atom_denom = asset::REGISTRY
-            .parse_base("HubPort/HubChannel/uatom")
+            .parse_denom("HubPort/HubChannel/uatom")
             .unwrap();
 
         let pen_id = asset::Id::from(pen_denom);
@@ -204,8 +204,8 @@ mod tests {
 
     #[test]
     fn value_parsing_happy() {
-        let upenumbra_base_denom = asset::REGISTRY.parse_base("upenumbra").unwrap();
-        let nala_base_denom = asset::REGISTRY.parse_base("nala").unwrap();
+        let upenumbra_base_denom = asset::REGISTRY.parse_denom("upenumbra").unwrap();
+        let nala_base_denom = asset::REGISTRY.parse_denom("nala").unwrap();
         let cache = [upenumbra_base_denom.clone(), nala_base_denom.clone()]
             .into_iter()
             .collect::<asset::Cache>();
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn try_format_picks_best_unit() {
-        let upenumbra_base_denom = asset::REGISTRY.parse_base("upenumbra").unwrap();
+        let upenumbra_base_denom = asset::REGISTRY.parse_denom("upenumbra").unwrap();
         let cache = [upenumbra_base_denom.clone()]
             .into_iter()
             .collect::<asset::Cache>();

--- a/pcli/src/fetch.rs
+++ b/pcli/src/fetch.rs
@@ -15,7 +15,7 @@ pub async fn assets(state: &mut ClientStateFile, wallet_uri: String) -> Result<(
     while let Some(asset) = stream.message().await? {
         state.asset_cache_mut().extend(std::iter::once(
             asset::REGISTRY
-                .parse_base(&asset.asset_denom)
+                .parse_denom(&asset.asset_denom)
                 .ok_or_else(|| {
                     anyhow::anyhow!("invalid asset denomination: {}", asset.asset_denom)
                 })?,

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use comfy_table::{presets, Table};
 use directories::ProjectDirs;
 use penumbra_crypto::{
-    asset::{self, BaseDenom},
+    asset::{self, Denom},
     keys::SpendSeed,
     Value, CURRENT_CHAIN_ID,
 };
@@ -216,7 +216,7 @@ async fn main() -> Result<()> {
             // assumes that the notes are all of the same denomination, and it is called below only
             // in the places where they are.
             fn tally_format_notes<'a>(
-                denom: &BaseDenom,
+                denom: &Denom,
                 cache: &asset::Cache,
                 notes: impl IntoIterator<Item = UnspentNote<'a>>,
             ) -> (String, String, String) {

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -113,7 +113,7 @@ impl App {
             tx_builder.add_output(allocation.note().expect("genesis allocations are valid"));
             // Add all assets found in the genesis transaction to the asset registry
             let id = asset::REGISTRY
-                .parse_base(&allocation.denom)
+                .parse_denom(&allocation.denom)
                 .expect("genesis allocations must have valid denominations")
                 .id();
             tracing::debug!(?id, "registering asset id");

--- a/pd/src/genesis.rs
+++ b/pd/src/genesis.rs
@@ -37,7 +37,7 @@ impl Allocation {
             Value {
                 amount: self.amount,
                 asset_id: asset::REGISTRY
-                    .parse_base(&self.denom)
+                    .parse_denom(&self.denom)
                     .ok_or_else(|| anyhow::anyhow!("invalid denomination"))?
                     .id(),
             },

--- a/pd/src/verify.rs
+++ b/pd/src/verify.rs
@@ -207,11 +207,11 @@ mod tests {
 
         let output_value = Value {
             amount: 10,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let spend_value = Value {
             amount: 20,
-            asset_id: asset::REGISTRY.parse_base("upenumbra").unwrap().id(),
+            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         // The note was previously sent to the sender.
         let note = Note::from_parts(

--- a/stake/src/epoch.rs
+++ b/stake/src/epoch.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Error};
-
 use tendermint::block;
 
 /// Epoch represents a given epoch for Penumbra and is used

--- a/stake/src/token.rs
+++ b/stake/src/token.rs
@@ -9,14 +9,14 @@ use crate::VALIDATOR_IDENTITY_BECH32_PREFIX;
 /// Delegation tokens represent a share of a particular validator's delegation pool.
 pub struct DelegationToken {
     validator_pubkey: PublicKey,
-    base_denom: asset::BaseDenom,
+    base_denom: asset::Denom,
 }
 
 impl DelegationToken {
     pub fn new(pk: PublicKey) -> Self {
         // This format string needs to be in sync with the asset registry
         let base_denom = asset::REGISTRY
-            .parse_base(&format!(
+            .parse_denom(&format!(
                 "udelegation_{}",
                 pk.to_bech32(VALIDATOR_IDENTITY_BECH32_PREFIX)
             ))
@@ -28,12 +28,12 @@ impl DelegationToken {
     }
 
     /// Get the base denomination for this delegation token.
-    pub fn base_denom(&self) -> asset::BaseDenom {
+    pub fn base_denom(&self) -> asset::Denom {
         self.base_denom.clone()
     }
 
     /// Get the default display denomination for this delegation token.
-    pub fn default_unit(&self) -> asset::DisplayDenom {
+    pub fn default_unit(&self) -> asset::Unit {
         self.base_denom.default_unit()
     }
 
@@ -48,9 +48,9 @@ impl DelegationToken {
     }
 }
 
-impl TryFrom<asset::BaseDenom> for DelegationToken {
+impl TryFrom<asset::Denom> for DelegationToken {
     type Error = anyhow::Error;
-    fn try_from(value: asset::BaseDenom) -> Result<Self, Self::Error> {
+    fn try_from(value: asset::Denom) -> Result<Self, Self::Error> {
         // Almost all of this code is devoted to parsing Bech32 in the
         // tendermint-specific way, perhaps we could upstream a Bech32 decoding
         // function to tendermint-rs
@@ -103,7 +103,7 @@ impl FromStr for DelegationToken {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         asset::REGISTRY
-            .parse_base(s)
+            .parse_denom(s)
             .ok_or_else(|| anyhow::anyhow!("could not parse {} as base denomination", s))?
             .try_into()
     }

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::Context;
 use penumbra_crypto::{
-    asset::{self, BaseDenom},
+    asset::{self, Denom},
     memo,
     merkle::{Frontier, NoteCommitmentTree, Tree, TreeExt},
     note, Address, FieldExt, Note, Nullifier, Transaction, Value, CURRENT_CHAIN_ID,
@@ -126,7 +126,7 @@ impl ClientState {
         &self,
         rng: &mut R,
         amount: u64,
-        denom: BaseDenom,
+        denom: Denom,
         source_address: Option<u64>,
     ) -> Result<Vec<&Note>, anyhow::Error> {
         let mut notes_by_address = self
@@ -194,7 +194,7 @@ impl ClientState {
             .set_fee(fee)
             .set_chain_id(CURRENT_CHAIN_ID.to_string());
 
-        let mut output_value = HashMap::<BaseDenom, u64>::new();
+        let mut output_value = HashMap::<Denom, u64>::new();
         for Value { amount, asset_id } in values {
             let denom = self
                 .asset_cache()
@@ -224,7 +224,7 @@ impl ClientState {
         let mut value_to_spend = output_value;
         if fee > 0 {
             *value_to_spend
-                .entry(asset::REGISTRY.parse_base("upenumbra").unwrap())
+                .entry(asset::REGISTRY.parse_denom("upenumbra").unwrap())
                 .or_default() += fee;
         }
 
@@ -313,7 +313,7 @@ impl ClientState {
     ///
     /// Notes are [`UnspentNote`]s, which describe whether the note is ready to spend, part of a
     /// pending output, or part of pending change expected to be received.
-    pub fn unspent_notes(&self) -> impl Iterator<Item = (u64, BaseDenom, UnspentNote)> + '_ {
+    pub fn unspent_notes(&self) -> impl Iterator<Item = (u64, Denom, UnspentNote)> + '_ {
         self.unspent_set
             .values()
             .map(UnspentNote::Ready)
@@ -350,7 +350,7 @@ impl ClientState {
     /// Returns unspent notes, grouped by address index and then by denomination.
     pub fn unspent_notes_by_address_and_denom(
         &self,
-    ) -> BTreeMap<u64, HashMap<BaseDenom, Vec<UnspentNote>>> {
+    ) -> BTreeMap<u64, HashMap<Denom, Vec<UnspentNote>>> {
         let mut notemap = BTreeMap::default();
 
         for (index, denom, note) in self.unspent_notes() {
@@ -368,7 +368,7 @@ impl ClientState {
     /// Returns unspent notes, grouped by denomination and then by address index.
     pub fn unspent_notes_by_denom_and_address(
         &self,
-    ) -> HashMap<BaseDenom, BTreeMap<u64, Vec<UnspentNote>>> {
+    ) -> HashMap<Denom, BTreeMap<u64, Vec<UnspentNote>>> {
         let mut notemap = HashMap::default();
 
         for (index, denom, note) in self.unspent_notes() {


### PR DESCRIPTION
This terminology is clearer, per discussions with @redshiftzero @zbuc @plaidfinch.