### PR TITLE
Align pending balance display and stabilize asset printing order

### DIFF
--- a/crypto/src/asset/denom.rs
+++ b/crypto/src/asset/denom.rs
@@ -155,6 +155,18 @@ impl PartialEq for Denom {
 
 impl Eq for Denom {}
 
+impl PartialOrd for Denom {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.inner.base_denom.partial_cmp(&other.inner.base_denom)
+    }
+}
+
+impl Ord for Denom {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.inner.base_denom.cmp(&other.inner.base_denom)
+    }
+}
+
 impl Debug for Denom {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.inner.base_denom.as_str())

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -350,13 +350,13 @@ impl ClientState {
     /// Returns unspent notes, grouped by address index and then by denomination.
     pub fn unspent_notes_by_address_and_denom(
         &self,
-    ) -> BTreeMap<u64, HashMap<Denom, Vec<UnspentNote>>> {
+    ) -> BTreeMap<u64, BTreeMap<Denom, Vec<UnspentNote>>> {
         let mut notemap = BTreeMap::default();
 
         for (index, denom, note) in self.unspent_notes() {
             notemap
                 .entry(index)
-                .or_insert_with(HashMap::default)
+                .or_insert_with(BTreeMap::default)
                 .entry(denom)
                 .or_insert_with(Vec::default)
                 .push(note.clone());
@@ -368,8 +368,8 @@ impl ClientState {
     /// Returns unspent notes, grouped by denomination and then by address index.
     pub fn unspent_notes_by_denom_and_address(
         &self,
-    ) -> HashMap<Denom, BTreeMap<u64, Vec<UnspentNote>>> {
-        let mut notemap = HashMap::default();
+    ) -> BTreeMap<Denom, BTreeMap<u64, Vec<UnspentNote>>> {
+        let mut notemap = BTreeMap::default();
 
         for (index, denom, note) in self.unspent_notes() {
             notemap


### PR DESCRIPTION
This implements two changes to make the output of `pcli balance` nicer:
- Assets are now printed in a stable order (determined by comparing their base denominations as strings)
- The pending change and pending spend columns are now aligned as columns for easier reading