### PR TITLE
pd: temporarily increase buffer size to work around probable tower-abci bug

### DIFF
--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> anyhow::Result<()> {
 
             let abci_app = App::new(state.clone()).await.unwrap();
 
-            let (consensus, mempool, snapshot, info) = tower_abci::split::service(abci_app, 1);
+            let (consensus, mempool, snapshot, info) = tower_abci::split::service(abci_app, 10);
 
             let abci_server = tokio::spawn(
                 tower_abci::Server::builder()


### PR DESCRIPTION
The `tower-abci` `Server` state machine's event loop selects over readiness of
either the stream of incoming requests, or the stream of responses to those
requests.  Once it receives a request, it checks which service should process
the request, and *then* waits for that service to become ready.  While it
waits, it doesn't drive the response futures to completion.

Increasing the buffer size adds more slack to the system and seems to make the
problem go away for now.