### PR TITLE
Change address version mismatch error to be more correct

### DIFF
--- a/crypto/src/address.rs
+++ b/crypto/src/address.rs
@@ -120,7 +120,7 @@ impl std::str::FromStr for Address {
         }
 
         if hrp != format!("penumbrav{}t", CURRENT_ADDRESS_VERSION) {
-            return Err(anyhow!("network ID no longer supported: {}", hrp));
+            return Err(anyhow!("address format no longer supported: {}", hrp));
         }
 
         let diversifier = Diversifier(diversifier_bytes);


### PR DESCRIPTION
Instead of referring to an address version as a "network ID", refer to it as an "address format"