### PR TITLE
pcli: fix bug introduced in refactoring

### DIFF
--- a/pcli/src/command/balance.rs
+++ b/pcli/src/command/balance.rs
@@ -68,7 +68,7 @@ fn tally_format_notes<'a>(
 
 impl BalanceCmd {
     pub fn needs_sync(&self) -> bool {
-        self.offline
+        !self.offline
     }
 
     pub fn exec(&self, state: &ClientState) -> Result<()> {


### PR DESCRIPTION
In #319 I split up the `pcli` command implementations, but reversed the meaning
of the `balance` needs-sync check.