### PR TITLE
Add protos for staking messages, set up code infrastructure for staking implementation

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,7 +15,7 @@ penumbra-proto = { path = "../proto/" }
 ark-ff = { git = "https://github.com/penumbra-zone/algebra", branch = "ours" }
 ark-serialize = { git = "https://github.com/penumbra-zone/algebra", branch = "ours" }
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
-decaf377-rdsa = { git = "https://github.com/penumbra-zone/decaf377-rdsa" }
+decaf377-rdsa = { version = "0.4", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 incrementalmerkletree = { git = "https://github.com/penumbra-zone/incrementalmerkletree" }
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377" }
 

--- a/crypto/src/asset/registry.rs
+++ b/crypto/src/asset/registry.rs
@@ -191,11 +191,13 @@ pub static REGISTRY: Lazy<Registry> = Lazy::new(|| {
             }) as for<'r> fn(&'r str) -> _,
         )
         .add_asset(
+            // Note: this regex must be in sync with DelegationToken::try_from
+            // and VALIDATOR_IDENTITY_BECH32_PREFIX in the penumbra-stake crate
             // TODO: this doesn't restrict the length of the bech32 encoding
-            "^udelegation_(?P<data>penumbravaloper1[a-zA-HJ-NP-Z0-9]+)$",
+            "^udelegation_(?P<data>penumbravalid1[a-zA-HJ-NP-Z0-9]+)$",
             &[
-                "^delegation_(?P<data>penumbravaloper1[a-zA-HJ-NP-Z0-9]+)$",
-                "^mdelegation_(?P<data>penumbravaloper1[a-zA-HJ-NP-Z0-9]+)$",
+                "^delegation_(?P<data>penumbravalid1[a-zA-HJ-NP-Z0-9]+)$",
+                "^mdelegation_(?P<data>penumbravalid1[a-zA-HJ-NP-Z0-9]+)$",
             ],
             (|data: &str| {
                 assert!(!data.is_empty());

--- a/pd/migrations/20211216025603_init.sql
+++ b/pd/migrations/20211216025603_init.sql
@@ -1,4 +1,3 @@
--- Add migration script here
 CREATE TABLE IF NOT EXISTS blobs (
     id varchar(64) PRIMARY KEY,
     data bytea NOT NULL
@@ -33,24 +32,29 @@ CREATE INDEX ON notes (position);
 CREATE INDEX ON notes (height);
 
 CREATE TABLE IF NOT EXISTS validators (
-    tm_pubkey bytea NOT NULL PRIMARY KEY
+    identity_key bytea NOT NULL PRIMARY KEY,
+    consensus_key bytea NOT NULL,
+    sequence_number bigint NOT NULL,
+    validator_data bytea NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS validator_fundingstreams (
-    tm_pubkey bytea NOT NULL,
+    identity_key bytea NOT NULL REFERENCES validators (identity_key),
     address varchar NOT NULL,
     rate_bps bigint NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS base_rates (
     epoch bigint PRIMARY KEY,
-    base_rate bigint NOT NULL
+    base_reward_rate bigint NOT NULL,
+    base_exchange_rate bigint NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS validator_rates (
+    identity_key bytea NOT NULL REFERENCES validators (identity_key),
     epoch bigint NOT NULL,
-    validator_pubkey bytea NOT NULL REFERENCES validators (tm_pubkey),
-    validator_rate bigint NOT NULL,
     voting_power bigint NOT NULL,
-    PRIMARY KEY(epoch, validator_pubkey)
+    validator_reward_rate bigint NOT NULL,
+    validator_exchange_rate bigint NOT NULL,
+    PRIMARY KEY(epoch, identity_key)
 );

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -1,19 +1,5 @@
 {
   "db": "PostgreSQL",
-  "0bb9011725723ccf9a5d2aa2967457b72579c90f9aa594d232528596c7cf1bd9": {
-    "query": "INSERT INTO validator_fundingstreams (tm_pubkey, address, rate_bps) VALUES ($1, $2, $3)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Varchar",
-          "Int8"
-        ]
-      },
-      "nullable": []
-    }
-  },
   "0c6a89db4de3642914e3cddf6e08a042eac9b140a03118943170433527ef5cc3": {
     "query": "INSERT INTO nullifiers VALUES ($1, $2)",
     "describe": {
@@ -92,29 +78,13 @@
       ]
     }
   },
-  "367663d8c6b6b179fc02c6a6edd8cf3dcda1a0d39fa231d320e72373e781d9a9": {
-    "query": " INSERT INTO validator_rates ( epoch, validator_pubkey, validator_rate, voting_power ) VALUES ($1, $2, $3, $4)",
+  "37dc2448272e62b1af649a73ae39b47ca5ec6ab625a9ff26d22c02a36b6be7ac": {
+    "query": "INSERT INTO base_rates (epoch, base_reward_rate, base_exchange_rate) VALUES (0, 0, $1)",
     "describe": {
       "columns": [],
       "parameters": {
         "Left": [
-          "Int8",
-          "Bytea",
-          "Int8",
           "Int8"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "3cbb441b10f4a068c16dd3a40accd689be26f2a6619b363fd966ee10e740f07b": {
-    "query": " INSERT INTO assets ( asset_id, denom) VALUES ($1, $2)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Varchar"
         ]
       },
       "nullable": []
@@ -127,6 +97,66 @@
       "parameters": {
         "Left": [
           "Bytea"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "5ea1dce201278be84f22c7c6baf15803c1cc44a533cfe21a09b4b625d3e72e99": {
+    "query": "SELECT identity_key, epoch, voting_power, validator_reward_rate, validator_exchange_rate\n            FROM validator_rates\n            WHERE epoch = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "identity_key",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 1,
+          "name": "epoch",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 2,
+          "name": "voting_power",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 3,
+          "name": "validator_reward_rate",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 4,
+          "name": "validator_exchange_rate",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "65b35b1ef216fc7b1b4d31d08c582e1160024199d91e56fd2a2aaa462006bba1": {
+    "query": "INSERT INTO validator_rates (\n                    identity_key,\n                    epoch,\n                    voting_power,\n                    validator_reward_rate,\n                    validator_exchange_rate\n                ) VALUES ($1, $2, $3, $4, $5)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Int8",
+          "Int8",
+          "Int8",
+          "Int8"
         ]
       },
       "nullable": []
@@ -162,38 +192,6 @@
         ]
       },
       "nullable": [
-        false
-      ]
-    }
-  },
-  "6cf3b0bf9cb07f0e9f7c4ccd37fff8ef360713779a9cc39d01f22891e234c515": {
-    "query": "SELECT tm_pubkey, address, rate_bps FROM validator_fundingstreams WHERE tm_pubkey = $1",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "tm_pubkey",
-          "type_info": "Bytea"
-        },
-        {
-          "ordinal": 1,
-          "name": "address",
-          "type_info": "Varchar"
-        },
-        {
-          "ordinal": 2,
-          "name": "rate_bps",
-          "type_info": "Int8"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Bytea"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
         false
       ]
     }
@@ -245,6 +243,21 @@
       ]
     }
   },
+  "7c1906126e67c3875f9eec2fc44ad472a9334df45095cf0d6d4c9a317f711840": {
+    "query": "INSERT INTO validators (\n                    identity_key, \n                    consensus_key, \n                    sequence_number, \n                    validator_data\n                ) VALUES ($1, $2, $3, $4)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Bytea",
+          "Int8",
+          "Bytea"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "8195450f9f1cedf05eebd974adbdc42dc70a8e2abb7753d7b02cba03786bee0d": {
     "query": "SELECT denom, asset_id FROM assets",
     "describe": {
@@ -269,26 +282,34 @@
       ]
     }
   },
-  "830e68c832d63748440f231cda5c02988e01b81954829b7de1b6197de8d3ebd2": {
-    "query": "select tm_pubkey, validator_rates.voting_power FROM validators LEFT JOIN validator_rates ON validator_rates.validator_pubkey = validators.tm_pubkey;",
+  "8c67c25c88aef9780fb468fde0efc219247511c20f13c9e1fc0545fddf7d485c": {
+    "query": "SELECT epoch, base_reward_rate, base_exchange_rate\n            FROM base_rates\n            WHERE epoch = $1",
     "describe": {
       "columns": [
         {
           "ordinal": 0,
-          "name": "tm_pubkey",
-          "type_info": "Bytea"
+          "name": "epoch",
+          "type_info": "Int8"
         },
         {
           "ordinal": 1,
-          "name": "voting_power",
+          "name": "base_reward_rate",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 2,
+          "name": "base_exchange_rate",
           "type_info": "Int8"
         }
       ],
       "parameters": {
-        "Left": []
+        "Left": [
+          "Int8"
+        ]
       },
       "nullable": [
-        true,
+        false,
+        false,
         false
       ]
     }
@@ -321,6 +342,36 @@
         false,
         false
       ]
+    }
+  },
+  "9a68a44f549c88ede7f9d70641f62dd537a4826694c2a50875c6ba8c651351e0": {
+    "query": "INSERT INTO validator_rates VALUES ($1, $2, $3, $4, $5)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Int8",
+          "Int8",
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "9ab28d6b1cdbe8fd02e4382ab9cf5a2fa2914aaf460020977aeadfb8818c70af": {
+    "query": "INSERT INTO base_rates VALUES ($1, $2, $3)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": []
     }
   },
   "aed57af72fe55a40c7fe24c06ff908821372686522783850b2db72fbed2aa9e4": {
@@ -400,28 +451,28 @@
       ]
     }
   },
-  "eef7c74c2338d6cfda95c4c8b3556c4ce5e257f90c261bedb8f337f7c7276b09": {
-    "query": "INSERT INTO validator_rates (epoch, validator_pubkey, validator_rate, voting_power) VALUES ($1, $2, $3, $4)",
+  "dd42bddc81dc82581542307fb7f388cf539ae7b9dc506464bb357d1a78b8056a": {
+    "query": "INSERT INTO validator_fundingstreams (\n                        identity_key, \n                        address, \n                        rate_bps\n                    ) VALUES ($1, $2, $3)",
     "describe": {
       "columns": [],
       "parameters": {
         "Left": [
-          "Int8",
           "Bytea",
-          "Int8",
+          "Varchar",
           "Int8"
         ]
       },
       "nullable": []
     }
   },
-  "fc128bcefa54c9a85bb3595c20fe253348135b4473dab9fee5847c7465a6d8f7": {
-    "query": "INSERT INTO validators (tm_pubkey) VALUES ($1)",
+  "f02fb84c77d1d5a7418debac7291c8524d6e4d6559596ff69217d629a1c7b1c2": {
+    "query": "INSERT INTO assets (asset_id, denom) VALUES ($1, $2)",
     "describe": {
       "columns": [],
       "parameters": {
         "Left": [
-          "Bytea"
+          "Bytea",
+          "Varchar"
         ]
       },
       "nullable": []

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -386,7 +386,7 @@ impl App {
                 };
 
                 let next_rates = current_rates
-                    .iter()
+                    .into_iter()
                     .map(|current_rate| {
                         // TODO (hdevalence) use funding streams here, this ignores funding streams
                         let validator_reward_rate = base_reward_rate; // (minus fs term)

--- a/pd/src/genesis.rs
+++ b/pd/src/genesis.rs
@@ -47,15 +47,21 @@ impl Allocation {
     }
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ValidatorPower {
+    pub validator: Validator,
+    pub power: tendermint::vote::Power,
+}
+
 /// The application state at genesis.
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct AppState {
-    /// The initial token allocations.
-    pub allocations: Vec<Allocation>,
     /// The number of blocks in each epoch.
     pub epoch_duration: u64,
     /// The initial validator set.
-    pub validators: Vec<Validator>,
+    pub validators: Vec<ValidatorPower>,
+    /// The initial token allocations.
+    pub allocations: Vec<Allocation>,
 }
 
 impl Default for AppState {

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -155,6 +155,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Command::CreateGenesisTemplate => {
             use penumbra_crypto::keys::SpendKey;
+            use penumbra_stake::IdentityKey;
 
             // Use this to make up some addresses
             let sk = SpendKey::generate(OsRng);
@@ -191,7 +192,7 @@ async fn main() -> anyhow::Result<()> {
                 validators: vec![
                     genesis::ValidatorPower {
                         validator: Validator {
-                            identity_key: validator_id_vk,
+                            identity_key: IdentityKey(validator_id_vk),
                             consensus_key: validator_cons_pk,
                             name: "Testnet Validator (Change Me!)".to_string(),
                             website: "https://example.com".to_string(),

--- a/pd/src/sequential.rs
+++ b/pd/src/sequential.rs
@@ -21,7 +21,11 @@ pub struct Sequencer {
 }
 
 impl Sequencer {
-    /// Execute the given future.
+    /// Execute the given future on a new task.
+    ///
+    /// Spans attached to the future *returned* by `execute` do not propagate to
+    /// the executed future, so the input `fut` should be `.instrument`ed if
+    /// that's desired.
     ///
     /// This function must only be called after `self.poll_ready()` returns
     /// `Poll::Ready`.  After it is called, `self.poll_ready()` will not return
@@ -34,8 +38,6 @@ impl Sequencer {
         let (tx, rx) = oneshot::channel();
         self.waiting = true;
         self.completion.set(rx);
-
-        // TODO: (@hdevalence) how do we propagate spans here?
 
         async move {
             // Spawn a new task to ensure the future is driven to completion.

--- a/pd/src/sequential.rs
+++ b/pd/src/sequential.rs
@@ -35,6 +35,8 @@ impl Sequencer {
         self.waiting = true;
         self.completion.set(rx);
 
+        // TODO: (@hdevalence) how do we propagate spans here?
+
         async move {
             // Spawn a new task to ensure the future is driven to completion.
             // (depending on the future, it may not ever complete, but not for

--- a/pd/src/verify.rs
+++ b/pd/src/verify.rs
@@ -122,6 +122,7 @@ impl StatelessTransactionExt for Transaction {
 
                     spent_nullifiers.insert(spend.body.nullifier.clone());
                 }
+                _ => todo!("delegate transaction verification checks??"),
             }
         }
 
@@ -166,8 +167,8 @@ pub fn mark_genesis_as_verified(transaction: Transaction) -> VerifiedTransaction
                     },
                 );
             }
-            Action::Spend(_) => {
-                panic!("genesis transaction has no spends")
+            _ => {
+                panic!("genesis transaction only has outputs")
             }
         }
     }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -10,7 +10,6 @@ bytes = "1"
 prost = "0.9"
 tonic = "0.6"
 serde = { version = "1", features = ["derive"] }
-serde_with = { version = "1.11", features = ["hex"] }
 hex = "0.4"
 anyhow = "1.0"
 subtle-encoding = "0.5"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -14,6 +14,7 @@ serde_with = { version = "1.11", features = ["hex"] }
 hex = "0.4"
 anyhow = "1.0"
 subtle-encoding = "0.5"
+bech32 = "0.8"
 
 [build-dependencies]
 prost-build = "0.9"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "penumbra-proto"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,6 +9,11 @@ edition = "2018"
 bytes = "1"
 prost = "0.9"
 tonic = "0.6"
+serde = { version = "1", features = ["derive"] }
+serde_with = { version = "1.11", features = ["hex"] }
+hex = "0.4"
+anyhow = "1.0"
+subtle-encoding = "0.5"
 
 [build-dependencies]
 prost-build = "0.9"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -83,6 +83,8 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.stake.BaseRateData", SERIALIZE),
     (".penumbra.stake.IdentityKey", SERIALIZE),
     (".penumbra.stake.IdentityKey", SERDE_TRANSPARENT),
+    (".penumbra.stake.Delegate", SERIALIZE),
+    (".penumbra.stake.Undelegate", SERIALIZE),
 ];
 
 static FIELD_ATTRIBUTES: &[(&str, &str)] = &[

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -58,6 +58,9 @@ fn main() -> Result<()> {
 // static SERDE_AS: &str = r#"#[::serde_with::serde_as]"#;
 static SERIALIZE: &str = r#"#[derive(::serde::Deserialize, ::serde::Serialize)]"#;
 
+/// Serializes newtype structs as if the inner field were serialized on its own.
+static SERDE_TRANSPARENT: &str = r#"#[serde(transparent)]"#;
+
 // Requires SERDE_AS on the container
 // :(
 // error: expected non-macro attribute, found attribute macro `::serde_with::serde_as`
@@ -67,6 +70,8 @@ static SERIALIZE: &str = r#"#[derive(::serde::Deserialize, ::serde::Serialize)]"
 
 static AS_HEX: &str = r#"#[serde(with = "crate::serializers::hexstr")]"#;
 static AS_BASE64: &str = r#"#[serde(with = "crate::serializers::base64str")]"#;
+static AS_BECH32_IDENTITY_KEY: &str =
+    r#"#[serde(with = "crate::serializers::bech32str::validator_identity_key")]"#;
 
 static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     //(".penumbra.stake.Validator", SERDE_AS),
@@ -76,14 +81,14 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.stake.ValidatorDefinition", SERIALIZE),
     (".penumbra.stake.RateData", SERIALIZE),
     (".penumbra.stake.BaseRateData", SERIALIZE),
+    (".penumbra.stake.IdentityKey", SERIALIZE),
+    (".penumbra.stake.IdentityKey", SERDE_TRANSPARENT),
 ];
 
 static FIELD_ATTRIBUTES: &[(&str, &str)] = &[
-    // TODO: use bech32 here?
-    (".penumbra.stake.Validator.identity_key", AS_HEX),
     // Using base64 for the validator's consensus key means that
     // the format is the same as the Tendermint json config files.
     (".penumbra.stake.Validator.consensus_key", AS_BASE64),
     (".penumbra.stake.ValidatorDefinition.auth_sig", AS_HEX),
-    (".penumbra.stake.RateData.identity_key", AS_HEX),
+    (".penumbra.stake.IdentityKey.ik", AS_BECH32_IDENTITY_KEY),
 ];

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -27,7 +27,17 @@ fn main() -> Result<()> {
         ".penumbra.light_wallet.CompactBlock",
     ]);
 
+    for (path, attribute) in TYPE_ATTRIBUTES.iter() {
+        config.type_attribute(path, attribute);
+    }
+    for (path, attribute) in FIELD_ATTRIBUTES.iter() {
+        config.field_attribute(path, attribute);
+    }
+
     config.compile_protos(&["proto/transaction.proto"], &["proto/"])?;
+    config.compile_protos(&["proto/stake.proto"], &["proto/"])?;
+
+    // These should disappear, eventually.
     config.compile_protos(&["proto/transparent_proofs.proto"], &["proto/"])?;
     config.compile_protos(&["proto/sighash.proto"], &["proto/"])?;
 
@@ -40,3 +50,40 @@ fn main() -> Result<()> {
 
     Ok(())
 }
+
+// WARNING: any type attributes adding SERDE_AS **MUST** be placed **BEFORE**
+// SERIALIZE. Otherwise, serde_as is applied to the output of the derive macro
+// (unstable), rather than the other way around.
+// This is a moot point for now, since we can't use field attributes for macro reasons
+// static SERDE_AS: &str = r#"#[::serde_with::serde_as]"#;
+static SERIALIZE: &str = r#"#[derive(::serde::Deserialize, ::serde::Serialize)]"#;
+
+// Requires SERDE_AS on the container
+// :(
+// error: expected non-macro attribute, found attribute macro `::serde_with::serde_as`
+// use tendermint-rs approach instead?
+// https://github.com/penumbra-zone/tendermint-rs/blob/master/proto/src/serializers/bytes.rs#L4-L30
+// static AS_HEX: &str = r#"#[::serde_with::serde_as(as = "::serde_with::hex::Hex")]"#;
+
+static AS_HEX: &str = r#"#[serde(with = "crate::serializers::hexstr")]"#;
+static AS_BASE64: &str = r#"#[serde(with = "crate::serializers::base64str")]"#;
+
+static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
+    //(".penumbra.stake.Validator", SERDE_AS),
+    (".penumbra.stake.Validator", SERIALIZE),
+    (".penumbra.stake.FundingStream", SERIALIZE),
+    //(".penumbra.stake.ValidatorDefinition", SERDE_AS),
+    (".penumbra.stake.ValidatorDefinition", SERIALIZE),
+    (".penumbra.stake.RateData", SERIALIZE),
+    (".penumbra.stake.BaseRateData", SERIALIZE),
+];
+
+static FIELD_ATTRIBUTES: &[(&str, &str)] = &[
+    // TODO: use bech32 here?
+    (".penumbra.stake.Validator.identity_key", AS_HEX),
+    // Using base64 for the validator's consensus key means that
+    // the format is the same as the Tendermint json config files.
+    (".penumbra.stake.Validator.consensus_key", AS_BASE64),
+    (".penumbra.stake.ValidatorDefinition.auth_sig", AS_HEX),
+    (".penumbra.stake.RateData.identity_key", AS_HEX),
+];

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -51,22 +51,9 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-// WARNING: any type attributes adding SERDE_AS **MUST** be placed **BEFORE**
-// SERIALIZE. Otherwise, serde_as is applied to the output of the derive macro
-// (unstable), rather than the other way around.
-// This is a moot point for now, since we can't use field attributes for macro reasons
-// static SERDE_AS: &str = r#"#[::serde_with::serde_as]"#;
 static SERIALIZE: &str = r#"#[derive(::serde::Deserialize, ::serde::Serialize)]"#;
-
 /// Serializes newtype structs as if the inner field were serialized on its own.
 static SERDE_TRANSPARENT: &str = r#"#[serde(transparent)]"#;
-
-// Requires SERDE_AS on the container
-// :(
-// error: expected non-macro attribute, found attribute macro `::serde_with::serde_as`
-// use tendermint-rs approach instead?
-// https://github.com/penumbra-zone/tendermint-rs/blob/master/proto/src/serializers/bytes.rs#L4-L30
-// static AS_HEX: &str = r#"#[::serde_with::serde_as(as = "::serde_with::hex::Hex")]"#;
 
 static AS_HEX: &str = r#"#[serde(with = "crate::serializers::hexstr")]"#;
 static AS_BASE64: &str = r#"#[serde(with = "crate::serializers::base64str")]"#;
@@ -74,10 +61,8 @@ static AS_BECH32_IDENTITY_KEY: &str =
     r#"#[serde(with = "crate::serializers::bech32str::validator_identity_key")]"#;
 
 static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
-    //(".penumbra.stake.Validator", SERDE_AS),
     (".penumbra.stake.Validator", SERIALIZE),
     (".penumbra.stake.FundingStream", SERIALIZE),
-    //(".penumbra.stake.ValidatorDefinition", SERDE_AS),
     (".penumbra.stake.ValidatorDefinition", SERIALIZE),
     (".penumbra.stake.RateData", SERIALIZE),
     (".penumbra.stake.BaseRateData", SERIALIZE),

--- a/proto/proto/sighash.proto
+++ b/proto/proto/sighash.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package penumbra.sighash;
 
 import "transaction.proto";
+import "stake.proto";
 
 // The content of a transaction, except for authorization signatures, for use
 // as a sighash input.
@@ -26,5 +27,8 @@ message SigHashAction {
   oneof action {
     transaction.SpendBody spend = 1;
     transaction.Output output = 2;
+    stake.Delegate delegate = 3;
+    stake.Undelegate undelegate = 4;
+    stake.ValidatorDefinition validator_definition = 16;
   }
 }

--- a/proto/proto/stake.proto
+++ b/proto/proto/stake.proto
@@ -1,11 +1,16 @@
 syntax = "proto3";
 package penumbra.stake;
 
+// A validator's identity key (decaf377-rdsa spendauth verification key).
+message IdentityKey {
+  bytes ik = 1;
+}
+
 // Describes a validator's configuration data.
 message Validator {
-  // The validator's identity verification key (decaf377-rdsa spendauth)
-  bytes identity_key = 1;
-  // The validator's consensus verification key (Ed25519)
+  // The validator's identity verification key.
+  IdentityKey identity_key = 1;
+  // The validator's consensus pubkey for use in Tendermint (Ed25519).
   bytes consensus_key = 2;
   // The validator's (human-readable) name.
   string name = 3;
@@ -32,7 +37,7 @@ message FundingStream {
 
 // Describes the reward and exchange rates and voting power for a validator in some epoch.
 message RateData {
-  bytes identity_key = 1;
+  IdentityKey identity_key = 1;
   uint64 epoch_index = 2;
   uint64 voting_power = 3;
   uint64 validator_reward_rate = 4;
@@ -57,7 +62,7 @@ message ValidatorDefinition {
 // A transaction action delegating stake to a validator's delegation pool.
 message Delegate {
   // The identity key of the validator to delegate to.
-  bytes validator_identity = 1;
+  IdentityKey validator_identity = 1;
   // The index of the epoch in which this delegation was performed.
   // The delegation takes effect in the next epoch.
   uint64 epoch_index = 2;
@@ -69,7 +74,7 @@ message Delegate {
 // A transaction action undelegating stake from a validator's delegation pool.
 message Undelegate {
   // The identity key of the validator to undelegate from.
-  bytes validator_identity = 1;
+  IdentityKey validator_identity = 1;
   // The index of the epoch in which this undelegation was performed.
   uint64 epoch_index = 2;
   // The amount to undelegate, in units of unbonded stake.

--- a/proto/proto/stake.proto
+++ b/proto/proto/stake.proto
@@ -59,7 +59,7 @@ message ValidatorDefinition {
   bytes auth_sig = 2;
 }
 
-// A transaction action delegating stake to a validator's delegation pool.
+// A transaction action adding stake to a validator's delegation pool.
 message Delegate {
   // The identity key of the validator to delegate to.
   IdentityKey validator_identity = 1;
@@ -71,7 +71,7 @@ message Delegate {
   uint64 unbonded_amount = 3;
 }
 
-// A transaction action undelegating stake from a validator's delegation pool.
+// A transaction action withdrawing stake from a validator's delegation pool.
 message Undelegate {
   // The identity key of the validator to undelegate from.
   IdentityKey validator_identity = 1;

--- a/proto/proto/stake.proto
+++ b/proto/proto/stake.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+package penumbra.stake;
+
+// Describes a validator's configuration data.
+message Validator {
+  // The validator's identity verification key (decaf377-rdsa spendauth)
+  bytes identity_key = 1;
+  // The validator's consensus verification key (Ed25519)
+  bytes consensus_key = 2;
+  // The validator's (human-readable) name.
+  string name = 3;
+  // The validator's website.
+  string website = 4;
+  // The validator's description.
+  string description = 5;
+  // A list of funding streams describing the validator's commission.
+  repeated FundingStream funding_streams = 6;
+  // The sequence number determines which validator data takes priority, and
+  // prevents replay attacks.  The chain only accepts new validator definitions
+  // with increasing sequence numbers.
+  uint32 sequence_number = 7;
+}
+
+// A portion of a validator's commission.
+message FundingStream {
+  // The destination address for the funding stream.
+  string address = 1;
+  // The portion of the staking reward for the entire delegation pool
+  // allocated to this funding stream, specified in basis points.
+  uint32 rate_bps = 2;
+}
+
+// Describes the reward and exchange rates and voting power for a validator in some epoch.
+message RateData {
+  bytes identity_key = 1;
+  uint64 epoch_index = 2;
+  uint64 voting_power = 3;
+  uint64 validator_reward_rate = 4;
+  uint64 validator_exchange_rate = 5;
+}
+
+// Describes the base reward and exchange rates in some epoch.
+message BaseRateData {
+  uint64 epoch_index = 1;
+  uint64 base_reward_rate = 2;
+  uint64 base_exchange_rate = 3;
+}
+
+// A transaction action (re)defining a validator.
+message ValidatorDefinition {
+  // The configuration data for the validator.
+  Validator validator = 1;
+  // A signature by the validator's identity key over the validator data.
+  bytes auth_sig = 2;
+}
+
+// A transaction action delegating stake to a validator's delegation pool.
+message Delegate {
+  // The identity key of the validator to delegate to.
+  bytes validator_identity = 1;
+  // The index of the epoch in which this delegation was performed.
+  // The delegation takes effect in the next epoch.
+  uint64 epoch_index = 2;
+  // The delegation amount, in units of unbonded stake.
+  // TODO: use flow aggregation to hide this, replacing it with bytes amount_ciphertext;
+  uint64 unbonded_amount = 3;
+}
+
+// A transaction action undelegating stake from a validator's delegation pool.
+message Undelegate {
+  // The identity key of the validator to undelegate from.
+  bytes validator_identity = 1;
+  // The index of the epoch in which this undelegation was performed.
+  uint64 epoch_index = 2;
+  // The amount to undelegate, in units of unbonded stake.
+  uint64 unbonded_amount = 3;
+}

--- a/proto/proto/transaction.proto
+++ b/proto/proto/transaction.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package penumbra.transaction;
 
+import "stake.proto";
+
 // A Penumbra transaction.
 message Transaction {
   TransactionBody body = 1;
@@ -28,6 +30,9 @@ message Action {
   oneof action {
     Spend spend = 1;
     Output output = 2;
+    stake.Delegate delegate = 3;
+    stake.Undelegate undelegate = 4;
+    stake.ValidatorDefinition validator_definition = 16;
   }
 }
 

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -17,7 +17,8 @@
 
 pub use prost::Message;
 
-mod serializers;
+/// Helper methods used for shaping the JSON (and other Serde) formats derived from the protos.
+pub mod serializers;
 
 mod protobuf;
 pub use protobuf::Protobuf;

--- a/proto/src/protobuf.rs
+++ b/proto/src/protobuf.rs
@@ -1,8 +1,20 @@
 /// A marker trait that captures the relationships between a domain type (`Self`) and a protobuf type (`P`).
 pub trait Protobuf<P>: Sized
 where
-    P: prost::Message,
+    P: prost::Message + Default,
     P: std::convert::From<Self>,
-    Self: std::convert::TryFrom<P>,
+    Self: std::convert::TryFrom<P> + Clone,
+    <Self as std::convert::TryFrom<P>>::Error: Into<anyhow::Error>,
 {
+    /// Encode this domain type to a byte vector, via proto type `P`.
+    fn encode_to_vec(&self) -> Vec<u8> {
+        P::from(self.clone()).encode_to_vec()
+    }
+
+    /// Decode this domain type from a byte buffer, via proto type `P`.
+    fn decode<B: bytes::Buf>(buf: B) -> Result<Self, anyhow::Error> {
+        <P as prost::Message>::decode(buf)?
+            .try_into()
+            .map_err(Into::into)
+    }
 }

--- a/proto/src/serializers.rs
+++ b/proto/src/serializers.rs
@@ -7,3 +7,5 @@
 pub mod hexstr;
 
 pub mod base64str;
+
+pub mod bech32str;

--- a/proto/src/serializers.rs
+++ b/proto/src/serializers.rs
@@ -1,0 +1,9 @@
+//! Serializers for adjusting the Serde implementations derived from the Rust
+//! proto types.
+//!
+//! This approach is inspired by the tendermint-rs implementation, and some of
+//! the serializers are adapted from that code.
+
+pub mod hexstr;
+
+pub mod base64str;

--- a/proto/src/serializers/base64str.rs
+++ b/proto/src/serializers/base64str.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Deserializer, Serializer};
+use subtle_encoding::base64;
+
+/// Deserialize base64string into Vec<u8>
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let string = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
+    base64::decode(&string).map_err(serde::de::Error::custom)
+}
+
+/// Serialize from T into base64string
+pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: AsRef<[u8]>,
+{
+    let base64_bytes = base64::encode(value.as_ref());
+    let base64_string = String::from_utf8(base64_bytes).map_err(serde::ser::Error::custom)?;
+    serializer.serialize_str(&base64_string)
+}

--- a/proto/src/serializers/bech32str.rs
+++ b/proto/src/serializers/bech32str.rs
@@ -1,0 +1,96 @@
+//! Bech32 serializers. Because Bech32 is parameterized by the HRP, this module
+//! implements (internal) helper functions that are used in submodules that fill
+//! in parameters for various key types.
+
+use bech32::{FromBase32, ToBase32};
+// re-exporting allows the convenience methods to be used without referencing
+// the underlying bech32 crate.
+pub use bech32::{Variant, Variant::*};
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Convenience method for (general-purpose) Bech32 decoding.
+///
+/// Works around a bit of awkwardness in the [`bech32`] API.
+pub fn decode(
+    string: &str,
+    expected_hrp: &str,
+    expected_variant: Variant,
+) -> anyhow::Result<Vec<u8>> {
+    let (hrp, data, variant) = bech32::decode(&string)?;
+
+    if variant != expected_variant {
+        return Err(anyhow::anyhow!(
+            "wrong bech32 variant {:?}, expected {:?}",
+            variant,
+            expected_variant
+        ));
+    }
+    if hrp != expected_hrp {
+        return Err(anyhow::anyhow!(
+            "wrong bech32 human readable part {}, expected {}",
+            hrp,
+            expected_hrp
+        ));
+    }
+
+    Ok(Vec::from_base32(&data).expect("bech32 decoding produces valid base32"))
+}
+
+/// Convenience method for (general-purpose) Bech32 encoding.
+///
+/// Works around a bit of awkwardness in the [`bech32`] API.
+/// Panics if the HRP is invalid.
+pub fn encode(data: &[u8], hrp: &str, variant: Variant) -> String {
+    bech32::encode(hrp, data.to_base32(), variant).expect("HRP should be valid")
+}
+
+fn deserialize_bech32<'de, D>(
+    deserializer: D,
+    expected_hrp: &str,
+    expected_variant: Variant,
+) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    decode(
+        &Option::<String>::deserialize(deserializer)?.unwrap_or_default(),
+        expected_hrp,
+        expected_variant,
+    )
+    .map_err(serde::de::Error::custom)
+}
+
+fn serialize_bech32<S, T>(
+    value: &T,
+    serializer: S,
+    hrp: &str,
+    variant: Variant,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: AsRef<[u8]>,
+{
+    serializer.serialize_str(&encode(value.as_ref(), hrp, variant))
+}
+
+pub mod validator_identity_key {
+    use super::*;
+
+    /// The Bech32 prefix used for validator identity keys.
+    pub const BECH32_PREFIX: &str = "penumbravalid";
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_bech32(deserializer, BECH32_PREFIX, Variant::Bech32m)
+    }
+
+    pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: AsRef<[u8]>,
+    {
+        serialize_bech32(value, serializer, BECH32_PREFIX, Variant::Bech32m)
+    }
+}

--- a/proto/src/serializers/hexstr.rs
+++ b/proto/src/serializers/hexstr.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Deserialize hexstring into Vec<u8>
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let string = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
+    hex::decode(&string).map_err(serde::de::Error::custom)
+}
+
+/// Serialize from T into hexstring
+pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: AsRef<[u8]>,
+{
+    serializer.serialize_str(&hex::encode(value.as_ref()))
+}

--- a/stake/Cargo.toml
+++ b/stake/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 [dependencies]
 # Workspace dependencies
 penumbra-crypto = { path = "../crypto" }
+penumbra-proto = { path = "../proto" }
 
 # Penumbra dependencies
 tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "master" }

--- a/stake/src/delegate.rs
+++ b/stake/src/delegate.rs
@@ -1,0 +1,44 @@
+use penumbra_proto::{stake as pb, Protobuf};
+use serde::{Deserialize, Serialize};
+
+use crate::IdentityKey;
+
+/// A transaction action adding stake to a validator's delegation pool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "pb::Delegate", into = "pb::Delegate")]
+pub struct Delegate {
+    /// The identity key of the validator to delegate to.
+    pub validator_identity: IdentityKey,
+    /// The index of the epoch in which this delegation was performed.
+    /// The delegation takes effect in the next epoch.
+    pub epoch_index: u64,
+    /// The delegation amount, in units of unbonded stake.
+    /// TODO: use flow aggregation to hide this, replacing it with bytes amount_ciphertext;
+    pub unbonded_amount: u64,
+}
+
+impl Protobuf<pb::Delegate> for Delegate {}
+
+impl From<Delegate> for pb::Delegate {
+    fn from(d: Delegate) -> Self {
+        pb::Delegate {
+            validator_identity: Some(d.validator_identity.into()),
+            epoch_index: d.epoch_index,
+            unbonded_amount: d.unbonded_amount,
+        }
+    }
+}
+
+impl TryFrom<pb::Delegate> for Delegate {
+    type Error = anyhow::Error;
+    fn try_from(d: pb::Delegate) -> Result<Self, Self::Error> {
+        Ok(Self {
+            validator_identity: d
+                .validator_identity
+                .ok_or_else(|| anyhow::anyhow!("missing validator identity"))?
+                .try_into()?,
+            epoch_index: d.epoch_index,
+            unbonded_amount: d.unbonded_amount,
+        })
+    }
+}

--- a/stake/src/epoch.rs
+++ b/stake/src/epoch.rs
@@ -1,4 +1,3 @@
-use anyhow::{anyhow, Error};
 use tendermint::block;
 
 /// Epoch represents a given epoch for Penumbra and is used
@@ -10,28 +9,10 @@ pub struct Epoch {
 }
 
 impl Epoch {
-    /// from_blockheight instantiates a new `Epoch` from a given
-    /// block height. Due to the implementation in tendermint using
-    /// signed representation for block height, we provide this
-    /// as well as an unsigned implemention (`from_blockheight_unsigned`)
-    pub fn from_blockheight(block_height: i64, epoch_duration: u64) -> Result<Self, Error> {
-        if block_height < 0 {
-            return Err(anyhow!("block height should never be negative"));
-        }
-
-        Ok(Epoch::from_blockheight_unsigned(
-            block_height.unsigned_abs(),
-            epoch_duration,
-        ))
-    }
-
-    /// from_blockheight_unsigned instantiates a new `Epoch` from a given
-    /// unsigned block height. Due to the implementation in tendermint using
-    /// signed representation for block height, we provide this
-    /// as well as a signed implemention (`from_blockheight`)
-    pub fn from_blockheight_unsigned(block_height: u64, epoch_duration: u64) -> Self {
+    /// Instantiates a new `Epoch` from a given block height and epoch duration.
+    pub fn from_height(height: u64, epoch_duration: u64) -> Epoch {
         Epoch {
-            index: block_height / epoch_duration,
+            index: height / epoch_duration,
             duration: epoch_duration,
         }
     }
@@ -47,11 +28,7 @@ impl Epoch {
             .expect("able to parse block height")
     }
 
-    pub fn is_epoch_boundary(block_height: i64, epoch_duration: u64) -> Result<bool, Error> {
-        if block_height < 0 {
-            return Err(anyhow!("block height should never be negative"));
-        }
-
-        Ok(block_height.unsigned_abs() % epoch_duration == 0)
+    pub fn is_epoch_boundary(height: u64, epoch_duration: u64) -> bool {
+        height % epoch_duration == 0
     }
 }

--- a/stake/src/funding_stream.rs
+++ b/stake/src/funding_stream.rs
@@ -1,8 +1,10 @@
 use penumbra_crypto::Address;
+use penumbra_proto::{stake as pb, Protobuf};
 use serde::{Deserialize, Serialize};
 
 /// A destination for a portion of a validator's commission of staking rewards.
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Copy)]
+#[serde(try_from = "pb::FundingStream", into = "pb::FundingStream")]
 pub struct FundingStream {
     /// The destinatination address for the funding stream..
     pub address: Address,
@@ -10,4 +12,35 @@ pub struct FundingStream {
     /// The portion (in terms of [basis points](https://en.wikipedia.org/wiki/Basis_point)) of the
     /// validator's total staking reward that goes to this funding stream.
     pub rate_bps: u16,
+}
+
+impl Protobuf<pb::FundingStream> for FundingStream {}
+
+impl From<FundingStream> for pb::FundingStream {
+    fn from(fs: FundingStream) -> Self {
+        pb::FundingStream {
+            address: fs.address.to_string(),
+            rate_bps: fs.rate_bps as u32,
+        }
+    }
+}
+
+impl TryFrom<pb::FundingStream> for FundingStream {
+    type Error = anyhow::Error;
+
+    fn try_from(fs: pb::FundingStream) -> Result<Self, Self::Error> {
+        let rate_bps = if fs.rate_bps <= 10_000 {
+            fs.rate_bps as u16
+        } else {
+            return Err(anyhow::anyhow!(
+                "rate_bps {} is more than 100%",
+                fs.rate_bps
+            ));
+        };
+
+        Ok(FundingStream {
+            address: fs.address.parse()?,
+            rate_bps,
+        })
+    }
 }

--- a/stake/src/identity_key.rs
+++ b/stake/src/identity_key.rs
@@ -1,0 +1,55 @@
+use penumbra_crypto::rdsa::{SpendAuth, VerificationKey};
+use penumbra_proto::{serializers::bech32str, stake as pb, Protobuf};
+use serde::{Deserialize, Serialize};
+
+/// A [`SpendAuth`] [`VerificationKey`] used as a validator's identity key.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "pb::IdentityKey", into = "pb::IdentityKey")]
+pub struct IdentityKey(pub VerificationKey<SpendAuth>);
+
+impl std::str::FromStr for IdentityKey {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        pb::IdentityKey {
+            ik: bech32str::decode(
+                s,
+                crate::VALIDATOR_IDENTITY_BECH32_PREFIX,
+                bech32str::Bech32m,
+            )?,
+        }
+        .try_into()
+    }
+}
+
+impl std::fmt::Display for IdentityKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&bech32str::encode(
+            &self.0.to_bytes(),
+            crate::VALIDATOR_IDENTITY_BECH32_PREFIX,
+            bech32str::Bech32m,
+        ))
+    }
+}
+
+impl std::fmt::Debug for IdentityKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <IdentityKey as std::fmt::Display>::fmt(self, f)
+    }
+}
+
+impl Protobuf<pb::IdentityKey> for IdentityKey {}
+
+impl From<IdentityKey> for pb::IdentityKey {
+    fn from(ik: IdentityKey) -> Self {
+        pb::IdentityKey {
+            ik: ik.0.to_bytes().to_vec(),
+        }
+    }
+}
+
+impl TryFrom<pb::IdentityKey> for IdentityKey {
+    type Error = anyhow::Error;
+    fn try_from(ik: pb::IdentityKey) -> Result<Self, Self::Error> {
+        Ok(Self(ik.ik.as_slice().try_into()?))
+    }
+}

--- a/stake/src/identity_key.rs
+++ b/stake/src/identity_key.rs
@@ -2,10 +2,18 @@ use penumbra_crypto::rdsa::{SpendAuth, VerificationKey};
 use penumbra_proto::{serializers::bech32str, stake as pb, Protobuf};
 use serde::{Deserialize, Serialize};
 
+use crate::DelegationToken;
+
 /// A [`SpendAuth`] [`VerificationKey`] used as a validator's identity key.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "pb::IdentityKey", into = "pb::IdentityKey")]
 pub struct IdentityKey(pub VerificationKey<SpendAuth>);
+
+impl IdentityKey {
+    pub fn delegation_token(&self) -> DelegationToken {
+        DelegationToken::new(self.clone())
+    }
+}
 
 impl std::str::FromStr for IdentityKey {
     type Err = anyhow::Error;

--- a/stake/src/lib.rs
+++ b/stake/src/lib.rs
@@ -1,16 +1,20 @@
+mod delegate;
 mod epoch;
 mod funding_stream;
 mod identity_key;
 mod rate;
 mod token;
+mod undelegate;
 mod validator;
 
+pub use delegate::Delegate;
 pub use epoch::Epoch;
 pub use funding_stream::FundingStream;
 pub use identity_key::IdentityKey;
 pub use rate::{BaseRateData, RateData};
 pub use token::DelegationToken;
-pub use validator::Validator;
+pub use undelegate::Undelegate;
+pub use validator::{Validator, ValidatorDefinition};
 
 /// The Bech32 prefix used for validator consensus pubkeys.
 pub const VALIDATOR_CONSENSUS_BECH32_PREFIX: &str = "penumbravalconspub";

--- a/stake/src/lib.rs
+++ b/stake/src/lib.rs
@@ -1,17 +1,18 @@
 mod epoch;
 mod funding_stream;
+mod identity_key;
 mod rate;
 mod token;
 mod validator;
 
 pub use epoch::Epoch;
 pub use funding_stream::FundingStream;
+pub use identity_key::IdentityKey;
 pub use rate::{BaseRateData, RateData};
 pub use token::DelegationToken;
 pub use validator::Validator;
 
-/// The Bech32 prefix used for validator identity keys.
-pub const VALIDATOR_IDENTITY_BECH32_PREFIX: &str = "penumbravalid";
-
 /// The Bech32 prefix used for validator consensus pubkeys.
 pub const VALIDATOR_CONSENSUS_BECH32_PREFIX: &str = "penumbravalconspub";
+
+pub use penumbra_proto::serializers::bech32str::validator_identity_key::BECH32_PREFIX as VALIDATOR_IDENTITY_BECH32_PREFIX;

--- a/stake/src/lib.rs
+++ b/stake/src/lib.rs
@@ -1,12 +1,17 @@
 mod epoch;
 mod funding_stream;
+mod rate;
 mod token;
 mod validator;
 
 pub use epoch::Epoch;
 pub use funding_stream::FundingStream;
+pub use rate::{BaseRateData, RateData};
 pub use token::DelegationToken;
 pub use validator::Validator;
 
 /// The Bech32 prefix used for validator identity keys.
-pub const VALIDATOR_IDENTITY_BECH32_PREFIX: &str = "penumbravaloper";
+pub const VALIDATOR_IDENTITY_BECH32_PREFIX: &str = "penumbravalid";
+
+/// The Bech32 prefix used for validator consensus pubkeys.
+pub const VALIDATOR_CONSENSUS_BECH32_PREFIX: &str = "penumbravalconspub";

--- a/stake/src/rate.rs
+++ b/stake/src/rate.rs
@@ -1,0 +1,81 @@
+use penumbra_crypto::rdsa::{SpendAuth, VerificationKey};
+use penumbra_proto::{stake as pb, Protobuf};
+use serde::{Deserialize, Serialize};
+
+/// Describes a validator's reward rate and voting power in some epoch.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(try_from = "pb::RateData", into = "pb::RateData")]
+pub struct RateData {
+    /// The validator's identity verification key.
+    pub identity_key: VerificationKey<SpendAuth>,
+    /// The index of the epoch for which this rate is valid.
+    pub epoch_index: u64,
+    /// The validator's voting power.
+    pub voting_power: u64,
+    /// The validator-specific reward rate.
+    pub validator_reward_rate: u64,
+    /// The validator-specific exchange rate.
+    pub validator_exchange_rate: u64,
+}
+
+/// Describes the base reward and exchange rates in some epoch.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(try_from = "pb::BaseRateData", into = "pb::BaseRateData")]
+pub struct BaseRateData {
+    /// The index of the epoch for which this rate is valid.
+    pub epoch_index: u64,
+    /// The base reward rate.
+    pub base_reward_rate: u64,
+    /// The base exchange rate.
+    pub base_exchange_rate: u64,
+}
+
+impl Protobuf<pb::RateData> for RateData {}
+
+impl From<RateData> for pb::RateData {
+    fn from(v: RateData) -> Self {
+        pb::RateData {
+            identity_key: v.identity_key.to_bytes().to_vec(),
+            epoch_index: v.epoch_index,
+            voting_power: v.voting_power,
+            validator_reward_rate: v.validator_reward_rate,
+            validator_exchange_rate: v.validator_exchange_rate,
+        }
+    }
+}
+
+impl TryFrom<pb::RateData> for RateData {
+    type Error = anyhow::Error;
+    fn try_from(v: pb::RateData) -> Result<Self, Self::Error> {
+        Ok(RateData {
+            identity_key: v.identity_key.as_slice().try_into()?,
+            epoch_index: v.epoch_index,
+            voting_power: v.voting_power,
+            validator_reward_rate: v.validator_reward_rate,
+            validator_exchange_rate: v.validator_exchange_rate,
+        })
+    }
+}
+
+impl Protobuf<pb::BaseRateData> for BaseRateData {}
+
+impl From<BaseRateData> for pb::BaseRateData {
+    fn from(v: BaseRateData) -> Self {
+        pb::BaseRateData {
+            epoch_index: v.epoch_index,
+            base_reward_rate: v.base_reward_rate,
+            base_exchange_rate: v.base_exchange_rate,
+        }
+    }
+}
+
+impl TryFrom<pb::BaseRateData> for BaseRateData {
+    type Error = anyhow::Error;
+    fn try_from(v: pb::BaseRateData) -> Result<Self, Self::Error> {
+        Ok(BaseRateData {
+            epoch_index: v.epoch_index,
+            base_reward_rate: v.base_reward_rate,
+            base_exchange_rate: v.base_exchange_rate,
+        })
+    }
+}

--- a/stake/src/token.rs
+++ b/stake/src/token.rs
@@ -56,8 +56,9 @@ impl TryFrom<asset::Denom> for DelegationToken {
         // function to tendermint-rs
 
         let (hrp, data, variant) = bech32::decode(
-            // Note: this regex must be in sync with asset::REGISTRY
-            Regex::new("udelegation_(?P<data>penumbravaloper1[a-zA-HJ-NP-Z0-9]+)")
+            // Note: this regex must be in sync with both asset::REGISTRY
+            // and VALIDATOR_IDENTITY_BECH32_PREFIX
+            Regex::new("udelegation_(?P<data>penumbravalid1[a-zA-HJ-NP-Z0-9]+)")
                 .expect("regex is valid")
                 .captures(&value.to_string())
                 .ok_or_else(|| {

--- a/stake/src/token.rs
+++ b/stake/src/token.rs
@@ -2,27 +2,23 @@ use std::str::FromStr;
 
 use penumbra_crypto::asset;
 use regex::Regex;
-use tendermint::PublicKey;
 
-use crate::VALIDATOR_IDENTITY_BECH32_PREFIX;
+use crate::IdentityKey;
 
 /// Delegation tokens represent a share of a particular validator's delegation pool.
 pub struct DelegationToken {
-    validator_pubkey: PublicKey,
+    validator_identity: IdentityKey,
     base_denom: asset::Denom,
 }
 
 impl DelegationToken {
-    pub fn new(pk: PublicKey) -> Self {
+    pub fn new(validator_identity: IdentityKey) -> Self {
         // This format string needs to be in sync with the asset registry
         let base_denom = asset::REGISTRY
-            .parse_denom(&format!(
-                "udelegation_{}",
-                pk.to_bech32(VALIDATOR_IDENTITY_BECH32_PREFIX)
-            ))
+            .parse_denom(&format!("udelegation_{}", validator_identity))
             .expect("base denom format is valid");
         DelegationToken {
-            validator_pubkey: pk,
+            validator_identity,
             base_denom,
         }
     }
@@ -43,60 +39,35 @@ impl DelegationToken {
     }
 
     /// Get the identity key of the validator this delegation token is associated with.
-    pub fn validator(&self) -> PublicKey {
-        self.validator_pubkey.clone()
+    pub fn validator(&self) -> IdentityKey {
+        self.validator_identity.clone()
     }
 }
 
 impl TryFrom<asset::Denom> for DelegationToken {
     type Error = anyhow::Error;
-    fn try_from(value: asset::Denom) -> Result<Self, Self::Error> {
-        // Almost all of this code is devoted to parsing Bech32 in the
-        // tendermint-specific way, perhaps we could upstream a Bech32 decoding
-        // function to tendermint-rs
-
-        let (hrp, data, variant) = bech32::decode(
-            // Note: this regex must be in sync with both asset::REGISTRY
-            // and VALIDATOR_IDENTITY_BECH32_PREFIX
+    fn try_from(base_denom: asset::Denom) -> Result<Self, Self::Error> {
+        // Note: this regex must be in sync with both asset::REGISTRY
+        // and VALIDATOR_IDENTITY_BECH32_PREFIX
+        let validator_identity =
             Regex::new("udelegation_(?P<data>penumbravalid1[a-zA-HJ-NP-Z0-9]+)")
                 .expect("regex is valid")
-                .captures(&value.to_string())
+                .captures(&base_denom.to_string())
                 .ok_or_else(|| {
-                    anyhow::anyhow!("base denom {} is not a delegation token", value.to_string())
+                    anyhow::anyhow!(
+                        "base denom {} is not a delegation token",
+                        base_denom.to_string()
+                    )
                 })?
                 .name("data")
                 .expect("data is a named capture")
-                .as_str(),
-        )?;
+                .as_str()
+                .parse()?;
 
-        if variant != bech32::Variant::Bech32 {
-            return Err(anyhow::anyhow!(
-                "delegation token denom uses wrong Bech32 variant"
-            ));
-        }
-        if hrp != VALIDATOR_IDENTITY_BECH32_PREFIX {
-            return Err(anyhow::anyhow!(
-                "wrong Bech32 HRP {}, expected {}",
-                hrp,
-                VALIDATOR_IDENTITY_BECH32_PREFIX
-            ));
-        }
-
-        use bech32::FromBase32;
-        let data = Vec::<u8>::from_base32(&data).expect("bech32 decoding produces valid base32");
-
-        // some custom tendermint thing (????)
-        // see PublicKey::to_bech32 impl
-        if &data[0..5] != &[0x16, 0x24, 0xDE, 0x64, 0x20] {
-            return Err(anyhow::anyhow!(
-                "invalid backward_compatible_amino_prefix bytes"
-            ));
-        }
-
-        Ok(DelegationToken::new(
-            PublicKey::from_raw_ed25519(&data[5..])
-                .ok_or_else(|| anyhow::anyhow!("invalid Ed25519 verification key"))?,
-        ))
+        Ok(Self {
+            base_denom,
+            validator_identity,
+        })
     }
 }
 
@@ -138,16 +109,17 @@ impl std::hash::Hash for DelegationToken {
 
 #[cfg(test)]
 mod tests {
+    use penumbra_crypto::rdsa::{SigningKey, SpendAuth};
+
     use super::*;
 
     #[test]
     fn delegation_token_denomination_round_trip() {
-        use ed25519_consensus::SigningKey;
         use rand_core::OsRng;
 
-        let vk = PublicKey::Ed25519(SigningKey::new(OsRng).verification_key());
+        let ik = IdentityKey(SigningKey::<SpendAuth>::new(OsRng).into());
 
-        let token = DelegationToken::new(vk);
+        let token = DelegationToken::new(ik);
 
         let denom = token.to_string();
         let token2 = DelegationToken::from_str(&denom).unwrap();

--- a/stake/src/undelegate.rs
+++ b/stake/src/undelegate.rs
@@ -1,0 +1,43 @@
+use penumbra_proto::{stake as pb, Protobuf};
+use serde::{Deserialize, Serialize};
+
+use crate::IdentityKey;
+
+/// A transaction action withdrawing stake from a validator's delegation pool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "pb::Undelegate", into = "pb::Undelegate")]
+pub struct Undelegate {
+    /// The identity key of the validator to undelegate from.
+    pub validator_identity: IdentityKey,
+    /// The index of the epoch in which this undelegation was performed.
+    /// The undelegation takes effect after the unbonding period.
+    pub epoch_index: u64,
+    /// The amount to undelegate, in units of unbonded stake.
+    pub unbonded_amount: u64,
+}
+
+impl Protobuf<pb::Undelegate> for Undelegate {}
+
+impl From<Undelegate> for pb::Undelegate {
+    fn from(d: Undelegate) -> Self {
+        pb::Undelegate {
+            validator_identity: Some(d.validator_identity.into()),
+            epoch_index: d.epoch_index,
+            unbonded_amount: d.unbonded_amount,
+        }
+    }
+}
+
+impl TryFrom<pb::Undelegate> for Undelegate {
+    type Error = anyhow::Error;
+    fn try_from(d: pb::Undelegate) -> Result<Self, Self::Error> {
+        Ok(Self {
+            validator_identity: d
+                .validator_identity
+                .ok_or_else(|| anyhow::anyhow!("missing validator identity"))?
+                .try_into()?,
+            epoch_index: d.epoch_index,
+            unbonded_amount: d.unbonded_amount,
+        })
+    }
+}

--- a/stake/src/validator.rs
+++ b/stake/src/validator.rs
@@ -1,58 +1,113 @@
+use penumbra_crypto::rdsa::{Signature, SpendAuth, VerificationKey};
+use penumbra_proto::{stake as pb, Protobuf};
 use serde::{Deserialize, Serialize};
-use tendermint::{vote, PublicKey};
 
-use crate::{FundingStream, VALIDATOR_IDENTITY_BECH32_PREFIX};
+use crate::FundingStream;
 
-/// Validator tracks the Penumbra validator's long-term consensus key (tm_pubkey), as well as their
-/// voting power.
-#[derive(Deserialize, Serialize, Debug, Eq, Clone)]
+/// Describes a Penumbra validator's configuration data.
+///
+/// This data is unauthenticated; the [`ValidatorDefinition`] structure includes
+/// a signature over the configuration with the validator's identity key.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(try_from = "pb::Validator", into = "pb::Validator")]
 pub struct Validator {
-    /// The validator's long-term Tendermint public key, where the private component
-    /// is used to sign blocks.
-    tm_pubkey: PublicKey,
+    /// The validator's identity verification key.
+    pub identity_key: VerificationKey<SpendAuth>,
 
-    /// The validator's current voting power.
-    pub voting_power: vote::Power,
+    /// The validator's consensus key, used by Tendermint for signing blocks and
+    /// other consensus operations.
+    pub consensus_key: tendermint::PublicKey,
+
+    /// The validator's (human-readable) name.
+    pub name: String,
+
+    /// The validator's website URL.
+    pub website: String,
+
+    /// The validator's description.
+    pub description: String,
 
     /// The destinations for the validator's staking reward. The commission is implicitly defined
     /// by the configuration of funding_streams, the sum of FundingStream.rate_bps.
     ///
     /// NOTE: sum(FundingRate.rate_bps) should not exceed 100% (10000bps. For now, we ignore this
     /// condition, in the future we should probably make it a slashable offense.
-    pub funding_streams: Vec<FundingStream>,
     // NOTE: unclaimed rewards are tracked by inserting reward notes for the last epoch into the
     // NCT at the beginning of each epoch
+    pub funding_streams: Vec<FundingStream>,
+
+    /// The sequence number determines which validator data takes priority, and
+    /// prevents replay attacks.  The chain only accepts new
+    /// [`ValidatorDefinition`]s with increasing sequence numbers, preventing a
+    /// third party from replaying previously valid but stale configuration data
+    /// as an update.
+    pub sequence_number: u32,
 }
 
-impl PartialEq for Validator {
-    fn eq(&self, other: &Self) -> bool {
-        self.tm_pubkey == other.tm_pubkey
-    }
+/// Authenticated configuration data for a validator.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(try_from = "pb::ValidatorDefinition", into = "pb::ValidatorDefinition")]
+pub struct ValidatorDefinition {
+    pub validator: Validator,
+    pub auth_sig: Signature<SpendAuth>,
 }
 
-impl Validator {
-    pub fn new(
-        pubkey: PublicKey,
-        voting_power: vote::Power,
-        funding_streams: Vec<FundingStream>,
-    ) -> Validator {
-        Validator {
-            tm_pubkey: pubkey,
-            voting_power,
-            funding_streams,
+impl Protobuf<pb::Validator> for Validator {}
+
+impl From<Validator> for pb::Validator {
+    fn from(v: Validator) -> Self {
+        pb::Validator {
+            identity_key: v.identity_key.to_bytes().to_vec(),
+            consensus_key: v.consensus_key.to_bytes(),
+            name: v.name,
+            website: v.website,
+            description: v.description,
+            funding_streams: v.funding_streams.into_iter().map(Into::into).collect(),
+            sequence_number: v.sequence_number,
         }
     }
+}
 
-    /// consensus_address returns the bech32-encoded address of the validator's primary consensus
-    /// public key.
-    ///
-    /// TKTK: should this return an address type?
-    pub fn consensus_address(&self) -> String {
-        self.tm_pubkey.to_bech32(VALIDATOR_IDENTITY_BECH32_PREFIX)
+impl TryFrom<pb::Validator> for Validator {
+    type Error = anyhow::Error;
+    fn try_from(v: pb::Validator) -> Result<Self, Self::Error> {
+        Ok(Validator {
+            identity_key: v.identity_key.as_slice().try_into()?,
+            consensus_key: tendermint::PublicKey::from_raw_ed25519(&v.consensus_key)
+                .ok_or_else(|| anyhow::anyhow!("invalid ed25519 consensus pubkey"))?,
+            name: v.name,
+            website: v.website,
+            description: v.description,
+            funding_streams: v
+                .funding_streams
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<_, _>>()?,
+            sequence_number: v.sequence_number,
+        })
     }
+}
 
-    // why isn't tm_pubkey public?
-    pub fn tm_pubkey(&self) -> &PublicKey {
-        &self.tm_pubkey
+impl Protobuf<pb::ValidatorDefinition> for ValidatorDefinition {}
+
+impl From<ValidatorDefinition> for pb::ValidatorDefinition {
+    fn from(v: ValidatorDefinition) -> Self {
+        pb::ValidatorDefinition {
+            validator: Some(v.validator.into()),
+            auth_sig: v.auth_sig.to_bytes().to_vec(),
+        }
+    }
+}
+
+impl TryFrom<pb::ValidatorDefinition> for ValidatorDefinition {
+    type Error = anyhow::Error;
+    fn try_from(v: pb::ValidatorDefinition) -> Result<Self, Self::Error> {
+        Ok(ValidatorDefinition {
+            validator: v
+                .validator
+                .ok_or_else(|| anyhow::anyhow!("missing validator field in proto"))?
+                .try_into()?,
+            auth_sig: v.auth_sig.as_slice().try_into()?,
+        })
     }
 }

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -9,6 +9,7 @@ decaf377-ka = { path = "../decaf377-ka/" }
 decaf377-fmd = { path = "../decaf377-fmd/" }
 penumbra-proto = { path = "../proto/" }
 penumbra-crypto = { path = "../crypto/" }
+penumbra-stake = { path = "../stake/" }
 
 # Git deps
 ark-ff = { git = "https://github.com/penumbra-zone/algebra", branch = "ours" }

--- a/transaction/src/action.rs
+++ b/transaction/src/action.rs
@@ -45,6 +45,7 @@ impl TryFrom<transaction::Action> for Action {
             transaction::action::Action::Output(inner) => Ok(Action::Output(inner.try_into()?)),
 
             transaction::action::Action::Spend(inner) => Ok(Action::Spend(inner.try_into()?)),
+            _ => todo!(),
         }
     }
 }

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -17,8 +17,7 @@ use penumbra_proto::{
 };
 
 // TODO: remove & replace with anyhow
-use crate::action::error::ProtoError;
-use crate::{Action, GenesisBuilder};
+use crate::{action::error::ProtoError, Action, GenesisBuilder};
 
 mod builder;
 pub use builder::Builder;

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -114,6 +114,7 @@ impl Transaction {
                 Action::Spend(inner) => {
                     value_commitments += inner.body.value_commitment.0;
                 }
+                _ => todo!("delegation binding signature contributions??"),
             }
         }
 


### PR DESCRIPTION
This chunk of work was meant to be simple and turned into an unexpectedly deep
rabbithole, but going down the rabbithole revealed some lessons for our
development process and helped build out a bunch of basic infrastructure.

The start was the creation of `stake.proto`, meant to define some stub proto
messages that we could use to do staking and delegation actions:

- defining (or updating) a validator;
- delegating to a validator;
- undelegating from a validator.

Delegation and undelegation messages are fairly straightforward: they specify
the validator, the unbonded amount, and the epoch.  (Those details determine
the rest of the parameters; the implementation work is in the checks that
they're consistent with the rest of the transaction, rather than in the data in
the message).

To avoid a separate process for creating a new validator and updating its
configuration, the idea is to use the same message with create-or-update
semantics.  This configuration data should be signed by the validator, and, as
with the other transaction structures, we split out the data-to-be-signed into
a separate message (`Validator`), and have the signed message
(`ValidatorDescription`) consist of a message+signature pair.  A transaction
can include a `ValidatorDescription` message to (re)define a validator.

Because this message includes a signature from the validator it configures,
it's self-authenticating.  However, a third party could create a transaction
including an authentic but stale validator description to roll back a
validator's configuration to some previous state.  To prevent this, the
`Validator` message includes a sequence number, so that the chain can require
that redefinitions have increasing sequence numbers, forcing each update to
pass through a signing oracle.

To specify the contents of the `Validator` description itself, we look at
the contents of the Cosmos SDK `create-validator` transaction as a model [0].
Some fields are just basic metadata, like the name, website, and description,
and others we ignore:

- initial commission rate, since we use funding streams;

- maximum commission and commission max change rate, which add implementation
  complexity to prevent a scenario with low impact (a validator advertises 0%
commission, then updates it to 100% in the hope the delegators won't notice)
that could be addressed by other means (social pressure, easy redelegation);

- minimum self-delegation, which doesn't fit cleanly with our delegation token
  model (and has unclear impact in a system with native delegation tokens
anyways).

However, looking at the address and pubkey fields reveals a problem with our
existing data modeling: Cosmos uses separate keys for the validator's identity
(determining the address, etc), and Tendermint consensus.  This is important
for various reasons, but most importantly, it allows the validator's identity
key to be stored offline, unlike the consensus key, which must be used online
to sign blocks.

The new `Validator` message distinguishes between the validator's
identity key (a decaf377-rdsa spend authorization key) and the validator's
consensus key (a Tendermint Ed25519 pubkey).  The validator's identity key
authenticates the consensus key by signing the `Validator` message.

Our existing code didn't notice this distinction, and changing the code to
account for it required propagating a bunch of other changes to the state
handling, effectively rewriting it.  While rewriting code isn't the end of the
world (especially when going from a first-pass of mapping out functionality to
a second-pass, coherent organization), in this instance the process was less
than ideal, and it would be good to figure out how we could try to improve it
in the future.

One observation is that it's not that the existing code was bad, but that we
worked "upwards" from the Tendermint API towards some idea of higher-level
application requirements, rather than specifying the eventual requirements in
more detail first, and then working from those requirements to the
implementation.  Writing down the requirements (in the form of proto
definitions for the messages the system uses to communicate) revealed a bunch
of details that we didn't previously think of.  The identity/consensus
distinction is a big one, but there are other, more trivial ones, like the fact
that we should record a validator's name and website, or that we'll need to
record both the exchange rates and reward rates.

This observation points to a potentially improved process: for each chunk of
functionality,

1. Write protos that define the data structures it will use;
2. Write domain types corresponding to those protos, and write the data
validation code as part of the conversions bundled with our `Protobuf` trait;
3. Implement the functionality using the domain types.

This way, in step 1, we can see how the data structures will fit together in
code review and map out the functionality without having to worry about the
details of the implementation, and the different components of step 3 can be
more easily parallelized, because people can work on different chunks of
implementation work using already-defined data structures.

Finally, another side benefit of centering the proto structures is that it
provides a clear definition of the data format, a centralized pathway for
validation (the conversion between the proto types and the domain types), and a
single location to define serializations in other formats (e.g., JSON).  Rather
than using Serde to derive serialization implementations ad-hoc, making every
structure definition potentially load-bearing and littering the code with
custom format-shaping annotations, we can use Serde on the proto structures.
This commit sets up the infrastructure to do that, based on the approach used
in `tendermint-rs`:

- The `penumbra-proto` `build.rs` has machinery to inject Serde derives, or
  format-shaping annotations ("serialize as hex string", "serialize as base64
string", etc.) into the Rust types generated from the proto files;

- The domain type for some proto type has a `TryFrom` impl that performs all of
  the validation logic;

- The domain type `Foo` derives `Serialize, Deserialize` with
  `#[serde(try_from = "pb::Foo", into = "pb::Foo")]`, so that the domain type's
Serde implementations are determined by the proto type, and there's a common
data validation pathway for both Protobuf and Serde serialization.

[0]: https://hub.cosmos.network/main/validators/validator-faq.html#how-to-become-a-validator