### PR TITLE
refactor rate calculations into stake crate

### DIFF
--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -415,6 +415,38 @@
       "nullable": []
     }
   },
+  "c0838e2487bc88b229fe4b5ab786b11780d5196f3e88a5281e7a409171fe4734": {
+    "query": "SELECT * from validator_fundingstreams WHERE identity_key = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "identity_key",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 1,
+          "name": "address",
+          "type_info": "Varchar"
+        },
+        {
+          "ordinal": 2,
+          "name": "rate_bps",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Bytea"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "cb7bac3962a9b0db3759bb2dc21f8bf7aeb58e208107aeb6b0f0f6a1e6c29d45": {
     "query": "\nINSERT INTO blobs (id, data) VALUES ('gc', $1)\n",
     "describe": {

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -369,7 +369,7 @@ impl App {
                 }
 
                 // here's where we should compute updated rates (moved from state code)
-                // TODO @ava insert calls here                let base_reward_rate = 3_0000; // 3bps -> 11% return over 365 epochs, why not
+                // TODO @ava insert calls here
                 let next_base_rate = current_base_rate.next_base_rate();
 
                 let mut next_rates = Vec::new();

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -368,8 +368,7 @@ impl App {
                     tracing::debug!(?current_rate);
                 }
 
-                // here's where we should compute updated rates (moved from state code)
-                // TODO @ava insert calls here
+                // compute updated rates
                 let next_base_rate = current_base_rate.next_base_rate();
 
                 let mut next_rates = Vec::new();

--- a/stake/src/rate.rs
+++ b/stake/src/rate.rs
@@ -1,7 +1,14 @@
-use penumbra_proto::{stake as pb, Protobuf};
+use penumbra_proto::{
+    stake::{self as pb},
+    Protobuf,
+};
 use serde::{Deserialize, Serialize};
 
-use crate::IdentityKey;
+use crate::{Epoch, IdentityKey, FundingStream};
+
+/// FIXME: set this less arbitrarily, and allow this to be set per-epoch
+/// 3bps -> 11% return over 365 epochs, why not
+const BASE_REWARD_RATE: u64 = 3_0000;
 
 /// Describes a validator's reward rate and voting power in some epoch.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
@@ -19,6 +26,44 @@ pub struct RateData {
     pub validator_exchange_rate: u64,
 }
 
+impl RateData {
+    pub fn next_rates(
+        &self,
+        base_rate_data: &BaseRateData,
+        funding_streams: Vec<FundingStream>,
+    ) -> RateData {
+        // compute the validator's total commissio
+        let commission_rate_bps = funding_streams
+            .iter()
+            .fold(0u64, |total, stream| total + stream.rate_bps as u64);
+
+        // compute next validator reward rate
+        // 1 bps = 1e-4, so here we group digits by 4s rather than 3s as is usual
+        let validator_reward_rate =
+            ((1_0000_0000u64 - (commission_rate_bps * 1_0000)) * BASE_REWARD_RATE) / 1_0000_0000;
+
+        // compute validator exchange rate
+        let validator_exchange_rate = (self.validator_exchange_rate
+            * (self.validator_reward_rate + 1_0000_0000))
+            / 1_0000_0000;
+
+        // this is supposed to be multiplied by the number of delegation tokens,
+        // how do we track that?
+        // 
+        // todo: consider specifying the voting power function as a pure function of current epoch
+        // state (delegation tokens, etc) instead of an adjustmenet function
+        let voting_power_adjustment =
+            (validator_exchange_rate * 1_0000_0000) / base_rate_data.base_exchange_rate;
+
+        RateData {
+            identity_key: self.identity_key.clone(),
+            epoch_index: self.epoch_index + 1,
+            voting_power: self.voting_power * voting_power_adjustment,
+            validator_reward_rate: validator_reward_rate,
+            validator_exchange_rate: validator_exchange_rate,
+        }
+    }
+}
 /// Describes the base reward and exchange rates in some epoch.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[serde(try_from = "pb::BaseRateData", into = "pb::BaseRateData")]
@@ -29,6 +74,20 @@ pub struct BaseRateData {
     pub base_reward_rate: u64,
     /// The base exchange rate.
     pub base_exchange_rate: u64,
+}
+
+impl BaseRateData {
+    /// compute the next base exchange rate, epoch index, and base reward rate based on the current
+    /// rates and the supplied Epoch.
+    pub fn next_base_rate(&self) -> BaseRateData {
+        let base_exchange_rate =
+            (self.base_exchange_rate * (BASE_REWARD_RATE + 1_0000_0000)) / 1_0000_0000;
+        return BaseRateData {
+            base_exchange_rate,
+            base_reward_rate: BASE_REWARD_RATE,
+            epoch_index: self.epoch_index + 1,
+        };
+    }
 }
 
 impl Protobuf<pb::RateData> for RateData {}

--- a/stake/src/rate.rs
+++ b/stake/src/rate.rs
@@ -4,7 +4,7 @@ use penumbra_proto::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{Epoch, IdentityKey, FundingStream};
+use crate::{Epoch, FundingStream, IdentityKey};
 
 /// FIXME: set this less arbitrarily, and allow this to be set per-epoch
 /// 3bps -> 11% return over 365 epochs, why not
@@ -49,7 +49,7 @@ impl RateData {
 
         // this is supposed to be multiplied by the number of delegation tokens,
         // how do we track that?
-        // 
+        //
         // todo: consider specifying the voting power function as a pure function of current epoch
         // state (delegation tokens, etc) instead of an adjustmenet function
         let voting_power_adjustment =

--- a/stake/src/rate.rs
+++ b/stake/src/rate.rs
@@ -36,6 +36,13 @@ impl RateData {
         let commission_rate_bps = funding_streams
             .iter()
             .fold(0u64, |total, stream| total + stream.rate_bps as u64);
+        
+        if commission_rate_bps > 1_0000 {
+            // we should never hit this branch: validator funding streams should be verified not to
+            // sum past 100% in the state machine's validation of registration of new funding
+            // streams
+            panic!("commission rate sums to > 100%")
+        }
 
         // compute next validator reward rate
         // 1 bps = 1e-4, so here we group digits by 4s rather than 3s as is usual

--- a/stake/src/rate.rs
+++ b/stake/src/rate.rs
@@ -36,7 +36,7 @@ impl RateData {
         let commission_rate_bps = funding_streams
             .iter()
             .fold(0u64, |total, stream| total + stream.rate_bps as u64);
-        
+
         if commission_rate_bps > 1_0000 {
             // we should never hit this branch: validator funding streams should be verified not to
             // sum past 100% in the state machine's validation of registration of new funding


### PR DESCRIPTION
This PR:

- factors out the rate calculations from App.end_block and puts them in the stake crate
- adds the computation of the validator reward rate based on the commission rate calculated from the sum of their funding streams