### PR TITLE
Consistent sign handling for value commitments, and (un)delegate commitments

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,3 +1,4 @@
+pub use ark_ff::{One, Zero};
 pub use decaf377::{FieldExt, Fq, Fr};
 pub use decaf377_fmd as fmd;
 pub use decaf377_ka as ka;

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -208,7 +208,7 @@ impl OutputProof {
         }
 
         // Value commitment integrity.
-        if self.value.commit(self.v_blinding) != value_commitment {
+        if value_commitment != -self.value.commit(self.v_blinding) {
             return Err(Error::ValueCommitmentMismatch);
         }
 
@@ -470,7 +470,7 @@ mod tests {
         };
 
         assert!(proof
-            .verify(value_to_send.commit(v_blinding), note.commit(), epk)
+            .verify(-value_to_send.commit(v_blinding), note.commit(), epk)
             .is_ok());
     }
 
@@ -510,7 +510,7 @@ mod tests {
 
         assert!(proof
             .verify(
-                value_to_send.commit(v_blinding),
+                -value_to_send.commit(v_blinding),
                 incorrect_note_commitment,
                 epk
             )
@@ -580,7 +580,7 @@ mod tests {
 
         assert!(proof
             .verify(
-                value_to_send.commit(v_blinding),
+                -value_to_send.commit(v_blinding),
                 note.commit(),
                 incorrect_epk
             )
@@ -615,7 +615,7 @@ mod tests {
         };
 
         assert!(proof
-            .verify(value_to_send.commit(v_blinding), note.commit(), epk)
+            .verify(-value_to_send.commit(v_blinding), note.commit(), epk)
             .is_err());
     }
 

--- a/crypto/src/value.rs
+++ b/crypto/src/value.rs
@@ -101,6 +101,13 @@ impl std::ops::Sub<Commitment> for Commitment {
     }
 }
 
+impl std::ops::Neg for Commitment {
+    type Output = Commitment;
+    fn neg(self) -> Self::Output {
+        Commitment(-self.0)
+    }
+}
+
 impl From<Commitment> for [u8; 32] {
     fn from(commitment: Commitment) -> [u8; 32] {
         commitment.0.compress().0

--- a/crypto/src/value.rs
+++ b/crypto/src/value.rs
@@ -25,6 +25,12 @@ pub struct Value {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Commitment(pub decaf377::Element);
 
+impl Default for Commitment {
+    fn default() -> Self {
+        Self(decaf377::Element::default())
+    }
+}
+
 pub static VALUE_BLINDING_GENERATOR: Lazy<decaf377::Element> = Lazy::new(|| {
     let s = Fq::from_le_bytes_mod_order(blake2b_simd::blake2b(b"decaf377-rdsa-binding").as_bytes());
     decaf377::Element::map_to_group_cdh(&s)

--- a/stake/src/delegate.rs
+++ b/stake/src/delegate.rs
@@ -1,7 +1,8 @@
+use penumbra_crypto::{value, Fr, Value, Zero};
 use penumbra_proto::{stake as pb, Protobuf};
 use serde::{Deserialize, Serialize};
 
-use crate::IdentityKey;
+use crate::{DelegationToken, IdentityKey};
 
 /// A transaction action adding stake to a validator's delegation pool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -21,6 +22,25 @@ pub struct Delegate {
     /// (and should be checked in transaction validation!), but including it allows
     /// stateless verification that the transaction is internally consistent.
     pub delegation_amount: u64,
+}
+
+impl Delegate {
+    /// Compute a commitment to the value contributed to a transaction by this delegation.
+    pub fn value_commitment(&self) -> value::Commitment {
+        let stake = Value {
+            amount: self.unbonded_amount,
+            asset_id: crate::STAKING_TOKEN_ASSET_ID.clone(),
+        }
+        .commit(Fr::zero());
+        let delegation = Value {
+            amount: self.delegation_amount,
+            asset_id: DelegationToken::new(self.validator_identity.clone()).id(),
+        }
+        .commit(Fr::zero());
+
+        // We produce the delegation tokens and consume the staking tokens.
+        delegation - stake
+    }
 }
 
 impl Protobuf<pb::Delegate> for Delegate {}

--- a/transaction/src/action.rs
+++ b/transaction/src/action.rs
@@ -1,5 +1,6 @@
 use std::convert::{TryFrom, TryInto};
 
+use penumbra_crypto::value;
 use penumbra_proto::{transaction as pb, Protobuf};
 use penumbra_stake as stake;
 
@@ -20,6 +21,20 @@ pub enum Action {
     Delegate(stake::Delegate),
     Undelegate(stake::Undelegate),
     ValidatorDefinition(stake::ValidatorDefinition),
+}
+
+impl Action {
+    /// Obtains or computes a commitment to the (typed) value added or subtracted from
+    /// the transaction's balance by this action.
+    pub fn value_commitment(&self) -> value::Commitment {
+        match self {
+            Action::Output(output) => output.body.value_commitment,
+            Action::Spend(spend) => spend.body.value_commitment,
+            Action::Delegate(delegate) => delegate.value_commitment(),
+            Action::Undelegate(undelegate) => undelegate.value_commitment(),
+            Action::ValidatorDefinition(_) => value::Commitment::default(),
+        }
+    }
 }
 
 impl Protobuf<pb::Action> for Action {}

--- a/transaction/src/action/output.rs
+++ b/transaction/src/action/output.rs
@@ -73,7 +73,9 @@ impl Body {
         esk: &ka::Secret,
     ) -> Body {
         // TODO: p. 43 Spec. Decide whether to do leadByte 0x01 method or 0x02 or other.
-        let value_commitment = note.value().commit(v_blinding);
+
+        // Outputs subtract from the transaction value balance, so commit to -value.
+        let value_commitment = -note.value().commit(v_blinding);
         let note_commitment = note.commit();
 
         let ephemeral_key = esk.diversified_public(&note.diversified_generator());

--- a/transaction/src/genesis.rs
+++ b/transaction/src/genesis.rs
@@ -63,7 +63,7 @@ impl GenesisBuilder {
             note.transmission_key(),
             &esk,
         );
-        self.value_commitments -= body.value_commitment.0;
+        self.value_commitments += body.value_commitment.0;
 
         // xx Hardcore something in the memo for genesis?
         // let encrypted_memo = memo.encrypt(&esk, &dest);

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -7,7 +7,7 @@ use penumbra_crypto::{
     asset,
     merkle::{self, NoteCommitmentTree, TreeExt},
     rdsa::{Binding, Signature, VerificationKey, VerificationKeyBytes},
-    Fr, Value,
+    value, Fr, Value,
 };
 use penumbra_proto::{
     transaction::{
@@ -106,16 +106,8 @@ impl Transaction {
     /// Verify the binding signature.
     pub fn binding_verification_key(&self) -> VerificationKey<Binding> {
         let mut value_commitments = decaf377::Element::default();
-        for action in self.transaction_body.actions.clone() {
-            match action {
-                Action::Output(inner) => {
-                    value_commitments += inner.body.value_commitment.0;
-                }
-                Action::Spend(inner) => {
-                    value_commitments += inner.body.value_commitment.0;
-                }
-                _ => todo!("delegation binding signature contributions??"),
-            }
+        for action in &self.transaction_body.actions {
+            value_commitments += action.value_commitment().0;
         }
 
         // Add fee into binding verification key computation.

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -109,7 +109,7 @@ impl Transaction {
         for action in self.transaction_body.actions.clone() {
             match action {
                 Action::Output(inner) => {
-                    value_commitments -= inner.body.value_commitment.0;
+                    value_commitments += inner.body.value_commitment.0;
                 }
                 Action::Spend(inner) => {
                     value_commitments += inner.body.value_commitment.0;

--- a/transaction/src/transaction/builder.rs
+++ b/transaction/src/transaction/builder.rs
@@ -111,7 +111,7 @@ impl Builder {
             transmission_key,
             &esk,
         );
-        self.value_commitments -= body.value_commitment.0;
+        self.value_commitments += body.value_commitment.0;
 
         let ovk_wrapped_key = note.encrypt_key(&esk, ovk, body.value_commitment);
 


### PR DESCRIPTION
Previously, we treated the value commitment in an output description as a
commitment to the (positive) value accruing to the output notes, rather than as
a commitment to the (negative) value contributed (i.e., withdrawn) from the
transaction's value balance.  This meant that when summing the value
commitments for each action, we needed to handle spends and outputs
differently, because they had inconsistent signs.

Instead, this commit changes the value commitment of the output description to
commit to the action's contribution to the transaction's value balance (a
negative number).  This means that the semantics of the action (whether it is
contributing or withdrawing) are encapsulated in the action logic, rather than
leaking out to the code that handles the actions.