### PR TITLE
pd: rename PendingBlock::new_assets to PendingBlock::supply_updates

### DIFF
--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -117,7 +117,7 @@ impl App {
             let id = denom.id();
             tracing::debug!(?id, "registering asset id");
             genesis_block
-                .new_assets
+                .supply_updates
                 .insert(id, (denom, allocation.amount));
         }
 

--- a/pd/src/pending_block.rs
+++ b/pd/src/pending_block.rs
@@ -18,8 +18,8 @@ pub struct PendingBlock {
     pub notes: BTreeMap<note::Commitment, PositionedNoteData>,
     /// Nullifiers that were spent in this block.
     pub spent_nullifiers: BTreeSet<Nullifier>,
-    /// Stores new asset types found in this block that need to be added to the asset registry.
-    pub new_assets: BTreeMap<asset::Id, (asset::Denom, u64)>,
+    /// Records any updates to the token supply of some asset that happened in this block.
+    pub supply_updates: BTreeMap<asset::Id, (asset::Denom, u64)>,
     /// Indicates the epoch the block belongs to.
     pub epoch: Option<Epoch>,
     /// Indicates the duration in blocks of each epoch.
@@ -37,7 +37,7 @@ impl PendingBlock {
             note_commitment_tree,
             notes: BTreeMap::new(),
             spent_nullifiers: BTreeSet::new(),
-            new_assets: BTreeMap::new(),
+            supply_updates: BTreeMap::new(),
             epoch: None,
             epoch_duration,
             next_base_rate: None,

--- a/pd/src/state.rs
+++ b/pd/src/state.rs
@@ -186,7 +186,10 @@ ON CONFLICT (id) DO UPDATE SET data = $1
         }
 
         // Save any new assets found in the block to the asset registry.
-        for (id, asset) in block.new_assets {
+        for (id, asset) in block.supply_updates {
+            // TODO: this needs to use an upsert using ON CONFLICT
+            // and should be fixed whenever we implement (un)delegation and
+            // would actually exercise that code path.
             query!(
                 r#"INSERT INTO assets (asset_id, denom, total_supply) VALUES ($1, $2, $3)"#,
                 &id.to_bytes()[..],


### PR DESCRIPTION
The changes in #346 #335 change the meaning of the field, so renaming it helps clarify its new meaning.