### PR TITLE
Add tests for roundtrip parsing of note commitments, and fix parse error

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -45,4 +45,5 @@ sqlx = { version = "0.5.9", features = ["postgres"], optional = true }
 [dev-dependencies]
 proptest = "1"
 bincode = "1"
+serde_json = "1"
 sqlx = { version = "0.5.9", features = ["postgres", "runtime-tokio-rustls"] }

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -331,6 +331,29 @@ impl TryFrom<[u8; NOTE_LEN_BYTES]> for Note {
 #[serde(into = "pb::NoteCommitment", try_from = "pb::NoteCommitment")]
 pub struct Commitment(pub Fq);
 
+#[cfg(test)]
+mod test_serde {
+    use super::Commitment;
+
+    #[test]
+    fn roundtrip_json_zero() {
+        let commitment = Commitment::try_from([0; 32]).unwrap();
+        let bytes = serde_json::to_vec(&commitment).unwrap();
+        println!("{:?}", bytes);
+        let deserialized: Commitment = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(commitment, deserialized);
+    }
+
+    #[test]
+    fn roundtrip_bincode_zero() {
+        let commitment = Commitment::try_from([0; 32]).unwrap();
+        let bytes = bincode::serialize(&commitment).unwrap();
+        println!("{:?}", bytes);
+        let deserialized: Commitment = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(commitment, deserialized);
+    }
+}
+
 impl From<Commitment> for pb::NoteCommitment {
     fn from(nc: Commitment) -> Self {
         Self {

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -93,5 +93,4 @@ static FIELD_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.stake.IdentityKey.ik", AS_BECH32_IDENTITY_KEY),
     (".penumbra.crypto.Address.inner", AS_BECH32_ADDRESS),
     (".penumbra.crypto.AssetId.inner", AS_BECH32_ASSET_ID),
-    (".penumbra.crypto.NoteCommitment.inner", AS_HEX),
 ];

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -93,4 +93,5 @@ static FIELD_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.stake.IdentityKey.ik", AS_BECH32_IDENTITY_KEY),
     (".penumbra.crypto.Address.inner", AS_BECH32_ADDRESS),
     (".penumbra.crypto.AssetId.inner", AS_BECH32_ASSET_ID),
+    (".penumbra.crypto.NoteCommitment.inner", AS_HEX),
 ];

--- a/proto/src/serializers/hexstr.rs
+++ b/proto/src/serializers/hexstr.rs
@@ -5,7 +5,7 @@ pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let string = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
+    let string = String::deserialize(deserializer)?;
     hex::decode(&string).map_err(serde::de::Error::custom)
 }
 


### PR DESCRIPTION
This fixes the error on latest `main` where `pcli wallet reset && pcli balance` would result in:

```
Error: Could not parse wallet data

Caused by:
    tag for enum is not valid, found 64
```