### PR TITLE
Use an associated type for the Protobuf trait

### DIFF
--- a/chain/src/params.rs
+++ b/chain/src/params.rs
@@ -9,7 +9,9 @@ pub struct AssetInfo {
     pub total_supply: u64,
 }
 
-impl Protobuf<pb::AssetInfo> for AssetInfo {}
+impl Protobuf for AssetInfo {
+    type Protobuf = pb::AssetInfo;
+}
 
 impl TryFrom<pb::AssetInfo> for AssetInfo {
     type Error = anyhow::Error;
@@ -41,7 +43,9 @@ pub struct ChainParams {
     pub epoch_duration: u64,
 }
 
-impl Protobuf<pb::ChainParams> for ChainParams {}
+impl Protobuf for ChainParams {
+    type Protobuf = pb::ChainParams;
+}
 
 impl From<pb::ChainParams> for ChainParams {
     fn from(msg: pb::ChainParams) -> Self {

--- a/crypto/src/asset/denom.rs
+++ b/crypto/src/asset/denom.rs
@@ -21,7 +21,9 @@ pub struct Denom {
     pub(super) inner: Arc<Inner>,
 }
 
-impl Protobuf<pb::Denom> for Denom {}
+impl Protobuf for Denom {
+    type Protobuf = pb::Denom;
+}
 
 impl From<Denom> for pb::Denom {
     fn from(dn: Denom) -> Self {

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -230,7 +230,9 @@ impl OutputProof {
 
 // Conversions
 
-impl Protobuf<transparent_proofs::SpendProof> for SpendProof {}
+impl Protobuf for SpendProof {
+    type Protobuf = transparent_proofs::SpendProof;
+}
 
 impl From<SpendProof> for transparent_proofs::SpendProof {
     fn from(msg: SpendProof) -> Self {
@@ -328,7 +330,9 @@ impl TryFrom<transparent_proofs::SpendProof> for SpendProof {
     }
 }
 
-impl Protobuf<transparent_proofs::OutputProof> for OutputProof {}
+impl Protobuf for OutputProof {
+    type Protobuf = transparent_proofs::OutputProof;
+}
 
 impl From<OutputProof> for transparent_proofs::OutputProof {
     fn from(msg: OutputProof) -> Self {

--- a/proto/src/protobuf.rs
+++ b/proto/src/protobuf.rs
@@ -1,19 +1,23 @@
 /// A marker trait that captures the relationships between a domain type (`Self`) and a protobuf type (`P`).
-pub trait Protobuf<P>: Sized
+pub trait Protobuf: Sized
 where
-    P: prost::Message + Default,
-    P: std::convert::From<Self>,
-    Self: std::convert::TryFrom<P> + Clone,
-    <Self as std::convert::TryFrom<P>>::Error: Into<anyhow::Error>,
+    Self::Protobuf: prost::Message + Default,
+    Self::Protobuf: std::convert::From<Self>,
+    Self: std::convert::TryFrom<Self::Protobuf> + Clone,
+    <Self as std::convert::TryFrom<Self::Protobuf>>::Error: Into<anyhow::Error>,
 {
+    /// The protobuf type corresponding to the domain type `Self`.
+    type Protobuf;
+
     /// Encode this domain type to a byte vector, via proto type `P`.
     fn encode_to_vec(&self) -> Vec<u8> {
-        P::from(self.clone()).encode_to_vec()
+        use prost::Message;
+        Self::Protobuf::from(self.clone()).encode_to_vec()
     }
 
     /// Decode this domain type from a byte buffer, via proto type `P`.
     fn decode<B: bytes::Buf>(buf: B) -> Result<Self, anyhow::Error> {
-        <P as prost::Message>::decode(buf)?
+        <Self::Protobuf as prost::Message>::decode(buf)?
             .try_into()
             .map_err(Into::into)
     }

--- a/stake/src/delegate.rs
+++ b/stake/src/delegate.rs
@@ -43,7 +43,9 @@ impl Delegate {
     }
 }
 
-impl Protobuf<pb::Delegate> for Delegate {}
+impl Protobuf for Delegate {
+    type Protobuf = pb::Delegate;
+}
 
 impl From<Delegate> for pb::Delegate {
     fn from(d: Delegate) -> Self {

--- a/stake/src/funding_stream.rs
+++ b/stake/src/funding_stream.rs
@@ -14,7 +14,9 @@ pub struct FundingStream {
     pub rate_bps: u16,
 }
 
-impl Protobuf<pb::FundingStream> for FundingStream {}
+impl Protobuf for FundingStream {
+    type Protobuf = pb::FundingStream;
+}
 
 impl From<FundingStream> for pb::FundingStream {
     fn from(fs: FundingStream) -> Self {

--- a/stake/src/identity_key.rs
+++ b/stake/src/identity_key.rs
@@ -45,7 +45,9 @@ impl std::fmt::Debug for IdentityKey {
     }
 }
 
-impl Protobuf<pb::IdentityKey> for IdentityKey {}
+impl Protobuf for IdentityKey {
+    type Protobuf = pb::IdentityKey;
+}
 
 impl From<IdentityKey> for pb::IdentityKey {
     fn from(ik: IdentityKey) -> Self {

--- a/stake/src/rate.rs
+++ b/stake/src/rate.rs
@@ -115,7 +115,9 @@ impl RateData {
     }
 }
 
-impl Protobuf<pb::RateData> for RateData {}
+impl Protobuf for RateData {
+    type Protobuf = pb::RateData;
+}
 
 impl From<RateData> for pb::RateData {
     fn from(v: RateData) -> Self {
@@ -145,7 +147,9 @@ impl TryFrom<pb::RateData> for RateData {
     }
 }
 
-impl Protobuf<pb::BaseRateData> for BaseRateData {}
+impl Protobuf for BaseRateData {
+    type Protobuf = pb::BaseRateData;
+}
 
 impl From<BaseRateData> for pb::BaseRateData {
     fn from(v: BaseRateData) -> Self {

--- a/stake/src/undelegate.rs
+++ b/stake/src/undelegate.rs
@@ -42,7 +42,9 @@ impl Undelegate {
     }
 }
 
-impl Protobuf<pb::Undelegate> for Undelegate {}
+impl Protobuf for Undelegate {
+    type Protobuf = pb::Undelegate;
+}
 
 impl From<Undelegate> for pb::Undelegate {
     fn from(d: Undelegate) -> Self {

--- a/stake/src/validator.rs
+++ b/stake/src/validator.rs
@@ -52,7 +52,9 @@ pub struct ValidatorDefinition {
     pub auth_sig: Signature<SpendAuth>,
 }
 
-impl Protobuf<pb::Validator> for Validator {}
+impl Protobuf for Validator {
+    type Protobuf = pb::Validator;
+}
 
 impl From<Validator> for pb::Validator {
     fn from(v: Validator) -> Self {
@@ -91,7 +93,9 @@ impl TryFrom<pb::Validator> for Validator {
     }
 }
 
-impl Protobuf<pb::ValidatorDefinition> for ValidatorDefinition {}
+impl Protobuf for ValidatorDefinition {
+    type Protobuf = pb::ValidatorDefinition;
+}
 
 impl From<ValidatorDefinition> for pb::ValidatorDefinition {
     fn from(v: ValidatorDefinition) -> Self {

--- a/transaction/src/action.rs
+++ b/transaction/src/action.rs
@@ -37,7 +37,9 @@ impl Action {
     }
 }
 
-impl Protobuf<pb::Action> for Action {}
+impl Protobuf for Action {
+    type Protobuf = pb::Action;
+}
 
 impl From<Action> for pb::Action {
     fn from(msg: Action) -> Self {

--- a/transaction/src/action/output.rs
+++ b/transaction/src/action/output.rs
@@ -15,7 +15,9 @@ pub struct Output {
     pub ovk_wrapped_key: [u8; note::OVK_WRAPPED_LEN_BYTES],
 }
 
-impl Protobuf<transaction::Output> for Output {}
+impl Protobuf for Output {
+    type Protobuf = transaction::Output;
+}
 
 impl From<Output> for transaction::Output {
     fn from(msg: Output) -> Self {
@@ -100,7 +102,9 @@ impl Body {
     }
 }
 
-impl Protobuf<transaction::OutputBody> for Body {}
+impl Protobuf for Body {
+    type Protobuf = transaction::OutputBody;
+}
 
 impl From<Body> for transaction::OutputBody {
     fn from(msg: Body) -> Self {

--- a/transaction/src/action/spend.rs
+++ b/transaction/src/action/spend.rs
@@ -18,7 +18,9 @@ pub struct Spend {
     pub auth_sig: Signature<SpendAuth>,
 }
 
-impl Protobuf<transaction::Spend> for Spend {}
+impl Protobuf for Spend {
+    type Protobuf = transaction::Spend;
+}
 
 impl From<Spend> for transaction::Spend {
     fn from(msg: Spend) -> Self {
@@ -105,7 +107,9 @@ impl From<Body> for Vec<u8> {
     }
 }
 
-impl Protobuf<transaction::SpendBody> for Body {}
+impl Protobuf for Body {
+    type Protobuf = transaction::SpendBody;
+}
 
 impl From<Body> for transaction::SpendBody {
     fn from(msg: Body) -> Self {

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -138,7 +138,9 @@ impl From<TransactionBody> for Vec<u8> {
     }
 }
 
-impl Protobuf<ProtoTransactionBody> for TransactionBody {}
+impl Protobuf for TransactionBody {
+    type Protobuf = ProtoTransactionBody;
+}
 
 impl From<TransactionBody> for ProtoTransactionBody {
     fn from(msg: TransactionBody) -> Self {
@@ -187,7 +189,9 @@ impl TryFrom<ProtoTransactionBody> for TransactionBody {
         })
     }
 }
-impl Protobuf<ProtoTransaction> for Transaction {}
+impl Protobuf for Transaction {
+    type Protobuf = ProtoTransaction;
+}
 
 impl From<Transaction> for ProtoTransaction {
     fn from(msg: Transaction) -> Self {
@@ -260,7 +264,9 @@ impl From<&Transaction> for Vec<u8> {
     }
 }
 
-impl Protobuf<ProtoFee> for Fee {}
+impl Protobuf for Fee {
+    type Protobuf = ProtoFee;
+}
 
 impl From<Fee> for ProtoFee {
     fn from(fee: Fee) -> Self {


### PR DESCRIPTION
This prevents anyone from making two impls of `Protobuf` for different domain types that are backed by the same protobuf type, ensuring a 1:1 mapping of domain types to protobuf types.