### PR TITLE
pd: make next epoch's rates available

### DIFF
--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -363,6 +363,24 @@
       "nullable": []
     }
   },
+  "bf52f1b1ec94ff12c0d86fe2021370784dd9de97ad2bea79856aa624444fa142": {
+    "query": "SELECT true",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "bool",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        null
+      ]
+    }
+  },
   "c0838e2487bc88b229fe4b5ab786b11780d5196f3e88a5281e7a409171fe4734": {
     "query": "SELECT * from validator_fundingstreams WHERE identity_key = $1",
     "describe": {

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -52,18 +52,6 @@
       ]
     }
   },
-  "37dc2448272e62b1af649a73ae39b47ca5ec6ab625a9ff26d22c02a36b6be7ac": {
-    "query": "INSERT INTO base_rates (epoch, base_reward_rate, base_exchange_rate) VALUES (0, 0, $1)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
-      "nullable": []
-    }
-  },
   "4f9e6ca2890b779cf788f5993de20c8a2b80baa56966dac4c4f1e215171db0c8": {
     "query": "INSERT INTO validator_rates (\n                    identity_key,\n                    epoch,\n                    validator_reward_rate,\n                    validator_exchange_rate\n                ) VALUES ($1, $2, $3, $4)",
     "describe": {
@@ -202,6 +190,20 @@
       "nullable": [
         false
       ]
+    }
+  },
+  "7d0c140b625f2fa931570362ebb17be51ca9426ae009f5965b0716b7fd8a5ec3": {
+    "query": "INSERT INTO base_rates (\n                epoch, \n                base_reward_rate, \n                base_exchange_rate\n            ) VALUES ($1, $2, $3)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": []
     }
   },
   "8195450f9f1cedf05eebd974adbdc42dc70a8e2abb7753d7b02cba03786bee0d": {

--- a/pd/src/state.rs
+++ b/pd/src/state.rs
@@ -41,6 +41,14 @@ impl State {
         tracing::info!("running migrations");
         sqlx::migrate!("./migrations").run(&pool).await?;
         tracing::info!("finished initializing state");
+
+        let start = std::time::Instant::now();
+        let mut conn = pool.acquire().await?;
+        query!("SELECT true").fetch_all(&mut conn).await?;
+        let end = start.elapsed();
+        let ms = (end.as_micros() as f64) / 1000.;
+        tracing::info!("no-op query took {}ms ({:.0} per second)", ms, 1000. / ms);
+
         Ok(State { pool })
     }
 

--- a/stake/src/epoch.rs
+++ b/stake/src/epoch.rs
@@ -31,4 +31,12 @@ impl Epoch {
     pub fn is_epoch_boundary(height: u64, epoch_duration: u64) -> bool {
         height % epoch_duration == 0
     }
+
+    /// Returns the epoch following this one.
+    pub fn next(&self) -> Self {
+        Epoch {
+            index: self.index + 1,
+            duration: self.duration,
+        }
+    }
 }


### PR DESCRIPTION
Staking actions are supposed to make use of the rates in the epoch in which
they take effect (the next epoch), so we need to compute them in advance. This
commit changes the end-epoch processing to more cleanly model the epoch
transition (it happens after the end of the last block in the epoch) and
precompute the next epoch's rates.