### PR TITLE
Track delegations per epoch.

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,7 +15,7 @@ penumbra-proto = { path = "../proto/" }
 ark-ff = { git = "https://github.com/penumbra-zone/algebra", branch = "ours" }
 ark-serialize = { git = "https://github.com/penumbra-zone/algebra", branch = "ours" }
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
-decaf377-rdsa = { version = "0.4", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
+decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 incrementalmerkletree = { git = "https://github.com/penumbra-zone/incrementalmerkletree" }
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377" }
 

--- a/pd/migrations/20211216025603_init.sql
+++ b/pd/migrations/20211216025603_init.sql
@@ -59,3 +59,33 @@ CREATE TABLE IF NOT EXISTS validator_rates (
     validator_exchange_rate bigint NOT NULL,
     PRIMARY KEY(epoch, identity_key)
 );
+
+CREATE TABLE IF NOT EXISTS delegation_changes (
+    validator_identity_key bytea NOT NULL REFERENCES validators (identity_key),
+    epoch bigint NOT NULL,
+    delegation_change bigint NOT NULL
+);
+CREATE INDEX ON delegation_changes (epoch);
+CREATE INDEX ON delegation_changes (validator_identity_key);
+
+CREATE TABLE IF NOT EXISTS unbonding_notes (
+    validator_identity_key bytea NOT NULL REFERENCES validators (identity_key),
+    unbonding_epoch bigint NOT NULL,
+    note_commitment bytea PRIMARY KEY,
+    ephemeral_key bytea NOT NULL,
+    encrypted_note bytea NOT NULL,
+    transaction_id bytea NOT NULL,
+    pre_position bigint NOT NULL,
+    height bigint NOT NULL REFERENCES blocks (height),
+    UNIQUE(pre_position, unbonding_epoch)
+);
+CREATE INDEX ON unbonding_notes (unbonding_epoch);
+CREATE INDEX ON unbonding_notes (validator_identity_key);
+
+CREATE TABLE IF NOT EXISTS unbonding_nullifiers (
+    validator_identity_key bytea NOT NULL REFERENCES validators (identity_key),
+    unbonding_epoch bigint NOT NULL,
+    nullifier bytea PRIMARY KEY REFERENCES nullifiers (nullifier)
+);
+CREATE INDEX ON unbonding_nullifiers (unbonding_epoch);
+CREATE INDEX ON unbonding_nullifiers (validator_identity_key);

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -13,6 +13,22 @@
       "nullable": []
     }
   },
+  "2bf593b7f2e93978cb0490ac7f1c64f55d16a2bb5823db241dfc0ed33ae8540f": {
+    "query": "INSERT INTO validators (\n                    identity_key,\n                    consensus_key,\n                    sequence_number,\n                    validator_data,\n                    voting_power\n                ) VALUES ($1, $2, $3, $4, $5)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Bytea",
+          "Int8",
+          "Bytea",
+          "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "302a33ec1eec61c43e6b5507b6e059e3c9f61c6da3c853ec9c6d4c815d04df61": {
     "query": "SELECT height, note_commitment, ephemeral_key, encrypted_note\n                    FROM notes\n                    WHERE height BETWEEN $1 AND $2\n                    ORDER BY position ASC",
     "describe": {
@@ -50,6 +66,20 @@
         false,
         false
       ]
+    }
+  },
+  "4501b3fc1446d51abde3513efb7df1201092a9695f858fc090043d81ad3db490": {
+    "query": "INSERT INTO validator_fundingstreams (\n                        identity_key,\n                        address,\n                        rate_bps\n                    ) VALUES ($1, $2, $3)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Varchar",
+          "Int8"
+        ]
+      },
+      "nullable": []
     }
   },
   "4f9e6ca2890b779cf788f5993de20c8a2b80baa56966dac4c4f1e215171db0c8": {
@@ -192,20 +222,6 @@
       ]
     }
   },
-  "7d0c140b625f2fa931570362ebb17be51ca9426ae009f5965b0716b7fd8a5ec3": {
-    "query": "INSERT INTO base_rates (\n                epoch, \n                base_reward_rate, \n                base_exchange_rate\n            ) VALUES ($1, $2, $3)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Int8",
-          "Int8",
-          "Int8"
-        ]
-      },
-      "nullable": []
-    }
-  },
   "8195450f9f1cedf05eebd974adbdc42dc70a8e2abb7753d7b02cba03786bee0d": {
     "query": "SELECT denom, asset_id FROM assets",
     "describe": {
@@ -292,24 +308,22 @@
       ]
     }
   },
-  "93b5d6d5374ff58344e0492f1478cc74ac331621c15a188dd951e80aeacf80e3": {
-    "query": "INSERT INTO validators (\n                    identity_key, \n                    consensus_key, \n                    sequence_number, \n                    validator_data,\n                    voting_power\n                ) VALUES ($1, $2, $3, $4, $5)",
+  "9ab28d6b1cdbe8fd02e4382ab9cf5a2fa2914aaf460020977aeadfb8818c70af": {
+    "query": "INSERT INTO base_rates VALUES ($1, $2, $3)",
     "describe": {
       "columns": [],
       "parameters": {
         "Left": [
-          "Bytea",
-          "Bytea",
           "Int8",
-          "Bytea",
+          "Int8",
           "Int8"
         ]
       },
       "nullable": []
     }
   },
-  "9ab28d6b1cdbe8fd02e4382ab9cf5a2fa2914aaf460020977aeadfb8818c70af": {
-    "query": "INSERT INTO base_rates VALUES ($1, $2, $3)",
+  "9efba3ba5ace824dfbf620cd5d9cd46ea8e0e99c6fc791723d1490a2b84d07ac": {
+    "query": "INSERT INTO base_rates (\n                epoch,\n                base_reward_rate,\n                base_exchange_rate\n            ) VALUES ($1, $2, $3)",
     "describe": {
       "columns": [],
       "parameters": {
@@ -425,6 +439,20 @@
       "nullable": []
     }
   },
+  "d12d2e8c0c1d522212ea874d422f99e950fbd843afe73bac2b7de7a1ec31af3f": {
+    "query": "INSERT INTO delegation_changes VALUES ($1, $2, $3)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "db8426f28750016ab6ed802dcfcf3cb216e04ccad385f23f867698e56529fedb": {
     "query": "SELECT id, data FROM blobs WHERE id = 'gc';",
     "describe": {
@@ -451,20 +479,6 @@
   },
   "dd092a6ec34f710ab7138a2e48f8fcbcf21970c19183fa57d615b059029ab90d": {
     "query": "INSERT INTO assets (asset_id, denom, total_supply) VALUES ($1, $2, $3)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Varchar",
-          "Int8"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "dd42bddc81dc82581542307fb7f388cf539ae7b9dc506464bb357d1a78b8056a": {
-    "query": "INSERT INTO validator_fundingstreams (\n                        identity_key, \n                        address, \n                        rate_bps\n                    ) VALUES ($1, $2, $3)",
     "describe": {
       "columns": [],
       "parameters": {

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -76,6 +76,13 @@ pub struct App {
     epoch_duration: u64,
 
     /// Rate data for the next epoch.
+    ///
+    /// The rate data is updated only at the epoch boundary but read by both
+    /// CheckTx and DeliverTx, so it's kept in an RwLock.  Using the RwLock in
+    /// an async context should be fine, because there should be no contention
+    /// on reads, as the only time we acquire a write lock is when processing an
+    /// epoch boundary (in EndBlock), and we don't process other messages at
+    /// that time.
     next_rate_data: Arc<RwLock<BTreeMap<IdentityKey, RateData>>>,
 }
 

--- a/pd/src/pending_block.rs
+++ b/pd/src/pending_block.rs
@@ -83,7 +83,7 @@ impl PendingBlock {
 
         // Tally the delegation changes in this transaction
         for (identity_key, delegation_change) in transaction.delegation_changes {
-            self.delegation_changes.entry(identity_key).or_insert(0) += delegation_change;
+            *self.delegation_changes.entry(identity_key).or_insert(0) += delegation_change;
         }
     }
 }

--- a/pd/src/state.rs
+++ b/pd/src/state.rs
@@ -210,11 +210,12 @@ ON CONFLICT (id) DO UPDATE SET data = $1
         }
 
         // Track the net change in delegations in this block.
+        let epoch_index = block.epoch.unwrap().index;
         for (identity_key, delegation_change) in block.delegation_changes {
             query!(
                 "INSERT INTO delegation_changes VALUES ($1, $2, $3)",
                 identity_key.encode_to_vec(),
-                block.epoch.unwrap().index,
+                epoch_index as i64,
                 delegation_change
             )
             .execute(&mut dbtx)

--- a/stake/src/identity_key.rs
+++ b/stake/src/identity_key.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::DelegationToken;
 
 /// A [`SpendAuth`] [`VerificationKey`] used as a validator's identity key.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(try_from = "pb::IdentityKey", into = "pb::IdentityKey")]
 pub struct IdentityKey(pub VerificationKey<SpendAuth>);
 

--- a/stake/src/rate.rs
+++ b/stake/src/rate.rs
@@ -53,8 +53,8 @@ impl RateData {
         RateData {
             identity_key: self.identity_key.clone(),
             epoch_index: self.epoch_index + 1,
-            validator_reward_rate: validator_reward_rate,
-            validator_exchange_rate: validator_exchange_rate,
+            validator_reward_rate,
+            validator_exchange_rate,
         }
     }
     /// Computes the amount of delegation tokens corresponding to the given amount of unbonded stake.


### PR DESCRIPTION
Work with @plaidfinch on tracking (un)delegations during an epoch.

There are two parts to the database changes:

- a `delegation_changes` table used for tracking the changes to delegation token supplies;
- some `undelegation_*` tables which are not currently used, but will be used for doing unbonding.

In this PR, only the delegation changes are used. We validate the (un)delegate descriptions statefully against the rate data for the next epoch.  