### PR TITLE
Add tracking of ChainParams to pcli wallet

### DIFF
--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -11,3 +11,4 @@ penumbra-crypto = { path = "../crypto" }
 
 # Crates.io deps
 anyhow = "1"
+serde = { version = "1", features = ["derive"] }

--- a/chain/src/params.rs
+++ b/chain/src/params.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use penumbra_crypto::asset;
 use penumbra_proto::{chain as pb, crypto as pbc, Protobuf};
 
@@ -35,7 +37,7 @@ impl From<AssetInfo> for pb::AssetInfo {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ChainParams {
     pub chain_id: String,
     pub epoch_duration: u64,

--- a/pcli/src/command/wallet.rs
+++ b/pcli/src/command/wallet.rs
@@ -46,11 +46,11 @@ impl WalletCmd {
         // wallet state to be saved to disk
         let state = match self {
             // These two commands return new wallets to be saved to disk:
-            WalletCmd::Generate => Some(ClientState::new(Wallet::generate(&mut OsRng))),
+            WalletCmd::Generate => Some(ClientState::new(Wallet::generate(&mut OsRng), None)),
             WalletCmd::Import { spend_seed } => {
                 let seed = hex::decode(spend_seed)?;
                 let seed = SpendSeed::try_from(seed.as_slice())?;
-                Some(ClientState::new(Wallet::import(seed)))
+                Some(ClientState::new(Wallet::import(seed), None))
             }
             // The rest of these commands don't require a wallet state to be saved to disk:
             WalletCmd::Export => {
@@ -90,7 +90,9 @@ impl WalletCmd {
 
                 // Write the new wallet JSON to disk as a temporary file
                 let (mut tmp, tmp_path) = NamedTempFile::new()?.into_parts();
-                tmp.write_all(serde_json::to_string_pretty(&ClientState::new(wallet))?.as_bytes())?;
+                tmp.write_all(
+                    serde_json::to_string_pretty(&ClientState::new(wallet, None))?.as_bytes(),
+                )?;
 
                 // Check that we can successfully parse the result from disk
                 ClientStateFile::load(tmp_path.to_path_buf()).context("can't parse wallet after attempting to reset: refusing to overwrite existing wallet file")?;

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -12,7 +12,7 @@ mod warning;
 
 use command::*;
 use state::ClientStateFile;
-use sync::sync;
+use sync::{set_chain_params, sync};
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -71,6 +71,12 @@ async fn main() -> Result<()> {
 
     // Synchronize the wallet if the command requires it to be synchronized before it is run.
     let mut state = ClientStateFile::load(wallet_path.clone())?;
+
+    // Chain params may not have been fetched yet, do so if necessary.
+    if state.chain_params().is_none() {
+        let light_wallet_server_uri = format!("http://{}:{}", opt.node, opt.light_wallet_port);
+        set_chain_params(&mut state, light_wallet_server_uri).await?;
+    }
 
     if opt.cmd.needs_sync() {
         let light_wallet_server_uri = format!("http://{}:{}", opt.node, opt.light_wallet_port);

--- a/pcli/src/sync.rs
+++ b/pcli/src/sync.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use penumbra_proto::light_wallet::{
-    light_wallet_client::LightWalletClient, CompactBlockRangeRequest,
+    light_wallet_client::LightWalletClient, ChainParamsRequest, CompactBlockRangeRequest,
 };
 use tracing::instrument;
 
@@ -32,6 +32,24 @@ pub async fn sync(state: &mut ClientStateFile, wallet_uri: String) -> Result<()>
     }
 
     state.prune_timeouts();
+    state.commit()?;
+    tracing::info!(end_height = ?state.last_block_height().unwrap(), "finished sync");
+    Ok(())
+}
+
+/// Fetches the global chain parameters and stores them on `ClientState`.
+#[instrument(skip(state), fields(start_height = state.last_block_height()))]
+pub async fn set_chain_params(state: &mut ClientStateFile, wallet_uri: String) -> Result<()> {
+    tracing::info!("starting set_chain_params");
+    let mut client = LightWalletClient::connect(wallet_uri).await?;
+
+    let params = client
+        .chain_params(tonic::Request::new(ChainParamsRequest {}))
+        .await?
+        .into_inner();
+
+    let cp_mut = state.chain_params_mut();
+    *cp_mut = Some(params.into());
     state.commit()?;
     tracing::info!(end_height = ?state.last_block_height().unwrap(), "finished sync");
     Ok(())

--- a/pd/src/wallet.rs
+++ b/pd/src/wallet.rs
@@ -34,9 +34,6 @@ impl LightWallet for State {
         &self,
         _request: tonic::Request<ChainParamsRequest>,
     ) -> Result<tonic::Response<ChainParams>, Status> {
-        // DB query every time this happens is not ideal.
-        // The epoch duration is stored in the `App`, but
-        // not exposed to `State`
         let genesis_configuration = self
             .genesis_configuration()
             .await

--- a/proto/proto/light_wallet.proto
+++ b/proto/proto/light_wallet.proto
@@ -1,13 +1,14 @@
 syntax = "proto3";
 package penumbra.light_wallet;
 
-import "transaction.proto";
+import "chain.proto";
 
 // A light wallet service.
 //
 // This protocol attempts to be trust-minimized, both in terms of integrity and privacy.
 service LightWallet {
   rpc CompactBlockRange(CompactBlockRangeRequest) returns (stream CompactBlock);
+  rpc ChainParams(ChainParamsRequest) returns (chain.ChainParams);
 }
 
 // Requests a range of compact block data.
@@ -36,4 +37,8 @@ message StateFragment {
   // An encryption of the newly created note.
   // 132 = 1(type) + 11(d) + 8(amount) + 32(asset_id) + 32(rcm) + 32(pk_d) + 16(MAC) bytes.
   bytes encrypted_note = 4;
+}
+
+// Requests the global configuration data for the chain.
+message ChainParamsRequest {
 }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 [dependencies]
 # Workspace dependencies
 penumbra-proto = { path = "../proto" }
+penumbra-chain = { path = "../chain" }
 penumbra-crypto = { path = "../crypto" }
 penumbra-transaction = { path = "../transaction" }
 


### PR DESCRIPTION
This will automatically sync the ChainParams to `pcli` when initially instantiated. There's currently no support for updating chain parameters afterwards. This shouldn't be an issue for now as they're currently static for the lifetime of the chain, but that may not always be the case.

Fixes #329 