### PR TITLE
Implement delegations and undelegations

### DIFF
--- a/chain/src/params.rs
+++ b/chain/src/params.rs
@@ -1,7 +1,6 @@
-use serde::{Deserialize, Serialize};
-
 use penumbra_crypto::asset;
 use penumbra_proto::{chain as pb, crypto as pbc, Protobuf};
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug)]
 pub struct AssetInfo {

--- a/crypto/src/asset/denom.rs
+++ b/crypto/src/asset/denom.rs
@@ -5,12 +5,11 @@ use std::{
     sync::Arc,
 };
 
-use penumbra_proto::{crypto as pb, Protobuf};
-
 use ark_ff::fields::PrimeField;
+use penumbra_proto::{crypto as pb, Protobuf};
+use serde::{Deserialize, Serialize};
 
 use crate::{asset, Fq, Value};
-use serde::{Deserialize, Serialize};
 /// An asset denomination.
 ///
 /// Each denomination has a unique [`asset::Id`] and base unit, and may also

--- a/crypto/src/merkle.rs
+++ b/crypto/src/merkle.rs
@@ -20,7 +20,7 @@ pub static MERKLE_DOMAIN_SEP: Lazy<Fq> = Lazy::new(|| {
 });
 
 // Return value from `Tree::authentication_path(value: &note::Commitment)`
-pub type Path = (usize, Vec<note::Commitment>);
+pub type Path = (Position, Vec<note::Commitment>);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Root(pub Fq);

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -237,7 +237,7 @@ impl From<SpendProof> for transparent_proofs::SpendProof {
         let ak_bytes: [u8; 32] = msg.ak.into();
         let nk_bytes: [u8; 32] = msg.nk.0.to_bytes();
         transparent_proofs::SpendProof {
-            merkle_path_field_0: msg.merkle_path.0 as u32,
+            merkle_path_field_0: u64::from(msg.merkle_path.0) as u32,
             merkle_path_field_1: msg
                 .merkle_path
                 .1
@@ -285,7 +285,7 @@ impl TryFrom<transparent_proofs::SpendProof> for SpendProof {
         }
 
         Ok(SpendProof {
-            merkle_path: (proto.merkle_path_field_0 as usize, merkle_path_vec),
+            merkle_path: ((proto.merkle_path_field_0 as usize).into(), merkle_path_vec),
             position: (proto.position as usize).into(),
             g_d: g_d_encoding
                 .decompress()
@@ -643,8 +643,7 @@ mod tests {
         nct.append(&note_commitment);
         let anchor = nct.root2();
         nct.witness();
-        let auth_path = nct.authentication_path(&note_commitment).unwrap();
-        let merkle_path = (u64::from(auth_path.0) as usize, auth_path.1);
+        let merkle_path = nct.authentication_path(&note_commitment).unwrap();
 
         let proof = SpendProof {
             merkle_path,
@@ -691,8 +690,7 @@ mod tests {
         let incorrect_anchor = nct.root2();
         nct.append(&note_commitment);
         nct.witness();
-        let auth_path = nct.authentication_path(&note_commitment).unwrap();
-        let merkle_path = (u64::from(auth_path.0) as usize, auth_path.1);
+        let merkle_path = nct.authentication_path(&note_commitment).unwrap();
 
         let proof = SpendProof {
             merkle_path,
@@ -738,8 +736,7 @@ mod tests {
         nct.append(&note_commitment);
         nct.witness();
         let anchor = nct.root2();
-        let auth_path = nct.authentication_path(&note_commitment).unwrap();
-        let merkle_path = (u64::from(auth_path.0) as usize, auth_path.1);
+        let merkle_path = nct.authentication_path(&note_commitment).unwrap();
 
         let proof = SpendProof {
             merkle_path,
@@ -785,8 +782,7 @@ mod tests {
         nct.append(&note_commitment);
         nct.witness();
         let anchor = nct.root2();
-        let auth_path = nct.authentication_path(&note_commitment).unwrap();
-        let merkle_path = (u64::from(auth_path.0) as usize, auth_path.1);
+        let merkle_path = nct.authentication_path(&note_commitment).unwrap();
 
         let proof = SpendProof {
             merkle_path,

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -16,8 +16,9 @@ publish = false
 penumbra-proto = { path = "../proto" }
 penumbra-chain = { path = "../chain" }
 penumbra-crypto = { path = "../crypto", features = ["sqlx"]}
-penumbra-wallet = { path = "../wallet" }
 penumbra-stake = { path = "../stake" }
+penumbra-transaction = { path = "../transaction" }
+penumbra-wallet = { path = "../wallet" }
 
 # Penumbra dependencies
 ark-ff = { git = "https://github.com/penumbra-zone/algebra", branch = "ours" }

--- a/pcli/src/command/stake.rs
+++ b/pcli/src/command/stake.rs
@@ -84,12 +84,6 @@ impl StakeCmd {
 
                 let to = to.parse::<IdentityKey>()?;
 
-                // If we're the first ever delegator to this validator, the corresponding
-                // asset might not be recorded on-chain already, so add it to the asset cache.
-                state
-                    .asset_cache_mut()
-                    .extend(std::iter::once(to.delegation_token().denom()));
-
                 // FIXME! need some kind of structure for recording chain
                 // parameters - connected with having protos for genesis data
                 // (though not all genesis data is chain parameters)

--- a/pcli/src/command/stake.rs
+++ b/pcli/src/command/stake.rs
@@ -84,12 +84,10 @@ impl StakeCmd {
 
                 let to = to.parse::<IdentityKey>()?;
 
-                // FIXME! need some kind of structure for recording chain
-                // parameters - connected with having protos for genesis data
-                // (though not all genesis data is chain parameters)
-                let epoch_duration = 10;
-                let current_epoch =
-                    Epoch::from_height(state.last_block_height().unwrap() as u64, epoch_duration);
+                let current_epoch = Epoch::from_height(
+                    state.last_block_height().unwrap() as u64,
+                    state.chain_params().unwrap().epoch_duration,
+                );
                 let next_epoch = current_epoch.next();
 
                 let mut client = opt.thin_wallet_client().await?;
@@ -132,12 +130,10 @@ impl StakeCmd {
 
                 let from = delegation_token.validator();
 
-                // FIXME! need some kind of structure for recording chain
-                // parameters - connected with having protos for genesis data
-                // (though not all genesis data is chain parameters)
-                let epoch_duration = 10;
-                let current_epoch =
-                    Epoch::from_height(state.last_block_height().unwrap() as u64, epoch_duration);
+                let current_epoch = Epoch::from_height(
+                    state.last_block_height().unwrap() as u64,
+                    state.chain_params().unwrap().epoch_duration,
+                );
                 let next_epoch = current_epoch.next();
 
                 let mut client = opt.thin_wallet_client().await?;

--- a/pcli/src/command/tx.rs
+++ b/pcli/src/command/tx.rs
@@ -52,8 +52,7 @@ impl TxCmd {
                     .parse()
                     .map_err(|_| anyhow::anyhow!("address is invalid"))?;
 
-                let tx =
-                    state.new_transaction(&mut OsRng, &values, *fee, to, *from, memo.clone())?;
+                let tx = state.build_send(&mut OsRng, &values, *fee, to, *from, memo.clone())?;
                 state.commit()?;
 
                 let serialized_tx: Vec<u8> = tx.into();

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -1,0 +1,66 @@
+use penumbra_proto::{
+    light_wallet::light_wallet_client::LightWalletClient,
+    thin_wallet::thin_wallet_client::ThinWalletClient, Protobuf,
+};
+use penumbra_transaction::Transaction;
+use tonic::transport::Channel;
+use tracing::instrument;
+
+use crate::Opt;
+
+impl Opt {
+    /// Submits a transaction to the network, returning `Ok` only when the remote
+    /// node has accepted the transaction, and erroring otherwise.
+    #[instrument(skip(self, transaction))]
+    pub async fn submit_transaction(&self, transaction: &Transaction) -> Result<(), anyhow::Error> {
+        tracing::info!("broadcasting transaction...");
+
+        let rsp: serde_json::Value = reqwest::get(format!(
+            r#"http://{}:{}/broadcast_tx_sync?tx=0x{}"#,
+            self.node,
+            self.rpc_port,
+            hex::encode(&transaction.encode_to_vec())
+        ))
+        .await?
+        .json()
+        .await?;
+
+        tracing::info!("{}", rsp);
+
+        let result = rsp
+            .get("result")
+            .ok_or_else(|| anyhow::anyhow!("could not parse JSON response"))?;
+
+        let code = result
+            .get("code")
+            .and_then(|c| c.as_i64())
+            .ok_or_else(|| anyhow::anyhow!("could not parse JSON response"))?;
+
+        if code == 0 {
+            Ok(())
+        } else {
+            let log = result
+                .get("log")
+                .and_then(|l| l.as_str())
+                .ok_or_else(|| anyhow::anyhow!("could not parse JSON response"))?;
+
+            Err(anyhow::anyhow!(
+                "Error submitting transaction: code {}, log: {}",
+                code,
+                log
+            ))
+        }
+    }
+
+    pub async fn thin_wallet_client(&self) -> Result<ThinWalletClient<Channel>, anyhow::Error> {
+        ThinWalletClient::connect(format!("http://{}:{}", self.node, self.thin_wallet_port))
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn light_wallet_client(&self) -> Result<LightWalletClient<Channel>, anyhow::Error> {
+        LightWalletClient::connect(format!("http://{}:{}", self.node, self.light_wallet_port))
+            .await
+            .map_err(Into::into)
+    }
+}

--- a/pcli/src/state.rs
+++ b/pcli/src/state.rs
@@ -27,7 +27,6 @@ impl DerefMut for ClientStateFile {
 
 impl Drop for ClientStateFile {
     fn drop(&mut self) {
-        self.commit().unwrap();
         self.lock.unlock().unwrap();
     }
 }
@@ -67,6 +66,7 @@ impl ClientStateFile {
 
     /// Commit the client state to disk.
     pub fn commit(&self) -> Result<()> {
+        tracing::debug!("committing state");
         // Open a new named temp file (this has to be a named temp file because we need to persist
         // it and there's no platform-independent way to do this using an anonymous temp file)
         let tmp = tempfile::NamedTempFile::new()?;

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -1,6 +1,7 @@
-use std::net::Ipv4Addr;
-use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    path::PathBuf,
+};
 
 use metrics_exporter_prometheus::PrometheusBuilder;
 use pd::{App, State};
@@ -200,24 +201,19 @@ async fn main() -> anyhow::Result<()> {
             output_dir,
             chain_id,
         } => {
-            use std::fs;
-            use std::fs::File;
-            use std::io::Write;
-            use std::str::FromStr;
-            use std::time::Duration;
-            use std::time::{SystemTime, UNIX_EPOCH};
+            use std::{
+                fs,
+                fs::File,
+                io::Write,
+                str::FromStr,
+                time::{Duration, SystemTime, UNIX_EPOCH},
+            };
 
-            use tendermint::account::Id;
-            use tendermint::public_key::Algorithm;
-            use tendermint::Genesis;
-            use tendermint::Time;
-            use tendermint_config::NodeKey;
-            use tendermint_config::PrivValidatorKey;
-
-            use pd::genesis::ValidatorPower;
-            use pd::{genesis, testnet::*};
+            use pd::{genesis, genesis::ValidatorPower, testnet::*};
             use penumbra_crypto::Address;
             use penumbra_stake::IdentityKey;
+            use tendermint::{account::Id, public_key::Algorithm, Genesis, Time};
+            use tendermint_config::{NodeKey, PrivValidatorKey};
 
             assert!(
                 num_validator_nodes > 0,

--- a/pd/src/testnet.rs
+++ b/pd/src/testnet.rs
@@ -1,14 +1,10 @@
-use std::env::current_dir;
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::{fmt, fs::File};
+use std::{env::current_dir, fmt, fs::File, path::PathBuf, str::FromStr};
 
 use anyhow::{Context, Result};
 use directories::UserDirs;
+use penumbra_crypto::Address;
 use regex::{Captures, Regex};
 use serde::{de, Deserialize};
-
-use penumbra_crypto::Address;
 use tendermint::PrivateKey;
 
 use crate::genesis;

--- a/pd/src/verify.rs
+++ b/pd/src/verify.rs
@@ -331,8 +331,8 @@ mod tests {
         nct.append(&note_commitment);
         let anchor = nct.root2();
         nct.witness();
-        let auth_path = nct.authentication_path(&note_commitment).unwrap();
-        let merkle_path = (u64::from(auth_path.0) as usize, auth_path.1);
+        let merkle_path = nct.authentication_path(&note_commitment).unwrap();
+        let position = merkle_path.0;
 
         let transaction = Transaction::build_with_root(anchor.clone())
             .set_fee(10)
@@ -344,7 +344,7 @@ mod tests {
                 MemoPlaintext::default(),
                 ovk_sender,
             )
-            .add_spend(&mut rng, sk_sender, merkle_path, note, auth_path.0)
+            .add_spend(&mut rng, sk_sender, merkle_path, note, position)
             .finalize(&mut rng)
             .expect("transaction created ok");
 

--- a/pd/src/verify.rs
+++ b/pd/src/verify.rs
@@ -174,6 +174,16 @@ impl StatefulTransactionExt for PendingTransaction {
                 anyhow::anyhow!("Unknown validator identity {}", d.validator_identity)
             })?;
 
+            // Check whether the epoch is correct first, to give a more helpful
+            // error message if it's wrong.
+            if d.epoch_index != rate_data.epoch_index {
+                return Err(anyhow::anyhow!(
+                    "Delegation was prepared for next epoch {} but the next epoch is {}",
+                    d.epoch_index,
+                    rate_data.epoch_index
+                ));
+            }
+
             // For delegations, we enforce correct computation (with rounding)
             // of the *delegation amount based on the unbonded amount*, because
             // users (should be) starting with the amount of unbonded stake they
@@ -208,6 +218,16 @@ impl StatefulTransactionExt for PendingTransaction {
             let rate_data = next_rate_data.get(&u.validator_identity).ok_or_else(|| {
                 anyhow::anyhow!("Unknown validator identity {}", u.validator_identity)
             })?;
+
+            // Check whether the epoch is correct first, to give a more helpful
+            // error message if it's wrong.
+            if u.epoch_index != rate_data.epoch_index {
+                return Err(anyhow::anyhow!(
+                    "Undelegation was prepared for next epoch {} but the next epoch is {}",
+                    u.epoch_index,
+                    rate_data.epoch_index
+                ));
+            }
 
             // For undelegations, we enforce correct computation (with rounding)
             // of the *unbonded amount based on the delegation amount*, because

--- a/pd/src/wallet.rs
+++ b/pd/src/wallet.rs
@@ -155,10 +155,10 @@ tracing::debug!(asset_id = ?hex::encode(&asset.asset_id), asset_denom = ?asset.a
         Ok(tonic::Response::new(Self::AssetListStream::new(rx)))
     }
 
-    #[instrument(skip(self, request))]
+    #[instrument(skip(self, _request))]
     async fn validator_status(
         &self,
-        request: tonic::Request<proto::stake::IdentityKey>,
+        _request: tonic::Request<proto::stake::IdentityKey>,
     ) -> Result<tonic::Response<proto::stake::ValidatorStatus>, Status> {
         todo!()
     }

--- a/stake/src/token.rs
+++ b/stake/src/token.rs
@@ -24,7 +24,7 @@ impl DelegationToken {
     }
 
     /// Get the base denomination for this delegation token.
-    pub fn base_denom(&self) -> asset::Denom {
+    pub fn denom(&self) -> asset::Denom {
         self.base_denom.clone()
     }
 

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -60,6 +60,8 @@ impl Transaction {
         Builder {
             spends: Vec::new(),
             outputs: Vec::new(),
+            delegations: Vec::new(),
+            undelegations: Vec::new(),
             fee: None,
             synthetic_blinding_factor: Fr::zero(),
             value_balance: decaf377::Element::default(),

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -119,9 +119,6 @@ impl Transaction {
         let fee_value_commitment = fee_value.commit(fee_v_blinding);
         value_commitments -= fee_value_commitment.0;
 
-        // This works for all non-genesis transactions. For transactions with
-        // non-zero value balance, the binding verification key must be computed
-        // as `(value_commitments - value_balance).compress().0.into()`.
         let binding_verification_key_bytes: VerificationKeyBytes<Binding> =
             value_commitments.compress().0.into();
 

--- a/transaction/src/transaction/builder.rs
+++ b/transaction/src/transaction/builder.rs
@@ -86,6 +86,22 @@ impl Builder {
         Ok(self)
     }
 
+    /// Create a new `Output`, implicitly creating a new note for it and encrypting the provided
+    /// [`MemoPlaintext`] with a fresh ephemeral secret key.
+    ///
+    /// To return the generated note, use [`Builder::add_output_producing_note`].
+    pub fn add_output<R: RngCore + CryptoRng>(
+        &mut self,
+        rng: &mut R,
+        dest: &Address,
+        value_to_send: Value,
+        memo: MemoPlaintext,
+        ovk: &OutgoingViewingKey,
+    ) -> &mut Self {
+        self.add_output_producing_note(rng, dest, value_to_send, memo, ovk);
+        self
+    }
+
     /// Generate a new note and add it to the output, returning a clone of the generated note.
     ///
     /// For chaining output, use [`Builder::add_output`].
@@ -132,21 +148,6 @@ impl Builder {
         note
     }
 
-    /// Create a new `Output`, implicitly creating a new note for it and encrypting the provided
-    /// [`MemoPlaintext`] with a fresh ephemeral secret key.
-    ///
-    /// To return the generated note, use [`Builder::add_output_producing_note`].
-    pub fn add_output<R: RngCore + CryptoRng>(
-        &mut self,
-        rng: &mut R,
-        dest: &Address,
-        value_to_send: Value,
-        memo: MemoPlaintext,
-        ovk: &OutgoingViewingKey,
-    ) -> &mut Self {
-        self.add_output_producing_note(rng, dest, value_to_send, memo, ovk);
-        self
-    }
 
     /// Set the transaction fee in PEN.
     ///

--- a/transaction/src/transaction/builder.rs
+++ b/transaction/src/transaction/builder.rs
@@ -159,13 +159,12 @@ impl Builder {
             asset_id: asset_id.clone(),
         };
 
-        let fee_v_blinding = Fr::zero();
-        let value_commitment = fee_value.commit(fee_v_blinding);
-
         // The fee is effectively an additional output, so we
         // add to the transaction's value balance.
-        self.synthetic_blinding_factor -= fee_v_blinding;
-        self.value_balance -= Fr::from(fee) * asset_id.value_generator();
+        let value_commitment = fee_value.commit(Fr::zero());
+        // The value commitment has 0 blinding factor, so we skip
+        // accumulating a blinding term into the synthetic blinding factor.
+        self.value_balance -= value_commitment.0;
         self.value_commitments -= value_commitment.0;
 
         self.fee = Some(Fee(fee));

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 penumbra-proto = { path = "../proto" }
 penumbra-chain = { path = "../chain" }
 penumbra-crypto = { path = "../crypto" }
+penumbra-stake = { path = "../stake" }
 penumbra-transaction = { path = "../transaction" }
 
 # External dependencies

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -165,12 +165,12 @@ impl ClientState {
         &mut self,
         rng: &mut R,
         amount: u64,
-        denom: Denom,
+        denom: &Denom,
         source_address: Option<u64>,
     ) -> Result<Vec<Note>, anyhow::Error> {
         let mut notes_by_address = self
             .unspent_notes_by_denom_and_address()
-            .remove(&denom)
+            .remove(denom)
             .ok_or_else(|| anyhow::anyhow!("no notes of denomination {} found", denom))?;
 
         let mut notes = if let Some(source) = source_address {
@@ -287,8 +287,7 @@ impl ClientState {
             }
 
             // Select a list of notes that provides at least the required amount.
-            let notes: Vec<Note> =
-                self.notes_to_spend(rng, amount, denom.clone(), source_address)?;
+            let notes: Vec<Note> = self.notes_to_spend(rng, amount, &denom, source_address)?;
             let change_address = self
                 .wallet
                 .change_address(notes.last().expect("spent at least one note"))?;

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -227,9 +227,6 @@ impl ClientState {
     }
 
     /// Generate a new transaction sending value to `dest_address`.
-    ///
-    /// TODO: this function is too complicated, merge with
-    /// builder API ?
     #[instrument(skip(self, rng))]
     pub fn build_send<R: RngCore + CryptoRng>(
         &mut self,
@@ -299,20 +296,12 @@ impl ClientState {
 
             // Spend each of the notes we selected.
             for note in notes {
-                let note_commitment = note.commit();
-
-                let merkle_path = self
-                    .note_commitment_tree
-                    .authentication_path(&note_commitment)
-                    .expect("tried to spend note not present in note commitment tree");
-                let merkle_position = merkle_path.0;
                 tx_builder.add_spend(
                     rng,
+                    &self.note_commitment_tree,
                     self.wallet.spend_key(),
-                    merkle_path,
                     note,
-                    merkle_position,
-                );
+                )?;
             }
 
             // Find out how much change we have and whether to add a change output.

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -226,12 +226,12 @@ impl ClientState {
         }
     }
 
-    /// Generate a new transaction.
+    /// Generate a new transaction sending value to `dest_address`.
     ///
     /// TODO: this function is too complicated, merge with
     /// builder API ?
     #[instrument(skip(self, rng))]
-    pub fn new_transaction<R: RngCore + CryptoRng>(
+    pub fn build_send<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
         values: &[Value],

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -121,8 +121,8 @@ impl ClientState {
     }
 
     /// Returns the global chain parameters.
-    pub fn chain_params(&self) -> &Option<ChainParams> {
-        &self.chain_params
+    pub fn chain_params(&self) -> Option<&ChainParams> {
+        self.chain_params.as_ref()
     }
 
     /// Returns a mutable reference to the global chain parameters.

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -301,12 +301,11 @@ impl ClientState {
             for note in notes {
                 let note_commitment = note.commit();
 
-                let auth_path = self
+                let merkle_path = self
                     .note_commitment_tree
                     .authentication_path(&note_commitment)
                     .expect("tried to spend note not present in note commitment tree");
-                let merkle_path = (u64::from(auth_path.0) as usize, auth_path.1);
-                let merkle_position = auth_path.0;
+                let merkle_position = merkle_path.0;
                 tx_builder.add_spend(
                     rng,
                     self.wallet.spend_key(),

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -47,9 +47,9 @@ impl Wallet {
         self.spend_key.full_viewing_key().outgoing()
     }
 
-    /// Spend key from this spend seed.
-    pub fn spend_key(&self) -> SpendKey {
-        self.spend_key.clone()
+    /// Returns the wallet's spend seed.
+    pub fn spend_key(&self) -> &SpendKey {
+        &self.spend_key
     }
 
     /// Get the full viewing key for this wallet.


### PR DESCRIPTION
Closes #45 #48, and does cleanup to `pcli` and the transaction builder code along the way; more details on the steps are in the commit messages.