### PR TITLE
pd: change asset_lookup to take asset::Id instead of bytes

### DIFF
--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -14,7 +14,6 @@ use penumbra_crypto::{
     merkle::{self, NoteCommitmentTree, TreeExt},
     note, Nullifier,
 };
-use penumbra_proto::Protobuf;
 use penumbra_stake::{
     Epoch, IdentityKey, RateData, ValidatorStatus, STAKING_TOKEN_ASSET_ID, STAKING_TOKEN_DENOM,
 };
@@ -426,7 +425,7 @@ impl App {
                 let current_rates = state.rate_data(current_epoch.index).await?;
 
                 let mut staking_token_supply = state
-                    .asset_lookup(STAKING_TOKEN_ASSET_ID.encode_to_vec())
+                    .asset_lookup(*STAKING_TOKEN_ASSET_ID)
                     .await?
                     .map(|info| info.total_supply)
                     .unwrap();
@@ -478,7 +477,7 @@ impl App {
                     let unbonded_amount = current_rate.unbonded_amount(delegation_amount);
 
                     let mut delegation_token_supply = state
-                        .asset_lookup(identity_key.delegation_token().id().encode_to_vec())
+                        .asset_lookup(identity_key.delegation_token().id())
                         .await?
                         .map(|info| info.total_supply)
                         .unwrap_or(0);
@@ -518,11 +517,15 @@ impl App {
                     // rename to curr_rate so it lines up with next_rate (same # chars)
                     tracing::debug!(curr_rate = ?current_rate);
                     tracing::debug!(?next_rate);
+                    tracing::debug!(?delegation_delta);
+                    tracing::debug!(?delegation_token_supply);
                     tracing::debug!(?next_status);
 
                     next_rates.push(next_rate);
                     next_validator_statuses.push(next_status);
                 }
+
+                tracing::debug!(?staking_token_supply);
 
                 pending_block.lock().unwrap().next_rates = Some(next_rates);
                 pending_block.lock().unwrap().next_base_rate = Some(next_base_rate);

--- a/pd/src/state.rs
+++ b/pd/src/state.rs
@@ -550,12 +550,12 @@ ON CONFLICT (id) DO UPDATE SET data = $1
     }
 
     /// Retrieve the [`Asset`] for a given asset ID.
-    pub async fn asset_lookup(&self, asset_id: Vec<u8>) -> Result<Option<chain::AssetInfo>> {
+    pub async fn asset_lookup(&self, asset_id: asset::Id) -> Result<Option<chain::AssetInfo>> {
         let mut conn = self.pool.acquire().await?;
 
         let asset = query!(
             "SELECT denom, asset_id, total_supply FROM assets WHERE asset_id = $1",
-            asset_id
+            asset_id.to_bytes().to_vec(),
         )
         .fetch_optional(&mut conn)
         .await?;

--- a/pd/src/wallet.rs
+++ b/pd/src/wallet.rs
@@ -115,11 +115,12 @@ impl ThinWallet for State {
         &self,
         request: tonic::Request<AssetId>,
     ) -> Result<tonic::Response<AssetInfo>, Status> {
-        let aid = request.into_inner().inner;
-        tracing::debug!(asset_id = ?hex::encode(&aid));
+        let asset_id = penumbra_crypto::asset::Id::try_from(request.into_inner())
+            .map_err(|_| tonic::Status::not_found("invalid asset ID"))?;
+        tracing::debug!(?asset_id);
         let state = self.clone();
         let asset = state
-            .asset_lookup(aid)
+            .asset_lookup(asset_id)
             .await
             .map_err(|_| tonic::Status::not_found("asset not found"))?
             .ok_or(|| anyhow::anyhow!("asset not found"))


### PR DESCRIPTION
This fixes a bug where different parts of the code were writing asset IDs to
bytes in different ways (either as a 32 byte array, or as that array wrapped in
a proto encoding), causing lookups to fail.