### PR TITLE
pcli: remove extra .commit() call

### DIFF
--- a/pcli/src/command/stake.rs
+++ b/pcli/src/command/stake.rs
@@ -103,7 +103,6 @@ impl StakeCmd {
 
                 let transaction =
                     state.build_delegate(&mut OsRng, rate_data, unbonded_amount, *fee, *source)?;
-                state.commit()?;
 
                 opt.submit_transaction(&transaction).await?;
                 // Only commit the state if the transaction was submitted successfully,


### PR DESCRIPTION
This fixes a problem where a failed delegation command would wrongly commit the client state.