### PR TITLE
implement validator commission rewards

### DIFF
--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -12,7 +12,7 @@ use futures::future::FutureExt;
 use penumbra_crypto::{
     asset,
     merkle::{self, NoteCommitmentTree, TreeExt},
-    note, Nullifier, Value,
+    note, Nullifier,
 };
 use penumbra_stake::{
     Epoch, IdentityKey, RateData, ValidatorStatus, STAKING_TOKEN_ASSET_ID, STAKING_TOKEN_DENOM,
@@ -514,10 +514,8 @@ impl App {
                     };
 
                     // distribute validator commission
-
                     for stream in funding_streams {
-                        let commission_reward_amount = current_rate.reward_amount(
-                            stream.rate_bps as u64,
+                        let commission_reward_amount = stream.reward_amount(
                             delegation_token_supply,
                             &next_base_rate,
                             &current_base_rate,

--- a/pd/src/app.rs
+++ b/pd/src/app.rs
@@ -466,8 +466,10 @@ impl App {
                     let identity_key = current_rate.identity_key.clone();
 
                     let funding_streams = state.funding_streams(identity_key.clone()).await?;
-
-                    let next_rate = current_rate.next(&next_base_rate, funding_streams);
+                    let validator_commission_sum = funding_streams
+                        .iter()
+                        .fold(0u64, |total, stream| total + stream.rate_bps as u64);
+                    let next_rate = current_rate.next(&next_base_rate, funding_streams.clone());
 
                     // TODO: if a validator isn't part of the consensus set, should we ignore them
                     // and not update their rates?
@@ -513,6 +515,16 @@ impl App {
                         identity_key,
                         voting_power,
                     };
+
+                    // distribute validator commission
+                    let commission_reward_amount = current_rate.reward_amount(
+                        validator_commission_sum,
+                        delegation_token_supply,
+                        &next_base_rate,
+                        &current_base_rate,
+                    );
+
+                    for stream in funding_streams {}
 
                     // rename to curr_rate so it lines up with next_rate (same # chars)
                     tracing::debug!(curr_rate = ?current_rate);

--- a/pd/src/pending_block.rs
+++ b/pd/src/pending_block.rs
@@ -7,8 +7,7 @@ use penumbra_crypto::{
     note, Address, Fq, Note, Nullifier, Value, Zero,
 };
 use penumbra_stake::{
-    BaseRateData, Epoch, FundingStream, IdentityKey, RateData, ValidatorStatus,
-    STAKING_TOKEN_ASSET_ID,
+    BaseRateData, Epoch, IdentityKey, RateData, ValidatorStatus, STAKING_TOKEN_ASSET_ID,
 };
 
 use crate::verify::{NoteData, PositionedNoteData, VerifiedTransaction};
@@ -63,8 +62,7 @@ impl PendingBlock {
         epoch
     }
 
-    /// Adds a reward output from a validator's funding stream.
-    /// currently we just construct a note with 0 blinding factor
+    /// Adds a reward output for a validator's funding stream.
     pub fn add_validator_reward_note(&mut self, amount: u64, destination: Address) {
         let val = Value {
             amount: amount,

--- a/stake/src/funding_stream.rs
+++ b/stake/src/funding_stream.rs
@@ -14,6 +14,27 @@ pub struct FundingStream {
     pub rate_bps: u16,
 }
 
+impl FundingStream {
+    /// Computes the amount of reward at the epoch specified by base_rate_data
+    pub fn reward_amount(
+        &self,
+        total_delegation_tokens: u64,
+        base_rate_data: &crate::BaseRateData,
+        prev_epoch_rate_data: &crate::BaseRateData,
+    ) -> u64 {
+        if prev_epoch_rate_data.epoch_index != base_rate_data.epoch_index - 1 {
+            panic!("wrong base rate data for previous epoch")
+        }
+        // take yv*cve*re*psi(e-1)
+        let mut r =
+            (total_delegation_tokens as u128 * (self.rate_bps as u128 * 1_0000)) / 1_0000_0000;
+        r = (r * base_rate_data.base_reward_rate as u128) / 1_0000_0000;
+        r = (r * prev_epoch_rate_data.base_exchange_rate as u128) / 1_0000_0000;
+
+        r as u64
+    }
+}
+
 impl Protobuf<pb::FundingStream> for FundingStream {}
 
 impl From<FundingStream> for pb::FundingStream {

--- a/stake/src/rate.rs
+++ b/stake/src/rate.rs
@@ -107,6 +107,28 @@ impl RateData {
             .try_into()
             .unwrap()
     }
+
+    /// Computes the amount of reward at the epoch specified by base_rate_data
+    pub fn reward_amount(
+        &self,
+        commission_rate_bps: u64,
+        total_delegation_tokens: u64,
+        base_rate_data: &BaseRateData,
+        prev_epoch_rate_data: &BaseRateData,
+    ) -> u64 {
+        if base_rate_data.epoch_index != self.epoch_index {
+            panic!("wrong base rate data for epoch")
+        }
+        if prev_epoch_rate_data.epoch_index != base_rate_data.epoch_index - 1 {
+            panic!("wrong base rate data for previous epoch")
+        }
+        // take yv*cve*re*psi(e-1)
+        let mut r = (total_delegation_tokens as u128 * (commission_rate_bps as u128 * 1_0000)) / 1_0000_0000;
+        r = (r * base_rate_data.base_reward_rate as u128) / 1_0000_0000;
+        r = (r * prev_epoch_rate_data.base_exchange_rate as u128) / 1_0000_0000;
+        
+        r as u64
+    }
 }
 /// Describes the base reward and exchange rates in some epoch.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]

--- a/stake/src/rate.rs
+++ b/stake/src/rate.rs
@@ -107,29 +107,8 @@ impl RateData {
             .try_into()
             .unwrap()
     }
-
-    /// Computes the amount of reward at the epoch specified by base_rate_data
-    pub fn reward_amount(
-        &self,
-        commission_rate_bps: u64,
-        total_delegation_tokens: u64,
-        base_rate_data: &BaseRateData,
-        prev_epoch_rate_data: &BaseRateData,
-    ) -> u64 {
-        if base_rate_data.epoch_index != self.epoch_index {
-            panic!("wrong base rate data for epoch")
-        }
-        if prev_epoch_rate_data.epoch_index != base_rate_data.epoch_index - 1 {
-            panic!("wrong base rate data for previous epoch")
-        }
-        // take yv*cve*re*psi(e-1)
-        let mut r = (total_delegation_tokens as u128 * (commission_rate_bps as u128 * 1_0000)) / 1_0000_0000;
-        r = (r * base_rate_data.base_reward_rate as u128) / 1_0000_0000;
-        r = (r * prev_epoch_rate_data.base_exchange_rate as u128) / 1_0000_0000;
-        
-        r as u64
-    }
 }
+
 /// Describes the base reward and exchange rates in some epoch.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[serde(try_from = "pb::BaseRateData", into = "pb::BaseRateData")]


### PR DESCRIPTION
closes #42 

this PR adds commission rewards processing to the EndBlock phase of consensus, by inserting notes for each validator's funding stream. the reward is calculated using the formula from the spec, that is 

`yv*cv,e*re*ψ(e−1)`

where yv is the total number of delegation tokens, cv,e is the rate for the funding stream, re is the base reward rate for the epoch, and psi(e-1) is the base exchange rate for the previous epoch. 

these notes are constructed using a zero ephemeral key and are assigned a 0 transaction ID in their `NoteData`. 