### PR TITLE
Use `u64` to represent block heights in light wallet `CompactBlock`

### DIFF
--- a/pd/src/state/reader.rs
+++ b/pd/src/state/reader.rs
@@ -425,7 +425,7 @@ impl Reader {
 
             for height in start_height..=end_height {
                 let mut compact_block = CompactBlock {
-                    height: height as u32,
+                    height: height as u64,
                     fragments: vec![],
                     nullifiers: vec![],
                 };

--- a/pd/src/wallet.rs
+++ b/pd/src/wallet.rs
@@ -82,7 +82,7 @@ impl LightWallet for state::Reader {
             .height()
             .await
             .map_err(|_| tonic::Status::unavailable("database error"))?
-            .value() as u32;
+            .value();
 
         // Treat end_height = 0 as end_height = current_height so that if the
         // end_height is unspecified in the proto, it will be treated as a
@@ -102,7 +102,10 @@ impl LightWallet for state::Reader {
         );
 
         let stream = self
-            .compact_blocks(start_height.into(), end_height.into())
+            .compact_blocks(
+                start_height.try_into().unwrap(),
+                end_height.try_into().unwrap(),
+            )
             .map_err(|e| tonic::Status::internal(e.to_string()));
 
         Ok(tonic::Response::new(stream.boxed()))

--- a/proto/proto/light_wallet.proto
+++ b/proto/proto/light_wallet.proto
@@ -16,14 +16,14 @@ service LightWallet {
 // Requests a range of compact block data.
 message CompactBlockRangeRequest {
   // The start height of the range.
-  uint32 start_height = 1;
+  uint64 start_height = 1;
   // The end height of the range.
-  uint32 end_height = 2;
+  uint64 end_height = 2;
 }
 
 // Contains the minimum data needed to update client state.
 message CompactBlock {
-  uint32 height = 1;
+  uint64 height = 1;
   // Fragments of new notes.
   repeated StateFragment fragments = 2;
   // Nullifiers identifying spent notes.

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -35,7 +35,7 @@ const SUBMITTED_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(60);
 )]
 pub struct ClientState {
     /// The last block height we've scanned to, if any.
-    last_block_height: Option<u32>,
+    last_block_height: Option<u64>,
     /// Note commitment tree.
     note_commitment_tree: NoteCommitmentTree,
     /// Our nullifiers and the notes they correspond to.
@@ -592,7 +592,7 @@ impl ClientState {
     }
 
     /// Returns the last block height the client state has synced up to, if any.
-    pub fn last_block_height(&self) -> Option<u32> {
+    pub fn last_block_height(&self) -> Option<u64> {
         self.last_block_height
     }
 
@@ -798,7 +798,7 @@ mod serde_helpers {
     #[derive(Serialize, Deserialize)]
     pub struct ClientStateHelper {
         wallet: Wallet, // this should be at the top to make `wallet reset` faster
-        last_block_height: Option<u32>,
+        last_block_height: Option<u64>,
         #[serde_as(as = "serde_with::hex::Hex")]
         note_commitment_tree: Vec<u8>,
         nullifier_map: Vec<(String, String)>,


### PR DESCRIPTION
Fixes #365.