### PR TITLE
Move to testnet.penumbra.zone, eliminate hardcoded CURRENT_CHAIN_ID

### DIFF
--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -5,9 +5,9 @@
     # Optional staging lets encrypt for testing. Comment out for production.
     # acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
 }
-eupheme.penumbra.zone {
+testnet.penumbra.zone {
     reverse_proxy grafana:3000
 }
-www.eupheme.penumbra.zone {
-    redir https://eupheme.penumbra.zone{uri}
+www.testnet.penumbra.zone {
+    redir https://testnet.penumbra.zone{uri}
 }

--- a/crypto/src/address.rs
+++ b/crypto/src/address.rs
@@ -6,9 +6,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{fmd, ka, keys::Diversifier, Fq};
 
-pub const CURRENT_CHAIN_ID: &str = "penumbra-eupheme";
-/// Incrementing prefix for the address.
-
 /// A valid payment address.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "pb::Address", into = "pb::Address")]

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -16,7 +16,7 @@ mod prf;
 pub mod proofs;
 pub mod value;
 
-pub use address::{Address, CURRENT_CHAIN_ID};
+pub use address::Address;
 pub use note::Note;
 pub use nullifier::Nullifier;
 pub use value::Value;

--- a/pcli/src/command/wallet.rs
+++ b/pcli/src/command/wallet.rs
@@ -1,8 +1,8 @@
-use std::{fs::File, io::Write, path::PathBuf};
+use std::{fs::File, path::PathBuf};
 
 use anyhow::{anyhow, Context as _, Result};
 use directories::ProjectDirs;
-use penumbra_crypto::{keys::SpendSeed, CURRENT_CHAIN_ID};
+use penumbra_crypto::keys::SpendSeed;
 use penumbra_wallet::{ClientState, Wallet};
 use rand_core::OsRng;
 use serde::Deserialize;
@@ -130,7 +130,10 @@ impl WalletCmd {
                 // TODO the chain ID should be synced from the server if
                 // `chain_params` is `None` (meaning a new wallet file),
                 // as it could have changed via consensus.
-                .join(CURRENT_CHAIN_ID)
+                // TODO: we can't currently get this without already having a
+                // clientstatefile (fetch::chain_params), restore this
+                // functionality by making a request, or drop it?
+                // .join(CURRENT_CHAIN_ID)
                 .join(hex::encode(&spend_key_hash[0..8]));
             std::fs::create_dir_all(&wallet_archive_dir)
                 .expect("can create penumbra wallet archive directory");

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -24,7 +24,7 @@ use sync::sync;
 )]
 pub struct Opt {
     /// The address of the pd+tendermint node.
-    #[structopt(short, long, default_value = "eupheme.penumbra.zone")]
+    #[structopt(short, long, default_value = "testnet.penumbra.zone")]
     pub node: String,
     /// The port to use to speak to tendermint.
     #[structopt(short, long, default_value = "26657")]

--- a/pd/src/genesis.rs
+++ b/pd/src/genesis.rs
@@ -1,7 +1,7 @@
 use ark_ff::Zero;
 use decaf377::Fq;
 use penumbra_chain::params::ChainParams;
-use penumbra_crypto::{asset, Address, Note, Value, CURRENT_CHAIN_ID};
+use penumbra_crypto::{asset, Address, Note, Value};
 use penumbra_proto::{genesis as pb, Protobuf};
 use penumbra_stake::Validator;
 use serde::{Deserialize, Serialize};
@@ -164,7 +164,7 @@ impl Default for AppState {
     fn default() -> Self {
         AppState {
             chain_params: ChainParams {
-                chain_id: CURRENT_CHAIN_ID.to_string(),
+                chain_id: "".to_string(),
                 epoch_duration: 8640,
             },
             allocations: Vec::default(),


### PR DESCRIPTION
This means we don't have to do DNS/config changes every time we redeploy a testnet.