### PR TITLE
pcli: avoid problem with response codes on thelxinoe testnet

### DIFF
--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -27,9 +27,8 @@ impl Opt {
 
         tracing::info!("{}", rsp);
 
-        let result = rsp
-            .get("result")
-            .ok_or_else(|| anyhow::anyhow!("could not parse JSON response"))?;
+        // Sometimes the result is in a result key, and sometimes it's bare? (??)
+        let result = rsp.get("result").unwrap_or(&rsp);
 
         let code = result
             .get("code")


### PR DESCRIPTION
For some reason, the Thelxinoe testnet node doesn't wrap the result of tx submission in a `result` object, as happens on local testnets (??).  This fixes the problem for now.