### PR TITLE
Fix regex bug that parsed "10" as a `Value`

### DIFF
--- a/crypto/src/value.rs
+++ b/crypto/src/value.rs
@@ -96,7 +96,7 @@ impl FromStr for Value {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let re = Regex::new(r"^([0-9.]+)(.+)$").unwrap();
+        let re = Regex::new(r"^([0-9.]+)([^0-9.].*)$").unwrap();
 
         if let Some(captures) = re.captures(s) {
             let numeric_str = captures.get(1).expect("matched regex").as_str();


### PR DESCRIPTION
2+-digit numbers without denomination names should not be parsed as `Value`s; they should be
rejected before they are even checked in the asset registry. This one-line change to the regex fixes
this problem, at the cost of preventing all assets beginning with a digit. This is fine, because we
couldn't handle those cases anyhow! (see
https://github.com/penumbra-zone/penumbra/issues/349 for more discussion of this issue).