### PR TITLE
Fix funding stream note detection bug

### DIFF
--- a/pd/src/pending_block.rs
+++ b/pd/src/pending_block.rs
@@ -10,6 +10,7 @@ use penumbra_stake::{
     BaseRateData, Epoch, IdentityKey, RateData, ValidatorStatus, STAKING_TOKEN_ASSET_ID,
 };
 use std::collections::{BTreeMap, BTreeSet};
+use tracing::instrument;
 
 use crate::verify::{NoteData, PositionedNoteData, VerifiedTransaction};
 
@@ -68,7 +69,13 @@ impl PendingBlock {
     }
 
     /// Adds a reward output for a validator's funding stream.
+    #[instrument(skip(self, destination), fields(destination = %destination))]
     pub fn add_validator_reward_note(&mut self, amount: u64, destination: Address) {
+        if amount == 0 {
+            // Skip adding an empty note to the chain.
+            return;
+        }
+
         let val = Value {
             amount,
             asset_id: *STAKING_TOKEN_ASSET_ID,
@@ -89,11 +96,14 @@ impl PendingBlock {
         )
         .unwrap();
         let commitment = note.commit();
+
+        tracing::debug!(?note, ?commitment);
+
         let esk = ka::Secret::new_from_field(Fr::one());
         let encrypted_note = note.encrypt(&esk);
 
         let note_data = NoteData {
-            ephemeral_key: esk.public(),
+            ephemeral_key: esk.diversified_public(&note.diversified_generator()),
             encrypted_note,
             transaction_id: [0; 32],
         };

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -237,7 +237,7 @@ impl ClientState {
     }
 
     /// Generate a new transaction delegating stake
-    #[instrument(skip(self, rng))]
+    #[instrument(skip(self, rng, rate_data))]
     pub fn build_delegate<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,


### PR DESCRIPTION
The ephemeral public key needs to be derived using the diversified generator
for the note, in order for the recipient to be able to scan it correctly.

We can apply this in-place on Thelxinoe; the existing notes will be undetected, but future notes will be constructed correctly.