### PR TITLE
Faster `pcli wallet reset`

### DIFF
--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -41,7 +41,7 @@ structopt = "0.3"
 tonic = "0.6.1"
 tracing-subscriber = "0.2"
 pin-project = "1"
-serde_json = { version = "1", features = ["raw_value"] }
+serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 serde_with = { version = "1.11", features = ["hex"] }
 reqwest = { version = "0.11", features = ["json"] }

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -41,7 +41,7 @@ structopt = "0.3"
 tonic = "0.6.1"
 tracing-subscriber = "0.2"
 pin-project = "1"
-serde_json = "1"
+serde_json = { version = "1", features = ["raw_value"] }
 serde = { version = "1", features = ["derive"] }
 serde_with = { version = "1.11", features = ["hex"] }
 reqwest = { version = "0.11", features = ["json"] }

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -772,6 +772,7 @@ mod serde_helpers {
     #[serde_as]
     #[derive(Serialize, Deserialize)]
     pub struct ClientStateHelper {
+        wallet: Wallet, // this should be at the top to make `wallet reset` faster
         last_block_height: Option<u32>,
         #[serde_as(as = "serde_with::hex::Hex")]
         note_commitment_tree: Vec<u8>,
@@ -784,7 +785,6 @@ mod serde_helpers {
         spent_set: Vec<(String, String)>,
         transactions: Vec<(String, String)>,
         asset_registry: Vec<(asset::Id, String)>,
-        wallet: Wallet,
         chain_params: Option<ChainParams>,
     }
 


### PR DESCRIPTION
This makes `pcli wallet reset` _much_ faster. Two changes:

1. The `File` used as a `Read` for `serde_json::from_reader` when parsing the `penumbra_wallet.json` is now wrapped in a `BufReader`, which _dramatically_ accelerates parsing.
2. The `wallet` field of `ClientState` is now listed _first_ in the struct, which means that it will be written out first in the JSON encoding. This should mean that when clients perform a single wallet reset using this new code, their wallet will be rearranged in all of the future such that extracting the spend seed is very fast, since it comes first, and therefore all future resets will be even quicker, even if the data contained is very large.