### PR TITLE
Update rate data query to select most recent rate data

### DIFF
--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -730,8 +730,8 @@
       "nullable": []
     }
   },
-  "f9bdaf15db286fffdd144af22f833b3adb6335c3174078e824182d8374a64f88": {
-    "query": "SELECT identity_key, epoch, validator_reward_rate, validator_exchange_rate\n            FROM validator_rates\n            WHERE epoch = $1",
+  "f7daa24d637dd84b5c4da5a2d9e9534fd0023810de9a3022fc0883422fb06b9e": {
+    "query": "SELECT vr.identity_key, vr.epoch, vr.validator_reward_rate, vr.validator_exchange_rate\n            FROM \n            (SELECT identity_key, epoch, validator_reward_rate, validator_exchange_rate\n             FROM\n                validator_rates\n             WHERE epoch <= $1\n             GROUP BY identity_key, epoch\n             ORDER BY epoch DESC\n             LIMIT 1\n            ) as vr\n            LEFT OUTER JOIN validator_rates as vr2\n            ON vr2.epoch = $1",
     "describe": {
       "columns": [
         {

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -160,6 +160,44 @@
       "nullable": []
     }
   },
+  "4e81d31b835953b15b3afce317f51732374cd7cbbf46f80407403bd1f3fd6248": {
+    "query": "\n            SELECT DISTINCT ON (identity_key)\n            identity_key, \n            epoch, \n            validator_reward_rate, \n            validator_exchange_rate\n\n            FROM validator_rates \n            WHERE epoch <= $1\n            ORDER BY identity_key, epoch DESC",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "identity_key",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 1,
+          "name": "epoch",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 2,
+          "name": "validator_reward_rate",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 3,
+          "name": "validator_exchange_rate",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "4f9e6ca2890b779cf788f5993de20c8a2b80baa56966dac4c4f1e215171db0c8": {
     "query": "INSERT INTO validator_rates (\n                    identity_key,\n                    epoch,\n                    validator_reward_rate,\n                    validator_exchange_rate\n                ) VALUES ($1, $2, $3, $4)",
     "describe": {
@@ -728,44 +766,6 @@
         ]
       },
       "nullable": []
-    }
-  },
-  "f7daa24d637dd84b5c4da5a2d9e9534fd0023810de9a3022fc0883422fb06b9e": {
-    "query": "SELECT vr.identity_key, vr.epoch, vr.validator_reward_rate, vr.validator_exchange_rate\n            FROM \n            (SELECT identity_key, epoch, validator_reward_rate, validator_exchange_rate\n             FROM\n                validator_rates\n             WHERE epoch <= $1\n             GROUP BY identity_key, epoch\n             ORDER BY epoch DESC\n             LIMIT 1\n            ) as vr\n            LEFT OUTER JOIN validator_rates as vr2\n            ON vr2.epoch = $1",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "identity_key",
-          "type_info": "Bytea"
-        },
-        {
-          "ordinal": 1,
-          "name": "epoch",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 2,
-          "name": "validator_reward_rate",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 3,
-          "name": "validator_exchange_rate",
-          "type_info": "Int8"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false
-      ]
     }
   },
   "feb219cf82779306d199c5f733359b2cafd5ab51fca03922a9e73c3a4ff44bf7": {

--- a/pd/src/consensus/worker.rs
+++ b/pd/src/consensus/worker.rs
@@ -313,6 +313,7 @@ impl Worker {
                 let identity_key = current_rate.identity_key.clone();
 
                 let funding_streams = reader.funding_streams(identity_key.clone()).await?;
+                // TODO: if this rate is for an inactive validator, do we need to do anything special here regarding the next rate value?
                 let next_rate = current_rate.next(&next_base_rate, funding_streams.as_ref());
 
                 // TODO: if a validator isn't part of the consensus set, should we ignore them

--- a/pd/src/state/reader.rs
+++ b/pd/src/state/reader.rs
@@ -238,16 +238,16 @@ impl Reader {
         // Select rate data for the given epoch, or for the most recent epoch with rate data less than or equal
         // to the given epoch.
         let rows = query!(
-            "SELECT vr.identity_key, vr.maxepoch, vr2.validator_reward_rate, vr2.validator_exchange_rate
-            FROM 
-            (SELECT identity_key, max(epoch) AS maxepoch
-                FROM
-                validator_rates
-                WHERE epoch <= $1
-                GROUP BY identity_key
-            ) as vr
-            INNER JOIN validator_rates as vr2
-            ON vr2.epoch = vr.maxepoch",
+            "
+            SELECT DISTINCT ON (identity_key)
+            identity_key, 
+            epoch, 
+            validator_reward_rate, 
+            validator_exchange_rate
+
+            FROM validator_rates 
+            WHERE epoch <= $1
+            ORDER BY identity_key, epoch DESC",
             epoch_index as i64,
         )
         .fetch_all(&mut conn)

--- a/pd/src/state/reader.rs
+++ b/pd/src/state/reader.rs
@@ -238,7 +238,7 @@ impl Reader {
         // Select rate data for the given epoch, or for the most recent epoch with rate data if none
         // exists for the given epoch.
         let rows = query!(
-            "SELECT vr.identity_key, vr2.epoch, vr2.validator_reward_rate, vr2.validator_exchange_rate
+            "SELECT vr.identity_key, vr.maxepoch, vr2.validator_reward_rate, vr2.validator_exchange_rate
             FROM 
             (SELECT identity_key, max(epoch) AS maxepoch
                 FROM

--- a/pd/src/state/reader.rs
+++ b/pd/src/state/reader.rs
@@ -235,8 +235,8 @@ impl Reader {
 
     pub async fn rate_data(&self, epoch_index: u64) -> Result<Vec<RateData>> {
         let mut conn = self.pool.acquire().await?;
-        // Select rate data for the given epoch, or for the most recent epoch with rate data if none
-        // exists for the given epoch.
+        // Select rate data for the given epoch, or for the most recent epoch with rate data less than or equal
+        // to the given epoch.
         let rows = query!(
             "SELECT vr.identity_key, vr.maxepoch, vr2.validator_reward_rate, vr2.validator_exchange_rate
             FROM 


### PR DESCRIPTION
Fixes the issue described in #402 where inactive validators without rate data for the given epoch don't return their last rate data.