### PR TITLE
feat(metrics): track counter of notes

### DIFF
--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -134,6 +134,30 @@
       "nullable": []
     }
   },
+  "321616ee11510c15f5ac2d1e6aa3c22c5f6601b926a5d41f8e0ce8410223b1bb": {
+    "query": "\n            WITH a AS\n            (SELECT COUNT(*) AS nullifier_count FROM nullifiers),\n            b AS\n            (SELECT COUNT(*) AS note_count FROM notes)\n            SELECT nullifier_count, note_count FROM a, b\n            ",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "nullifier_count",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
+          "name": "note_count",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": []
+      },
+      "nullable": [
+        true,
+        null
+      ]
+    }
+  },
   "3f13d5f8a2ffc438e79f3297b7dfbcc14ffca7611f5ea3d4a5e8acfba3b9807e": {
     "query": "\n            INSERT INTO blobs (id, data) VALUES ('nct', $1)\n            ON CONFLICT (id) DO UPDATE SET data = $1\n            ",
     "describe": {
@@ -907,24 +931,6 @@
         ]
       },
       "nullable": []
-    }
-  },
-  "f67369fd61cb4ff4a7f0dd51fabcd4557ff3e104f50f9fce7601e4787cb60f7c": {
-    "query": "SELECT COUNT(*) as \"count!\" FROM nullifiers",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "count!",
-          "type_info": "Int8"
-        }
-      ],
-      "parameters": {
-        "Left": []
-      },
-      "nullable": [
-        null
-      ]
     }
   },
   "feb219cf82779306d199c5f733359b2cafd5ab51fca03922a9e73c3a4ff44bf7": {

--- a/pd/src/consensus/worker.rs
+++ b/pd/src/consensus/worker.rs
@@ -178,9 +178,9 @@ impl Worker {
     ) -> Result<abci::response::BeginBlock> {
         tracing::debug!(?begin_block);
 
-        // Update metrics.
-        let current_nullifier_count = self.state.private_reader().nullifier_count().await?;
-        absolute_counter!("node_spent_nullifiers_total", current_nullifier_count);
+        let block_metrics = self.state.private_reader().metrics().await?;
+        absolute_counter!("node_spent_nullifiers_total", block_metrics.nullifier_count);
+        absolute_counter!("node_notes_total", block_metrics.note_count);
 
         assert!(self.pending_block.is_none());
         self.pending_block = Some(PendingBlock::new(self.note_commitment_tree.clone()));

--- a/pd/src/pd_metrics.rs
+++ b/pd/src/pd_metrics.rs
@@ -3,5 +3,12 @@ use metrics::register_counter;
 /// Registers all metrics tracked by `pd`.
 pub fn register_all_metrics() {
     register_counter!("node_spent_nullifiers_total");
+    register_counter!("node_notes_total");
     register_counter!("node_transactions_total");
+}
+
+/// Represents a bundle of structured metrics data.
+pub struct MetricsData {
+    pub nullifier_count: u64,
+    pub note_count: u64,
 }


### PR DESCRIPTION
Implements another bullet in #211 and does the refactor suggested in #426 (to have the method on the reader return a bundle of metrics-related data)