### PR TITLE
feat(decaf377_fmd): improve subkey generation logic

### DIFF
--- a/decaf377-fmd/src/clue_key.rs
+++ b/decaf377-fmd/src/clue_key.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, cell::RefCell};
+use std::cell::RefCell;
 
 use ark_ff::{Field, UniformRand};
 use bitvec::{array::BitArray, order};
@@ -34,7 +34,7 @@ impl ClueKey {
     #[allow(non_snake_case)]
     pub fn expand(&self, precision: usize) -> Result<ExpandedClueKey, Error> {
         if precision > MAX_PRECISION {
-            return Err(Error::PrecisionTooLarge(precision))
+            return Err(Error::PrecisionTooLarge(precision));
         }
 
         let root_pub_enc = decaf377::Encoding(self.0);
@@ -49,7 +49,9 @@ impl ClueKey {
             .map(|i| hkd::derive_public(&root_pub, &root_pub_enc, i as u8))
             .collect::<Vec<_>>();
 
-        Ok(ExpandedClueKey { subkeys: RefCell::new(Xs) })
+        Ok(ExpandedClueKey {
+            subkeys: RefCell::new(Xs),
+        })
     }
 }
 
@@ -75,7 +77,7 @@ impl ExpandedClueKey {
         }
 
         if !self.ensure_at_least(precision_bits) {
-            return Err(Error::PrecisionTooLarge(precision_bits))
+            return Err(Error::PrecisionTooLarge(precision_bits));
         }
 
         let r = Fr::rand(&mut rng);
@@ -111,7 +113,6 @@ impl ExpandedClueKey {
     /// Checks that the expanded clue key has at least `precision` subkeys
     fn ensure_at_least(&self, precision: usize) -> bool {
         // TODO: handle try_borrow failure via Result
-        return self.subkeys.try_borrow().unwrap().len() >= precision
+        return self.subkeys.try_borrow().unwrap().len() >= precision;
     }
-
 }

--- a/decaf377-fmd/src/clue_key.rs
+++ b/decaf377-fmd/src/clue_key.rs
@@ -14,28 +14,15 @@ use crate::{hash, hkd, Clue, Error, MAX_PRECISION};
 /// situations where clue key might or might not actually be used.  This saves
 /// computation; at the point that a clue key will be used to create a [`Clue`],
 /// it can be expanded to an [`ExpandedClueKey`].
-/// Implement copy
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct ClueKey {
-    pub root: [u8; 32],
-    subkeys: RefCell<Vec<decaf377::Element>>,
-}
+/// TODO: use Zeroize?
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct ClueKey(pub [u8; 32]);
 
 /// An expanded and validated clue key that can be used to create [`Clue`]s
 /// intended for the corresponding [`DetectionKey`](crate::DetectionKey).
 #[allow(non_snake_case)]
 pub struct ExpandedClueKey {
-    // should this really generate everything upfront?
-    Xs: [decaf377::Element; MAX_PRECISION],
-}
-
-impl From<[u8; 32]> for ClueKey {
-    fn from(root: [u8; 32]) -> Self {
-        ClueKey {
-            root: root,
-            subkeys: RefCell::new(Vec::new()),
-        }
-    }
+    subkeys: RefCell<Vec<decaf377::Element>>,
 }
 
 impl ClueKey {
@@ -45,27 +32,24 @@ impl ClueKey {
     ///
     /// Fails if the bytes don't encode a valid clue key.
     #[allow(non_snake_case)]
-    pub fn expand(&self) -> Result<ExpandedClueKey, Error> {
-        let root_pub_enc = decaf377::Encoding(self.root);
+    pub fn expand(&self, precision: usize) -> Result<ExpandedClueKey, Error> {
+        if precision > MAX_PRECISION {
+            return Err(Error::PrecisionTooLarge(precision))
+        }
+
+        let root_pub_enc = decaf377::Encoding(self.0);
         let root_pub = root_pub_enc
             .decompress()
             .map_err(|_| Error::InvalidAddress)?;
 
-        let Xs: [_; MAX_PRECISION] = (0..MAX_PRECISION)
+        // TOOD: generate subkeys between 0 and `precision`, should we instead handle an arbitrary
+        //       range (e.g. K_i <> K_{i+k})
+        let Xs = (0..precision)
             .into_iter()
             .map(|i| hkd::derive_public(&root_pub, &root_pub_enc, i as u8))
-            .collect::<Vec<_>>()
-            // this conversion into an array will always succeed because we started with an iterator
-            // of length `MAX_PRECISION` and we're converting to an array of the same length
-            .try_into()
-            .expect("iterator of length `MAX_PRECISION`");
+            .collect::<Vec<_>>();
 
-        Ok(ExpandedClueKey { Xs })
-    }
-
-    #[allow(non_snake_case)]
-    pub fn generate_subkeys(&self, n: usize) -> Result<ExpandedClueKey, Error> {
-        unimplemented!()
+        Ok(ExpandedClueKey { subkeys: RefCell::new(Xs) })
     }
 }
 
@@ -79,6 +63,7 @@ impl ExpandedClueKey {
     /// # Errors
     ///
     /// `precision_bits` must be smaller than [`MAX_PRECISION`].
+    /// `precision_bits` must be smaller or equal to the `ExpandedClueKey` precision.
     #[allow(non_snake_case)]
     pub fn create_clue<R: RngCore + CryptoRng>(
         &self,
@@ -87,6 +72,10 @@ impl ExpandedClueKey {
     ) -> Result<Clue, Error> {
         if precision_bits >= MAX_PRECISION {
             return Err(Error::PrecisionTooLarge(precision_bits));
+        }
+
+        if !self.ensure_at_least(precision_bits) {
+            return Err(Error::PrecisionTooLarge(precision_bits))
         }
 
         let r = Fr::rand(&mut rng);
@@ -98,9 +87,10 @@ impl ExpandedClueKey {
         let Q_encoding = Q.compress();
 
         let mut ctxts = BitArray::<order::Lsb0, [u8; 3]>::zeroed();
+        let Xs = self.subkeys.try_borrow().unwrap();
 
         for i in 0..precision_bits {
-            let rXi = (r * self.Xs[i]).compress();
+            let rXi = (r * Xs[i]).compress();
             let key_i = hash::to_bit(&P_encoding.0, &rXi.0, &Q_encoding.0);
             let ctxt_i = key_i ^ 1u8;
             ctxts.set(i, ctxt_i != 0);
@@ -117,4 +107,11 @@ impl ExpandedClueKey {
 
         Ok(Clue(buf))
     }
+
+    /// Checks that the expanded clue key has at least `precision` subkeys
+    fn ensure_at_least(&self, precision: usize) -> bool {
+        // TODO: handle try_borrow failure via Result
+        return self.subkeys.try_borrow().unwrap().len() >= precision
+    }
+
 }

--- a/decaf377-fmd/src/clue_key.rs
+++ b/decaf377-fmd/src/clue_key.rs
@@ -19,7 +19,6 @@ pub struct ClueKey(pub [u8; 32]);
 
 /// An expanded and validated clue key that can be used to create [`Clue`]s
 /// intended for the corresponding [`DetectionKey`](crate::DetectionKey).
-#[allow(non_snake_case)]
 pub struct ExpandedClueKey {
     root_pub: decaf377::Element,
     root_pub_enc: decaf377::Encoding,
@@ -32,7 +31,6 @@ impl ClueKey {
     /// # Errors
     ///
     /// Fails if the bytes don't encode a valid clue key.
-    #[allow(non_snake_case)]
     pub fn expand(&self) -> Result<ExpandedClueKey, Error> {
         ExpandedClueKey::new(&self)
     }
@@ -58,7 +56,7 @@ impl ExpandedClueKey {
             return Err(Error::PrecisionTooLarge(precision));
         }
 
-        let current_precision = self.subkeys.try_borrow()?.len();
+        let current_precision = self.subkeys.borrow().len();
 
         // The cached expansion is large enough to accomodate the specified precision.
         if precision <= current_precision {
@@ -70,7 +68,7 @@ impl ExpandedClueKey {
             .map(|i| hkd::derive_public(&self.root_pub, &self.root_pub_enc, i as u8))
             .collect::<Vec<_>>();
 
-        self.subkeys.try_borrow_mut()?.append(&mut expanded_keys);
+        self.subkeys.borrow_mut().append(&mut expanded_keys);
 
         return Ok(());
     }
@@ -84,7 +82,6 @@ impl ExpandedClueKey {
     /// # Errors
     ///
     /// `precision_bits` must be smaller than [`MAX_PRECISION`].
-    /// `precision_bits` must be smaller or equal to the `ExpandedClueKey` precision.
     #[allow(non_snake_case)]
     pub fn create_clue<R: RngCore + CryptoRng>(
         &self,
@@ -107,7 +104,7 @@ impl ExpandedClueKey {
         let Q_encoding = Q.compress();
 
         let mut ctxts = BitArray::<order::Lsb0, [u8; 3]>::zeroed();
-        let Xs = self.subkeys.try_borrow()?;
+        let Xs = self.subkeys.borrow();
 
         for i in 0..precision_bits {
             let rXi = (r * Xs[i]).compress();

--- a/decaf377-fmd/src/detection.rs
+++ b/decaf377-fmd/src/detection.rs
@@ -67,7 +67,7 @@ impl DetectionKey {
 
     /// Obtain the clue key corresponding to this detection key.
     pub fn clue_key(&self) -> ClueKey {
-        ClueKey::from((self.dtk * decaf377::basepoint()).compress().0)
+        ClueKey((self.dtk * decaf377::basepoint()).compress().0)
     }
 
     /// Use this detection key to examine the given `clue`, returning `true` if the

--- a/decaf377-fmd/src/detection.rs
+++ b/decaf377-fmd/src/detection.rs
@@ -67,7 +67,7 @@ impl DetectionKey {
 
     /// Obtain the clue key corresponding to this detection key.
     pub fn clue_key(&self) -> ClueKey {
-        ClueKey((self.dtk * decaf377::basepoint()).compress().0)
+        ClueKey::from((self.dtk * decaf377::basepoint()).compress().0)
     }
 
     /// Use this detection key to examine the given `clue`, returning `true` if the

--- a/decaf377-fmd/src/error.rs
+++ b/decaf377-fmd/src/error.rs
@@ -1,5 +1,3 @@
-use std::cell::{BorrowError, BorrowMutError};
-
 use thiserror::Error;
 
 /// An error in message detection.
@@ -14,19 +12,4 @@ pub enum Error {
     /// A detection key encoding was invalid.
     #[error("Invalid detection key.")]
     InvalidDetectionKey,
-    /// Wrapper for a runtime internal error.
-    #[error("Internal Error.")]
-    InternalError(String),
-}
-
-impl From<BorrowError> for Error {
-    fn from(err: BorrowError) -> Error {
-        Error::InternalError(err.to_string())
-    }
-}
-
-impl From<BorrowMutError> for Error {
-    fn from(err: BorrowMutError) -> Error {
-        Error::InternalError(err.to_string())
-    }
 }

--- a/decaf377-fmd/src/error.rs
+++ b/decaf377-fmd/src/error.rs
@@ -1,3 +1,5 @@
+use std::cell::{BorrowError, BorrowMutError};
+
 use thiserror::Error;
 
 /// An error in message detection.
@@ -12,4 +14,19 @@ pub enum Error {
     /// A detection key encoding was invalid.
     #[error("Invalid detection key.")]
     InvalidDetectionKey,
+    /// Wrapper for a runtime internal error.
+    #[error("Internal Error.")]
+    InternalError(String),
+}
+
+impl From<BorrowError> for Error {
+    fn from(err: BorrowError) -> Error {
+        Error::InternalError(err.to_string())
+    }
+}
+
+impl From<BorrowMutError> for Error {
+    fn from(err: BorrowMutError) -> Error {
+        Error::InternalError(err.to_string())
+    }
 }

--- a/decaf377-fmd/src/error.rs
+++ b/decaf377-fmd/src/error.rs
@@ -4,12 +4,12 @@ use thiserror::Error;
 #[derive(Clone, Error, Debug)]
 pub enum Error {
     /// Clue creation for larger than maximum precision was requested.
-    #[error("Precision {0} bigger than MAX_PRECISION")]
+    #[error("Precision {0} is larger than `MAX_PRECISION` or current key expansion.")]
     PrecisionTooLarge(usize),
     /// An address encoding was invalid.
-    #[error("Invalid address")]
+    #[error("Invalid address.")]
     InvalidAddress,
     /// A detection key encoding was invalid.
-    #[error("Invalid detection key")]
+    #[error("Invalid detection key.")]
     InvalidDetectionKey,
 }

--- a/decaf377-fmd/tests/fmd.rs
+++ b/decaf377-fmd/tests/fmd.rs
@@ -4,7 +4,7 @@ use rand_core::OsRng;
 #[test]
 fn detection_distribution_matches_expectation() {
     let alice_dk = fmd::DetectionKey::new(OsRng);
-    let alice_clue_key = alice_dk.clue_key().expand().unwrap();
+    let alice_clue_key = alice_dk.clue_key().expand(4).unwrap();
     // alice's friend bobce, whose name has the same number of letters
     let bobce_dk = fmd::DetectionKey::new(OsRng);
 
@@ -28,4 +28,27 @@ fn detection_distribution_matches_expectation() {
 
     assert_eq!(alice_detections, NUM_CLUES);
     assert!((expected_rate - bobce_detection_rate).abs() < 0.04);
+}
+
+#[test]
+fn fails_to_expand_clue_key() {
+    let detection_key = fmd::DetectionKey::new(OsRng);
+
+    detection_key
+        .clue_key()
+        .expand(fmd::MAX_PRECISION + 1)
+        .err()
+        .expect("fails to generate expanded clue key with precision greater than `MAX_PRECISION`");
+}
+
+#[test]
+fn fails_to_generate_clue() {
+    const PRECISION_BITS: usize = 2;
+    let detection_key = fmd::DetectionKey::new(OsRng);
+    let expanded_clue_key = detection_key.clue_key().expand(PRECISION_BITS).unwrap();
+
+    expanded_clue_key
+        .create_clue(PRECISION_BITS + 1, OsRng)
+        .err()
+        .expect("fails to generate clue with excessive precision");
 }

--- a/decaf377-fmd/tests/fmd.rs
+++ b/decaf377-fmd/tests/fmd.rs
@@ -32,9 +32,8 @@ fn detection_distribution_matches_expectation() {
 }
 
 #[test]
-#[ignore] // TODO: test vector with invalid encoding
 fn fails_to_expand_clue_key() {
-    let clue_key = ClueKey([0; 32]);
+    let clue_key = ClueKey([1; 32]);
 
     clue_key
         .expand()

--- a/decaf377-fmd/tests/fmd.rs
+++ b/decaf377-fmd/tests/fmd.rs
@@ -1,10 +1,11 @@
 use decaf377_fmd as fmd;
+use fmd::ClueKey;
 use rand_core::OsRng;
 
 #[test]
 fn detection_distribution_matches_expectation() {
     let alice_dk = fmd::DetectionKey::new(OsRng);
-    let alice_clue_key = alice_dk.clue_key().expand(4).unwrap();
+    let alice_clue_key = alice_dk.clue_key().expand().unwrap();
     // alice's friend bobce, whose name has the same number of letters
     let bobce_dk = fmd::DetectionKey::new(OsRng);
 
@@ -31,24 +32,23 @@ fn detection_distribution_matches_expectation() {
 }
 
 #[test]
+#[ignore] // TODO: test vector with invalid encoding
 fn fails_to_expand_clue_key() {
-    let detection_key = fmd::DetectionKey::new(OsRng);
+    let clue_key = ClueKey([0; 32]);
 
-    detection_key
-        .clue_key()
-        .expand(fmd::MAX_PRECISION + 1)
+    clue_key
+        .expand()
         .err()
-        .expect("fails to generate expanded clue key with precision greater than `MAX_PRECISION`");
+        .expect("fails to generate an expanded clue key with invalid encoding");
 }
 
 #[test]
 fn fails_to_generate_clue() {
-    const PRECISION_BITS: usize = 2;
     let detection_key = fmd::DetectionKey::new(OsRng);
-    let expanded_clue_key = detection_key.clue_key().expand(PRECISION_BITS).unwrap();
+    let expanded_clue_key = detection_key.clue_key().expand().unwrap();
 
     expanded_clue_key
-        .create_clue(PRECISION_BITS + 1, OsRng)
+        .create_clue(fmd::MAX_PRECISION + 1, OsRng)
         .err()
         .expect("fails to generate clue with excessive precision");
 }


### PR DESCRIPTION
This PR implements #82, it's still a draft but the main parts are here. Beside evaluating whether adding nice-to-haves (e.g. `Zeroize` on `ClueKey`), fmt and tests, I need to improve error propagation if `ensure_at_least` fails. 
