### PR TITLE
deps: pin f4jumble

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -19,7 +19,7 @@ decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf
 incrementalmerkletree = { git = "https://github.com/penumbra-zone/incrementalmerkletree" }
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377" }
 jmt = { git = "https://github.com/penumbra-zone/jellyfish-merkle.git", branch = "async-poc" }
-f4jumble = { git = "https://github.com/zcash/librustzcash" }
+f4jumble = { git = "https://github.com/zcash/librustzcash", rev="2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps
 regex = "1.5"


### PR DESCRIPTION
Hit a build error on `main` (https://github.com/penumbra-zone/penumbra/runs/5308110178?check_suite_focus=true) upon merge of #430 due to an upstream change in `f4jumble`

This PR pins `f4jumble` to a specific commit hash for stability