### PR TITLE
Track unbonding stake in `pcli`

### DIFF
--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -32,6 +32,8 @@ bytes = "1"
 comfy-table = "5"
 directories = "4.0.1"
 fslock = "0.2"
+humantime = "2"
+itertools = "0.10"
 tokio = { version = "1", features = ["full"]}
 tokio-stream = "0.1"
 tokio-util = "0.6"

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -83,6 +83,33 @@
       "nullable": []
     }
   },
+  "1d865734f3b465d0683ec471b6977eca9fb873c0c7a673f2d7f2ecca6b5fc119": {
+    "query": "SELECT quarantined_height AS height, nullifier\n                    FROM quarantined_nullifiers\n                    WHERE\n                        quarantined_height BETWEEN $1 AND $2 AND\n                        reverted_height IS NULL\n                    ORDER BY height ASC",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "height",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
+          "name": "nullifier",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
   "23271acfbb896cd6a0875d6420c5dad66e5ff20d09f8c61e7c82fb62e1a1b6a2": {
     "query": "UPDATE quarantined_notes SET reverted_height = $1 WHERE note_commitment = $2",
     "describe": {

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -1,44 +1,5 @@
 {
   "db": "PostgreSQL",
-  "06ea89fe4519f7aaa5f896b6de480805148fce68dc4c775283243192f27b5ca2": {
-    "query": "SELECT\n                    reverted_height AS height,\n                    note_commitment,\n                    ephemeral_key,\n                    encrypted_note\n                FROM quarantined_notes\n                WHERE\n                    reverted_height IS NOT NULL AND\n                    reverted_height BETWEEN $1 and $2\n                ORDER BY height ASC",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "height",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 1,
-          "name": "note_commitment",
-          "type_info": "Bytea"
-        },
-        {
-          "ordinal": 2,
-          "name": "ephemeral_key",
-          "type_info": "Bytea"
-        },
-        {
-          "ordinal": 3,
-          "name": "encrypted_note",
-          "type_info": "Bytea"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8",
-          "Int8"
-        ]
-      },
-      "nullable": [
-        true,
-        false,
-        false,
-        false
-      ]
-    }
-  },
   "0a6306cae406df1b23e52d503b22768210c72fb679fda34fa80d08cd2498fec4": {
     "query": "INSERT INTO validators (\n                    identity_key,\n                    consensus_key,\n                    sequence_number,\n                    name,\n                    website,\n                    description,\n                    voting_power,\n                    validator_state,\n                    unbonding_epoch\n                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
     "describe": {
@@ -937,6 +898,51 @@
         "Left": []
       },
       "nullable": [
+        false,
+        false
+      ]
+    }
+  },
+  "df15838c798214432eac670477b9ce6838d04cb19aff8443a50fea3074e216f1": {
+    "query": "SELECT\n                    quarantined_height,\n                    reverted_height AS height,\n                    note_commitment,\n                    ephemeral_key,\n                    encrypted_note\n                FROM quarantined_notes\n                WHERE\n                    reverted_height IS NOT NULL AND\n                    reverted_height BETWEEN $1 and $2\n                ORDER BY height ASC",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "quarantined_height",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
+          "name": "height",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 2,
+          "name": "note_commitment",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 3,
+          "name": "ephemeral_key",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 4,
+          "name": "encrypted_note",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false,
+        true,
+        false,
         false,
         false
       ]

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -83,12 +83,13 @@
       "nullable": []
     }
   },
-  "2b00fd7700707a635a3d5827f69f2a16a45737fe24797d9aae3874c95d640524": {
-    "query": "DELETE FROM nullifiers WHERE nullifier = $1",
+  "23271acfbb896cd6a0875d6420c5dad66e5ff20d09f8c61e7c82fb62e1a1b6a2": {
+    "query": "UPDATE quarantined_notes SET reverted_height = $1 WHERE note_commitment = $2",
     "describe": {
       "columns": [],
       "parameters": {
         "Left": [
+          "Int8",
           "Bytea"
         ]
       },
@@ -134,20 +135,6 @@
       ]
     }
   },
-  "308588a01bb3ed66958ef26b636e2c344ac302749e3538f8a6698ed719fe3a73": {
-    "query": "\n                    INSERT INTO quarantined_nullifiers (nullifier, unbonding_height, validator_identity_key)\n                    VALUES ($1, $2, $3)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Int8",
-          "Bytea"
-        ]
-      },
-      "nullable": []
-    }
-  },
   "321616ee11510c15f5ac2d1e6aa3c22c5f6601b926a5d41f8e0ce8410223b1bb": {
     "query": "\n            WITH a AS\n            (SELECT COUNT(*) AS nullifier_count FROM nullifiers),\n            b AS\n            (SELECT COUNT(*) AS note_count FROM notes)\n            SELECT nullifier_count, note_count FROM a, b\n            ",
     "describe": {
@@ -184,6 +171,26 @@
       "nullable": []
     }
   },
+  "409ccf7907870212891003a8d4bfaf6bb6a8fd2d802125227a9cac4679a8f37b": {
+    "query": "SELECT nullifier FROM nullifiers WHERE nullifier = ANY($1)\n            UNION\n            SELECT nullifier FROM quarantined_nullifiers WHERE nullifier = ANY($1) AND reverted_height IS NULL",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "nullifier",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "ByteaArray"
+        ]
+      },
+      "nullable": [
+        null
+      ]
+    }
+  },
   "40da344f10b8dfccf3ebc3ac7c44f028bdef4b924b900c9f2125320caf04e8d6": {
     "query": "SELECT validator_identity_key, delegation_change FROM delegation_changes WHERE epoch = $1",
     "describe": {
@@ -208,6 +215,21 @@
         false,
         false
       ]
+    }
+  },
+  "411101a7d2f094b3c7fcb95553bc651450dec68554e61b226bcc7340956e9144": {
+    "query": "\n                    INSERT INTO quarantined_nullifiers\n                        (nullifier, quarantined_height, unbonding_height, validator_identity_key)\n                    VALUES ($1, $2, $3, $4)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Int8",
+          "Int8",
+          "Bytea"
+        ]
+      },
+      "nullable": []
     }
   },
   "4501b3fc1446d51abde3513efb7df1201092a9695f858fc090043d81ad3db490": {
@@ -238,44 +260,6 @@
       "nullable": []
     }
   },
-  "4e81d31b835953b15b3afce317f51732374cd7cbbf46f80407403bd1f3fd6248": {
-    "query": "\n            SELECT DISTINCT ON (identity_key)\n            identity_key, \n            epoch, \n            validator_reward_rate, \n            validator_exchange_rate\n\n            FROM validator_rates \n            WHERE epoch <= $1\n            ORDER BY identity_key, epoch DESC",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "identity_key",
-          "type_info": "Bytea"
-        },
-        {
-          "ordinal": 1,
-          "name": "epoch",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 2,
-          "name": "validator_reward_rate",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 3,
-          "name": "validator_exchange_rate",
-          "type_info": "Int8"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
   "4f9e6ca2890b779cf788f5993de20c8a2b80baa56966dac4c4f1e215171db0c8": {
     "query": "INSERT INTO validator_rates (\n                    identity_key,\n                    epoch,\n                    validator_reward_rate,\n                    validator_exchange_rate\n                ) VALUES ($1, $2, $3, $4)",
     "describe": {
@@ -304,72 +288,6 @@
         ]
       },
       "nullable": []
-    }
-  },
-  "5b21c8f02b71c8101743848e10e198ca4bf1b06fa0a703382354f241d8c86b0f": {
-    "query": "SELECT validator_identity_key, note_commitment, ephemeral_key, encrypted_note, transaction_id\n            FROM quarantined_notes\n            WHERE\n                unbonding_height <= $1 AND\n                ($2 OR validator_identity_key = ANY($3))",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "validator_identity_key",
-          "type_info": "Bytea"
-        },
-        {
-          "ordinal": 1,
-          "name": "note_commitment",
-          "type_info": "Bytea"
-        },
-        {
-          "ordinal": 2,
-          "name": "ephemeral_key",
-          "type_info": "Bytea"
-        },
-        {
-          "ordinal": 3,
-          "name": "encrypted_note",
-          "type_info": "Bytea"
-        },
-        {
-          "ordinal": 4,
-          "name": "transaction_id",
-          "type_info": "Bytea"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8",
-          "Bool",
-          "ByteaArray"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
-  "5f0f6af5d9b30fbea0e33d478e61d311cd065dd0552bfc3988710b6655a3cd1c": {
-    "query": "SELECT nullifier FROM nullifiers WHERE nullifier = ANY($1)",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "nullifier",
-          "type_info": "Bytea"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "ByteaArray"
-        ]
-      },
-      "nullable": [
-        false
-      ]
     }
   },
   "68ecee6442fbca8293efe210d7b798e0a070f2be083b074583048ac513c3dc96": {
@@ -436,35 +354,6 @@
         false,
         false
       ]
-    }
-  },
-  "71bf9cc82a3fd6ebbb72e56a7f19850e64cb41222a454582917da54aa21c914e": {
-    "query": "\n                    INSERT INTO quarantined_notes (\n                        note_commitment,\n                        ephemeral_key,\n                        encrypted_note,\n                        transaction_id,\n                        unbonding_height,\n                        validator_identity_key\n                    ) VALUES ($1, $2, $3, $4, $5, $6)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Bytea",
-          "Bytea",
-          "Bytea",
-          "Int8",
-          "Bytea"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "7274786d3be393b0c70c571dde279722f79b8654b771dfebd11f0653c4fec002": {
-    "query": "DELETE FROM quarantined_nullifiers WHERE nullifier = $1",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Bytea"
-        ]
-      },
-      "nullable": []
     }
   },
   "73d0d102af9c9dbf753248c60bd967e744e909208ba53271f1f8238438da52b7": {
@@ -600,6 +489,47 @@
       ]
     }
   },
+  "75ef7a8f69ca5c7ef191098e849ea78309b527f56538a835692314ef2b632643": {
+    "query": "UPDATE quarantined_nullifiers SET reverted_height = $1 WHERE nullifier = $2",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Bytea"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "7b95ef68a3b25791189802abf8bd8b8ed4e45aaac36580a4f816bfc048cf28f8": {
+    "query": "SELECT validator_identity_key, nullifier\n            FROM quarantined_nullifiers\n            WHERE\n                unbonding_height <= $1 AND\n                ($2 OR validator_identity_key = ANY($3)) AND\n                reverted_height IS NULL",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "validator_identity_key",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 1,
+          "name": "nullifier",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Bool",
+          "ByteaArray"
+        ]
+      },
+      "nullable": [
+        false,
+        false
+      ]
+    }
+  },
   "8195450f9f1cedf05eebd974adbdc42dc70a8e2abb7753d7b02cba03786bee0d": {
     "query": "SELECT denom, asset_id FROM assets",
     "describe": {
@@ -624,16 +554,24 @@
       ]
     }
   },
-  "89bf53aa2587b0bdb4f4937cfa9954795e8dd5f319c860d6648ceaa3ee8c7f9d": {
-    "query": "DELETE FROM quarantined_notes WHERE note_commitment = $1",
+  "8307f09e9e3099cb6048bd97ac169607bef15bce35a7fc5610f055f820fc6e61": {
+    "query": "SELECT height FROM nullifiers WHERE nullifier = $1\n            UNION\n            SELECT quarantined_height AS height\n                FROM quarantined_nullifiers\n                WHERE nullifier = $1 AND reverted_height IS NULL\n            LIMIT 1",
     "describe": {
-      "columns": [],
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "height",
+          "type_info": "Int8"
+        }
+      ],
       "parameters": {
         "Left": [
           "Bytea"
         ]
       },
-      "nullable": []
+      "nullable": [
+        null
+      ]
     }
   },
   "8c67c25c88aef9780fb468fde0efc219247511c20f13c9e1fc0545fddf7d485c": {
@@ -753,6 +691,24 @@
       "nullable": []
     }
   },
+  "b4889e77812ce68f2ea6bf59c0dbab5a5197210d76048b4e9bace6af0b4695f1": {
+    "query": "\n                    INSERT INTO quarantined_notes (\n                        note_commitment,\n                        ephemeral_key,\n                        encrypted_note,\n                        transaction_id,\n                        quarantined_height,\n                        unbonding_height,\n                        validator_identity_key\n                    ) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Bytea",
+          "Bytea",
+          "Bytea",
+          "Int8",
+          "Int8",
+          "Bytea"
+        ]
+      },
+      "nullable": []
+    }
+  },
   "ba507b5c58a391df95f9bfac4985ab63e799383309e17717fbcb1f5e4f6ca936": {
     "query": "SELECT value FROM jmt WHERE key = $1 LIMIT 1",
     "describe": {
@@ -818,6 +774,52 @@
       "nullable": []
     }
   },
+  "d02a1f319b146158c24c3cb76eca9050180306dd200b3e43ca99743870482121": {
+    "query": "SELECT validator_identity_key, note_commitment, ephemeral_key, encrypted_note, transaction_id\n            FROM quarantined_notes\n            WHERE\n                unbonding_height <= $1 AND\n                ($2 OR validator_identity_key = ANY($3)) AND\n                reverted_height IS NULL",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "validator_identity_key",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 1,
+          "name": "note_commitment",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 2,
+          "name": "ephemeral_key",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 3,
+          "name": "encrypted_note",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 4,
+          "name": "transaction_id",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Bool",
+          "ByteaArray"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "d12d2e8c0c1d522212ea874d422f99e950fbd843afe73bac2b7de7a1ec31af3f": {
     "query": "INSERT INTO delegation_changes VALUES ($1, $2, $3)",
     "describe": {
@@ -868,34 +870,6 @@
       "nullable": []
     }
   },
-  "e4a933931ef751ddebcffc649efe21929b949c314284f8615b03086cd90d00e0": {
-    "query": "SELECT validator_identity_key, nullifier\n            FROM quarantined_nullifiers\n            WHERE\n                unbonding_height <= $1 AND\n                ($2 OR validator_identity_key = ANY($3))",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "validator_identity_key",
-          "type_info": "Bytea"
-        },
-        {
-          "ordinal": 1,
-          "name": "nullifier",
-          "type_info": "Bytea"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8",
-          "Bool",
-          "ByteaArray"
-        ]
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
-  },
   "e57d8617299261390fc7448d3bfda816a5b2bbdf7cb03c0f76af7da9f26743ba": {
     "query": "INSERT INTO validator_rates VALUES ($1, $2, $3, $4)",
     "describe": {
@@ -909,6 +883,44 @@
         ]
       },
       "nullable": []
+    }
+  },
+  "eb19e8763905f060f3f9341d4fc5f2970ebc678cc2e9aa4906e901c8f72aef83": {
+    "query": "\n            SELECT DISTINCT ON (identity_key)\n            identity_key,\n            epoch,\n            validator_reward_rate,\n            validator_exchange_rate\n\n            FROM validator_rates\n            WHERE epoch <= $1\n            ORDER BY identity_key, epoch DESC",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "identity_key",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 1,
+          "name": "epoch",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 2,
+          "name": "validator_reward_rate",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 3,
+          "name": "validator_exchange_rate",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false
+      ]
     }
   },
   "ebeb8d290f5ee97174d57b70ea2898a0e259573fa3cad6158779158092e771a0": {
@@ -946,26 +958,6 @@
         ]
       },
       "nullable": []
-    }
-  },
-  "feb219cf82779306d199c5f733359b2cafd5ab51fca03922a9e73c3a4ff44bf7": {
-    "query": "SELECT height FROM nullifiers WHERE nullifier = $1 LIMIT 1",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "height",
-          "type_info": "Int8"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Bytea"
-        ]
-      },
-      "nullable": [
-        false
-      ]
     }
   }
 }

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -83,29 +83,22 @@
       "nullable": []
     }
   },
-  "1d865734f3b465d0683ec471b6977eca9fb873c0c7a673f2d7f2ecca6b5fc119": {
-    "query": "SELECT quarantined_height AS height, nullifier\n                    FROM quarantined_nullifiers\n                    WHERE\n                        quarantined_height BETWEEN $1 AND $2 AND\n                        reverted_height IS NULL\n                    ORDER BY height ASC",
+  "1f5d0fb80de71c6cfbe06d1fd186b85c18d64e73862f658e075edf250e49c163": {
+    "query": "SELECT nullifier FROM nullifiers WHERE nullifier = ANY($1) AND reverted_height IS NULL",
     "describe": {
       "columns": [
         {
           "ordinal": 0,
-          "name": "height",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 1,
           "name": "nullifier",
           "type_info": "Bytea"
         }
       ],
       "parameters": {
         "Left": [
-          "Int8",
-          "Int8"
+          "ByteaArray"
         ]
       },
       "nullable": [
-        false,
         false
       ]
     }
@@ -186,6 +179,34 @@
       ]
     }
   },
+  "39b5b249c803249b252343e112173acd656ad5544912db18bb4426b48da896f6": {
+    "query": "SELECT validator_identity_key, nullifier\n            FROM nullifiers\n            WHERE\n                unbonding_height IS NOT NULL AND\n                unbonding_height <= $1 AND\n                ($2 OR validator_identity_key = ANY($3)) AND\n                reverted_height IS NULL",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "validator_identity_key",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 1,
+          "name": "nullifier",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Bool",
+          "ByteaArray"
+        ]
+      },
+      "nullable": [
+        true,
+        false
+      ]
+    }
+  },
   "3f13d5f8a2ffc438e79f3297b7dfbcc14ffca7611f5ea3d4a5e8acfba3b9807e": {
     "query": "\n            INSERT INTO blobs (id, data) VALUES ('nct', $1)\n            ON CONFLICT (id) DO UPDATE SET data = $1\n            ",
     "describe": {
@@ -198,23 +219,30 @@
       "nullable": []
     }
   },
-  "409ccf7907870212891003a8d4bfaf6bb6a8fd2d802125227a9cac4679a8f37b": {
-    "query": "SELECT nullifier FROM nullifiers WHERE nullifier = ANY($1)\n            UNION\n            SELECT nullifier FROM quarantined_nullifiers WHERE nullifier = ANY($1) AND reverted_height IS NULL",
+  "3fad9360a2ca39e075d04e3ac0f5fc2bca9159ba4a4aa85be9ed5d7d57c3c052": {
+    "query": "SELECT unbonding_height AS height, nullifier\n                    FROM nullifiers\n                    WHERE\n                        height BETWEEN $1 AND $2 AND\n                        reverted_height IS NULL\n                    ORDER BY unbonding_height ASC",
     "describe": {
       "columns": [
         {
           "ordinal": 0,
+          "name": "height",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
           "name": "nullifier",
           "type_info": "Bytea"
         }
       ],
       "parameters": {
         "Left": [
-          "ByteaArray"
+          "Int8",
+          "Int8"
         ]
       },
       "nullable": [
-        null
+        true,
+        false
       ]
     }
   },
@@ -242,21 +270,6 @@
         false,
         false
       ]
-    }
-  },
-  "411101a7d2f094b3c7fcb95553bc651450dec68554e61b226bcc7340956e9144": {
-    "query": "\n                    INSERT INTO quarantined_nullifiers\n                        (nullifier, quarantined_height, unbonding_height, validator_identity_key)\n                    VALUES ($1, $2, $3, $4)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Int8",
-          "Int8",
-          "Bytea"
-        ]
-      },
-      "nullable": []
     }
   },
   "4501b3fc1446d51abde3513efb7df1201092a9695f858fc090043d81ad3db490": {
@@ -310,6 +323,19 @@
         "Left": [
           "Int8",
           "Varchar",
+          "Int8",
+          "Bytea"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "5fb7b2ea74ad768b7fb7345f0324f6d9e41553d31455f9da71fde11f0f81fc4d": {
+    "query": "UPDATE nullifiers SET reverted_height = $1 WHERE nullifier = $2",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
           "Int8",
           "Bytea"
         ]
@@ -378,33 +404,6 @@
       },
       "nullable": [
         false,
-        false,
-        false
-      ]
-    }
-  },
-  "73d0d102af9c9dbf753248c60bd967e744e909208ba53271f1f8238438da52b7": {
-    "query": "SELECT height, nullifier\n                    FROM nullifiers\n                    WHERE height BETWEEN $1 AND $2\n                    ORDER BY height ASC",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "height",
-          "type_info": "Int8"
-        },
-        {
-          "ordinal": 1,
-          "name": "nullifier",
-          "type_info": "Bytea"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8",
-          "Int8"
-        ]
-      },
-      "nullable": [
         false,
         false
       ]
@@ -516,47 +515,6 @@
       ]
     }
   },
-  "75ef7a8f69ca5c7ef191098e849ea78309b527f56538a835692314ef2b632643": {
-    "query": "UPDATE quarantined_nullifiers SET reverted_height = $1 WHERE nullifier = $2",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Int8",
-          "Bytea"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "7b95ef68a3b25791189802abf8bd8b8ed4e45aaac36580a4f816bfc048cf28f8": {
-    "query": "SELECT validator_identity_key, nullifier\n            FROM quarantined_nullifiers\n            WHERE\n                unbonding_height <= $1 AND\n                ($2 OR validator_identity_key = ANY($3)) AND\n                reverted_height IS NULL",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "validator_identity_key",
-          "type_info": "Bytea"
-        },
-        {
-          "ordinal": 1,
-          "name": "nullifier",
-          "type_info": "Bytea"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Int8",
-          "Bool",
-          "ByteaArray"
-        ]
-      },
-      "nullable": [
-        false,
-        false
-      ]
-    }
-  },
   "8195450f9f1cedf05eebd974adbdc42dc70a8e2abb7753d7b02cba03786bee0d": {
     "query": "SELECT denom, asset_id FROM assets",
     "describe": {
@@ -578,26 +536,6 @@
       "nullable": [
         false,
         false
-      ]
-    }
-  },
-  "8307f09e9e3099cb6048bd97ac169607bef15bce35a7fc5610f055f820fc6e61": {
-    "query": "SELECT height FROM nullifiers WHERE nullifier = $1\n            UNION\n            SELECT quarantined_height AS height\n                FROM quarantined_nullifiers\n                WHERE nullifier = $1 AND reverted_height IS NULL\n            LIMIT 1",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "height",
-          "type_info": "Int8"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Bytea"
-        ]
-      },
-      "nullable": [
-        null
       ]
     }
   },
@@ -833,6 +771,39 @@
       ]
     }
   },
+  "c3ef567d69223884354c3725f59aee2d163972a09bf7a00cb616b30a1edc6b13": {
+    "query": "SELECT height, nullifier, (validator_identity_key = NULL) AS quarantined\n                    FROM nullifiers\n                    WHERE height BETWEEN $1 AND $2\n                    ORDER BY height ASC",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "height",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
+          "name": "nullifier",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 2,
+          "name": "quarantined",
+          "type_info": "Bool"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        null
+      ]
+    }
+  },
   "c4883ef6ef60bb03503ea9f5f67c96cbc47afedcd6ba9aeb11b3e71173c62915": {
     "query": "\n                    INSERT INTO jmt (key, value) VALUES ($1, $2)\n                    ",
     "describe": {
@@ -840,6 +811,21 @@
       "parameters": {
         "Left": [
           "Bytea",
+          "Bytea"
+        ]
+      },
+      "nullable": []
+    }
+  },
+  "c9fa67e55cb9b5fd6ed25b0d64f18b1795bfe54f6eeb31cd8869b70565bf60a0": {
+    "query": "\n                    INSERT INTO nullifiers\n                        (nullifier, height, unbonding_height, validator_identity_key)\n                    VALUES ($1, $2, $3, $4)",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Int8",
+          "Int8",
           "Bytea"
         ]
       },
@@ -926,6 +912,26 @@
       },
       "nullable": [
         false,
+        false
+      ]
+    }
+  },
+  "de1c18af3b0b9dfe6f246ae78075298fc8efc270c448bfdd3279e412cdadb5e5": {
+    "query": "SELECT height FROM nullifiers WHERE nullifier = $1 AND reverted_height IS NULL LIMIT 1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "height",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Bytea"
+        ]
+      },
+      "nullable": [
         false
       ]
     }

--- a/pd/sqlx-data.json
+++ b/pd/sqlx-data.json
@@ -1,5 +1,44 @@
 {
   "db": "PostgreSQL",
+  "06ea89fe4519f7aaa5f896b6de480805148fce68dc4c775283243192f27b5ca2": {
+    "query": "SELECT\n                    reverted_height AS height,\n                    note_commitment,\n                    ephemeral_key,\n                    encrypted_note\n                FROM quarantined_notes\n                WHERE\n                    reverted_height IS NOT NULL AND\n                    reverted_height BETWEEN $1 and $2\n                ORDER BY height ASC",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "height",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
+          "name": "note_commitment",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 2,
+          "name": "ephemeral_key",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 3,
+          "name": "encrypted_note",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": [
+        true,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "0a6306cae406df1b23e52d503b22768210c72fb679fda34fa80d08cd2498fec4": {
     "query": "INSERT INTO validators (\n                    identity_key,\n                    consensus_key,\n                    sequence_number,\n                    name,\n                    website,\n                    description,\n                    voting_power,\n                    validator_state,\n                    unbonding_epoch\n                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
     "describe": {
@@ -600,6 +639,51 @@
         ]
       },
       "nullable": [
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "8ee50b0f5a24770d8e4d729ec19bcf1a209f93c00a3d663df4e037fec8288097": {
+    "query": "SELECT\n                    quarantined_height AS height,\n                    unbonding_height,\n                    note_commitment,\n                    ephemeral_key,\n                    encrypted_note\n                FROM quarantined_notes\n                WHERE\n                    quarantined_height BETWEEN $1 and $2\n                ORDER BY height ASC",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "height",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
+          "name": "unbonding_height",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 2,
+          "name": "note_commitment",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 3,
+          "name": "ephemeral_key",
+          "type_info": "Bytea"
+        },
+        {
+          "ordinal": 4,
+          "name": "encrypted_note",
+          "type_info": "Bytea"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8",
+          "Int8"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
         false,
         false,
         false

--- a/pd/src/lib.rs
+++ b/pd/src/lib.rs
@@ -1,7 +1,7 @@
 //! Source code for the Penumbra node software.
 
 // This is for the async_stream macros
-#![recursion_limit = "512"]
+#![recursion_limit = "1024"]
 #![allow(clippy::clone_on_copy)]
 
 mod consensus;

--- a/pd/src/pending_block.rs
+++ b/pd/src/pending_block.rs
@@ -26,9 +26,6 @@ pub struct PendingBlock {
     reward_counter: u64,
     /// Records all the quarantined inputs/outputs from this block.
     pub quarantine: Vec<QuarantineGroup>,
-    /// Nullifiers to remove from the quarantined set when this block is committed, making their
-    /// spend permanent.
-    pub unbonding_nullifiers: BTreeSet<Nullifier>,
     /// Notes to be dropped from the quarantine set when this block is committed, reverting their spend.
     pub reverting_notes: BTreeSet<note::Commitment>,
     /// Nullifiers to remove from the nullifier set when this block is committed, reverting their spend.
@@ -59,7 +56,6 @@ impl PendingBlock {
             reward_counter: 0,
             quarantine: Vec::new(),
             reverting_notes: BTreeSet::new(),
-            unbonding_nullifiers: BTreeSet::new(),
             reverting_nullifiers: BTreeSet::new(),
             epoch: None,
         }

--- a/pd/src/state/reader.rs
+++ b/pd/src/state/reader.rs
@@ -456,6 +456,40 @@ impl Reader {
             .fetch(&pool)
             .peekable();
 
+            let mut quarantined_fragments = query!(
+                "SELECT
+                    quarantined_height AS height,
+                    unbonding_height,
+                    note_commitment,
+                    ephemeral_key,
+                    encrypted_note
+                FROM quarantined_notes
+                WHERE
+                    quarantined_height BETWEEN $1 and $2
+                ORDER BY height ASC",
+                start_height,
+                end_height
+            )
+            .fetch(&pool)
+            .peekable();
+
+            let mut reverted_fragments = query!(
+                "SELECT
+                    reverted_height AS height,
+                    note_commitment,
+                    ephemeral_key,
+                    encrypted_note
+                FROM quarantined_notes
+                WHERE
+                    reverted_height IS NOT NULL AND
+                    reverted_height BETWEEN $1 and $2
+                ORDER BY height ASC",
+                start_height,
+                end_height
+            )
+            .fetch(&pool)
+            .peekable();
+
             for height in start_height..=end_height {
                 let mut compact_block = CompactBlock {
                     height: height as u64,

--- a/pd/src/state/writer.rs
+++ b/pd/src/state/writer.rs
@@ -247,7 +247,7 @@ impl Writer {
         // in this block (thus reverting their spend)
         for nullifier in block.reverting_nullifiers {
             query!(
-                "UPDATE quarantined_nullifiers SET reverted_height = $1 WHERE nullifier = $2",
+                "UPDATE nullifiers SET reverted_height = $1 WHERE nullifier = $2",
                 height as i64,
                 &nullifier.to_bytes()[..],
             )
@@ -342,8 +342,8 @@ impl Writer {
                 // Keep track of the nullifier associated with the block height
                 query!(
                     r#"
-                    INSERT INTO quarantined_nullifiers
-                        (nullifier, quarantined_height, unbonding_height, validator_identity_key)
+                    INSERT INTO nullifiers
+                        (nullifier, height, unbonding_height, validator_identity_key)
                     VALUES ($1, $2, $3, $4)"#,
                     nullifier_bytes,
                     height as i64,

--- a/proto/proto/light_wallet.proto
+++ b/proto/proto/light_wallet.proto
@@ -41,6 +41,18 @@ message StateFragment {
   // An encryption of the newly created note.
   // 132 = 1(type) + 11(d) + 8(amount) + 32(asset_id) + 32(rcm) + 32(pk_d) + 16(MAC) bytes.
   bytes encrypted_note = 4;
+  // If the state fragment represents an update related to quarantine (excepting successful
+  // unbonding, which is handled along totally ordinary codepaths client-side), this describes what
+  // sort of update the state fragment represents.
+  oneof quarantine_update {
+    // The fragment is the result of an undelegation to a validator and is currently being
+    // quarantined, and will unbond at this height if the validator from which it was undelegated is
+    // not slashed before then.
+    uint64 quarantined_with_unbonding_height = 5;
+    // The fragment is the result of an undelegation to a validator and has been reverted to being
+    // spendable again because the validator from which it was undelegated is slashed.
+    uint64 reverted_from_quarantined_height = 6;
+  }
 }
 
 // Requests the global configuration data for the chain.

--- a/proto/proto/light_wallet.proto
+++ b/proto/proto/light_wallet.proto
@@ -28,8 +28,10 @@ message CompactBlock {
   uint64 height = 1;
   // Fragments of new notes.
   repeated StateFragment fragments = 2;
-  // Nullifiers identifying spent notes.
+  // Nullifiers identifying spent notes that are permanently committed and will never be reverted.
   repeated bytes nullifiers = 3;
+  // Nullifiers identifying spent notes that might be reverted later.
+  repeated bytes quarantined_nullifiers = 4;
 }
 
 // The minimum data needed to identify a new note.


### PR DESCRIPTION
This will be a breaking change for `pcli`/`pd` communication, because although the protobufs are shape-compatible, it changes the circumstances in which a nullifier appears in the `CompactBlock`: namely, it is only to appear in the `CompactBlock`'s `nullifiers` field after it has been fully unbonded; before then, it appears only in the `quarantined_nullfiers` field.

I have not yet tested any of this; that's for tomorrow.

One thing not accomplished by this so far is to display which validator the stake is being unbonded from. At present, this information is not exposed by the `CompactBlock`, but it would be easy to do so, and then to thread through tracking it into the wallet, and thereby into `pcli`. Is this worth doing now?