### PR TITLE
Automatically detect latest testnet when generating testnet

### DIFF
--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -68,3 +68,4 @@ once_cell = "1.7.2"
 
 [build-dependencies]
 vergen = "5"
+anyhow = "1"

--- a/pd/build.rs
+++ b/pd/build.rs
@@ -1,5 +1,104 @@
+use std::path::Path;
+
+use anyhow::Context;
 use vergen::{vergen, Config};
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     vergen(Config::default()).unwrap();
+    setup_testnet_config()?;
+    Ok(())
+}
+
+// Set build-time environment variables to point to the latest testnet's config files.
+fn setup_testnet_config() -> anyhow::Result<()> {
+    // Get the path to the testnets directory, in a platform-agnostic manner
+    let testnets_path = std::env::current_dir()
+        .context("could not get current working directory")?
+        .parent()
+        .ok_or(anyhow::anyhow!(
+            "could not get parent of current working directory"
+        ))?
+        .join("testnets");
+
+    // Get the most recent testnet name and its configuration directory
+    let (latest_testnet_name, latest_testnet_dir) = latest_testnet(&testnets_path)?;
+
+    // Output the name of the most recent testnet as a build-time environment variable
+    println!(
+        "cargo:rustc-env=PD_LATEST_TESTNET_NAME={}",
+        latest_testnet_name
+    );
+
+    // For each association of environment variable to filename, set the full path to that file in
+    // the environment variable, so that we can include its contents at build time
+    for (env_var, filename) in [
+        ("PD_LATEST_TESTNET_ALLOCATIONS", "allocations.csv"),
+        ("PD_LATEST_TESTNET_VALIDATORS", "validators.json"),
+    ] {
+        let path = testnets_path.join(&latest_testnet_dir).join(filename);
+        println!(
+            "cargo:rustc-env={}={}",
+            env_var,
+            path.to_str()
+                .ok_or(anyhow::anyhow!("invalid UTF-8 in path"))?
+        );
+    }
+
+    Ok(())
+}
+
+// Scan through the testnets directory to find the latest one
+fn latest_testnet(testnets_path: impl AsRef<Path>) -> anyhow::Result<(String, String)> {
+    let mut testnets = Vec::new();
+    for result in std::fs::read_dir(testnets_path.as_ref()).with_context(|| {
+        format!(
+            "could not read testnet directory {:?}",
+            testnets_path.as_ref()
+        )
+    })? {
+        let entry = result.context("error reading directory entry")?;
+        if entry
+            .file_type()
+            .context("error checking filetype of directory entry")?
+            .is_dir()
+        {
+            let path = entry.path();
+            let dir_name = entry
+                .file_name()
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("testnet path '{:?}' is invalid utf8", path))?
+                .to_string();
+            // Split the testnet directory name into (index, name), i.e. `001-valetudo`
+            // becomes (1, "valetudo")
+            let (index, name): (u64, _) = dir_name
+                .split_once('-')
+                .ok_or_else(|| {
+                    anyhow::anyhow!("testnet path '{:?}' is not correctly formatted", path)
+                })
+                .and_then(|(index_str, name)| {
+                    Ok((
+                        index_str.parse().with_context(|| {
+                            format!(
+                                "could not parse testnet index as a number in path '{:?}'",
+                                path
+                            )
+                        })?,
+                        name.to_string(),
+                    ))
+                })?;
+            testnets.push((index, name, dir_name));
+        }
+    }
+
+    // Compute the maximum index testnet in the testnets directory
+    testnets
+        .into_iter()
+        .max_by_key(|(index, _, _)| *index)
+        .map(|(_, name, dir_name)| ("penumbra-".to_string() + &name, dir_name))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "no testnets found in directory {:?}",
+                testnets_path.as_ref()
+            )
+        })
 }

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -385,7 +385,7 @@ async fn main() -> anyhow::Result<()> {
                 let node_name = format!("node{}", n);
 
                 let app_state = genesis::AppState {
-                    allocations: allocations.iter().map(|a| a.into()).collect(),
+                    allocations: allocations.clone(),
                     chain_params: ChainParams {
                         chain_id: chain_id.clone(),
                         epoch_duration,


### PR DESCRIPTION
This uses the build script to compute the chronologically most recent testnet and embed the allocations and validators of it in the binary, which means several things:

1. Running `pd generate-testnet` is no longer dependent on being run from the root of the `penumbra` repository, as it previously implicitly was.
2. Running `pd generate-testnet` now appropriately uses the latest available testnet as a default for the chain id, allocations, and validator set, although each can be individually overridden by a command line flag as before.
3. We do not need to maintain these defaults every time we do a new testnet (and indeed, we had forgotten to maintain them before; I found this issue because they were still pointed at Thelxinoe).

This also incorporates a smattering of improvements to error reporting during testnet generation, most notably better error contexts for file reading and parsing, which should lead to easier diagnostics when deploying testnets in the future.