### PR TITLE
add IBC chain parameters

### DIFF
--- a/chain/src/params.rs
+++ b/chain/src/params.rs
@@ -46,6 +46,13 @@ pub struct ChainParams {
     pub active_validator_limit: u64,
     /// Slashing penalty in basis points
     pub slashing_penalty: u64,
+
+    /// Whether IBC (forming connections, processing IBC packets) is enabled.
+    pub ibc_enabled: bool,
+    /// Whether inbound ICS-20 transfers are enabled
+    pub inbound_ics20_transfers_enabled: bool,
+    /// Whether outbound ICS-20 transfers are enabled
+    pub outbound_ics20_transfers_enabled: bool,
 }
 
 impl Protobuf<pb::ChainParams> for ChainParams {}
@@ -58,6 +65,9 @@ impl From<pb::ChainParams> for ChainParams {
             unbonding_epochs: msg.unbonding_epochs,
             active_validator_limit: msg.active_validator_limit,
             slashing_penalty: msg.slashing_penalty,
+            ibc_enabled: msg.ibc_enabled,
+            inbound_ics20_transfers_enabled: msg.inbound_ics20_transfers_enabled,
+            outbound_ics20_transfers_enabled: msg.outbound_ics20_transfers_enabled,
         }
     }
 }
@@ -70,6 +80,9 @@ impl From<ChainParams> for pb::ChainParams {
             unbonding_epochs: params.unbonding_epochs,
             active_validator_limit: params.active_validator_limit,
             slashing_penalty: params.slashing_penalty,
+            ibc_enabled: params.ibc_enabled,
+            inbound_ics20_transfers_enabled: params.inbound_ics20_transfers_enabled,
+            outbound_ics20_transfers_enabled: params.outbound_ics20_transfers_enabled,
         }
     }
 }
@@ -85,6 +98,9 @@ impl Default for ChainParams {
             active_validator_limit: 10,
             // 1000 basis points = 10%
             slashing_penalty: 1000,
+            ibc_enabled: false,
+            inbound_ics20_transfers_enabled: false,
+            outbound_ics20_transfers_enabled: false,
         }
     }
 }

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -310,6 +310,9 @@ async fn main() -> anyhow::Result<()> {
                         unbonding_epochs,
                         active_validator_limit,
                         slashing_penalty,
+                        ibc_enabled: false,
+                        inbound_ics20_transfers_enabled: false,
+                        outbound_ics20_transfers_enabled: false,
                     },
                     validators: validators
                         .iter()

--- a/proto/proto/chain.proto
+++ b/proto/proto/chain.proto
@@ -15,6 +15,12 @@ message ChainParams {
   uint64 active_validator_limit = 4;
   // The penalty expressed in base points to be applied to slashed validators' rates.
   uint64 slashing_penalty = 5;
+  /// Whether IBC (forming connections, processing IBC packets) is enabled.
+  bool ibc_enabled = 6;
+  /// Whether inbound ICS-20 transfers are enabled
+  bool inbound_ics20_transfers_enabled = 7;
+  /// Whether outbound ICS-20 transfers are enabled
+  bool outbound_ics20_transfers_enabled = 8;
 }
 
 // Information about a given asset at a given time (as specified by block


### PR DESCRIPTION
this PR adds `ibc_enabled`, `inbound_ics20_transfers_enabled`, and `outbound_ics20_transfers_enabled` chain parameters in preparation for our IBC implementation. Addresses #466 