### PR TITLE
ci: add gh action with pd smoke test

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,26 @@
+on: [push, pull_request]
+
+jobs:
+  smoke_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Install sqlx.
+        run: cargo install sqlx-cli
+
+      - name: Build the testnet.
+        run: |
+          mkdir ~/scratch
+          ./scripts/docker_compose_freshstart.sh ~/scratch/testnet_build
+          chmod -R 777 ~/scratch/testnet_build
+          docker-compose build
+
+      - name: Run testnet for smoke test duration.
+        run: timeout $TESTNET_RUNTIME docker-compose up
+        env:
+          TESTNET_RUNTIME: 20s

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -21,6 +21,6 @@ jobs:
           docker-compose build
 
       - name: Run testnet for smoke test duration.
-        run: timeout $TESTNET_RUNTIME docker-compose up
+        run: timeout --preserve-status $TESTNET_RUNTIME docker-compose up
         env:
           TESTNET_RUNTIME: 20s

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -21,6 +21,6 @@ jobs:
           docker-compose build
 
       - name: Run testnet for smoke test duration.
-        run: timeout --preserve-status $TESTNET_RUNTIME docker-compose up
+        run: timeout --preserve-status $TESTNET_RUNTIME docker-compose up --exit-code-from pd
         env:
-          TESTNET_RUNTIME: 20s
+          TESTNET_RUNTIME: 4m

--- a/README.md
+++ b/README.md
@@ -329,12 +329,9 @@ To load genesis state for a fresh Docker configuration:
 for pd/postgres/tendermint!
 
 ```bash
-./scripts/docker_compose_freshstart.sh ~/scratch/testnet_build penumbra-thelxinoe testnets/004-thelxinoe/allocations.csv testnets/004-thelxinoe/validators.json 1
+./scripts/docker_compose_freshstart.sh ~/scratch/testnet_build
 # the ~/scratch/testnet_build directory should be the root of the volume mounted
 # to the tendermint node containers in docker-compose.yml
-#
-# the second argument is the name of the testnet chain ID
-# the last argument is the # of validators to create
 ```
 
 The script will handle generating genesis JSON data (but not editing it).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   # The Tendermint node
   tendermint-node0:
-    image: "tendermint/tendermint:latest"
+    image: "tendermint/tendermint:v0.35.0"
     container_name: tendermint-node0
     ports:
       - "26656:26656"

--- a/scripts/docker_compose_freshstart.sh
+++ b/scripts/docker_compose_freshstart.sh
@@ -35,8 +35,8 @@ docker volume rm penumbra_db_data || true
 # The db container must be running for pd build to succeed
 docker-compose up -d db
 export DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/penumbra
-# sleep 1 second because postgres isn't immediately responsive
-sleep 1
+# sleep because postgres isn't immediately responsive
+sleep 2
 cd pd
 printf "Preparing DB\n"
 cargo sqlx database create


### PR DESCRIPTION
Closes #475 (https://github.com/penumbra-zone/penumbra/issues/475#issuecomment-1063425837 I'll put in a new ticket since that's a good next step)

This adds a gh action that builds and runs a testnet for a configurable amount of time. It will fail the job (non-zero exit code from pd) if a crash is encountered in that time. See [here](https://github.com/redshiftzero/penumbra/runs/5487945502?check_suite_focus=true) for a successful build and [here](https://github.com/redshiftzero/penumbra/runs/5487953621?check_suite_focus=true) for a failed build where a panic occurred during `InitChain`. 

Currently this is configured to run only on the `main` branch since the job is slow. I think it's better to put slow jobs on `main` and act on build failures, but if we are finding that we're having a lot of crashers hit `main` then we could reconsider and add to PRs (and maybe spend some cycles speeding up this job). 