### PR TITLE
expose IBC module in `proto`

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -14,7 +14,9 @@ hex = "0.4"
 anyhow = "1.0"
 subtle-encoding = "0.5"
 bech32 = "0.8"
+ibc-proto = { git = "https://github.com/penumbra-zone/ibc-rs" }
 
 [build-dependencies]
 prost-build = "0.9"
+ibc-proto = { git = "https://github.com/penumbra-zone/ibc-rs" }
 tonic-build = "0.6"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -14,9 +14,9 @@ hex = "0.4"
 anyhow = "1.0"
 subtle-encoding = "0.5"
 bech32 = "0.8"
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-rs" }
+ibc-proto = "0.12.0"
 
 [build-dependencies]
 prost-build = "0.9"
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-rs" }
+ibc-proto = "0.12.0"
 tonic-build = "0.6"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -39,7 +39,11 @@ fn main() -> Result<()> {
     config.compile_protos(&["proto/stake.proto"], &["proto/"])?;
     config.compile_protos(&["proto/chain.proto"], &["proto/"])?;
     config.compile_protos(&["proto/genesis.proto"], &["proto/"])?;
-    config.extern_path(".ibc", "::ibc-proto::ibc");
+
+    // NOTE: we need this because the rust module that defines the IBC types is external, and not
+    // part of this crate.
+    // See https://docs.rs/prost-build/0.5.0/prost_build/struct.Config.html#method.extern_path
+    config.extern_path(".ibc", "::ibc_proto::ibc");
     config.compile_protos(&["proto/ibc.proto"], &["proto/", "ibc-go-vendor/"])?;
 
     // These should disappear, eventually.

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -39,6 +39,7 @@ fn main() -> Result<()> {
     config.compile_protos(&["proto/stake.proto"], &["proto/"])?;
     config.compile_protos(&["proto/chain.proto"], &["proto/"])?;
     config.compile_protos(&["proto/genesis.proto"], &["proto/"])?;
+    config.extern_path(".ibc", "::ibc-proto::ibc");
     config.compile_protos(&["proto/ibc.proto"], &["proto/", "ibc-go-vendor/"])?;
 
     // These should disappear, eventually.

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -58,6 +58,11 @@ pub mod thin_wallet {
     tonic::include_proto!("penumbra.thin_wallet");
 }
 
+/// IBC protocol structures.
+pub mod ibc {
+    tonic::include_proto!("penumbra.ibc");
+}
+
 pub mod sighash {
     include!(concat!(env!("OUT_DIR"), "/penumbra.sighash.rs"));
 


### PR DESCRIPTION
This is a small PR that exposes the `ibc` proto types as part of the `proto` crate.