### PR TITLE
Implement needed changes following refactor and asyncification of the JMT crate

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -18,7 +18,7 @@ decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
 decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 incrementalmerkletree = { git = "https://github.com/penumbra-zone/incrementalmerkletree" }
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377" }
-jmt = { git = "https://github.com/penumbra-zone/jellyfish-merkle.git", branch = "async-poc" }
+jmt = { git = "https://github.com/penumbra-zone/jellyfish-merkle.git", branch = "main" }
 f4jumble = { git = "https://github.com/zcash/librustzcash", rev="2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps

--- a/crypto/src/merkle.rs
+++ b/crypto/src/merkle.rs
@@ -28,16 +28,6 @@ pub type Path = (Position, Vec<note::Commitment>);
 #[serde(try_from = "pb::MerkleRoot", into = "pb::MerkleRoot")]
 pub struct Root(pub Fq);
 
-impl jmt::Value for Root {}
-
-impl jmt::hash::CryptoHash for Root {
-    type Hasher = jmt::hash::TestOnlyHasher;
-
-    fn hash(&self) -> jmt::hash::HashValue {
-        jmt::hash::HashValue::sha3_256_of(&self.to_bytes())
-    }
-}
-
 impl TryFrom<pb::MerkleRoot> for Root {
     type Error = anyhow::Error;
 

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -26,7 +26,7 @@ tower-abci = { git = "https://github.com/penumbra-zone/tower-abci/" }
 tendermint-config = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "master" }
 tendermint-proto = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "master" }
 tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "master" }
-jmt = { git = "https://github.com/penumbra-zone/jellyfish-merkle.git", branch = "async-poc" }
+jmt = { git = "https://github.com/penumbra-zone/jellyfish-merkle.git", branch = "main" }
 
 
 # External dependencies

--- a/pd/src/state/writer.rs
+++ b/pd/src/state/writer.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, VecDeque};
 use anyhow::Result;
 use ark_ff::PrimeField;
 use decaf377::{Fq, Fr};
-use jmt::TreeWriterAsync;
+use jmt::storage::TreeWriter;
 use penumbra_chain::params::ChainParams;
 use penumbra_crypto::asset::{Denom, Id};
 use penumbra_crypto::merkle::Frontier;
@@ -287,7 +287,7 @@ impl Writer {
                 // a different domain-separated hash
                 vec![(
                     jellyfish::Key::NoteCommitmentAnchor.hash(),
-                    nct_anchor.clone(),
+                    nct_anchor.clone().to_bytes().to_vec(),
                 )],
                 // height 0 for genesis
                 0,
@@ -299,7 +299,7 @@ impl Writer {
             .await?;
 
         // The app hash needs to be returned to Tendermint
-        let app_hash: [u8; 32] = jmt_root.to_vec().try_into().unwrap();
+        let app_hash: [u8; 32] = jmt_root.0.to_vec().try_into().unwrap();
 
         // Insert the block into the DB
         query!(
@@ -388,7 +388,7 @@ impl Writer {
                 // a different domain-separated hash
                 vec![(
                     jellyfish::Key::NoteCommitmentAnchor.hash(),
-                    nct_anchor.clone(),
+                    nct_anchor.clone().to_bytes().to_vec(),
                 )],
                 height,
             )
@@ -402,7 +402,7 @@ impl Writer {
         // NCT anchor separately for convenience, but it's already included in
         // the JMT root.
         // TODO: no way to access the Diem HashValue as array, even though it's stored that way?
-        let app_hash: [u8; 32] = jmt_root.to_vec().try_into().unwrap();
+        let app_hash: [u8; 32] = jmt_root.0.to_vec().try_into().unwrap();
 
         query!(
             "INSERT INTO blocks (height, nct_anchor, app_hash) VALUES ($1, $2, $3)",


### PR DESCRIPTION
Retarget `jmt main` from `penumbra` following asyncification. Closes #486.