### PR TITLE
Hardcode build path in freshstart script

### DIFF
--- a/scripts/docker_compose_freshstart.sh
+++ b/scripts/docker_compose_freshstart.sh
@@ -10,10 +10,7 @@ die () {
     exit 1
 }
 
-[ "$#" -eq 1 ] || die "build path argument required"
-
-
-build_path="$1"
+build_path="$HOME/scratch/testnet_build/"
 
 if [ -d "${build_path}" ] 
 then


### PR DESCRIPTION
The docker-compose files only work when it's set to $HOME/scratch/testnet_build, so we might as well hardcode that path.