### PR TITLE
Only run smoke test on successful pushes to `main`

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+name: Smoke Test
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   smoke_test:


### PR DESCRIPTION
While it's nice to get pre-merge checks, this change avoids two problems:

- it avoids spawning many ephemeral CI runs;
- it means we don't get into the habit of skipping checks.