### PR TITLE
Sketch an application/component interface.

### DIFF
--- a/pd/src/components.rs
+++ b/pd/src/components.rs
@@ -1,2 +1,19 @@
-pub mod shielded_pool;
+use std::sync::{Arc, Mutex};
+
+use jmt::WriteOverlay;
+
+use crate::Storage;
+
+mod app;
+mod component;
+mod shielded_pool;
+
+// TODO: demote this from `pub` at some point when that's
+// not likely to generate conflicts
 pub mod validator_set;
+
+pub use app::App;
+pub use component::Component;
+pub use shielded_pool::ShieldedPool;
+
+type Overlay = Arc<Mutex<WriteOverlay<Storage>>>;

--- a/pd/src/components/app.rs
+++ b/pd/src/components/app.rs
@@ -1,0 +1,78 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use jmt::{RootHash, Version};
+use penumbra_transaction::Transaction;
+use tendermint::abci;
+
+use super::{Component, Overlay, ShieldedPool};
+use crate::{genesis, Storage};
+
+/// The Penumbra application, written as a bundle of [`Component`]s.
+///
+/// The [`App`] is also a [`Component`], but as the top-level component,
+/// it constructs the others and exposes a [`commit`](App::commit) that
+/// commits the changes to the persistent storage and resets its subcomponents.
+pub struct App {
+    overlay: Overlay,
+    // list of components goes here
+    // having all the components explicitly is a bit repetitive
+    // to invoke compared to Vec of dyn Component or w/e, but
+    // leaves open the possibility of having component-specific
+    // behavior and is simpler.
+    shielded_pool: ShieldedPool,
+}
+
+impl App {
+    /// Commits the application state to persistent storage,
+    /// returning the new root hash and storage version.
+    ///
+    /// This method also resets `self` as if it were constructed
+    /// as an empty overlay of the newly written state.
+    pub async fn commit(&mut self, storage: Storage) -> Result<(RootHash, Version)> {
+        // Commit the pending writes, clearing the overlay.
+        let (root_hash, version) = self.overlay.lock().unwrap().commit(storage).await?;
+        // Now re-instantiate all of the components:
+        self.shielded_pool = ShieldedPool::new(self.overlay.clone());
+
+        Ok((root_hash, version))
+    }
+}
+
+#[async_trait]
+impl Component for App {
+    fn new(overlay: Overlay) -> Self {
+        let shielded_pool = ShieldedPool::new(overlay.clone());
+
+        Self {
+            overlay,
+            shielded_pool,
+        }
+    }
+
+    fn init_chain(&self, app_state: &genesis::AppState) {
+        self.shielded_pool.init_chain(app_state);
+    }
+
+    async fn begin_block(&self, begin_block: &abci::request::BeginBlock) {
+        self.shielded_pool.begin_block(begin_block).await;
+    }
+
+    fn check_tx_stateless(tx: &Transaction) -> Result<()> {
+        ShieldedPool::check_tx_stateless(tx)?;
+        Ok(())
+    }
+
+    async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()> {
+        self.shielded_pool.check_tx_stateful(tx).await?;
+        Ok(())
+    }
+
+    async fn execute_tx(&self, tx: &Transaction) {
+        self.shielded_pool.execute_tx(tx).await;
+    }
+
+    async fn end_block(&self, end_block: &abci::request::EndBlock) {
+        // TODO: should these calls be in reverse order from begin_block?
+        self.shielded_pool.end_block(end_block).await;
+    }
+}

--- a/pd/src/components/component.rs
+++ b/pd/src/components/component.rs
@@ -1,0 +1,127 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use penumbra_transaction::Transaction;
+use tendermint::abci;
+
+use super::Overlay;
+use crate::genesis;
+
+/// A component of the Penumbra application.
+///
+/// Each component is a thin wrapper around a shared [`WriteOverlay`], over a
+/// Jellyfish tree held in persistent [`Storage`].  The Jellyfish tree is a
+/// generic, byte-oriented key/value store.  Components can read from and write
+/// to the tree, and all components in the same [`Application`] instance will
+/// see each others' writes when they perform reads.  However, those writes are
+/// buffered in the [`WriteOverlay`] until it commits a batch of changes to the
+/// persistent [`Storage`], making it possible to maintain and evolve multiple
+/// copies of the application state, as each [`Application`] is effectively its
+/// own copy-on-write instance of the chain state.
+///
+/// The data and execution flow looks like:
+/// ```ascii,no_run
+/// ┌────────────┐          ┌───────────┐                           
+/// │WriteOverlay│          │ Component │                           
+/// │  ::new()   │═════════▶│  ::new()  │      ═══▶ Execution Flow  
+/// └────────────┘          └───────────┘           (Approximate)   
+///        │                      ║            ───▶ Data Flow       
+///        ▼               ╔══════╩══════╗                          
+/// ┌────────────┐         ▼             ║                          
+/// │            │   ┌───────────┐       ║         ┌───────────────┐
+/// │            │◀──│init_chain │◀──────╬─────────│ Genesis State │
+/// │            │   └───────────┘       ║         └───────────────┘
+/// │            │         ║             ▼                          
+/// │            │         ║       ┌───────────┐   ┌───────────────┐
+/// │            │◀────────╬──────▶│begin_block│◀──│ABCI BeginBlock│
+/// │            │         ║       └───────────┘   └───────────────┘
+/// │            │         ║             ║                          
+/// │            │         ║    ╔═══════▶║                          
+/// │            │         ║    ║        ▼                          
+/// │            │         ║    ║  ┌───────────┐   ┌───────────────┐
+/// │            │         ║    ║  │check_tx   │ ┌─│  Transaction  │
+/// │            │         ║    ║  │_stateless │◀┤ └───────────────┘
+/// │WriteOverlay│         ║    ║  └───────────┘ │                  
+/// │            │         ║    ║  ┌───────────┐ │                  
+/// │            │         ║    ║  │check_tx   │ │                  
+/// │            │─────────╬────╬─▶│_stateful  │◀┤                  
+/// │            │         ║    ║  └───────────┘ │                  
+/// │            │         ║    ║  ┌───────────┐ │                  
+/// │            │◀────────╬────╬─▶│execute_tx │◀┘                  
+/// │            │         ║    ║  └───────────┘                    
+/// │            │         ║    ║        ║                          
+/// │            │         ║    ╚════════╣                          
+/// │            │         ║             ║                          
+/// │            │         ║             ▼                          
+/// │            │         ║       ┌───────────┐   ┌───────────────┐
+/// │            │◀────────╬──────▶│end_block  │◀──│ ABCI EndBlock │
+/// └────────────┘         ║       └───────────┘   └───────────────┘
+///        │               ║             ║                          
+///        ▼               ║             ║                          
+/// ┌────────────┐         ║             ║                          
+/// │WriteOverlay│         ║             ║                          
+/// │ ::commit() │◀════════╩═════════════╝                          
+/// └────────────┘                                                  
+/// ```
+#[async_trait]
+pub trait Component {
+    /// Initializes the component relative to a shared state.
+    ///
+    /// This method should be called every time the [`WriteOverlay`] is
+    /// re-initialized.
+    fn new(overlay: Overlay) -> Self;
+
+    /// Performs initialization, given the genesis state.
+    ///
+    /// This method is called once per chain, and should only perform
+    /// writes, since the backing tree for the [`WriteOverlay`] will
+    /// be empty.
+    ///
+    /// # Invariants
+    ///
+    /// This method should only be called immediately after [`Component::new`].
+    /// No methods should be called following this method.
+    fn init_chain(&self, app_state: &genesis::AppState);
+
+    /// Begins a new block, optionally inspecting the ABCI
+    /// [`BeginBlock`](abci::request::BeginBlock) request.
+    ///
+    /// # Invariants
+    ///
+    /// This method should only be called immediately after [`Component::new`].
+    /// This method need not be called before [`Component::execute_tx`] (e.g.,
+    /// in order to simulate executing a transaction in the mempool).
+    async fn begin_block(&self, begin_block: &abci::request::BeginBlock);
+
+    /// Performs all of this component's stateless validity checks on the given
+    /// [`Transaction`].
+    fn check_tx_stateless(tx: &Transaction) -> Result<()>;
+
+    /// Performs all of this component's stateful validity checks on the given
+    /// [`Transaction`].
+    ///
+    /// # Invariants
+    ///
+    /// This method should only be called on transactions that have been
+    /// checked with [`Component::check_tx_stateless`].
+    /// This method can be called before [`Component::begin_block`].
+    async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()>;
+
+    /// Executes the given [`Transaction`] against the current state.
+    ///
+    /// # Invariants
+    ///
+    /// This method should only be called immediately following a successful
+    /// invocation of [`Component::check_tx_stateful`] on the same transaction.
+    /// This method can be called before [`Component::begin_block`].
+    async fn execute_tx(&self, tx: &Transaction);
+
+    /// Ends the block, optionally inspecting the ABCI
+    /// [`EndBlock`](abci::request::EndBlock) request, and performing any batch
+    /// processing.
+    ///
+    /// # Invariants
+    ///
+    /// This method should only be called after [`Component::begin_block`].
+    /// No methods should be called following this method.
+    async fn end_block(&self, end_block: &abci::request::EndBlock);
+}

--- a/pd/src/components/shielded_pool.rs
+++ b/pd/src/components/shielded_pool.rs
@@ -1,1 +1,43 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use penumbra_transaction::Transaction;
+use tendermint::abci;
 
+use super::{Component, Overlay};
+use crate::genesis;
+
+// Stub component
+pub struct ShieldedPool {
+    overlay: Overlay,
+}
+
+#[async_trait]
+impl Component for ShieldedPool {
+    fn new(overlay: Overlay) -> Self {
+        Self { overlay }
+    }
+
+    fn init_chain(&self, _app_state: &genesis::AppState) {
+        todo!()
+    }
+
+    async fn begin_block(&self, _begin_block: &abci::request::BeginBlock) {
+        todo!()
+    }
+
+    fn check_tx_stateless(_tx: &Transaction) -> Result<()> {
+        todo!()
+    }
+
+    async fn check_tx_stateful(&self, _tx: &Transaction) -> Result<()> {
+        todo!()
+    }
+
+    async fn execute_tx(&self, _tx: &Transaction) {
+        todo!()
+    }
+
+    async fn end_block(&self, _end_block: &abci::request::EndBlock) {
+        todo!()
+    }
+}

--- a/pd/src/lib.rs
+++ b/pd/src/lib.rs
@@ -21,6 +21,7 @@ pub mod genesis;
 pub mod state;
 pub mod testnet;
 
+pub use components::App;
 pub use consensus::Consensus;
 pub use info::Info;
 pub use mempool::Mempool;
@@ -28,7 +29,7 @@ pub use pd_metrics::register_all_metrics;
 use pending_block::PendingBlock;
 use request_ext::RequestExt;
 pub use snapshot::Snapshot;
-pub use storage::Storage;
+pub use storage::{Storage, WriteOverlayExt};
 
 /// The age limit, in blocks, on anchors accepted in transaction verification.
 pub const NUM_RECENT_ANCHORS: usize = 256;

--- a/pd/src/lib.rs
+++ b/pd/src/lib.rs
@@ -21,7 +21,7 @@ pub mod genesis;
 pub mod state;
 pub mod testnet;
 
-pub use components::App;
+pub use components::{App, Component};
 pub use consensus::Consensus;
 pub use info::Info;
 pub use mempool::Mempool;

--- a/pd/src/storage.rs
+++ b/pd/src/storage.rs
@@ -1,9 +1,13 @@
+use std::{path::PathBuf, sync::Arc};
+
 use anyhow::Result;
 use futures::future::BoxFuture;
 use jmt::storage::{Node, NodeBatch, NodeKey, TreeReader, TreeWriter};
 use rocksdb::DB;
-use std::{path::PathBuf, sync::Arc};
 use tracing::{instrument, Span};
+
+mod write_overlay_ext;
+pub use write_overlay_ext::WriteOverlayExt;
 
 #[derive(Clone, Debug)]
 pub struct Storage(Arc<DB>);

--- a/pd/src/storage/write_overlay_ext.rs
+++ b/pd/src/storage/write_overlay_ext.rs
@@ -1,0 +1,88 @@
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use jmt::{storage::TreeReader, KeyHash, WriteOverlay};
+use penumbra_proto::{Message, Protobuf};
+
+/// An extension trait that allows writing proto-encoded domain types to
+/// a shared [`WriteOverlay`].
+#[async_trait]
+pub trait WriteOverlayExt {
+    /// Reads a domain type from the overlay, using the proto encoding.
+    async fn get_domain<D, P>(&self, key: KeyHash) -> Result<Option<D>>
+    where
+        D: Protobuf<P>,
+        // TODO: does this get less awful if P is an associated type of D?
+        P: Message + Default,
+        P: From<D>,
+        D: TryFrom<P> + Clone,
+        <D as TryFrom<P>>::Error: Into<anyhow::Error>;
+
+    /// Puts a domain type into the overlay, using the proto encoding.
+    fn put_domain<D, P>(&self, key: KeyHash, value: D) -> Result<Option<D>>
+    where
+        D: Protobuf<P> + Send,
+        // TODO: does this get less awful if P is an associated type of D?
+        P: Message + Default,
+        P: From<D>,
+        D: TryFrom<P> + Clone,
+        <D as TryFrom<P>>::Error: Into<anyhow::Error>;
+
+    /// Reads a proto type from the overlay.
+    ///
+    /// It's probably preferable to use [`WriteOverlayExt::get_domain`] instead,
+    /// but there are cases where it's convenient to use the proto directly.
+    async fn get_proto<P>(&self, key: KeyHash) -> Result<Option<P>>
+    where
+        P: Message;
+
+    /// Puts a proto type into the overlay.
+    ///
+    /// It's probably preferable to use [`WriteOverlayExt::put_domain`] instead,
+    /// but there are cases where it's convenient to use the proto directly.
+    fn put_proto<P>(&self, key: KeyHash, value: P) -> Result<Option<P>>
+    where
+        P: Message;
+}
+
+#[async_trait]
+impl<R: TreeReader + Sync> WriteOverlayExt for Arc<Mutex<WriteOverlay<R>>> {
+    async fn get_domain<D, P>(&self, _key: KeyHash) -> Result<Option<D>>
+    where
+        D: Protobuf<P>,
+        // TODO: does this get less awful if P is an associated type of D?
+        P: Message + Default,
+        P: From<D>,
+        D: TryFrom<P> + Clone,
+        <D as TryFrom<P>>::Error: Into<anyhow::Error>,
+    {
+        todo!()
+    }
+
+    fn put_domain<D, P>(&self, _key: KeyHash, _value: D) -> Result<Option<D>>
+    where
+        D: Protobuf<P>,
+        // TODO: does this get less awful if P is an associated type of D?
+        P: Message + Default,
+        P: From<D>,
+        D: TryFrom<P> + Clone,
+        <D as TryFrom<P>>::Error: Into<anyhow::Error>,
+    {
+        todo!()
+    }
+
+    async fn get_proto<P>(&self, _key: KeyHash) -> Result<Option<P>>
+    where
+        P: Message,
+    {
+        todo!()
+    }
+
+    fn put_proto<P>(&self, _key: KeyHash, _value: P) -> Result<Option<P>>
+    where
+        P: Message,
+    {
+        todo!()
+    }
+}


### PR DESCRIPTION
Notes from Discord are below -- though the actual design ended up being
slightly different, handling init_chain as a special case, and splitting out
separate check_tx_stateless and check_tx_stateful methods.

Another addition to the design in the notes is the WriteOverlayExt trait; if
we're encoding data into the tree, it's much easier if we encode it using our
existing, proto-based encoding framework.

> some thoughts on a new design for our state handling:
> as a prerequisite, we'd shift all of our persistent state to be recorded in a rocksdb-backed jellyfish tree, eliminating postgres entirely
> this has a bunch of advantages, but one really important one is that it means that our apphashes are actually hashes of the entire application state, which improves replicability. another is that we don't have to worry about latency for state queries as much.
> next, we'd restructure the penumbra application logic as an Application containing a bunch of Components, and a jmt::WriteOverlay
> https://rustdoc.penumbra.zone/main/jmt/struct.WriteOverlay.html
> the WriteOverlay is a wrapper over a JMT that maintains a cache of pending writes, and reads through that cache, so that it reflects the pending changes.  it also has a commit method that takes a writer and commits all the pending writes to the backing store.
> each Component shares access to its application's WriteOverlay (how? maybe a RefCell, doesn't really matter), and uses that for reading and writing application state
> and each Component is responsible for doing some area of the application logic, like the shielded pool, ibc, staking, etc.
> there'd be a trait Component that has something like the following methods:
> - check_tx(&self, tx: &Transaction) -> Result<(), Error>: this performs all transaction checks relevant to that component against the current state;
> - begin_block(&mut self, begin_block: &BeginBlock): executes any necessary steps as part of beginning a block;
> - execute_tx(&mut self, tx: &Transaction): executes the transaction against the current state. this is infallible (errors should panic), and unlike our current deliver_tx functionality, it doesn't do any checking. rather, we'd implement deliver_tx as a check_tx(); execute_tx() sequence;
> - end_block(&mut self, end_block: &EndBlock): executes any necessary steps as part of ending a block
>
> notice that there's no commit anywhere, because the Components aren't responsible for managing when stuff is committed, they just have to write it to the shared WriteOverlay, and actually committing the state just requires having the Application call self.overlay.commit() and return the result
> now, the thing that's really cool about this is that there is no requirement for the Application to be unique!!! (edited)
> because the components get all of their state from the write overlay, and the write overlay is a wrapper around the persistent state, you can create multiple Application instances, and do stuff to them independently, as long as only one of them is actually committing changes to the persistent state
> and this means that we can have total code reuse between the mempool (pre-consensus transaction handling) and the consensus worker
> how does that work? well, both the consensus worker and the mempool have separate Application instances, so they have different sets of un-committed state on top of some common finalized state.
> when transactions go to the mempool with check_tx, the mempool uses check_tx to check the proposed transaction against the mempool state, then execute_tx to execute it, writing to its un-committed overlay on top of the finalized state. later, when the worker commits a new block, it notifies the mempool, which wipes its Application copy and creates a new one (edited)
> this means that we don't need to have any special casing of "is there a duplicate nullifier?" "what about duplicate validator definitions?" "what about ...." in the mempool