### PR TITLE
Make the `Component` trait more usable

### DIFF
--- a/pd/src/components/ibc.rs
+++ b/pd/src/components/ibc.rs
@@ -12,15 +12,15 @@ pub struct IBCComponent {
 
 #[async_trait]
 impl Component for IBCComponent {
-    fn new(overlay: Overlay) -> Self {
-        Self { overlay }
+    async fn new(overlay: Overlay) -> Result<Self> {
+        Ok(Self { overlay })
     }
 
-    fn init_chain(&self, _app_state: &genesis::AppState) {
+    fn init_chain(&mut self, _app_state: &genesis::AppState) -> Result<()> {
         todo!()
     }
 
-    async fn begin_block(&self, _begin_block: &abci::request::BeginBlock) {
+    async fn begin_block(&mut self, _begin_block: &abci::request::BeginBlock) -> Result<()> {
         todo!()
     }
 
@@ -32,11 +32,11 @@ impl Component for IBCComponent {
         todo!()
     }
 
-    async fn execute_tx(&self, _tx: &Transaction) {
+    async fn execute_tx(&mut self, _tx: &Transaction) -> Result<()> {
         todo!()
     }
 
-    async fn end_block(&self, _end_block: &abci::request::EndBlock) {
+    async fn end_block(&mut self, _end_block: &abci::request::EndBlock) -> Result<()> {
         todo!()
     }
 }

--- a/pd/src/components/shielded_pool.rs
+++ b/pd/src/components/shielded_pool.rs
@@ -13,15 +13,15 @@ pub struct ShieldedPool {
 
 #[async_trait]
 impl Component for ShieldedPool {
-    fn new(overlay: Overlay) -> Self {
-        Self { overlay }
+    async fn new(overlay: Overlay) -> Result<Self> {
+        Ok(Self { overlay })
     }
 
-    fn init_chain(&self, _app_state: &genesis::AppState) {
+    fn init_chain(&mut self, _app_state: &genesis::AppState) -> Result<()> {
         todo!()
     }
 
-    async fn begin_block(&self, _begin_block: &abci::request::BeginBlock) {
+    async fn begin_block(&mut self, _begin_block: &abci::request::BeginBlock) -> Result<()> {
         todo!()
     }
 
@@ -33,11 +33,11 @@ impl Component for ShieldedPool {
         todo!()
     }
 
-    async fn execute_tx(&self, _tx: &Transaction) {
+    async fn execute_tx(&mut self, _tx: &Transaction) -> Result<()> {
         todo!()
     }
 
-    async fn end_block(&self, _end_block: &abci::request::EndBlock) {
+    async fn end_block(&mut self, _end_block: &abci::request::EndBlock) -> Result<()> {
         todo!()
     }
 }


### PR DESCRIPTION
This commit makes three changes to the `Component` trait:

- it adds `Result`s even to methods that are "logically" infallible, like execution, so that internal errors can be more easily propagated upwards via ? to the original caller, who can decide whether to panic;
- it changes `new` to be an `async` method, so that constructors can read data from the state and cache it internally (e.g., a note commitment tree);
- it changes `&self` to `&mut self` so that components can edit their internal data while doing things.