### PR TITLE
Add a `PenumbraStore` extension trait for accessing common data.

### DIFF
--- a/pd/src/components/app.rs
+++ b/pd/src/components/app.rs
@@ -5,7 +5,7 @@ use penumbra_transaction::Transaction;
 use tendermint::abci;
 
 use super::{Component, IBCComponent, Overlay, ShieldedPool};
-use crate::{genesis, Storage, WriteOverlayExt};
+use crate::{genesis, PenumbraStore, Storage, WriteOverlayExt};
 
 /// The Penumbra application, written as a bundle of [`Component`]s.
 ///
@@ -55,8 +55,13 @@ impl Component for App {
 
     async fn init_chain(&mut self, app_state: &genesis::AppState) -> Result<()> {
         self.overlay
+            .put_chain_params(app_state.chain_params.clone())
+            .await;
+        // TODO: do we actually need to store the app state here?
+        self.overlay
             .put_domain(b"genesis/app_state".into(), app_state.clone())
             .await;
+
         self.shielded_pool.init_chain(app_state).await?;
         self.ibc.init_chain(app_state).await?;
         Ok(())

--- a/pd/src/lib.rs
+++ b/pd/src/lib.rs
@@ -29,7 +29,7 @@ pub use pd_metrics::register_all_metrics;
 use pending_block::PendingBlock;
 use request_ext::RequestExt;
 pub use snapshot::Snapshot;
-pub use storage::{Storage, WriteOverlayExt};
+pub use storage::{PenumbraStore, Storage, WriteOverlayExt};
 
 /// The age limit, in blocks, on anchors accepted in transaction verification.
 pub const NUM_RECENT_ANCHORS: usize = 256;

--- a/pd/src/storage.rs
+++ b/pd/src/storage.rs
@@ -6,7 +6,10 @@ use jmt::storage::{Node, NodeBatch, NodeKey, TreeReader, TreeWriter};
 use rocksdb::DB;
 use tracing::{instrument, Span};
 
+mod penumbra_store;
 mod write_overlay_ext;
+
+pub use penumbra_store::PenumbraStore;
 pub use write_overlay_ext::WriteOverlayExt;
 
 #[derive(Clone, Debug)]

--- a/pd/src/storage/penumbra_store.rs
+++ b/pd/src/storage/penumbra_store.rs
@@ -1,0 +1,37 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use penumbra_chain::params::ChainParams;
+
+use crate::WriteOverlayExt;
+
+/// This trait provides read and write access to common parts of the Penumbra
+/// state store.
+///
+/// Note: the `get_` methods in this trait assume that the state store has been
+/// initialized, so they will error on an empty state.
+#[async_trait]
+pub trait PenumbraStore: WriteOverlayExt {
+    /// Gets the chain parameters from the JMT.
+    async fn get_chain_params(&self) -> Result<ChainParams> {
+        self.get_domain(b"chain_params".into())
+            .await?
+            .ok_or_else(|| anyhow!("Missing ChainParams"))
+    }
+
+    /// Writes the provided chain parameters to the JMT.
+    async fn put_chain_params(&self, params: ChainParams) {
+        self.put_domain(b"chain_params".into(), params).await
+    }
+
+    /// Gets the epoch duration for the chain.
+    async fn get_epoch_duration(&self) -> Result<u64> {
+        // this might be a bit wasteful -- does it matter?  who knows, at this
+        // point. but having it be a separate method means we can do a narrower
+        // load later if we want
+        self.get_chain_params()
+            .await
+            .map(|params| params.epoch_duration)
+    }
+}
+
+impl<T: WriteOverlayExt> PenumbraStore for T {}


### PR DESCRIPTION
This trait is motivated by the need to have multiple application components
that access common data.  So far we've had the idea that there are going to be
sub-trees of the JMT for the different application areas, like shielded_pool/,
ibc/, staking/, etc, and that each component is responsible for managing the
state in there, and that we handle "transactions affecting multiple areas" by
"each area does its part separately".

However, there's going to be some cases where we'd want to have different
components accessing common data -- like the epoch_duration.  In individual
components, most of the actual "business logic" of the component is separated
from accesses to the state store, by means of accessor methods that just handle
interfacing with the tree.

This is obviously a good approach, since we don't have to deal with the store
paths or whatever except in the get/put methods themselves, but how does that
work for the epoch_duration, which we may want to access in multiple
components?

One solution is sketched in this commit, which adds a new extension trait that
any component can use to access common data.