### PR TITLE
Remove git-pin on tracing now that tower-abci no longer needs it.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ members = [
 ]
 
 [patch.crates-io]
-tracing = { git = "https://github.com/tokio-rs/tracing/", rev = "6cc6c47354ceeb47da7c95faa41c6d29b71b5f37" }
-tracing-subscriber = { git = "https://github.com/tokio-rs/tracing/", rev = "6cc6c47354ceeb47da7c95faa41c6d29b71b5f37" }
-
 # The "ours" branch is based off of v0.3.0
 ark-ff = { git = "https://github.com/penumbra-zone/algebra", branch = "ours" }
 ark-serialize = { git = "https://github.com/penumbra-zone/algebra", branch = "ours" }


### PR DESCRIPTION
xref https://github.com/penumbra-zone/tower-abci/pull/14 