### PR TITLE
Revert proof lifting

### DIFF
--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -39,7 +39,7 @@ pub enum Error {
 ///
 /// This structure keeps track of the auxiliary (private)
 /// inputs for each action in the transaction.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct TransactionProof {
     pub proof_actions: Vec<ProofAction>,
 }
@@ -49,16 +49,6 @@ pub struct TransactionProof {
 pub enum ProofAction {
     Output(OutputProof),
     Spend(SpendProof),
-}
-
-impl TransactionProof {
-    pub fn add_spend(&mut self, spend: SpendProof) {
-        self.proof_actions.push(ProofAction::Spend(spend))
-    }
-
-    pub fn add_output(&mut self, output: OutputProof) {
-        self.proof_actions.push(ProofAction::Output(output))
-    }
 }
 
 impl Protobuf<transparent_proofs::ProofAction> for ProofAction {}

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -35,60 +35,6 @@ pub enum Error {
     ProtoMalformed,
 }
 
-/// Transparent proof for a transaction.
-///
-/// This structure keeps track of the auxiliary (private)
-/// inputs for each action in the transaction.
-#[derive(Clone, Debug)]
-pub struct TransactionProof {
-    pub proof_actions: Vec<ProofAction>,
-}
-
-/// Supported actions in a Penumbra transaction proof.
-#[derive(Clone, Debug)]
-pub enum ProofAction {
-    Output(OutputProof),
-    Spend(SpendProof),
-}
-
-impl Protobuf<transparent_proofs::ProofAction> for ProofAction {}
-
-impl From<ProofAction> for transparent_proofs::ProofAction {
-    fn from(msg: ProofAction) -> Self {
-        match msg {
-            ProofAction::Output(inner) => transparent_proofs::ProofAction {
-                proof_action: Some(transparent_proofs::proof_action::ProofAction::Output(
-                    inner.into(),
-                )),
-            },
-            ProofAction::Spend(inner) => transparent_proofs::ProofAction {
-                proof_action: Some(transparent_proofs::proof_action::ProofAction::Spend(
-                    inner.into(),
-                )),
-            },
-        }
-    }
-}
-
-impl TryFrom<transparent_proofs::ProofAction> for ProofAction {
-    type Error = anyhow::Error;
-
-    fn try_from(proto: transparent_proofs::ProofAction) -> anyhow::Result<Self, Self::Error> {
-        if proto.proof_action.is_none() {
-            return Err(anyhow::anyhow!("no action!"));
-        }
-
-        match proto.proof_action.unwrap() {
-            transparent_proofs::proof_action::ProofAction::Output(inner) => {
-                Ok(ProofAction::Output(inner.try_into()?))
-            }
-            transparent_proofs::proof_action::ProofAction::Spend(inner) => {
-                Ok(ProofAction::Spend(inner.try_into()?))
-            }
-        }
-    }
-}
-
 /// Transparent proof for spending existing notes.
 ///
 /// This structure keeps track of the auxiliary (private) inputs.
@@ -284,38 +230,13 @@ impl OutputProof {
 
 // Conversions
 
-impl Protobuf<transparent_proofs::TransactionProof> for TransactionProof {}
+impl Protobuf<transparent_proofs::SpendProof> for SpendProof {}
 
-impl From<TransactionProof> for transparent_proofs::TransactionProof {
-    fn from(msg: TransactionProof) -> Self {
-        let proof_actions = msg
-            .proof_actions
-            .into_iter()
-            .map(|proof_action| proof_action.into())
-            .collect();
-        transparent_proofs::TransactionProof { proof_actions }
-    }
-}
-
-impl TryFrom<transparent_proofs::TransactionProof> for TransactionProof {
-    type Error = anyhow::Error;
-
-    fn try_from(proto: transparent_proofs::TransactionProof) -> anyhow::Result<Self, Self::Error> {
-        let mut proof_actions = Vec::new();
-        for proof_action in proto.proof_actions {
-            proof_actions.push(proof_action.try_into()?)
-        }
-        Ok(TransactionProof { proof_actions })
-    }
-}
-
-impl Protobuf<transparent_proofs::Spend> for SpendProof {}
-
-impl From<SpendProof> for transparent_proofs::Spend {
+impl From<SpendProof> for transparent_proofs::SpendProof {
     fn from(msg: SpendProof) -> Self {
         let ak_bytes: [u8; 32] = msg.ak.into();
         let nk_bytes: [u8; 32] = msg.nk.0.to_bytes();
-        transparent_proofs::Spend {
+        transparent_proofs::SpendProof {
             merkle_path_field_0: u64::from(msg.merkle_path.0) as u32,
             merkle_path_field_1: msg
                 .merkle_path
@@ -338,10 +259,10 @@ impl From<SpendProof> for transparent_proofs::Spend {
     }
 }
 
-impl TryFrom<transparent_proofs::Spend> for SpendProof {
+impl TryFrom<transparent_proofs::SpendProof> for SpendProof {
     type Error = Error;
 
-    fn try_from(proto: transparent_proofs::Spend) -> anyhow::Result<Self, Self::Error> {
+    fn try_from(proto: transparent_proofs::SpendProof) -> anyhow::Result<Self, Self::Error> {
         let g_d_bytes: [u8; 32] = proto.g_d.try_into().map_err(|_| Error::ProtoMalformed)?;
         let g_d_encoding = decaf377::Encoding(g_d_bytes);
 
@@ -407,11 +328,11 @@ impl TryFrom<transparent_proofs::Spend> for SpendProof {
     }
 }
 
-impl Protobuf<transparent_proofs::Output> for OutputProof {}
+impl Protobuf<transparent_proofs::OutputProof> for OutputProof {}
 
-impl From<OutputProof> for transparent_proofs::Output {
+impl From<OutputProof> for transparent_proofs::OutputProof {
     fn from(msg: OutputProof) -> Self {
-        transparent_proofs::Output {
+        transparent_proofs::OutputProof {
             g_d: msg.g_d.compress().0.to_vec(),
             pk_d: msg.pk_d.0.to_vec(),
             value_amount: msg.value.amount,
@@ -423,10 +344,10 @@ impl From<OutputProof> for transparent_proofs::Output {
     }
 }
 
-impl TryFrom<transparent_proofs::Output> for OutputProof {
+impl TryFrom<transparent_proofs::OutputProof> for OutputProof {
     type Error = Error;
 
-    fn try_from(proto: transparent_proofs::Output) -> anyhow::Result<Self, Self::Error> {
+    fn try_from(proto: transparent_proofs::OutputProof) -> anyhow::Result<Self, Self::Error> {
         let g_d_bytes: [u8; 32] = proto.g_d.try_into().map_err(|_| Error::ProtoMalformed)?;
         let g_d_encoding = decaf377::Encoding(g_d_bytes);
 
@@ -472,7 +393,7 @@ impl TryFrom<transparent_proofs::Output> for OutputProof {
 
 impl From<SpendProof> for Vec<u8> {
     fn from(spend_proof: SpendProof) -> Vec<u8> {
-        let protobuf_serialized_proof: transparent_proofs::Spend = spend_proof.into();
+        let protobuf_serialized_proof: transparent_proofs::SpendProof = spend_proof.into();
         protobuf_serialized_proof.encode_to_vec()
     }
 }
@@ -482,7 +403,7 @@ impl TryFrom<&[u8]> for SpendProof {
 
     fn try_from(bytes: &[u8]) -> Result<SpendProof, Self::Error> {
         let protobuf_serialized_proof =
-            transparent_proofs::Spend::decode(bytes).map_err(|_| Error::ProtoMalformed)?;
+            transparent_proofs::SpendProof::decode(bytes).map_err(|_| Error::ProtoMalformed)?;
         protobuf_serialized_proof
             .try_into()
             .map_err(|_| Error::ProtoMalformed)
@@ -491,7 +412,7 @@ impl TryFrom<&[u8]> for SpendProof {
 
 impl From<OutputProof> for Vec<u8> {
     fn from(output_proof: OutputProof) -> Vec<u8> {
-        let protobuf_serialized_proof: transparent_proofs::Output = output_proof.into();
+        let protobuf_serialized_proof: transparent_proofs::OutputProof = output_proof.into();
         protobuf_serialized_proof.encode_to_vec()
     }
 }
@@ -501,7 +422,7 @@ impl TryFrom<&[u8]> for OutputProof {
 
     fn try_from(bytes: &[u8]) -> Result<OutputProof, Self::Error> {
         let protobuf_serialized_proof =
-            transparent_proofs::Output::decode(bytes).map_err(|_| Error::ProtoMalformed)?;
+            transparent_proofs::OutputProof::decode(bytes).map_err(|_| Error::ProtoMalformed)?;
         protobuf_serialized_proof
             .try_into()
             .map_err(|_| Error::ProtoMalformed)

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -470,10 +470,9 @@ impl TryFrom<transparent_proofs::Output> for OutputProof {
     }
 }
 
-impl From<TransactionProof> for Vec<u8> {
-    fn from(transaction_proof: TransactionProof) -> Vec<u8> {
-        let protobuf_serialized_proof: transparent_proofs::TransactionProof =
-            transaction_proof.into();
+impl From<SpendProof> for Vec<u8> {
+    fn from(spend_proof: SpendProof) -> Vec<u8> {
+        let protobuf_serialized_proof: transparent_proofs::Spend = spend_proof.into();
         protobuf_serialized_proof.encode_to_vec()
     }
 }
@@ -484,25 +483,6 @@ impl TryFrom<&[u8]> for SpendProof {
     fn try_from(bytes: &[u8]) -> Result<SpendProof, Self::Error> {
         let protobuf_serialized_proof =
             transparent_proofs::Spend::decode(bytes).map_err(|_| Error::ProtoMalformed)?;
-        protobuf_serialized_proof
-            .try_into()
-            .map_err(|_| Error::ProtoMalformed)
-    }
-}
-
-impl From<SpendProof> for Vec<u8> {
-    fn from(spend_proof: SpendProof) -> Vec<u8> {
-        let protobuf_serialized_proof: transparent_proofs::Spend = spend_proof.into();
-        protobuf_serialized_proof.encode_to_vec()
-    }
-}
-
-impl TryFrom<&[u8]> for TransactionProof {
-    type Error = Error;
-
-    fn try_from(bytes: &[u8]) -> Result<TransactionProof, Self::Error> {
-        let protobuf_serialized_proof = transparent_proofs::TransactionProof::decode(bytes)
-            .map_err(|_| Error::ProtoMalformed)?;
         protobuf_serialized_proof
             .try_into()
             .map_err(|_| Error::ProtoMalformed)

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -1,6 +1,5 @@
 //! Transparent proofs for `MVP1` of the Penumbra system.
 
-use std::collections::VecDeque;
 use std::convert::{TryFrom, TryInto};
 
 use decaf377::FieldExt;
@@ -42,7 +41,7 @@ pub enum Error {
 /// inputs for each action in the transaction.
 #[derive(Clone, Debug, Default)]
 pub struct TransactionProof {
-    pub proof_actions: VecDeque<ProofAction>,
+    pub proof_actions: Vec<ProofAction>,
 }
 
 /// Supported actions in a Penumbra transaction proof.
@@ -54,11 +53,11 @@ pub enum ProofAction {
 
 impl TransactionProof {
     pub fn add_spend(&mut self, spend: SpendProof) {
-        self.proof_actions.push_back(ProofAction::Spend(spend))
+        self.proof_actions.push(ProofAction::Spend(spend))
     }
 
     pub fn add_output(&mut self, output: OutputProof) {
-        self.proof_actions.push_back(ProofAction::Output(output))
+        self.proof_actions.push(ProofAction::Output(output))
     }
 }
 
@@ -312,9 +311,9 @@ impl TryFrom<transparent_proofs::TransactionProof> for TransactionProof {
     type Error = anyhow::Error;
 
     fn try_from(proto: transparent_proofs::TransactionProof) -> anyhow::Result<Self, Self::Error> {
-        let mut proof_actions = VecDeque::new();
+        let mut proof_actions = Vec::new();
         for proof_action in proto.proof_actions {
-            proof_actions.push_back(proof_action.try_into()?)
+            proof_actions.push(proof_action.try_into()?)
         }
         Ok(TransactionProof { proof_actions })
     }

--- a/pd/src/verify/stateless.rs
+++ b/pd/src/verify/stateless.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Error};
-use penumbra_crypto::{note, proofs::transparent::ProofAction, Nullifier};
+use penumbra_crypto::{note, Nullifier};
 use penumbra_proto::{stake::Validator as ProtoValidator, Message};
 use penumbra_stake::{Delegate, Undelegate, ValidatorDefinition};
 use penumbra_transaction::{Action, Transaction};
@@ -39,38 +39,21 @@ impl StatelessTransactionExt for Transaction {
         let mut undelegation = None::<Undelegate>;
         let mut validator_definitions = Vec::<ValidatorDefinition>::new();
 
-        let transaction_proof = self.proof();
-        let mut transaction_proof_constraints =
-            transaction_proof.clone().unwrap_or_default().proof_actions;
         for action in self.transaction_body().actions {
             match action {
                 Action::Output(output) => {
-                    if transaction_proof.clone().is_none() {
-                        return Err(anyhow::anyhow!("Proof not included in transaction"));
-                    }
-                    let constraints = transaction_proof_constraints.pop_front();
-                    if constraints.is_none() {
-                        return Err(anyhow::anyhow!("Constraints not found for an action"));
-                    }
-                    match constraints.unwrap() {
-                        ProofAction::Output(constraints) => {
-                            if constraints
-                                .verify(
-                                    output.body.value_commitment,
-                                    output.body.note_commitment,
-                                    output.body.ephemeral_key,
-                                )
-                                .is_err()
-                            {
-                                // TODO should the verification error be bubbled up here?
-                                return Err(anyhow::anyhow!("Output constraints did not verify"));
-                            }
-                        }
-                        _ => {
-                            return Err(anyhow::anyhow!(
-                                "Wrong proof constraints found for this action"
-                            ))
-                        }
+                    if output
+                        .body
+                        .proof
+                        .verify(
+                            output.body.value_commitment,
+                            output.body.note_commitment,
+                            output.body.ephemeral_key,
+                        )
+                        .is_err()
+                    {
+                        // TODO should the verification error be bubbled up here?
+                        return Err(anyhow::anyhow!("An output proof did not verify"));
                     }
 
                     new_notes.insert(
@@ -89,33 +72,19 @@ impl StatelessTransactionExt for Transaction {
                         .verify(&sighash, &spend.auth_sig)
                         .context("spend auth signature failed to verify")?;
 
-                    if transaction_proof.clone().is_none() {
-                        return Err(anyhow::anyhow!("Proof not included in transaction"));
-                    }
-                    let constraints = transaction_proof_constraints.pop_front();
-                    if constraints.is_none() {
-                        return Err(anyhow::anyhow!("Constraints not found for an action"));
-                    }
-                    match constraints.unwrap() {
-                        ProofAction::Spend(constraints) => {
-                            if constraints
-                                .verify(
-                                    self.transaction_body().merkle_root,
-                                    spend.body.value_commitment,
-                                    spend.body.nullifier.clone(),
-                                    spend.body.rk,
-                                )
-                                .is_err()
-                            {
-                                // TODO should the verification error be bubbled up here?
-                                return Err(anyhow::anyhow!("Spend constraints did not verify"));
-                            }
-                        }
-                        _ => {
-                            return Err(anyhow::anyhow!(
-                                "Wrong proof constraints found for this action"
-                            ))
-                        }
+                    if spend
+                        .body
+                        .proof
+                        .verify(
+                            self.transaction_body().merkle_root,
+                            spend.body.value_commitment,
+                            spend.body.nullifier.clone(),
+                            spend.body.rk,
+                        )
+                        .is_err()
+                    {
+                        // TODO should the verification error be bubbled up here?
+                        return Err(anyhow::anyhow!("A spend proof did not verify"));
                     }
 
                     // Check nullifier has not been revealed already in this transaction.

--- a/pd/src/verify/stateless.rs
+++ b/pd/src/verify/stateless.rs
@@ -39,52 +39,40 @@ impl StatelessTransactionExt for Transaction {
         let mut undelegation = None::<Undelegate>;
         let mut validator_definitions = Vec::<ValidatorDefinition>::new();
 
-        // First check the transaction proof.
-        let mut transaction_proof = self.proof();
-        for action in &self.transaction_body().actions {
-            match action {
-                Action::Output(output) => {
-                    if let Some(ProofAction::Output(witness_data)) = transaction_proof
-                        .as_mut()
-                        .and_then(|proof| proof.proof_actions.pop_front())
-                    {
-                        witness_data.verify(
-                            output.body.value_commitment,
-                            output.body.note_commitment,
-                            output.body.ephemeral_key,
-                        )?;
-                    } else {
-                        return Err(anyhow::anyhow!("Did not find output witness data"));
-                    };
-                }
-                Action::Spend(spend) => {
-                    spend
-                        .body
-                        .rk
-                        .verify(&sighash, &spend.auth_sig)
-                        .context("spend auth signature failed to verify")?;
-
-                    if let Some(ProofAction::Spend(witness_data)) = transaction_proof
-                        .as_mut()
-                        .and_then(|proof| proof.proof_actions.pop_front())
-                    {
-                        witness_data.verify(
-                            self.transaction_body().merkle_root,
-                            spend.body.value_commitment,
-                            spend.body.nullifier.clone(),
-                            spend.body.rk,
-                        )?;
-                    } else {
-                        return Err(anyhow::anyhow!("Did not find spend witness data"));
-                    };
-                }
-                _ => {} // Only outputs and spends have proofs
-            }
-        }
-
+        let transaction_proof = self.proof();
+        let mut transaction_proof_constraints =
+            transaction_proof.clone().unwrap_or_default().proof_actions;
         for action in self.transaction_body().actions {
             match action {
                 Action::Output(output) => {
+                    if transaction_proof.clone().is_none() {
+                        return Err(anyhow::anyhow!("Proof not included in transaction"));
+                    }
+                    let constraints = transaction_proof_constraints.pop_front();
+                    if constraints.is_none() {
+                        return Err(anyhow::anyhow!("Constraints not found for an action"));
+                    }
+                    match constraints.unwrap() {
+                        ProofAction::Output(constraints) => {
+                            if constraints
+                                .verify(
+                                    output.body.value_commitment,
+                                    output.body.note_commitment,
+                                    output.body.ephemeral_key,
+                                )
+                                .is_err()
+                            {
+                                // TODO should the verification error be bubbled up here?
+                                return Err(anyhow::anyhow!("Output constraints did not verify"));
+                            }
+                        }
+                        _ => {
+                            return Err(anyhow::anyhow!(
+                                "Wrong proof constraints found for this action"
+                            ))
+                        }
+                    }
+
                     new_notes.insert(
                         output.body.note_commitment,
                         NoteData {
@@ -100,6 +88,35 @@ impl StatelessTransactionExt for Transaction {
                         .rk
                         .verify(&sighash, &spend.auth_sig)
                         .context("spend auth signature failed to verify")?;
+
+                    if transaction_proof.clone().is_none() {
+                        return Err(anyhow::anyhow!("Proof not included in transaction"));
+                    }
+                    let constraints = transaction_proof_constraints.pop_front();
+                    if constraints.is_none() {
+                        return Err(anyhow::anyhow!("Constraints not found for an action"));
+                    }
+                    match constraints.unwrap() {
+                        ProofAction::Spend(constraints) => {
+                            if constraints
+                                .verify(
+                                    self.transaction_body().merkle_root,
+                                    spend.body.value_commitment,
+                                    spend.body.nullifier.clone(),
+                                    spend.body.rk,
+                                )
+                                .is_err()
+                            {
+                                // TODO should the verification error be bubbled up here?
+                                return Err(anyhow::anyhow!("Spend constraints did not verify"));
+                            }
+                        }
+                        _ => {
+                            return Err(anyhow::anyhow!(
+                                "Wrong proof constraints found for this action"
+                            ))
+                        }
+                    }
 
                     // Check nullifier has not been revealed already in this transaction.
                     if spent_nullifiers.contains(&spend.body.nullifier.clone()) {

--- a/proto/proto/transaction.proto
+++ b/proto/proto/transaction.proto
@@ -24,8 +24,8 @@ message TransactionBody {
   string chain_id = 4;
   // The transaction fee.
   Fee fee = 5;
-  // The proof over all actions. Optional to support the IBC relayer case.
-  optional bytes zkproof = 6;
+  // The proof over all actions.
+  bytes zkproof = 6;
 }
 
 // A state change performed by a transaction.

--- a/proto/proto/transaction.proto
+++ b/proto/proto/transaction.proto
@@ -24,8 +24,6 @@ message TransactionBody {
   string chain_id = 4;
   // The transaction fee.
   Fee fee = 5;
-  // The proof over all actions.
-  bytes zkproof = 6;
 }
 
 // A state change performed by a transaction.
@@ -60,6 +58,8 @@ message SpendBody {
   bytes nullifier = 3;
   // The randomized validating key for the spend authorization signature.
   bytes rk = 4;
+  // The spend proof.
+  bytes zkproof = 5;
 }
 
 // Creates a new shielded note.
@@ -85,4 +85,6 @@ message OutputBody {
   // An encryption of the newly created note.
   // 132 = 1(type) + 11(d) + 8(amount) + 32(asset_id) + 32(rcm) + 32(pk_d) + 16(MAC) bytes.
   bytes encrypted_note = 4;
+  // The output proof. 192 bytes.
+  bytes zkproof = 5;
 }

--- a/proto/proto/transparent_proofs.proto
+++ b/proto/proto/transparent_proofs.proto
@@ -6,7 +6,7 @@ message TransactionProof {
   repeated ProofAction proof_actions = 1;
 }
 
-// Witness data associated with a given action.
+// Constraints associated with a given action.
 message ProofAction {
   oneof proof_action {
     Spend spend = 1;
@@ -14,7 +14,7 @@ message ProofAction {
   }
 }
 
-// Witness data for a Penumbra transparent spend.
+// Constraints for a Penumbra transparent spend.
 message Spend {
   // Auxiliary inputs
   uint32 merkle_path_field_0 = 1;
@@ -32,7 +32,7 @@ message Spend {
   bytes nk = 13;
 }
 
-// Witness data for a Penumbra transparent output.
+// Constraints for a Penumbra transparent output.
 message Output {
   // Auxiliary inputs
   bytes g_d = 1;

--- a/proto/proto/transparent_proofs.proto
+++ b/proto/proto/transparent_proofs.proto
@@ -1,21 +1,8 @@
 syntax = "proto3";
 package penumbra.transparent_proofs;
 
-// A Penumbra transaction proof.
-message TransactionProof {
-  repeated ProofAction proof_actions = 1;
-}
-
-// Constraints associated with a given action.
-message ProofAction {
-  oneof proof_action {
-    Spend spend = 1;
-    Output output = 2;
-  }
-}
-
-// Constraints for a Penumbra transparent spend.
-message Spend {
+// A Penumbra transparent Spend Proof.
+message SpendProof {
   // Auxiliary inputs
   uint32 merkle_path_field_0 = 1;
   repeated bytes merkle_path_field_1 = 2;
@@ -32,8 +19,8 @@ message Spend {
   bytes nk = 13;
 }
 
-// Constraints for a Penumbra transparent output.
-message Output {
+// A Penumbra transparent output proof.
+message OutputProof {
   // Auxiliary inputs
   bytes g_d = 1;
   bytes pk_d = 2;

--- a/transaction/src/action/spend.rs
+++ b/transaction/src/action/spend.rs
@@ -3,6 +3,7 @@ use std::convert::{TryFrom, TryInto};
 use bytes::Bytes;
 use penumbra_crypto::{
     keys, merkle,
+    proofs::transparent::SpendProof,
     rdsa::{Signature, SigningKey, SpendAuth, VerificationKey},
     value, Fr, Note, Nullifier,
 };
@@ -55,6 +56,7 @@ pub struct Body {
     pub nullifier: Nullifier,
     // Randomized verification key.
     pub rk: VerificationKey<SpendAuth>,
+    pub proof: SpendProof,
 }
 
 impl Body {
@@ -64,16 +66,33 @@ impl Body {
         spend_auth_randomizer: Fr,
         merkle_path: merkle::Path,
         note: Note,
+        v_blinding: Fr,
         nk: keys::NullifierKey,
     ) -> Body {
         let rsk = ask.randomize(&spend_auth_randomizer);
         let rk = rsk.into();
         let note_commitment = note.commit();
         let position = merkle_path.0.clone();
+        let proof = SpendProof {
+            // XXX: the position field duplicates data from the merkle path
+            // probably not worth fixing before we just make them snarks...
+            position,
+            merkle_path,
+            g_d: note.diversified_generator(),
+            pk_d: note.transmission_key(),
+            value: note.value(),
+            v_blinding,
+            note_commitment,
+            note_blinding: note.note_blinding(),
+            spend_auth_randomizer,
+            ak: ask.into(),
+            nk,
+        };
         Body {
             value_commitment,
             nullifier: nk.derive_nullifier(position, &note_commitment),
             rk,
+            proof,
         }
     }
 }
@@ -92,10 +111,12 @@ impl From<Body> for transaction::SpendBody {
         let cv_bytes: [u8; 32] = msg.value_commitment.into();
         let nullifier_bytes: [u8; 32] = msg.nullifier.into();
         let rk_bytes: [u8; 32] = msg.rk.into();
+        let proof: Vec<u8> = msg.proof.into();
         transaction::SpendBody {
             cv: Bytes::copy_from_slice(&cv_bytes),
             nullifier: Bytes::copy_from_slice(&nullifier_bytes),
             rk: Bytes::copy_from_slice(&rk_bytes),
+            zkproof: proof.into(),
         }
     }
 }
@@ -118,10 +139,16 @@ impl TryFrom<transaction::SpendBody> for Body {
         let rk = rk_bytes
             .try_into()
             .map_err(|_| anyhow::anyhow!("spend body malformed"))?;
+
+        let proof = (proto.zkproof[..])
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("spend body malformed"))?;
+
         Ok(Body {
             value_commitment,
             nullifier,
             rk,
+            proof,
         })
     }
 }

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -32,7 +32,7 @@ pub struct TransactionBody {
     pub expiry_height: u32,
     pub chain_id: String,
     pub fee: Fee,
-    pub zkproof: Option<TransactionProof>,
+    pub zkproof: TransactionProof,
 }
 
 impl TransactionBody {
@@ -74,7 +74,6 @@ impl Transaction {
             merkle_root,
             expiry_height: None,
             chain_id: None,
-            zkproof: None,
         }
     }
 
@@ -166,14 +165,12 @@ impl Protobuf<ProtoTransactionBody> for TransactionBody {}
 
 impl From<TransactionBody> for ProtoTransactionBody {
     fn from(msg: TransactionBody) -> Self {
-        let zkproof: Option<Vec<u8>> = msg.zkproof.map(|proof| proof.into());
         ProtoTransactionBody {
             actions: msg.actions.into_iter().map(|x| x.into()).collect(),
             anchor: Bytes::copy_from_slice(&msg.merkle_root.0.to_bytes()),
             expiry_height: msg.expiry_height,
             chain_id: msg.chain_id,
             fee: Some(msg.fee.into()),
-            zkproof: zkproof.map(|proof| proof.into()),
         }
     }
 }
@@ -204,22 +201,12 @@ impl TryFrom<ProtoTransactionBody> for TransactionBody {
             .ok_or(anyhow::anyhow!("transaction body malformed"))?
             .into();
 
-        let zkproof = match proto.zkproof {
-            None => None,
-            Some(inner) => Some(
-                inner[..]
-                    .try_into()
-                    .map_err(|_| ProtoError::ProofMalformed)?,
-            ),
-        };
-
         Ok(TransactionBody {
             actions,
             merkle_root,
             expiry_height,
             chain_id,
             fee,
-            zkproof,
         })
     }
 }

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -6,7 +6,6 @@ use decaf377::FieldExt;
 use penumbra_chain::sync::CompactOutput;
 use penumbra_crypto::{
     merkle,
-    proofs::transparent::TransactionProof,
     rdsa::{Binding, Signature, VerificationKey, VerificationKeyBytes},
     Fr, Nullifier, Value,
 };
@@ -32,7 +31,6 @@ pub struct TransactionBody {
     pub expiry_height: u32,
     pub chain_id: String,
     pub fee: Fee,
-    pub zkproof: TransactionProof,
 }
 
 impl TransactionBody {

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -213,7 +213,7 @@ impl TryFrom<ProtoTransactionBody> for TransactionBody {
             Some(inner) => Some(
                 inner[..]
                     .try_into()
-                    .map_err(|_| anyhow::anyhow!("transaction body malformed"))?,
+                    .map_err(|_| ProtoError::ProofMalformed)?,
             ),
         };
 

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -78,10 +78,6 @@ impl Transaction {
         }
     }
 
-    pub fn proof(&self) -> Option<TransactionProof> {
-        self.transaction_body.zkproof.clone()
-    }
-
     pub fn compact_outputs(&self) -> Vec<CompactOutput> {
         self.transaction_body
             .actions

--- a/transaction/src/transaction/builder.rs
+++ b/transaction/src/transaction/builder.rs
@@ -7,7 +7,6 @@ use penumbra_crypto::{
     keys::{OutgoingViewingKey, SpendKey},
     memo::MemoPlaintext,
     merkle::{self, NoteCommitmentTree},
-    proofs::transparent::TransactionProof,
     rdsa::{Binding, Signature, SigningKey, SpendAuth},
     value, Address, Fr, Note, Value,
 };
@@ -48,8 +47,6 @@ pub struct Builder {
     pub expiry_height: Option<u32>,
     /// Chain ID. None if unset.
     pub chain_id: Option<String>,
-    /// Proof. Can be None if no actions with proofs are added.
-    pub zkproof: Option<TransactionProof>,
 }
 
 impl Builder {
@@ -320,7 +317,6 @@ impl Builder {
             expiry_height: self.expiry_height.unwrap_or(0),
             chain_id: self.chain_id.take().unwrap(),
             fee: self.fee.take().unwrap(),
-            zkproof: self.zkproof.take(),
         };
 
         // The transaction body is filled except for the signatures,


### PR DESCRIPTION
Related to #450 

In benchmarking PLONK libraries, it turns out circuit preprocessing can take a significant amount of time (for jellyfish, ~seconds), so having custom circuits based on the actions in each transaction may introduce significant performance implications (or complexity trying to reduce the performance hit, e.g. by caching circuits for common sets of actions in a transaction). For now we'll back out the proof lifting changes.