### PR TITLE
Commit App state following init_chain

### DIFF
--- a/pd/src/consensus/worker.rs
+++ b/pd/src/consensus/worker.rs
@@ -168,6 +168,8 @@ impl Worker {
 
         // Begin new sidecar code
         self.app.init_chain(&app_state).await?;
+        // Note: App::commit resets internal components, so we don't need to do that ourselves.
+        self.app.commit(self.storage.clone()).await?;
         // End new sidecar code
 
         // Initialize the database with the app state.

--- a/pd/src/consensus/worker.rs
+++ b/pd/src/consensus/worker.rs
@@ -167,6 +167,17 @@ impl Worker {
             .expect("can parse app_state in genesis file");
 
         // Begin new sidecar code
+
+        // We want to write the genesis state as version 0 of the tree, so we
+        // need to initialize the write overlay with the PRE_GENESIS_VERSION.
+        // To do this, it's easiest to just overwrite the app here.
+        self.app = App::new(Arc::new(Mutex::new(WriteOverlay::new(
+            self.storage.clone(),
+            // Some kind of visibility issue on associated consts?
+            //WriteOverlay::PRE_GENESIS_VERSION,
+            u64::MAX,
+        ))))
+        .await?;
         self.app.init_chain(&app_state).await?;
         // Note: App::commit resets internal components, so we don't need to do that ourselves.
         self.app.commit(self.storage.clone()).await?;

--- a/pd/src/storage.rs
+++ b/pd/src/storage.rs
@@ -51,7 +51,7 @@ impl TreeWriter for Storage {
                     for (node_key, node) in node_batch.clone() {
                         let key_bytes = &node_key.encode()?;
                         let value_bytes = &node.encode()?;
-                        tracing::trace!(?key_bytes, ?value_bytes);
+                        tracing::debug!(?key_bytes, value_bytes = ?hex::encode(&value_bytes));
                         db.put(key_bytes, value_bytes)?;
                     }
 
@@ -86,7 +86,7 @@ impl TreeReader for Storage {
                         .map(|db_slice| Node::decode(&db_slice))
                         .transpose()?;
 
-                    tracing::trace!(?node_key, ?value);
+                    tracing::debug!(?node_key, ?value);
                     Ok(value)
                 })
             })


### PR DESCRIPTION
The initial sidecar use of the `App` code didn't call `commit` following `init_chain`, so the genesis state was never actually committed.

However, trying to commit that state causes new problems, which are probably related to the JMT's handling of the empty tree:
```
Mar 31 14:55:03.809 DEBUG abci:InitChain{chain_id="penumbra-orthosie-23a3e8b8"}:commit: pd::storage: node_key=NodeKey { version: 0, nibble_path:  } value=None
thread 'tokio-runtime-worker' panicked at 'called `Option::unwrap()` on a `None` value', /Users/hdevalence/.cargo/git/checkouts/jellyfish-merkle-6b18a07b8fd5fec6/445c51a/src/tree_cache.rs:188:58
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```