### PR TITLE
Unlink the JMT from the legacy Postgres state

### DIFF
--- a/pd/src/state/writer.rs
+++ b/pd/src/state/writer.rs
@@ -78,11 +78,7 @@ impl Writer {
     /// The database queries here have quite a bit of overlap with the queries in
     /// commit_block(), but this is because the genesis setup is better treated
     /// as a simple special case rather than creating a fake pseudo-block.
-    pub async fn commit_genesis(
-        &self,
-        genesis_config: &genesis::AppState,
-        mut storage: Storage,
-    ) -> Result<Vec<u8>> {
+    pub async fn commit_genesis(&self, genesis_config: &genesis::AppState) -> Result<Vec<u8>> {
         let mut dbtx = self.pool.begin().await?;
 
         let genesis_bytes = serde_json::to_vec(&genesis_config)?;
@@ -295,6 +291,7 @@ impl Writer {
         .execute(&mut dbtx)
         .await?;
 
+        /*
         // ... and add its root to the public chain state ...
         let (jmt_root, tree_update_batch) = jmt::JellyfishMerkleTree::new(&storage)
             .put_value_set(
@@ -310,6 +307,8 @@ impl Writer {
 
         // As the very last step, compute the JMT root and return it as the apphash.
         let app_hash: [u8; 32] = jmt_root.0;
+         */
+        let app_hash = [9; 32]; // value that is recognizable as not being 0
 
         // Insert the block into the DB
         query!(
@@ -377,7 +376,6 @@ impl Writer {
         &self,
         block: PendingBlock,
         block_validator_set: &mut ValidatorSet,
-        storage: Storage,
     ) -> Result<Vec<u8>> {
         // TODO: batch these queries?
         let mut dbtx = self.pool.begin().await?;
@@ -397,6 +395,7 @@ impl Writer {
         let epoch = block.epoch.unwrap();
         let height = block.height.expect("height must be set");
 
+        /*
         let mut overlay = jmt::WriteOverlay::new(storage.clone(), height - 1);
         overlay.put(b"nct_anchor".into(), nct_anchor.clone().to_bytes().to_vec());
         let (jmt_root, _height) = overlay.commit(storage).await?;
@@ -406,6 +405,8 @@ impl Writer {
         // the JMT root.
         // TODO: no way to access the Diem HashValue as array, even though it's stored that way?
         let app_hash: [u8; 32] = jmt_root.0.to_vec().try_into().unwrap();
+         */
+        let app_hash = [9; 32]; // recognizably not 0
 
         query!(
             "INSERT INTO blocks (height, nct_anchor, app_hash) VALUES ($1, $2, $3)",


### PR DESCRIPTION
This commit fixes a problem where the `chain_params` key of the JMT was
mysteriously unavailable, even though it had been written, causing a crash.
The problem was that although we started using the JMT in the new component
code, we didn't remove its use from the legacy Postgres state.  This caused the
legacy postgres code to clobber the tree roots, so although the tree roots were
actually written to the backing store, they were inaccessible, because the
roots had been overwritten with ones that didn't point to those leaves.

In the short term, the fix for this is to remove the JMT from the legacy state
code, so that there is only one writer.

In the long term, we should probably try to have the `Storage` impl return an
error if it is about to clobber existing data; since the JMT is an append-only
data structure, we should never have the backing store overwriting existing
key/value pairs.  Maybe there is an easy way to do this in RocksDB.