### PR TITLE
Only do CI runs on pull_request, not push

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,5 @@
 name: integration
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   integration:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request]
 
 name: Rust CI
 


### PR DESCRIPTION
This will hopefully avoid duplicate CI jobs.  We don't generally have ongoing
work in branches that doesn't have a (draft) PR.