### PR TITLE
pd: add ShieldedPoolStore extension trait

### DIFF
--- a/pd/src/components.rs
+++ b/pd/src/components.rs
@@ -18,7 +18,7 @@ pub mod validator_set;
 pub use app::App;
 pub use component::Component;
 pub use ibc::IBCComponent;
-pub use shielded_pool::ShieldedPool;
+pub use shielded_pool::{ShieldedPool, ShieldedPoolStore};
 pub use staking::Staking;
 
 type Overlay = Arc<Mutex<WriteOverlay<Storage>>>;


### PR DESCRIPTION
This allows other components to read relevant data stored by the ShieldedPool component, initially just the token supply.

This is needed for #507, which needs to be able to read the delegation token supplies.