### PR TITLE
"Correctly" report AppHash in Info messages

### DIFF
--- a/pd/src/consensus/worker.rs
+++ b/pd/src/consensus/worker.rs
@@ -45,6 +45,7 @@ impl Worker {
         // special case.
 
         let height = state.private_reader().height().into();
+        tracing::warn!(?height);
         let app = App::new(Arc::new(Mutex::new(WriteOverlay::new(
             storage.clone(),
             height,
@@ -94,6 +95,14 @@ impl Worker {
 
         // Now (re)load the caches from the state writer:
         self.state.init_caches().await?;
+
+        let height = self.state.private_reader().height().into();
+        tracing::warn!(?height);
+        self.app = App::new(Arc::new(Mutex::new(WriteOverlay::new(
+            self.storage.clone(),
+            height,
+        ))))
+        .await?;
 
         Ok(())
     }

--- a/pd/src/state/writer.rs
+++ b/pd/src/state/writer.rs
@@ -49,7 +49,16 @@ impl Writer {
             .genesis_configuration()
             .await?
             .chain_params;
-        let height = self.private_reader.height();
+        // This is incorrect, it just reads from the channel it's supposed to be updating
+        // let height = self.private_reader.height();
+        let height = self
+            .private_reader
+            .latest_block_info()
+            .await?
+            .map(|row| row.height)
+            .unwrap_or(0)
+            .try_into()
+            .unwrap();
         let next_rate_data = self.private_reader.next_rate_data().await?;
         let valid_anchors = self
             .private_reader


### PR DESCRIPTION
We now report the AppHash from the RocksDB-backed JMT code, since we don't have
a JMT implementation in the legacy implementation any more.  This means that
the node will fail to restart, because (until this commit) it would query the
Postgres instance for the app hash, returning a dummy value.

Also this revealed that the height cache / notification channel thing never
even worked.  We need to trash all of this code ASAP