### PR TITLE
Separate multinode configuration into a new override file

### DIFF
--- a/docker-compose.multinode.override.yml
+++ b/docker-compose.multinode.override.yml
@@ -39,6 +39,69 @@ services:
     ports:
       - "5432:5432"
 
+  # for local development, configure the penumbra daemon with more logging.
+  pd-node1:
+    container_name: penumbra-node1
+    environment:
+      - RUST_LOG=${RUST_LOG:-warn,pd=debug,penumbra=debug,jmt=debug}
+    build:
+      # Use the dev Dockerfile which has better cacheing and doesn't use the release
+      # target
+      dockerfile: Dockerfile.dev
+      context: .
+    volumes:
+      - ~/scratch/testnet_build/node1/pd:/pd
+    command: pd start --host 0.0.0.0 --database-uri
+      postgres://postgres:postgres@db-node1/penumbra -r /pd/rocksdb
+    depends_on:
+      - db-node1
+    #links:
+    #  - db:db
+    restart: on-failure
+    networks:
+      localnet:
+        ipv4_address: 192.167.10.20
+    ports:
+      - "27658:26658"
+      - "27666:26666"
+      - "27667:26667"
+
+  # database - postgres - on prod we are using managed DB instances
+  db-node1:
+    image: postgres:13.0
+    container_name: db-node1
+    volumes:
+      - "db_node1_data:/var/lib/postgresql/data"
+    environment:
+      - POSTGRES_DB=penumbra
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    networks:
+      localnet:
+        ipv4_address: 192.167.10.22
+    # expose database on a port so it is easy to play with
+    #ports:
+    #  - "5432:5432"
+
+  # The Tendermint node
+  tendermint-node1:
+    image: "tendermint/tendermint:v0.35.0"
+    container_name: tendermint-node1
+    ports:
+      - "27656:26656"
+      - "27657:26657"
+    volumes:
+      - ~/scratch/testnet_build/node1/tendermint:/tendermint
+    command: start --proxy-app=tcp://pd-node1:26658
+    environment:
+      - ID=1
+      - LOG=${LOG:-tendermint.log}
+    depends_on:
+      - pd-node1
+    networks:
+      localnet:
+        ipv4_address: 192.167.10.21
+
   # add prometheus and grafana
   #
   # in production, users will want to bring their own monitoring stack, rather
@@ -78,6 +141,7 @@ services:
 volumes:
   prometheus_data: {}
   db_node0_data: {}
+  db_node1_data: {}
 
 networks:
   # add a separate network for grafana and prometheus to talk to each other.


### PR DESCRIPTION
This way by default `docker-compose` without arguments will use a single-node testnet but we can easily change to multinode for testing.