### PR TITLE
pd: add a new, Component-based mempool.

### DIFF
--- a/pd/src/lib.rs
+++ b/pd/src/lib.rs
@@ -24,7 +24,7 @@ pub mod testnet;
 pub use components::{App, Component};
 pub use consensus::Consensus;
 pub use info::Info;
-pub use mempool::Mempool;
+pub use mempool::OldMempool;
 pub use pd_metrics::register_all_metrics;
 use pending_block::PendingBlock;
 use request_ext::RequestExt;

--- a/pd/src/lib.rs
+++ b/pd/src/lib.rs
@@ -24,7 +24,7 @@ pub mod testnet;
 pub use components::{App, Component};
 pub use consensus::Consensus;
 pub use info::Info;
-pub use mempool::OldMempool;
+pub use mempool::{Mempool, OldMempool};
 pub use pd_metrics::register_all_metrics;
 use pending_block::PendingBlock;
 use request_ext::RequestExt;

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -136,7 +136,7 @@ async fn main() -> anyhow::Result<()> {
             let storage = pd::Storage::load(rocks_path).await?;
 
             let consensus = pd::Consensus::new(state_writer, storage.clone()).await?;
-            let mempool = pd::Mempool::new(state_reader.clone(), storage.clone());
+            let mempool = pd::OldMempool::new(state_reader.clone(), storage.clone());
             let info = pd::Info::new(state_reader.clone(), storage.clone());
             let snapshot = pd::Snapshot {};
 

--- a/pd/src/mempool.rs
+++ b/pd/src/mempool.rs
@@ -25,7 +25,7 @@ use tracing::Instrument;
 use crate::{state, verify::StatelessTransactionExt, RequestExt, Storage};
 
 #[derive(Clone, Debug)]
-pub struct Mempool {
+pub struct OldMempool {
     nullifiers: Arc<AsyncMutex<BTreeSet<Nullifier>>>,
     state: state::Reader,
     storage: Storage,
@@ -34,7 +34,7 @@ pub struct Mempool {
     height_rx: watch::Receiver<block::Height>,
 }
 
-impl Mempool {
+impl OldMempool {
     pub fn new(state: state::Reader, storage: Storage) -> Self {
         let nullifiers = Arc::new(AsyncMutex::new(Default::default()));
         let height_rx = state.height_rx().clone();
@@ -104,7 +104,7 @@ impl Mempool {
     }
 }
 
-impl tower::Service<MempoolRequest> for Mempool {
+impl tower::Service<MempoolRequest> for OldMempool {
     type Response = MempoolResponse;
     type Error = BoxError;
     type Future = Pin<Box<dyn Future<Output = Result<MempoolResponse, BoxError>> + Send + 'static>>;

--- a/pd/src/mempool/message.rs
+++ b/pd/src/mempool/message.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+use bytes::Bytes;
+use tokio::sync::oneshot;
+use tracing::Span;
+
+#[derive(Debug)]
+pub struct Message {
+    pub tx_bytes: Bytes,
+    pub rsp_sender: oneshot::Sender<Result<()>>,
+    pub span: Span,
+}

--- a/pd/src/mempool/service.rs
+++ b/pd/src/mempool/service.rs
@@ -1,0 +1,77 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::FutureExt;
+use tendermint::{
+    abci::{
+        request::CheckTx as CheckTxReq, response::CheckTx as CheckTxRsp, MempoolRequest,
+        MempoolResponse,
+    },
+    block,
+};
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio_util::sync::PollSender;
+use tower_abci::BoxError;
+
+use super::{Message, Worker};
+use crate::{RequestExt, Storage};
+
+#[derive(Clone)]
+pub struct Mempool {
+    queue: PollSender<Message>,
+}
+
+impl Mempool {
+    pub async fn new(
+        storage: Storage,
+        height_rx: watch::Receiver<block::Height>,
+    ) -> anyhow::Result<Self> {
+        let (queue_tx, queue_rx) = mpsc::channel(10);
+
+        tokio::spawn(Worker::new(storage, queue_rx, height_rx).await?.run());
+
+        Ok(Self {
+            queue: PollSender::new(queue_tx),
+        })
+    }
+}
+
+impl tower::Service<MempoolRequest> for Mempool {
+    type Response = MempoolResponse;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<MempoolResponse, BoxError>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.queue.poll_reserve(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: MempoolRequest) -> Self::Future {
+        let span = req.create_span();
+        let (tx, rx) = oneshot::channel();
+
+        let MempoolRequest::CheckTx(CheckTxReq { tx: tx_bytes, .. }) = req;
+
+        self.queue
+            .send_item(Message {
+                tx_bytes,
+                rsp_sender: tx,
+                span,
+            })
+            .expect("called without `poll_ready`");
+
+        async move {
+            match rx.await.expect("worker error??") {
+                Ok(()) => Ok(MempoolResponse::CheckTx(CheckTxRsp::default())),
+                Err(e) => Ok(MempoolResponse::CheckTx(CheckTxRsp {
+                    code: 1,
+                    log: e.to_string(),
+                    ..Default::default()
+                })),
+            }
+        }
+        .boxed()
+    }
+}

--- a/pd/src/mempool/worker.rs
+++ b/pd/src/mempool/worker.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use bytes::Bytes;
+use jmt::WriteOverlay;
+use penumbra_proto::Protobuf;
+use penumbra_transaction::Transaction;
+use tendermint::block;
+use tokio::sync::{mpsc, watch, Mutex};
+use tracing::Instrument;
+
+use super::Message;
+use crate::{App, Component, Storage};
+
+pub struct Worker {
+    queue: mpsc::Receiver<Message>,
+    storage: Storage,
+    app: App,
+    height_rx: watch::Receiver<block::Height>,
+}
+
+impl Worker {
+    pub async fn new(
+        storage: Storage,
+        queue: mpsc::Receiver<Message>,
+        mut height_rx: watch::Receiver<block::Height>,
+    ) -> Result<Self> {
+        let app = App::new(Arc::new(Mutex::new(WriteOverlay::new(
+            storage.clone(),
+            height_rx.borrow_and_update().value(),
+        ))))
+        .await?;
+
+        Ok(Self {
+            queue,
+            storage,
+            app,
+            height_rx,
+        })
+    }
+
+    /// Currently, we perform all stateless and stateful checks sequentially in
+    /// the mempool worker.  A possibly more performant design would be to only
+    /// perform the stateful checks in the worker, and have a frontend service
+    /// that performs the stateless checks.  However, this probably isn't
+    /// important to do until we know that it's a bottleneck.
+    async fn check_and_execute_tx(&mut self, tx_bytes: Bytes) -> Result<()> {
+        let tx = Transaction::decode(tx_bytes.as_ref())?;
+        App::check_tx_stateless(&tx)?;
+        self.app.check_tx_stateful(&tx).await?;
+        self.app.execute_tx(&tx).await?;
+        Ok(())
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        loop {
+            tokio::select! {
+                // Use a biased select to poll for height changes *before* polling for messages.
+                biased;
+                // Check whether the height has changed, which requires us to throw away our
+                // ephemeral mempool state, and create a new one based on the new state.
+                change = self.height_rx.changed() => {
+                    if let Ok(()) = change {
+                        let height = self.height_rx.borrow().value();
+                        tracing::info!(?height, "resetting ephemeral mempool state");
+                        self.app = App::new(Arc::new(Mutex::new(WriteOverlay::new(
+                            self.storage.clone(),
+                            height,
+                        ))))
+                        .await?;
+                    } else {
+                        tracing::info!("consensus worker shut down, shutting down mempool worker");
+                        // The consensus worker shut down, we should too.
+                        return Ok(());
+                    }
+                }
+                message = self.queue.recv() => {
+                    if let Some(Message {
+                        tx_bytes,
+                        rsp_sender,
+                        span,
+                    }) = message {
+                        // ... and then execute it if it was valid.
+                        let _ = rsp_sender.send(
+                            self.check_and_execute_tx(tx_bytes)
+                                .instrument(span)
+                                .await
+                        );
+                    } else {
+                        // The queue is closed, so we're done.
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/penumbra/issues/521

Currently, the new mempool is threaded through the old mempool, and its
processing is executed on a newly spawned task, with the results printed to a
tracing event and then forgotten.  This lets us compare validation results
against the old code (they're currently different, because of missing reward
notes causing NCT root divergence), and then drop the old mempool when we
migrate.