### PR TITLE
refactor: migrate verification checks to relevant `Component` 

### DIFF
--- a/pd/src/components/staking.rs
+++ b/pd/src/components/staking.rs
@@ -437,6 +437,17 @@ impl Component for Staking {
             ));
         }
 
+        // We prohibit actions other than `Spend`, `Delegate`, `Output` and `Undelegate` in
+        // transactions that contain `Undelegate`, to avoid having to quarantine them.
+        if undelegation_identities.len() == 1 {
+            use Action::*;
+            for action in tx.transaction_body().actions {
+                if !matches!(action, Undelegate(_) | Delegate(_) | Spend(_) | Output(_)) {
+                    return Err(anyhow::anyhow!("transaction contains an undelegation, but also contains an action other than Spend, Delegate, Output or Undelegate"));
+                }
+            }
+        }
+
         // Check that validator definitions are correctly signed and well-formed:
         for definition in tx.validator_definitions() {
             // First, check the signature:

--- a/pd/src/verify/stateless.rs
+++ b/pd/src/verify/stateless.rs
@@ -21,6 +21,8 @@ pub trait StatelessTransactionExt {
 impl StatelessTransactionExt for Transaction {
     // TODO: use tokio's blocking code when we do work here -- internally to verify_stateless?
     fn verify_stateless(&self) -> Result<PendingTransaction, Error> {
+        // TODO: This method and trait can be removed once the `Component` refactor is
+        // complete (issue #488).
         let id = self.id();
 
         let sighash = self.transaction_body().sighash();


### PR DESCRIPTION
Closes #565
This contains the migration of the (relevant) stateless checks into the `ShieldedPool` component. Everything in the stateful checks has already been migrated to either the `ShieldedPool` or the `Staking` component.