### PR TITLE
pd: move functionality into ShieldedPool's View trait

### DIFF
--- a/crypto/src/merkle.rs
+++ b/crypto/src/merkle.rs
@@ -8,7 +8,7 @@ pub use incrementalmerkletree::{
     Altitude, Frontier, Hashable, Position, Recording, Tree,
 };
 use once_cell::sync::Lazy;
-use penumbra_proto::crypto as pb;
+use penumbra_proto::{crypto as pb, Protobuf};
 use serde::{Deserialize, Serialize};
 
 use crate::note;
@@ -27,6 +27,8 @@ pub type Path = (Position, Vec<note::Commitment>);
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "pb::MerkleRoot", into = "pb::MerkleRoot")]
 pub struct Root(pub Fq);
+
+impl Protobuf<pb::MerkleRoot> for Root {}
 
 impl std::fmt::Display for Root {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -8,7 +8,7 @@ use chacha20poly1305::{
 };
 use decaf377::FieldExt;
 use once_cell::sync::Lazy;
-use penumbra_proto::crypto as pb;
+use penumbra_proto::{crypto as pb, Protobuf};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use thiserror;
@@ -330,6 +330,8 @@ impl TryFrom<[u8; NOTE_LEN_BYTES]> for Note {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(into = "pb::NoteCommitment", try_from = "pb::NoteCommitment")]
 pub struct Commitment(pub Fq);
+
+impl Protobuf<pb::NoteCommitment> for Commitment {}
 
 #[cfg(test)]
 mod test_serde {


### PR DESCRIPTION
The initial implementation of the `ShieldedPool` didn't make much use of the `View` trait. This commit moves all of the tree access (with the exception of the raw NCT data, which isn't protoized and will be replaced by the TCT) into the `View` trait so it can be used by other things (e.g., RPC)