### PR TITLE
Better `Span` handling in `App` and `Components`

### DIFF
--- a/crypto/src/merkle.rs
+++ b/crypto/src/merkle.rs
@@ -24,7 +24,7 @@ pub static MERKLE_DOMAIN_SEP: Lazy<Fq> = Lazy::new(|| {
 // Return value from `Tree::authentication_path(value: &note::Commitment)`
 pub type Path = (Position, Vec<note::Commitment>);
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "pb::MerkleRoot", into = "pb::MerkleRoot")]
 pub struct Root(pub Fq);
 
@@ -33,6 +33,14 @@ impl Protobuf<pb::MerkleRoot> for Root {}
 impl std::fmt::Display for Root {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&hex::encode(&self.0.to_bytes()))
+    }
+}
+
+impl std::fmt::Debug for Root {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("merkle::Root")
+            .field(&hex::encode(&self.0.to_bytes()))
+            .finish()
     }
 }
 

--- a/pd/src/components/app.rs
+++ b/pd/src/components/app.rs
@@ -21,11 +21,6 @@ use super::{Component, IBCComponent, Overlay, ShieldedPool, Staking};
 /// commits the changes to the persistent storage and resets its subcomponents.
 pub struct App {
     overlay: Overlay,
-    // list of components goes here
-    // having all the components explicitly is a bit repetitive
-    // to invoke compared to Vec of dyn Component or w/e, but
-    // leaves open the possibility of having component-specific
-    // behavior and is simpler.
     shielded_pool: ShieldedPool,
     ibc: IBCComponent,
     staking: Staking,

--- a/pd/src/components/app.rs
+++ b/pd/src/components/app.rs
@@ -53,6 +53,7 @@ impl App {
 
 #[async_trait]
 impl Component for App {
+    #[instrument(skip(overlay))]
     async fn new(overlay: Overlay) -> Result<Self> {
         let staking = Staking::new(overlay.clone()).await?;
         let ibc = IBCComponent::new(overlay.clone()).await?;
@@ -66,6 +67,7 @@ impl Component for App {
         })
     }
 
+    #[instrument(skip(self, app_state))]
     async fn init_chain(&mut self, app_state: &genesis::AppState) -> Result<()> {
         self.overlay
             .put_chain_params(app_state.chain_params.clone())
@@ -85,6 +87,7 @@ impl Component for App {
         Ok(())
     }
 
+    #[instrument(skip(self, begin_block))]
     async fn begin_block(&mut self, begin_block: &abci::request::BeginBlock) -> Result<()> {
         // store the block height
         self.overlay
@@ -104,6 +107,7 @@ impl Component for App {
         Ok(())
     }
 
+    #[instrument(skip(tx))]
     fn check_tx_stateless(tx: &Transaction) -> Result<()> {
         Staking::check_tx_stateless(tx)?;
         IBCComponent::check_tx_stateless(tx)?;
@@ -111,6 +115,7 @@ impl Component for App {
         Ok(())
     }
 
+    #[instrument(skip(self, tx))]
     async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()> {
         self.staking.check_tx_stateful(tx).await?;
         self.ibc.check_tx_stateful(tx).await?;
@@ -120,6 +125,7 @@ impl Component for App {
         Ok(())
     }
 
+    #[instrument(skip(self, tx))]
     async fn execute_tx(&mut self, tx: &Transaction) -> Result<()> {
         self.staking.execute_tx(tx).await?;
         self.ibc.execute_tx(tx).await?;
@@ -129,6 +135,7 @@ impl Component for App {
         Ok(())
     }
 
+    #[instrument(skip(self, end_block))]
     async fn end_block(&mut self, end_block: &abci::request::EndBlock) -> Result<()> {
         self.staking.end_block(end_block).await?;
         self.ibc.end_block(end_block).await?;

--- a/pd/src/components/ibc.rs
+++ b/pd/src/components/ibc.rs
@@ -24,10 +24,12 @@ pub struct IBCComponent {
 
 #[async_trait]
 impl Component for IBCComponent {
+    #[instrument(name = "ibc", skip(overlay))]
     async fn new(overlay: Overlay) -> Result<Self> {
         Ok(Self { overlay })
     }
 
+    #[instrument(name = "ibc", skip(self, _app_state))]
     async fn init_chain(&mut self, _app_state: &genesis::AppState) -> Result<()> {
         // set the initial client count
         self.overlay.put_client_counter(ClientCounter(0)).await;
@@ -35,18 +37,22 @@ impl Component for IBCComponent {
         Ok(())
     }
 
+    #[instrument(name = "ibc", skip(self, _begin_block))]
     async fn begin_block(&mut self, _begin_block: &abci::request::BeginBlock) -> Result<()> {
         Ok(())
     }
 
+    #[instrument(name = "ibc", skip(_tx))]
     fn check_tx_stateless(_tx: &Transaction) -> Result<()> {
         Ok(())
     }
 
+    #[instrument(name = "ibc", skip(self, _tx))]
     async fn check_tx_stateful(&self, _tx: &Transaction) -> Result<()> {
         Ok(())
     }
 
+    #[instrument(name = "ibc", skip(self, tx))]
     async fn execute_tx(&mut self, tx: &Transaction) -> Result<()> {
         // handle client transactions
         for ibc_action in tx
@@ -64,6 +70,7 @@ impl Component for IBCComponent {
         Ok(())
     }
 
+    #[instrument(name = "ibc", skip(self, _end_block))]
     async fn end_block(&mut self, _end_block: &abci::request::EndBlock) -> Result<()> {
         Ok(())
     }

--- a/pd/src/components/shielded_pool.rs
+++ b/pd/src/components/shielded_pool.rs
@@ -465,9 +465,8 @@ pub trait View: WriteOverlayExt {
             .await
     }
 
-    #[instrument(skip(self))]
     async fn set_nct_anchor(&self, height: u64, anchor: merkle::Root) {
-        tracing::debug!("writing anchor to tree");
+        tracing::debug!(?height, ?anchor, "writing anchor");
 
         // Write the NCT anchor both as a value, so we can look it up,
         self.put_domain(

--- a/pd/src/components/shielded_pool.rs
+++ b/pd/src/components/shielded_pool.rs
@@ -31,6 +31,7 @@ pub struct ShieldedPool {
 
 #[async_trait]
 impl Component for ShieldedPool {
+    #[instrument(name = "shielded_pool", skip(overlay))]
     async fn new(overlay: Overlay) -> Result<Self> {
         let note_commitment_tree = Self::get_nct(&overlay).await?;
 
@@ -41,6 +42,7 @@ impl Component for ShieldedPool {
         })
     }
 
+    #[instrument(name = "shielded_pool", skip(self, app_state))]
     async fn init_chain(&mut self, app_state: &genesis::AppState) -> Result<()> {
         for allocation in &app_state.allocations {
             tracing::info!(?allocation, "processing allocation");
@@ -79,10 +81,12 @@ impl Component for ShieldedPool {
         Ok(())
     }
 
+    #[instrument(name = "shielded_pool", skip(self, _begin_block))]
     async fn begin_block(&mut self, _begin_block: &abci::request::BeginBlock) -> Result<()> {
         Ok(())
     }
 
+    #[instrument(name = "shielded_pool", skip(tx))]
     fn check_tx_stateless(tx: &Transaction) -> Result<()> {
         // TODO: add a check that ephemeral_key is not identity to prevent scanning dos attack ?
         let sighash = tx.transaction_body().sighash();
@@ -161,6 +165,7 @@ impl Component for ShieldedPool {
         Ok(())
     }
 
+    #[instrument(name = "shielded_pool", skip(self, tx))]
     async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()> {
         // TODO: rename transaction_body.merkle_root now that we have 2 merkle trees
         self.overlay
@@ -177,6 +182,7 @@ impl Component for ShieldedPool {
         Ok(())
     }
 
+    #[instrument(name = "shielded_pool", skip(self, tx))]
     async fn execute_tx(&mut self, tx: &Transaction) -> Result<()> {
         let should_quarantine = tx
             .transaction_body
@@ -200,6 +206,7 @@ impl Component for ShieldedPool {
         Ok(())
     }
 
+    #[instrument(name = "shielded_pool", skip(self, end_block))]
     async fn end_block(&mut self, end_block: &abci::request::EndBlock) -> Result<()> {
         self.compact_block.height = end_block.height as u64;
         self.write_block().await?;

--- a/pd/src/components/staking.rs
+++ b/pd/src/components/staking.rs
@@ -31,7 +31,7 @@ pub struct Staking {
 }
 
 impl Staking {
-    #[instrument(skip(self))]
+    #[instrument(skip(self, epoch_to_end), fields(index = epoch_to_end.index))]
     async fn end_epoch(&mut self, epoch_to_end: Epoch) -> Result<()> {
         // calculate rate data for next rate, move previous next rate to cur rate,
         // and save the next rate data. ensure that non-Active validators maintain constant rates.

--- a/pd/src/components/staking.rs
+++ b/pd/src/components/staking.rs
@@ -338,6 +338,7 @@ impl Staking {
 
 #[async_trait]
 impl Component for Staking {
+    #[instrument(name = "staking", skip(overlay))]
     async fn new(overlay: Overlay) -> Result<Self> {
         Ok(Self {
             overlay,
@@ -345,6 +346,7 @@ impl Component for Staking {
         })
     }
 
+    #[instrument(name = "staking", skip(self, app_state))]
     async fn init_chain(&mut self, app_state: &genesis::AppState) -> Result<()> {
         let starting_height = self.overlay.get_block_height().await?;
         let starting_epoch =
@@ -435,6 +437,7 @@ impl Component for Staking {
         Ok(())
     }
 
+    #[instrument(name = "staking", skip(self, begin_block))]
     async fn begin_block(&mut self, begin_block: &abci::request::BeginBlock) -> Result<()> {
         tracing::debug!("Staking: begin_block");
 
@@ -447,6 +450,7 @@ impl Component for Staking {
         Ok(())
     }
 
+    #[instrument(name = "staking", skip(tx))]
     fn check_tx_stateless(tx: &Transaction) -> Result<()> {
         // Check that the transaction undelegates from at most one validator.
         let undelegation_identities = tx
@@ -502,6 +506,7 @@ impl Component for Staking {
         Ok(())
     }
 
+    #[instrument(name = "staking", skip(self, tx))]
     async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()> {
         // Tally the delegations and undelegations
         let mut delegation_changes = BTreeMap::new();
@@ -647,6 +652,7 @@ impl Component for Staking {
         Ok(())
     }
 
+    #[instrument(name = "staking", skip(self, tx))]
     async fn execute_tx(&mut self, tx: &Transaction) -> Result<()> {
         // Queue any (un)delegations for processing at the next epoch boundary.
         for action in &tx.transaction_body.actions {
@@ -715,6 +721,7 @@ impl Component for Staking {
         Ok(())
     }
 
+    #[instrument(name = "staking", skip(self, end_block))]
     async fn end_block(&mut self, end_block: &abci::request::EndBlock) -> Result<()> {
         // Write the delegation changes for this block.
         self.overlay


### PR DESCRIPTION
This PR changes the methods in the `App` impl of `Component` to create top-level spans for each of the component methods, and changes the methods in all of the other components' `Component` impls to have spans with only the name of the component.

This lets us watch what the `App` is doing, whether it's in the mempool:
```
Apr 08 00:28:55.884 DEBUG abci:CheckTx{kind=New txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:check_tx_stateful:shielded_pool: jmt: key_hash=KeyHash("39a6276c184e99911c0fc0664ec54ebf49d4e185c59a54fb3b429083ac6aa6e0") key=b"shielded_pool/valid_anchors/04fc076435b20be65816ced9435de189c5b06a71bcfad7d4b6439b238280aa07"
Apr 08 00:28:55.884 DEBUG abci:CheckTx{kind=New txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:check_tx_stateful:shielded_pool: pd::components::shielded_pool: anchor is valid anchor=merkle::Root("04fc076435b20be65816ced9435de189c5b06a71bcfad7d4b6439b238280aa07") anchor_height=0
Apr 08 00:28:55.884 DEBUG abci:CheckTx{kind=New txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:check_tx_stateful:shielded_pool:check_nullifier_unspent{nullifier=Nullifier(94dff2a19919374f1dd459e359c060c28492eaca0dfb95ddff6e92b949467a11)}: jmt: key_hash=KeyHash("9c1d166def9cc72a88e8710d2625f7bb7d88469e69be10f8a0453283022e8964") key=b"shielded_pool/spent_nullifiers/94dff2a19919374f1dd459e359c060c28492eaca0dfb95ddff6e92b949467a11"
Apr 08 00:28:55.884 DEBUG abci:CheckTx{kind=New txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:staking: jmt: key_hash=KeyHash("c4b4e25a8824650a238d3451f754dcda1551dec8bec1a96abe23d2ff8b454db8") key=b"block_height"
Apr 08 00:28:55.884 DEBUG abci:CheckTx{kind=New txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:staking: jmt: key_hash=KeyHash("111493a3b144602d58199e6bc86ce9cd08f3bceebe0582f9c8d249c274480732") key=b"chain_params"
Apr 08 00:28:55.884 DEBUG abci:CheckTx{kind=New txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:staking:get_domain: pd::storage::write_overlay_ext: key=KeyHash("111493a3b144602d58199e6bc86ce9cd08f3bceebe0582f9c8d249c274480732") value=ChainParams { chain_id: "penumbra-orthosie-23a3e8b8", epoch_duration: 40, unbonding_epochs: 40, active_validator_limit: 10, slashing_penalty: 1000, ibc_enabled: false, inbound_ics20_transfers_enabled: false, outbound_ics20_transfers_enabled: false }
Apr 08 00:28:55.884 DEBUG abci:CheckTx{kind=New txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:shielded_pool:add_note: pd::components::shielded_pool: appending to NCT in component commitment=note::Commitment(70ff7ff3f6c4d89da0655600e073aaf255bb39535e10a1314b105abb53a5f911)
Apr 08 00:28:55.885 DEBUG abci:CheckTx{kind=New txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:shielded_pool:add_note: jmt: key_hash=KeyHash("6e3fb080155474231379e8d62151b6cff7b65731b8b0a9c9a11ab31f5c5d33a7") key=b"shielded_pool/note_source/70ff7ff3f6c4d89da0655600e073aaf255bb39535e10a1314b105abb53a5f911"
Apr 08 00:28:55.885 DEBUG abci:CheckTx{kind=New txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:shielded_pool:add_note: pd::components::shielded_pool: appending to NCT in component commitment=note::Commitment(403668d8e4845dfee74343e7feee16d5de7f46fbc7b60142ce41045e1380ed04)
Apr 08 00:28:55.885 DEBUG abci:CheckTx{kind=New txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:shielded_pool:add_note: jmt: key_hash=KeyHash("e97a64b06388ec2eac09190b718a5a5f99d115634b4d316d4fd8f2260b84e958") key=b"shielded_pool/note_source/403668d8e4845dfee74343e7feee16d5de7f46fbc7b60142ce41045e1380ed04"
Apr 08 00:28:55.885 DEBUG abci:CheckTx{kind=New txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:shielded_pool:spend_nullifier{nullifier=Nullifier(94dff2a19919374f1dd459e359c060c28492eaca0dfb95ddff6e92b949467a11) source=Transaction { id: [248, 62, 207, 197, 174, 147, 186, 100, 34, 103, 10, 178, 106, 124, 121, 76, 189, 37, 177, 30, 179, 204, 242, 224, 174, 230, 51, 166, 230, 109, 182, 203] }}: jmt: key_hash=KeyHash("9c1d166def9cc72a88e8710d2625f7bb7d88469e69be10f8a0453283022e8964") key=b"shielded_pool/spent_nullifiers/94dff2a19919374f1dd459e359c060c28492eaca0dfb95ddff6e92b949467a11"
Apr 08 00:28:55.885  INFO abci:CheckTx{kind=New txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}: pd::mempool: new mempool response rsp2=Ok(CheckTx(CheckTx { code: 0, data: b"", log: "", info: "", gas_wanted: 0, gas_used: 0, events: [], codespace: "", sender: "", priority: 0 }))
```
or in the consensus worker:
```
Apr 08 00:28:56.462 DEBUG abci:BeginBlock{height=block::Height(6) hash="488e181ebc1b7ecb386c6bb0e901add631814d6b45a3165eff5b7fe86dbe8517"}:begin_block: jmt: key_hash=KeyHash("c4b4e25a8824650a238d3451f754dcda1551dec8bec1a96abe23d2ff8b454db8") key=b"block_height"
Apr 08 00:28:56.462 DEBUG abci:BeginBlock{height=block::Height(6) hash="488e181ebc1b7ecb386c6bb0e901add631814d6b45a3165eff5b7fe86dbe8517"}:begin_block: jmt: key_hash=KeyHash("b6059f1c6391dc3d8e1b7aa6f33664355dfaa06358f9833d320da31c859356fb") key=b"block_timestamp"
Apr 08 00:28:56.462 DEBUG abci:BeginBlock{height=block::Height(6) hash="488e181ebc1b7ecb386c6bb0e901add631814d6b45a3165eff5b7fe86dbe8517"}:begin_block:staking: pd::components::staking: Staking: begin_block
Apr 08 00:28:56.530 DEBUG abci:DeliverTx{txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:check_tx_stateful:shielded_pool: jmt: key_hash=KeyHash("39a6276c184e99911c0fc0664ec54ebf49d4e185c59a54fb3b429083ac6aa6e0") key=b"shielded_pool/valid_anchors/04fc076435b20be65816ced9435de189c5b06a71bcfad7d4b6439b238280aa07"
Apr 08 00:28:56.531 DEBUG abci:DeliverTx{txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:check_tx_stateful:shielded_pool: pd::components::shielded_pool: anchor is valid anchor=merkle::Root("04fc076435b20be65816ced9435de189c5b06a71bcfad7d4b6439b238280aa07") anchor_height=0
Apr 08 00:28:56.531 DEBUG abci:DeliverTx{txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:check_tx_stateful:shielded_pool:check_nullifier_unspent{nullifier=Nullifier(94dff2a19919374f1dd459e359c060c28492eaca0dfb95ddff6e92b949467a11)}: jmt: key_hash=KeyHash("9c1d166def9cc72a88e8710d2625f7bb7d88469e69be10f8a0453283022e8964") key=b"shielded_pool/spent_nullifiers/94dff2a19919374f1dd459e359c060c28492eaca0dfb95ddff6e92b949467a11"
Apr 08 00:28:56.531 DEBUG abci:DeliverTx{txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:staking: jmt: key_hash=KeyHash("c4b4e25a8824650a238d3451f754dcda1551dec8bec1a96abe23d2ff8b454db8") key=b"block_height"
Apr 08 00:28:56.531 DEBUG abci:DeliverTx{txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:staking: jmt: key_hash=KeyHash("111493a3b144602d58199e6bc86ce9cd08f3bceebe0582f9c8d249c274480732") key=b"chain_params"
Apr 08 00:28:56.531 DEBUG abci:DeliverTx{txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:staking:get_domain: pd::storage::write_overlay_ext: key=KeyHash("111493a3b144602d58199e6bc86ce9cd08f3bceebe0582f9c8d249c274480732") value=ChainParams { chain_id: "penumbra-orthosie-23a3e8b8", epoch_duration: 40, unbonding_epochs: 40, active_validator_limit: 10, slashing_penalty: 1000, ibc_enabled: false, inbound_ics20_transfers_enabled: false, outbound_ics20_transfers_enabled: false }
Apr 08 00:28:56.531 DEBUG abci:DeliverTx{txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:shielded_pool:add_note: pd::components::shielded_pool: appending to NCT in component commitment=note::Commitment(70ff7ff3f6c4d89da0655600e073aaf255bb39535e10a1314b105abb53a5f911)
Apr 08 00:28:56.532 DEBUG abci:DeliverTx{txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:shielded_pool:add_note: jmt: key_hash=KeyHash("6e3fb080155474231379e8d62151b6cff7b65731b8b0a9c9a11ab31f5c5d33a7") key=b"shielded_pool/note_source/70ff7ff3f6c4d89da0655600e073aaf255bb39535e10a1314b105abb53a5f911"
Apr 08 00:28:56.532 DEBUG abci:DeliverTx{txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:shielded_pool:add_note: pd::components::shielded_pool: appending to NCT in component commitment=note::Commitment(403668d8e4845dfee74343e7feee16d5de7f46fbc7b60142ce41045e1380ed04)
Apr 08 00:28:56.532 DEBUG abci:DeliverTx{txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:shielded_pool:add_note: jmt: key_hash=KeyHash("e97a64b06388ec2eac09190b718a5a5f99d115634b4d316d4fd8f2260b84e958") key=b"shielded_pool/note_source/403668d8e4845dfee74343e7feee16d5de7f46fbc7b60142ce41045e1380ed04"
Apr 08 00:28:56.532 DEBUG abci:DeliverTx{txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}:execute_tx:shielded_pool:spend_nullifier{nullifier=Nullifier(94dff2a19919374f1dd459e359c060c28492eaca0dfb95ddff6e92b949467a11) source=Transaction { id: [248, 62, 207, 197, 174, 147, 186, 100, 34, 103, 10, 178, 106, 124, 121, 76, 189, 37, 177, 30, 179, 204, 242, 224, 174, 230, 51, 166, 230, 109, 182, 203] }}: jmt: key_hash=KeyHash("9c1d166def9cc72a88e8710d2625f7bb7d88469e69be10f8a0453283022e8964") key=b"shielded_pool/spent_nullifiers/94dff2a19919374f1dd459e359c060c28492eaca0dfb95ddff6e92b949467a11"
Apr 08 00:28:56.532  INFO abci:DeliverTx{txid="f83ecfc5ae93ba6422670ab26a7c794cbd25b11eb3ccf2e0aee633a6e66db6cb"}: pd::consensus::worker: new_rsp=Ok(())
```