### PR TITLE
Switch to new JMT, `Component` state machine from Postgres

### DIFF
--- a/pd/src/components.rs
+++ b/pd/src/components.rs
@@ -5,11 +5,12 @@ use tokio::sync::Mutex;
 
 use crate::Storage;
 
-pub(crate) mod app;
 mod component;
-mod ibc;
-pub(crate) mod shielded_pool;
-pub(crate) mod staking;
+
+pub mod app;
+pub mod ibc;
+pub mod shielded_pool;
+pub mod staking;
 
 // TODO: demote this from `pub` at some point when that's
 // not likely to generate conflicts
@@ -20,5 +21,3 @@ pub use app::App;
 pub use component::Component;
 pub use shielded_pool::ShieldedPool;
 pub use staking::Staking;
-
-pub type Overlay = Arc<Mutex<WriteOverlay<Storage>>>;

--- a/pd/src/components.rs
+++ b/pd/src/components.rs
@@ -1,10 +1,3 @@
-use std::sync::Arc;
-
-use jmt::WriteOverlay;
-use tokio::sync::Mutex;
-
-use crate::Storage;
-
 mod component;
 
 pub mod app;

--- a/pd/src/components/app.rs
+++ b/pd/src/components/app.rs
@@ -10,7 +10,7 @@ use tendermint::abci::{self, types::ValidatorUpdate};
 use tendermint::Time;
 use tracing::instrument;
 
-use crate::{genesis, Overlay, Storage, WriteOverlayExt};
+use crate::{genesis, Overlay, OverlayExt, Storage};
 
 use super::{Component, IBCComponent, ShieldedPool, Staking};
 
@@ -152,7 +152,7 @@ impl Component for App {
 /// Note: the `get_` methods in this trait assume that the state store has been
 /// initialized, so they will error on an empty state.
 #[async_trait]
-pub trait View: WriteOverlayExt {
+pub trait View: OverlayExt {
     /// Gets the chain parameters from the JMT.
     async fn get_chain_params(&self) -> Result<ChainParams> {
         self.get_domain(b"chain_params".into())
@@ -243,4 +243,4 @@ pub trait View: WriteOverlayExt {
     }
 }
 
-impl<T: WriteOverlayExt> View for T {}
+impl<T: OverlayExt> View for T {}

--- a/pd/src/components/app.rs
+++ b/pd/src/components/app.rs
@@ -10,9 +10,9 @@ use tendermint::abci::{self, types::ValidatorUpdate};
 use tendermint::Time;
 use tracing::instrument;
 
-use crate::{genesis, Storage, WriteOverlayExt};
+use crate::{genesis, Overlay, Storage, WriteOverlayExt};
 
-use super::{Component, IBCComponent, Overlay, ShieldedPool, Staking};
+use super::{Component, IBCComponent, ShieldedPool, Staking};
 
 /// The Penumbra application, written as a bundle of [`Component`]s.
 ///

--- a/pd/src/components/component.rs
+++ b/pd/src/components/component.rs
@@ -3,8 +3,8 @@ use async_trait::async_trait;
 use penumbra_transaction::Transaction;
 use tendermint::abci;
 
-use super::Overlay;
 use crate::genesis;
+use crate::Overlay;
 
 /// A component of the Penumbra application.
 ///

--- a/pd/src/components/ibc.rs
+++ b/pd/src/components/ibc.rs
@@ -12,8 +12,8 @@ use ibc::core::{
 };
 use penumbra_proto::ibc::ibc_action::Action::CreateClient;
 
-use super::{app::View as _, Component, Overlay};
-use crate::{genesis, WriteOverlayExt};
+use super::{app::View as _, Component};
+use crate::{genesis, Overlay, WriteOverlayExt};
 
 pub struct IBCComponent {
     overlay: Overlay,

--- a/pd/src/components/ibc.rs
+++ b/pd/src/components/ibc.rs
@@ -13,7 +13,7 @@ use ibc::core::{
 use penumbra_proto::ibc::ibc_action::Action::CreateClient;
 
 use super::{app::View as _, Component};
-use crate::{genesis, Overlay, WriteOverlayExt};
+use crate::{genesis, Overlay, OverlayExt};
 
 pub struct IBCComponent {
     overlay: Overlay,
@@ -149,7 +149,7 @@ impl IBCComponent {
 }
 
 #[async_trait]
-pub trait View: WriteOverlayExt + Send + Sync {
+pub trait View: OverlayExt + Send + Sync {
     async fn put_client_counter(&mut self, counter: ClientCounter) {
         self.put_domain("ibc/ics02-client/client_counter".into(), counter)
             .await;
@@ -189,4 +189,4 @@ pub trait View: WriteOverlayExt + Send + Sync {
     }
 }
 
-impl<T: WriteOverlayExt + Send + Sync> View for T {}
+impl<T: OverlayExt + Send + Sync> View for T {}

--- a/pd/src/components/shielded_pool.rs
+++ b/pd/src/components/shielded_pool.rs
@@ -16,9 +16,8 @@ use penumbra_transaction::{action::output, Action, Transaction};
 use tendermint::abci;
 use tracing::instrument;
 
-use super::{app::View as _, staking::View as _};
-use super::{Component, Overlay};
-use crate::{genesis, WriteOverlayExt};
+use super::{app::View as _, staking::View as _, Component};
+use crate::{genesis, Overlay, WriteOverlayExt};
 
 // Stub component
 pub struct ShieldedPool {

--- a/pd/src/components/shielded_pool.rs
+++ b/pd/src/components/shielded_pool.rs
@@ -17,7 +17,7 @@ use tendermint::abci;
 use tracing::instrument;
 
 use super::{app::View as _, staking::View as _, Component};
-use crate::{genesis, Overlay, WriteOverlayExt};
+use crate::{genesis, Overlay, OverlayExt};
 
 // Stub component
 pub struct ShieldedPool {
@@ -362,7 +362,7 @@ impl ShieldedPool {
 ///
 /// TODO: should this be split into Read and Write traits?
 #[async_trait]
-pub trait View: WriteOverlayExt {
+pub trait View: OverlayExt {
     async fn token_supply(&self, asset_id: &asset::Id) -> Result<Option<u64>> {
         self.get_proto(format!("shielded_pool/assets/{}/token_supply", asset_id).into())
             .await
@@ -539,4 +539,4 @@ pub trait View: WriteOverlayExt {
     }
 }
 
-impl<T: WriteOverlayExt> View for T {}
+impl<T: OverlayExt> View for T {}

--- a/pd/src/components/staking.rs
+++ b/pd/src/components/staking.rs
@@ -19,8 +19,8 @@ use tendermint::{
 };
 use tracing::instrument;
 
-use super::{app::View as _, shielded_pool::View as _, Component, Overlay};
-use crate::{genesis, WriteOverlayExt};
+use super::{app::View as _, shielded_pool::View as _, Component};
+use crate::{genesis, Overlay, WriteOverlayExt};
 
 // Staking component
 pub struct Staking {

--- a/pd/src/components/staking.rs
+++ b/pd/src/components/staking.rs
@@ -20,7 +20,7 @@ use tendermint::{
 use tracing::instrument;
 
 use super::{app::View as _, shielded_pool::View as _, Component};
-use crate::{genesis, Overlay, WriteOverlayExt};
+use crate::{genesis, Overlay, OverlayExt};
 
 // Staking component
 pub struct Staking {
@@ -748,7 +748,7 @@ impl Component for Staking {
 ///
 /// TODO: should this be split into Read and Write traits?
 #[async_trait]
-pub trait View: WriteOverlayExt {
+pub trait View: OverlayExt {
     async fn current_base_rate(&self) -> Result<BaseRateData> {
         self.get_domain("staking/base_rate/current".into())
             .await
@@ -1024,4 +1024,4 @@ pub trait View: WriteOverlayExt {
     }
 }
 
-impl<T: WriteOverlayExt + Send + Sync> View for T {}
+impl<T: OverlayExt + Send + Sync> View for T {}

--- a/pd/src/consensus/service.rs
+++ b/pd/src/consensus/service.rs
@@ -28,9 +28,6 @@ impl Consensus {
     ) -> anyhow::Result<(Self, watch::Receiver<block::Height>)> {
         let (queue_tx, queue_rx) = mpsc::channel(10);
         let initial_height = match storage.latest_version().await? {
-            // The storage might report PRE_GENESIS_VERSION, which
-            // we should map to 0.
-            Some(u64::MAX) => 0u32.into(),
             Some(version) => version.try_into().unwrap(),
             _ => 0u32.into(),
         };

--- a/pd/src/consensus/worker.rs
+++ b/pd/src/consensus/worker.rs
@@ -1,11 +1,7 @@
-use std::borrow::Borrow;
-
 use anyhow::{anyhow, Result};
-use futures::StreamExt;
-use metrics::absolute_counter;
-use penumbra_crypto::merkle::NoteCommitmentTree;
+
 use penumbra_proto::Protobuf;
-use penumbra_stake::Epoch;
+
 use penumbra_transaction::Transaction;
 use tendermint::{
     abci::{self, ConsensusRequest as Request, ConsensusResponse as Response},
@@ -15,89 +11,29 @@ use tokio::sync::{mpsc, watch};
 use tracing::Instrument;
 
 use super::Message;
-use crate::{
-    components::validator_set::ValidatorSet, genesis, state, verify::StatelessTransactionExt, App,
-    Component, PendingBlock, Storage,
-};
+use crate::{genesis, App, Component, Storage};
 
 pub struct Worker {
     queue: mpsc::Receiver<Message>,
     height_tx: watch::Sender<block::Height>,
-    // new app code
     storage: Storage,
     app: App,
-    // legacy app code below
-    state: state::Writer,
-    pending_block: Option<PendingBlock>,
-    validator_set: ValidatorSet,
-    note_commitment_tree: NoteCommitmentTree,
 }
 
 impl Worker {
     pub async fn new(
-        state: state::Writer,
         storage: Storage,
         queue: mpsc::Receiver<Message>,
         height_tx: watch::Sender<block::Height>,
     ) -> Result<Self> {
-        // Because we want to be able to handle (re)loading the worker data after writing
-        // the state snapshot in init_chain, we split out the real data loading into a single
-        // Worker::load() method that can be called from both places. Since we need to initialize
-        // the worker, though, fill in some garbage data that we'll immediately overwrite.
-        // A more pedantically correct option would be to make everything Optional, but that
-        // "contaminates" all of the other logic of the application to handle the initialization
-        // special case.
-
         let app = App::new(storage.overlay().await?).await?;
 
-        let reader = state.private_reader().clone();
-        let mut worker = Self {
+        Ok(Self {
             queue,
             height_tx,
             storage,
             app,
-            state,
-            pending_block: None,
-            note_commitment_tree: NoteCommitmentTree::new(0),
-            validator_set: ValidatorSet::new(
-                reader,
-                Epoch {
-                    index: 0,
-                    duration: 1,
-                },
-            )
-            .await?,
-        };
-        // If the database is still empty, this will still be garbage data, but we'll call
-        // load() again when processing init_chain.
-        worker.load().await?;
-
-        Ok(worker)
-    }
-
-    /// Loads the worker's application data from the state.
-    ///
-    /// This is called in `new`, and also when (re)loading after writing the state snapshot from init_chain.
-    async fn load(&mut self) -> Result<()> {
-        let height = self.state.private_reader().height().into();
-        let epoch_duration = self
-            .state
-            .private_reader()
-            .chain_params_rx()
-            .borrow()
-            .epoch_duration;
-        let epoch = Epoch::from_height(height, epoch_duration);
-
-        self.note_commitment_tree = self.state.private_reader().note_commitment_tree().await?;
-        self.validator_set = ValidatorSet::new(self.state.private_reader().clone(), epoch).await?;
-        self.pending_block = None;
-
-        // Now (re)load the caches from the state writer:
-        self.state.init_caches().await?;
-
-        self.app = App::new(self.storage.overlay().await?).await?;
-
-        Ok(())
+        })
     }
 
     pub async fn run(mut self) -> Result<()> {
@@ -154,10 +90,6 @@ impl Worker {
     ///
     /// The genesis data is provided by tendermint, and is used to initialize
     /// the database.
-    ///
-    /// After the database has been initialized, the worker is reinstantiated,
-    /// which will cause it to reload its state from the database, preparing it
-    /// for the first block to begin.
     async fn init_chain(
         &mut self,
         init_chain: abci::request::InitChain,
@@ -166,8 +98,6 @@ impl Worker {
         // Note that errors cannot be handled in InitChain, the application must crash.
         let app_state: genesis::AppState = serde_json::from_slice(&init_chain.app_state_bytes)
             .expect("can parse app_state in genesis file");
-
-        // Begin new sidecar code
 
         // Check that we haven't got a duplicated InitChain message for some reason:
         if self.storage.latest_version().await?.is_some() {
@@ -178,13 +108,6 @@ impl Worker {
         let (jmt_root, _) = self.app.commit(self.storage.clone()).await?;
 
         let app_hash = jmt_root.0.to_vec();
-        // End new sidecar code
-
-        // Initialize the database with the app state.
-        let _legacy_app_hash = self.state.commit_genesis(&app_state).await?;
-
-        // Reload the worker data from the database.
-        self.load().await?;
 
         // Extract the Tendermint validators from the app state
         //
@@ -192,17 +115,14 @@ impl Worker {
         // to be provided inside the initial app genesis state (`GenesisAppState`). Returning those
         // validators in InitChain::Response tells Tendermint that they are the initial validator
         // set. See https://docs.tendermint.com/master/spec/abci/abci.html#initchain
-        let validators = self
-            .validator_set
-            .validators_info()
-            .map(|v| {
-                Ok(tendermint::abci::types::ValidatorUpdate {
-                    pub_key: v.borrow().validator.consensus_key,
-                    power: v.borrow().status.voting_power.try_into()?,
-                })
-            })
-            .collect::<Result<Vec<tendermint::abci::types::ValidatorUpdate>>>()
-            .expect("expected genesis state to reload correctly");
+        let validators = self.app.tm_validator_updates().await?;
+
+        tracing::info!(
+            consensus_params = ?init_chain.consensus_params,
+            ?validators,
+            app_hash = ?jmt_root,
+            "finished init_chain"
+        );
 
         Ok(abci::response::InitChain {
             consensus_params: Some(init_chain.consensus_params),
@@ -215,41 +135,9 @@ impl Worker {
         &mut self,
         begin_block: abci::request::BeginBlock,
     ) -> Result<abci::response::BeginBlock> {
-        tracing::debug!(?begin_block);
-
-        // Begin new sidecar code
         self.app.begin_block(&begin_block).await?;
-        // End new sidecar code
-
-        // TODO: fold into separate begin_block_metrics() function
-        let block_metrics = self.state.private_reader().metrics().await?;
-        absolute_counter!("node_spent_nullifiers_total", block_metrics.nullifier_count);
-        absolute_counter!("node_notes_total", block_metrics.note_count);
-
-        // TODO: eventually eliminate pending block, and just have a bunch of application components
-        // that can queue whatever changes are relevant to their application scope
-        assert!(self.pending_block.is_none());
-        self.pending_block = Some(PendingBlock::new(self.note_commitment_tree.clone()));
-
-        self.validator_set.begin_block().await?;
-
-        // For each validator identified as byzantine by tendermint, update its
-        // status to be slashed.
-        for evidence in begin_block.byzantine_validators.iter() {
-            self.validator_set.slash_validator(evidence)?;
-        }
-
         // TODO(events): consider creating + returning Events to Tendermint here.
         Ok(Default::default())
-    }
-
-    /// Stub function; this code is broken out so that we can bubble up errors with ?
-    /// without interfering with the main consensus logic.
-    async fn deliver_tx_new(&mut self, transaction: &Transaction) -> Result<()> {
-        App::check_tx_stateless(&transaction)?;
-        self.app.check_tx_stateful(&transaction).await?;
-        self.app.execute_tx(&transaction).await?;
-        Ok(())
     }
 
     /// Perform full transaction validation via `DeliverTx`.
@@ -262,59 +150,17 @@ impl Worker {
     async fn deliver_tx(&mut self, deliver_tx: abci::request::DeliverTx) -> Result<()> {
         // Verify the transaction is well-formed...
         let transaction = Transaction::decode(deliver_tx.tx)?;
-
-        // Begin new sidecar code
-        // We *don't* use ? here, since we want to keep going if the sidecar code errors.
-        let new_rsp = self.deliver_tx_new(&transaction).await;
-        tracing::info!(?new_rsp);
-        // End new sidecar code
-
-        // Use the current state of the validators in the state machine, not the ones in the db.
-        let block_validators = self.validator_set.validators_info();
-        // ... and that it is internally consistent ...
-        let transaction = transaction.verify_stateless()?;
-        // ... and that it is consistent with the existing chain state.
-        let transaction = self
-            .state
-            .private_reader()
-            .verify_stateful(transaction, block_validators)
-            .await?;
-
-        // TODO: this conflict mechanism is really a special case of conflicts
-        // that happen within the shielded pool, but other components could
-        // potentially have conflicting requirements -- for instance, can we
-        // understand multiple validator definitions using this mechanism?
-
-        // if we used ABCI++, we have control over voting, so we can not vote
-        // for blocks that have conflicts and maybe that problem goes away?
-
-        let mut conflicts = self
-            .pending_block
-            .as_ref()
-            .unwrap()
-            .spent_nullifiers
-            .intersection(&transaction.spent_nullifiers);
-
-        if let Some(conflict) = conflicts.next() {
-            return Err(anyhow!(
-                "nullifier {:?} is already spent in the pending block",
-                conflict
-            ));
-        }
-
-        // validator set changes
-        for v in &transaction.validator_definitions {
-            self.validator_set.add_validator_definition(v.clone());
-        }
-        self.validator_set
-            .update_delegations(&transaction.delegation_changes);
-
-        // changes to shielded pool
-        self.pending_block
-            .as_mut()
-            .unwrap()
-            .add_transaction(transaction);
-
+        // ... and statelessly valid...
+        App::check_tx_stateless(&transaction)?;
+        // ... and statefully valid.
+        self.app.check_tx_stateful(&transaction).await?;
+        // Now execute the transaction. It's important to panic on error here, since if
+        // we fail to execute the transaction here, it's because of an internal
+        // error and we may have left the chain in an inconsistent state.
+        self.app
+            .execute_tx(&transaction)
+            .await
+            .expect("execution of valid tx must succeed, up to internal errors");
         Ok(())
     }
 
@@ -322,81 +168,17 @@ impl Worker {
         &mut self,
         end_block: abci::request::EndBlock,
     ) -> Result<abci::response::EndBlock> {
-        tracing::debug!(?end_block);
-
-        // Begin sidecar code
         self.app.end_block(&end_block).await?;
-        // End sidecar code
-
-        let reader = self.state.private_reader();
-
-        // pending block code should be folded into shielded pool ?
-        //
-        // possible exception: the height / epoch, should these be on the worker directly?
-        // should we have an App that contains all the components and the worker just has an App?
-
-        let pending_block = self
-            .pending_block
-            .as_mut()
-            .expect("pending block must be Some in EndBlock");
-
-        let height = end_block
-            .height
-            .try_into()
-            .expect("height should be nonnegative");
-        let epoch = pending_block.set_height(
-            height,
-            self.state
-                .private_reader()
-                .chain_params_rx()
-                .borrow()
-                .epoch_duration,
-        );
-
-        // The block validator set also needs to know the epoch to perform rate calculations.
-
-        tracing::debug!(?height, ?epoch, end_height = ?epoch.end_height());
-
-        // Validator updates need to be sent back to Tendermint during end_block, so we need to
-        // tell the validator set the block has ended so it can resolve conflicts and prepare
-        // data to commit.
-        let (slashed_validators, validator_updates) = self.validator_set.end_block(height).await?;
 
         // Set `tm_validator_updates` to the complete set of
         // validators and voting power. This must be the last step performed,
         // after all voting power calculations and validator state transitions have
         // been completed.
-        let validator_updates_new = self.app.tm_validator_updates().await?;
-        tracing::debug!(?validator_updates_new);
-
-        // Immediately revert notes and nullifiers immediately from slashed validators in this block
-        let (mut slashed_notes, mut slashed_nullifiers) = (
-            reader.quarantined_notes(
-                None,
-                Some(slashed_validators.iter().map(|v| &v.identity_key)),
-            ),
-            reader.quarantined_nullifiers(
-                None,
-                Some(slashed_validators.iter().map(|v| &v.identity_key)),
-            ),
-        );
-        while let Some(result) = slashed_notes.next().await {
-            pending_block.reverting_notes.insert(result?.1); // insert the commitment
-        }
-        while let Some(result) = slashed_nullifiers.next().await {
-            pending_block.reverting_nullifiers.insert(result?.1); // insert the nullifier
-        }
-        drop(slashed_notes);
-        drop(slashed_nullifiers);
-
-        // If we are at the end of an epoch, process changes for it
-        if epoch.end_height().value() == height {
-            self.end_epoch().await?;
-        }
+        let validator_updates = self.app.tm_validator_updates().await?;
 
         tracing::debug!(
             ?validator_updates,
-            "sending validator updates to tendermint"
+            "SKIPPING sending validator updates to tendermint"
         );
 
         // We discovered issues during Orthosie testnet deployment with new validators
@@ -406,57 +188,6 @@ impl Worker {
             consensus_param_updates: None,
             events: Vec::new(),
         })
-    }
-
-    /// Process the state transitions for the end of an epoch.
-    async fn end_epoch(&mut self) -> Result<()> {
-        tracing::debug!("consensus: end_epoch");
-        let reader = self.state.private_reader();
-
-        let pending_block = self
-            .pending_block
-            .as_mut()
-            .expect("pending block must be Some in EndBlock");
-
-        let height = pending_block
-            .height
-            .expect("height must already have been set");
-
-        // Find all the validators which are *not* slashed in this block
-        let well_behaved_validators = &self
-            .validator_set
-            .unslashed_validators()
-            .map(|v| v.borrow().identity_key.clone())
-            .collect::<Vec<_>>();
-
-        // Process unbonding notes and nullifiers for this epoch
-        let (mut unbonding_notes, mut unbonding_nullifiers) = (
-            reader.quarantined_notes(Some(height), Some(well_behaved_validators.iter())),
-            reader.quarantined_nullifiers(Some(height), Some(well_behaved_validators.iter())),
-        );
-        while let Some(result) = unbonding_notes.next().await {
-            let (_, commitment, data) = result?;
-            pending_block.add_note(commitment, data);
-        }
-        while let Some(result) = unbonding_nullifiers.next().await {
-            pending_block.unbonding_nullifiers.insert(result?.1); // insert the nullifier
-        }
-        drop(unbonding_notes);
-        drop(unbonding_nullifiers);
-
-        // TODO: we need to share some state between the pending block and the validator set.
-        // we are reaching into the validator set to get the epoch changes for now but we should
-        // address how to share data between components more generally in the future.
-        let epoch_changes = self
-            .validator_set
-            .epoch_changes()
-            .expect("expect epoch changes during end_epoch");
-        // Add reward notes to the pending block.
-        for reward_note in &epoch_changes.reward_notes {
-            pending_block.add_validator_reward_note(reward_note.0, reward_note.1);
-        }
-
-        Ok(())
     }
 
     async fn commit(&mut self) -> Result<abci::response::Commit> {
@@ -473,21 +204,6 @@ impl Worker {
                 .try_into()
                 .unwrap(),
         );
-
-        // End sidecar code
-
-        let pending_block = self
-            .pending_block
-            .take()
-            .expect("pending_block must be Some in Commit");
-
-        // Pull the updated note commitment tree, for use in the next block.
-        self.note_commitment_tree = pending_block.note_commitment_tree.clone();
-
-        let _legacy_app_hash = self
-            .state
-            .commit_block(pending_block, &mut self.validator_set)
-            .await?;
 
         tracing::info!(app_hash = ?hex::encode(&app_hash), "finished block commit");
 

--- a/pd/src/info.rs
+++ b/pd/src/info.rs
@@ -9,7 +9,7 @@ use tendermint::abci::{self, response::Echo, InfoRequest, InfoResponse};
 use tower_abci::BoxError;
 use tracing::Instrument;
 
-use crate::{db::schema, state, RequestExt, OverlayExt, Storage};
+use crate::{db::schema, state, OverlayExt, RequestExt, Storage};
 
 mod light_wallet;
 mod thin_wallet;

--- a/pd/src/info.rs
+++ b/pd/src/info.rs
@@ -9,13 +9,10 @@ use tendermint::abci::{self, response::Echo, InfoRequest, InfoResponse};
 use tower_abci::BoxError;
 use tracing::Instrument;
 
-use crate::{db::schema, state, OverlayExt, RequestExt, Storage};
+use crate::{db::schema, state, RequestExt, Storage};
 
 mod light_wallet;
 mod thin_wallet;
-
-/// Wrapper struct that circumvents the orphan rules for Tonic impls.
-pub struct RpcOverlay<T: OverlayExt>(pub T);
 
 const ABCI_INFO_VERSION: &str = env!("VERGEN_GIT_SEMVER");
 

--- a/pd/src/info.rs
+++ b/pd/src/info.rs
@@ -14,6 +14,9 @@ use crate::{db::schema, state, RequestExt, Storage};
 mod light_wallet;
 mod thin_wallet;
 
+/// Wrapper struct that circumvents the orphan rules for Tonic impls.
+pub struct RpcOverlay<T: WriteOverlayExt>(pub T);
+
 const ABCI_INFO_VERSION: &str = env!("VERGEN_GIT_SEMVER");
 
 #[derive(Clone, Debug)]

--- a/pd/src/info.rs
+++ b/pd/src/info.rs
@@ -9,13 +9,13 @@ use tendermint::abci::{self, response::Echo, InfoRequest, InfoResponse};
 use tower_abci::BoxError;
 use tracing::Instrument;
 
-use crate::{db::schema, state, RequestExt, Storage};
+use crate::{db::schema, state, RequestExt, OverlayExt, Storage};
 
 mod light_wallet;
 mod thin_wallet;
 
 /// Wrapper struct that circumvents the orphan rules for Tonic impls.
-pub struct RpcOverlay<T: WriteOverlayExt>(pub T);
+pub struct RpcOverlay<T: OverlayExt>(pub T);
 
 const ABCI_INFO_VERSION: &str = env!("VERGEN_GIT_SEMVER");
 

--- a/pd/src/info/light_wallet.rs
+++ b/pd/src/info/light_wallet.rs
@@ -24,10 +24,10 @@ use tracing::instrument;
 use crate::components::{app::View as _, shielded_pool::View as _, staking::View as _};
 use crate::WriteOverlayExt;
 
-struct WalletOverlay<T: WriteOverlayExt>(T);
+use super::RpcOverlay;
 
 #[tonic::async_trait]
-impl<T: WriteOverlayExt> LightWallet for WalletOverlay<T> {
+impl<T: WriteOverlayExt> LightWallet for RpcOverlay<T> {
     type CompactBlockRangeStream =
         Pin<Box<dyn futures::Stream<Item = Result<CompactBlock, tonic::Status>> + Send>>;
 

--- a/pd/src/info/light_wallet.rs
+++ b/pd/src/info/light_wallet.rs
@@ -22,12 +22,12 @@ use tracing::instrument;
 // use tracing_futures::Instrument;
 
 use crate::components::{app::View as _, shielded_pool::View as _, staking::View as _};
-use crate::WriteOverlayExt;
+use crate::OverlayExt;
 
 use super::RpcOverlay;
 
 #[tonic::async_trait]
-impl<T: WriteOverlayExt> LightWallet for RpcOverlay<T> {
+impl<T: OverlayExt> LightWallet for RpcOverlay<T> {
     type CompactBlockRangeStream =
         Pin<Box<dyn futures::Stream<Item = Result<CompactBlock, tonic::Status>> + Send>>;
 

--- a/pd/src/info/thin_wallet.rs
+++ b/pd/src/info/thin_wallet.rs
@@ -17,10 +17,10 @@ use tracing::instrument;
 use crate::components::{app::View as _, shielded_pool::View as _, staking::View as _};
 use crate::WriteOverlayExt;
 
-struct WalletOverlay<T: WriteOverlayExt>(T);
+use super::RpcOverlay;
 
 #[tonic::async_trait]
-impl<T: 'static + WriteOverlayExt> ThinWallet for WalletOverlay<T> {
+impl<T: 'static + WriteOverlayExt> ThinWallet for RpcOverlay<T> {
     #[instrument(skip(self, request))]
     async fn transaction_by_note(
         &self,

--- a/pd/src/info/thin_wallet.rs
+++ b/pd/src/info/thin_wallet.rs
@@ -15,12 +15,12 @@ use tracing::instrument;
 //use tracing_futures::Instrument;
 
 use crate::components::{app::View as _, shielded_pool::View as _, staking::View as _};
-use crate::WriteOverlayExt;
+use crate::OverlayExt;
 
 use super::RpcOverlay;
 
 #[tonic::async_trait]
-impl<T: 'static + WriteOverlayExt> ThinWallet for RpcOverlay<T> {
+impl<T: 'static + OverlayExt> ThinWallet for RpcOverlay<T> {
     #[instrument(skip(self, request))]
     async fn transaction_by_note(
         &self,

--- a/pd/src/lib.rs
+++ b/pd/src/lib.rs
@@ -29,7 +29,7 @@ pub use pd_metrics::register_all_metrics;
 use pending_block::PendingBlock;
 use request_ext::RequestExt;
 pub use snapshot::Snapshot;
-pub use storage::{Storage, WriteOverlayExt};
+pub use storage::{Overlay, Storage, WriteOverlayExt};
 
 /// The age limit, in blocks, on anchors accepted in transaction verification.
 pub const NUM_RECENT_ANCHORS: usize = 256;

--- a/pd/src/lib.rs
+++ b/pd/src/lib.rs
@@ -29,7 +29,7 @@ pub use pd_metrics::register_all_metrics;
 use pending_block::PendingBlock;
 use request_ext::RequestExt;
 pub use snapshot::Snapshot;
-pub use storage::{Overlay, Storage, WriteOverlayExt};
+pub use storage::{Overlay, OverlayExt, Storage};
 
 /// The age limit, in blocks, on anchors accepted in transaction verification.
 pub const NUM_RECENT_ANCHORS: usize = 256;

--- a/pd/src/storage.rs
+++ b/pd/src/storage.rs
@@ -29,14 +29,13 @@ impl Storage {
         .unwrap()
     }
 
+    /// Returns the latest version (block height) of the tree recorded by the
+    /// `Storage`, or `None` if the tree is empty.
     pub async fn latest_version(&self) -> Result<Option<jmt::Version>> {
-        match Storage::get_rightmost_leaf(self).await {
-            Ok(x) => match x {
-                Some(t) => Ok(Some(t.0.version())),
-                None => Ok(Some(WriteOverlay::<Storage>::PRE_GENESIS_VERSION)),
-            },
-            Err(e) => Err(e),
-        }
+        Ok(self
+            .get_rightmost_leaf()
+            .await?
+            .map(|(node_key, _)| node_key.version()))
     }
 }
 

--- a/pd/src/storage.rs
+++ b/pd/src/storage.rs
@@ -56,6 +56,18 @@ impl Storage {
             version,
         ))))
     }
+
+    /// Like [`Self::overlay`], but bundles in a [`tonic`] error conversion.
+    ///
+    /// This is useful for implementing gRPC services that query the storage:
+    /// each gRPC request can create an ephemeral [`Overlay`] pinning the current
+    /// version at the time the request was received, and then query it using
+    /// component `View`s to handle the request.
+    pub async fn overlay_tonic(&self) -> std::result::Result<Overlay, tonic::Status> {
+        self.overlay()
+            .await
+            .map_err(|e| tonic::Status::internal(e.to_string()))
+    }
 }
 
 impl TreeWriter for Storage {

--- a/pd/src/storage.rs
+++ b/pd/src/storage.rs
@@ -7,11 +7,14 @@ use jmt::{
     WriteOverlay,
 };
 use rocksdb::DB;
+use tokio::sync::Mutex;
 use tracing::{instrument, Span};
 
 mod write_overlay_ext;
 
 pub use write_overlay_ext::WriteOverlayExt;
+
+pub type Overlay = Arc<Mutex<WriteOverlay<Storage>>>;
 
 #[derive(Clone, Debug)]
 pub struct Storage(Arc<DB>);

--- a/pd/src/storage.rs
+++ b/pd/src/storage.rs
@@ -40,6 +40,22 @@ impl Storage {
             .await?
             .map(|(node_key, _)| node_key.version()))
     }
+
+    /// Returns a new [`Overlay`] on top of the latest version of the tree.
+    pub async fn overlay(&self) -> Result<Overlay> {
+        // If the tree is empty, use PRE_GENESIS_VERSION as the version,
+        // so that the first commit will be at version 0.
+        let version = self
+            .latest_version()
+            .await?
+            .unwrap_or(WriteOverlay::<Storage>::PRE_GENESIS_VERSION);
+
+        tracing::debug!("creating overlay for version {}", version);
+        Ok(Arc::new(Mutex::new(WriteOverlay::new(
+            self.clone(),
+            version,
+        ))))
+    }
 }
 
 impl TreeWriter for Storage {

--- a/pd/src/storage.rs
+++ b/pd/src/storage.rs
@@ -10,9 +10,9 @@ use rocksdb::DB;
 use tokio::sync::Mutex;
 use tracing::{instrument, Span};
 
-mod write_overlay_ext;
+mod overlay_ext;
 
-pub use write_overlay_ext::WriteOverlayExt;
+pub use overlay_ext::OverlayExt;
 
 pub type Overlay = Arc<Mutex<WriteOverlay<Storage>>>;
 

--- a/pd/src/storage/overlay_ext.rs
+++ b/pd/src/storage/overlay_ext.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 /// An extension trait that allows writing proto-encoded domain types to
 /// a shared [`WriteOverlay`].
 #[async_trait]
-pub trait WriteOverlayExt: Send + Sync + Sized + Clone + 'static {
+pub trait OverlayExt: Send + Sync + Sized + Clone + 'static {
     /// Reads a domain type from the overlay, using the proto encoding.
     async fn get_domain<D, P>(&self, key: KeyHash) -> Result<Option<D>>
     where
@@ -45,7 +45,7 @@ pub trait WriteOverlayExt: Send + Sync + Sized + Clone + 'static {
 }
 
 #[async_trait]
-impl<R: TreeReader + Sync + 'static> WriteOverlayExt for Arc<Mutex<WriteOverlay<R>>> {
+impl<R: TreeReader + Sync + 'static> OverlayExt for Arc<Mutex<WriteOverlay<R>>> {
     #[instrument(skip(self, key))]
     async fn get_domain<D, P>(&self, key: KeyHash) -> Result<Option<D>>
     where


### PR DESCRIPTION
Following #571, this switches over to use only the `Storage` backend and the new code.  It doesn't delete all of the old code; that's for a later PR.