### PR TITLE
pd: add context to `Storage::load` errors

### DIFF
--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -126,8 +126,9 @@ async fn main() -> anyhow::Result<()> {
                 "starting pd"
             );
 
-            // Initialize state
-            let storage = pd::Storage::load(rocks_path).await?;
+            let storage = pd::Storage::load(rocks_path)
+                .await
+                .context("Unable to initialize RocksDB storage")?;
 
             let (consensus, height_rx) = pd::Consensus::new(storage.clone()).await?;
             let mempool = pd::Mempool::new(storage.clone(), height_rx).await?;


### PR DESCRIPTION
This might be helpful for cases where #601 is caused by a user error rather than a bug on our end.