### PR TITLE
proto: better naming for client (sub)protocols

### DIFF
--- a/pcli/src/command/stake.rs
+++ b/pcli/src/command/stake.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context, Result};
 use comfy_table::{presets, Table};
 use futures::stream::TryStreamExt;
 use penumbra_crypto::Value;
-use penumbra_proto::light_client::ValidatorInfoRequest;
+use penumbra_proto::client::oblivious::ValidatorInfoRequest;
 use penumbra_stake::{
     DelegationToken, IdentityKey, RateData, ValidatorInfo, STAKING_TOKEN_ASSET_ID,
     STAKING_TOKEN_DENOM,
@@ -94,7 +94,7 @@ impl StakeCmd {
 
                 let to = to.parse::<IdentityKey>()?;
 
-                let mut client = opt.thin_protocol_client().await?;
+                let mut client = opt.specific_client().await?;
                 let rate_data: RateData = client
                     .next_validator_rate(tonic::Request::new(to.into()))
                     .await?
@@ -129,7 +129,7 @@ impl StakeCmd {
 
                 let from = delegation_token.validator();
 
-                let mut client = opt.thin_protocol_client().await?;
+                let mut client = opt.specific_client().await?;
                 let rate_data: RateData = client
                     .next_validator_rate(tonic::Request::new(from.into()))
                     .await?
@@ -153,7 +153,7 @@ impl StakeCmd {
                 todo!()
             }
             StakeCmd::Show => {
-                let mut client = opt.light_protocol_client().await?;
+                let mut client = opt.oblivious_client().await?;
 
                 let validators = client
                     .validator_info(ValidatorInfoRequest {
@@ -252,7 +252,7 @@ impl StakeCmd {
                 show_inactive,
                 detailed,
             } => {
-                let mut client = opt.light_protocol_client().await?;
+                let mut client = opt.oblivious_client().await?;
 
                 let mut validators = client
                     .validator_info(ValidatorInfoRequest {

--- a/pcli/src/fetch.rs
+++ b/pcli/src/fetch.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 use penumbra_chain::KnownAssets;
-use penumbra_proto::light_client::{AssetListRequest, ChainParamsRequest};
+use penumbra_proto::client::oblivious::{AssetListRequest, ChainParamsRequest};
 use tracing::instrument;
 
 use crate::{ClientStateFile, Opt};
 
 #[instrument(skip(opt, state))]
 pub async fn assets(opt: &Opt, state: &mut ClientStateFile) -> Result<()> {
-    let mut client = opt.light_protocol_client().await?;
+    let mut client = opt.oblivious_client().await?;
 
     // Update asset registry.
     let request = tonic::Request::new(AssetListRequest {
@@ -26,7 +26,7 @@ pub async fn assets(opt: &Opt, state: &mut ClientStateFile) -> Result<()> {
 /// Fetches the global chain parameters and stores them on `ClientState`.
 #[instrument(skip(opt, state))]
 pub async fn chain_params(opt: &Opt, state: &mut ClientStateFile) -> Result<()> {
-    let mut client = opt.light_protocol_client().await?;
+    let mut client = opt.oblivious_client().await?;
 
     let params = client
         .chain_params(tonic::Request::new(ChainParamsRequest {

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -31,10 +31,10 @@ pub struct Opt {
     pub rpc_port: u16,
     /// The port to use to speak to pd's light wallet server.
     #[structopt(short, long, default_value = "26666")]
-    pub light_client_port: u16,
+    pub oblivious_query_port: u16,
     /// The port to use to speak to pd's thin wallet server.
     #[structopt(short, long, default_value = "26667")]
-    pub thin_client_port: u16,
+    pub specific_query_port: u16,
     #[structopt(subcommand)]
     pub cmd: Command,
     /// The location of the wallet file [default: platform appdata directory]

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -1,6 +1,9 @@
 use penumbra_proto::{
-    light_client::light_protocol_client::LightProtocolClient,
-    thin_client::thin_protocol_client::ThinProtocolClient, Protobuf,
+    client::{
+        oblivious::oblivious_query_client::ObliviousQueryClient,
+        specific::specific_query_client::SpecificQueryClient,
+    },
+    Protobuf,
 };
 use penumbra_transaction::Transaction;
 use rand::Rng;
@@ -89,17 +92,18 @@ impl Opt {
         Ok(())
     }
 
-    pub async fn thin_protocol_client(&self) -> Result<ThinProtocolClient<Channel>, anyhow::Error> {
-        ThinProtocolClient::connect(format!("http://{}:{}", self.node, self.thin_client_port))
+    pub async fn specific_client(&self) -> Result<SpecificQueryClient<Channel>, anyhow::Error> {
+        SpecificQueryClient::connect(format!("http://{}:{}", self.node, self.specific_query_port))
             .await
             .map_err(Into::into)
     }
 
-    pub async fn light_protocol_client(
-        &self,
-    ) -> Result<LightProtocolClient<Channel>, anyhow::Error> {
-        LightProtocolClient::connect(format!("http://{}:{}", self.node, self.light_client_port))
-            .await
-            .map_err(Into::into)
+    pub async fn oblivious_client(&self) -> Result<ObliviousQueryClient<Channel>, anyhow::Error> {
+        ObliviousQueryClient::connect(format!(
+            "http://{}:{}",
+            self.node, self.oblivious_query_port
+        ))
+        .await
+        .map_err(Into::into)
     }
 }

--- a/pcli/src/sync.rs
+++ b/pcli/src/sync.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use penumbra_proto::light_client::CompactBlockRangeRequest;
+use penumbra_proto::client::oblivious::CompactBlockRangeRequest;
 use tracing::instrument;
 
 use crate::{ClientStateFile, Opt};
@@ -7,7 +7,7 @@ use crate::{ClientStateFile, Opt};
 #[instrument(skip(opt, state), fields(start_height = state.last_block_height()))]
 pub async fn sync(opt: &Opt, state: &mut ClientStateFile) -> Result<()> {
     tracing::info!("starting client sync");
-    let mut client = opt.light_protocol_client().await?;
+    let mut client = opt.oblivious_client().await?;
 
     let start_height = state.last_block_height().map(|h| h + 1).unwrap_or(0);
     let mut stream = client

--- a/pd/src/info.rs
+++ b/pd/src/info.rs
@@ -11,8 +11,8 @@ use tracing::Instrument;
 
 use crate::{RequestExt, Storage};
 
-mod light_client;
-mod thin_client;
+mod oblivious;
+mod specific;
 
 const ABCI_INFO_VERSION: &str = env!("VERGEN_GIT_SEMVER");
 

--- a/pd/src/info/oblivious.rs
+++ b/pd/src/info/oblivious.rs
@@ -4,8 +4,8 @@ use async_stream::try_stream;
 use futures::stream::{StreamExt, TryStreamExt};
 use penumbra_proto::{
     chain::{ChainParams, CompactBlock, KnownAssets},
-    light_client::{
-        light_protocol_server::LightProtocol, AssetListRequest, ChainParamsRequest,
+    client::oblivious::{
+        oblivious_query_server::ObliviousQuery, AssetListRequest, ChainParamsRequest,
         CompactBlockRangeRequest, ValidatorInfoRequest,
     },
     stake::ValidatorInfo,
@@ -25,7 +25,7 @@ use crate::components::{app::View as _, shielded_pool::View as _, staking::View 
 use crate::Storage;
 
 #[tonic::async_trait]
-impl LightProtocol for Storage {
+impl ObliviousQuery for Storage {
     type CompactBlockRangeStream =
         Pin<Box<dyn futures::Stream<Item = Result<CompactBlock, tonic::Status>> + Send>>;
 

--- a/pd/src/info/specific.rs
+++ b/pd/src/info/specific.rs
@@ -1,8 +1,8 @@
 use penumbra_proto::{
     self as proto,
     chain::NoteSource,
+    client::specific::{specific_query_server::SpecificQuery, ValidatorStatusRequest},
     crypto::NoteCommitment,
-    thin_client::{thin_protocol_server::ThinProtocol, ValidatorStatusRequest},
 };
 
 use tonic::Status;
@@ -18,7 +18,7 @@ use crate::components::{app::View as _, shielded_pool::View as _, staking::View 
 use crate::Storage;
 
 #[tonic::async_trait]
-impl ThinProtocol for Storage {
+impl SpecificQuery for Storage {
     #[instrument(skip(self, request))]
     async fn transaction_by_note(
         &self,

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -60,7 +60,10 @@ fn main() -> Result<()> {
     // For the client code, we also want to generate RPC instances, so compile via tonic:
     tonic_build::configure().compile_with_config(
         config,
-        &["proto/light_client.proto", "proto/thin_client.proto"],
+        &[
+            "proto/client/oblivious.proto",
+            "proto/client/specific.proto",
+        ],
         &["proto/", "ibc-go-vendor/"],
     )?;
 

--- a/proto/proto/client/oblivious.proto
+++ b/proto/proto/client/oblivious.proto
@@ -1,14 +1,16 @@
 syntax = "proto3";
-package penumbra.light_client;
+package penumbra.client.oblivious;
 
 import "crypto.proto";
 import "chain.proto";
 import "stake.proto";
 
-// A light client service.
-//
-// This protocol attempts to be trust-minimized, both in terms of integrity and privacy.
-service LightProtocol {
+// Methods for accessing chain state that are "oblivious" in the sense that they
+// do not request specific portions of the chain state that could reveal private
+// client data.  For instance, requesting all asset denominations is oblivious,
+// but requesting the asset denomination for a specific asset id is not, because
+// it reveals that the client has an interest in that asset specifically.
+service ObliviousQuery {
   rpc CompactBlockRange(CompactBlockRangeRequest) returns (stream chain.CompactBlock);
   rpc ChainParams(ChainParamsRequest) returns (chain.ChainParams);
   rpc ValidatorInfo(ValidatorInfoRequest) returns (stream stake.ValidatorInfo);

--- a/proto/proto/client/specific.proto
+++ b/proto/proto/client/specific.proto
@@ -1,15 +1,16 @@
 syntax = "proto3";
-package penumbra.thin_client;
+package penumbra.client.specific;
 
 import "crypto.proto";
 import "chain.proto";
 import "stake.proto";
 
-// A thin client service.
-//
-// Unlike the "light client" service, this protocol does not attempt to be
-// trust-minimized, either in terms of integrity or privacy.
-service ThinProtocol {
+// Methods for accessing chain state that are "specific" in the sense that they
+// request specific portions of the chain state that could reveal private
+// client data.  For instance, requesting all asset denominations is oblivious,
+// but requesting the asset denomination for a specific asset id is not, because
+// it reveals that the client has an interest in that asset specifically.
+service SpecificQuery {
   rpc TransactionByNote(crypto.NoteCommitment) returns (chain.NoteSource);
   rpc ValidatorStatus(ValidatorStatusRequest) returns (stake.ValidatorStatus);
   rpc NextValidatorRate(stake.IdentityKey) returns (stake.RateData);

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -48,14 +48,14 @@ pub mod genesis {
     tonic::include_proto!("penumbra.genesis");
 }
 
-/// Light client protocol structures.
-pub mod light_client {
-    tonic::include_proto!("penumbra.light_client");
-}
-
-/// Thin client protocol structures.
-pub mod thin_client {
-    tonic::include_proto!("penumbra.thin_client");
+/// Client protocol structures.
+pub mod client {
+    pub mod oblivious {
+        tonic::include_proto!("penumbra.client.oblivious");
+    }
+    pub mod specific {
+        tonic::include_proto!("penumbra.client.specific");
+    }
 }
 
 /// IBC protocol structures.


### PR DESCRIPTION
This should close #611; we might as well clean up the naming for the request types while we're doing it, since the current names don't make much sense.

TODO: update the rest of the code to fix import paths.