### PR TITLE
Corrected Genesis

### DIFF
--- a/testnets/007-herse/genesis.json
+++ b/testnets/007-herse/genesis.json
@@ -1,8 +1,4 @@
 {
-  "jsonrpc": "2.0",
-  "id": -1,
-  "result": {
-    "genesis": {
       "genesis_time": "2022-04-11T21:57:22Z",
       "chain_id": "penumbra-herse",
       "initial_height": "1",
@@ -30950,6 +30946,4 @@
           }
         ]
       }
-    }
-  }
 }


### PR DESCRIPTION
There was a json RPC element in the Genesis file, because of which Tendermint would not start with it, and gave an error. I've installed the corrected Genesis that works in Tendermint.