### PR TITLE
pcli: add validator template-definition and fetch-definition commands

### DIFF
--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -23,7 +23,9 @@ penumbra-wallet = { path = "../wallet" }
 # Penumbra dependencies
 ark-ff = { git = "https://github.com/penumbra-zone/algebra", branch = "ours" }
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
+tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "master" }
 # External dependencies
+ed25519-consensus = "2"
 futures = "0.3"
 async-stream = "0.2"
 bincode = "1.3.3"

--- a/pd/src/components/staking.rs
+++ b/pd/src/components/staking.rs
@@ -961,8 +961,11 @@ pub trait View: OverlayExt {
     ) -> Result<()> {
         tracing::debug!(?validator);
         let id = validator.identity_key.clone();
+
         self.put_domain(format!("staking/validators/{}", id).into(), validator)
             .await;
+        self.register_denom(&id.delegation_token().denom()).await?;
+
         self.set_validator_rates(&id, current_rates, next_rates)
             .await;
         self.set_validator_state(&id, state).await;


### PR DESCRIPTION
Closes #648

Along the way to this, I noticed that we have a lot of overlapping "validator"
structures, and maybe we should try to streamline those later?