### PR TITLE
crypto: make FullViewingKey serializable

### DIFF
--- a/proto/build.rs
+++ b/proto/build.rs
@@ -80,6 +80,8 @@ static AS_BECH32_IDENTITY_KEY: &str =
     r#"#[serde(with = "crate::serializers::bech32str::validator_identity_key")]"#;
 static AS_BECH32_ADDRESS: &str = r#"#[serde(with = "crate::serializers::bech32str::address")]"#;
 static AS_BECH32_ASSET_ID: &str = r#"#[serde(with = "crate::serializers::bech32str::asset_id")]"#;
+static AS_BECH32_FULL_VIEWING_KEY: &str =
+    r#"#[serde(with = "crate::serializers::bech32str::full_viewing_key")]"#;
 
 static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.stake.Validator", SERIALIZE),
@@ -108,6 +110,12 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.crypto.Asset", SERIALIZE),
     (".penumbra.crypto.MerkleRoot", SERIALIZE),
     (".penumbra.crypto.MerkleRoot", SERDE_TRANSPARENT),
+    (".penumbra.crypto.FullViewingKey", SERIALIZE),
+    (".penumbra.crypto.FullViewingKey", SERDE_TRANSPARENT),
+    (".penumbra.crypto.Diversifier", SERIALIZE),
+    (".penumbra.crypto.Diversifier", SERDE_TRANSPARENT),
+    (".penumbra.crypto.DiversifierIndex", SERIALIZE),
+    (".penumbra.crypto.DiversifierIndex", SERDE_TRANSPARENT),
     (".penumbra.chain.ChainParams", SERIALIZE),
     (".penumbra.chain.CompactBlock", SERIALIZE),
     (".penumbra.chain.KnownAssets", SERIALIZE),
@@ -129,5 +137,11 @@ static FIELD_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.crypto.AssetId.inner", AS_BECH32_ASSET_ID),
     (".penumbra.crypto.NoteCommitment.inner", AS_HEX),
     (".penumbra.crypto.MerkleRoot.inner", AS_HEX),
+    (
+        ".penumbra.crypto.FullViewingKey.inner",
+        AS_BECH32_FULL_VIEWING_KEY,
+    ),
+    (".penumbra.crypto.Diversifier.inner", AS_HEX),
+    (".penumbra.crypto.DiversifierIndex.inner", AS_HEX),
     (".penumbra.chain.NoteSource.inner", AS_HEX),
 ];

--- a/proto/proto/crypto.proto
+++ b/proto/proto/crypto.proto
@@ -5,6 +5,18 @@ message Address {
     bytes inner = 1;
 }
 
+message FullViewingKey {
+    bytes inner = 1;
+}
+
+message Diversifier {
+    bytes inner = 1;
+}
+
+message DiversifierIndex {
+    bytes inner = 1;
+}
+
 message NoteCommitment {
     bytes inner = 1;
 }

--- a/proto/src/serializers/bech32str.rs
+++ b/proto/src/serializers/bech32str.rs
@@ -138,3 +138,25 @@ pub mod asset_id {
         serialize_bech32(value, serializer, BECH32_PREFIX, Variant::Bech32m)
     }
 }
+
+pub mod full_viewing_key {
+    use super::*;
+
+    /// The Bech32 prefix used for asset IDs.
+    pub const BECH32_PREFIX: &str = "penumbrafullviewingkey";
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_bech32(deserializer, BECH32_PREFIX, Variant::Bech32m)
+    }
+
+    pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: AsRef<[u8]>,
+    {
+        serialize_bech32(value, serializer, BECH32_PREFIX, Variant::Bech32m)
+    }
+}


### PR DESCRIPTION
This will be useful for things like `pwalletd` where we want to give only viewing capability.