### PR TITLE
Send tm validator updates

### DIFF
--- a/pd/src/consensus/worker.rs
+++ b/pd/src/consensus/worker.rs
@@ -178,11 +178,11 @@ impl Worker {
 
         tracing::debug!(
             ?validator_updates,
-            "SKIPPING sending validator updates to tendermint"
+            "sending validator updates to tendermint"
         );
 
         Ok(abci::response::EndBlock {
-            validator_updates: Vec::new(),
+            validator_updates,
             consensus_param_updates: None,
             events: Vec::new(),
         })


### PR DESCRIPTION
This sends validator power back to Tendermint, as it's been verified working