### PR TITLE
docs: render the version of the tendermint crate with ABCI

### DIFF
--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -41,8 +41,9 @@ jobs:
           # indexes is overwritten on each cargo doc invocation.
           # (The version specifier for tendermint avoids ambiguity from multiple
           # package versions but will break in the future).
+          # NOTE: make sure we're rendering the version of the tendermint crate that has ABCI support (?? this is a mess)
           cargo doc --no-deps \
-            -p tendermint:0.23.5 \
+            -p tendermint:0.23.0 \
             -p tower-abci \
             -p incrementalmerkletree \
             -p jmt \


### PR DESCRIPTION
There are two versions of the tendermint crate floating around our dep tree:

- a version from our own fork, which we started using because it took a long
  time to get the ABCI domain types changes merged upstream;
- another version, pulled in by some ibc-rs code.

We can only document one of them, so we had to specify; I picked the one with
the higher version number, but the version with the ABCI domain types actually
has a *lower* version number for some reason, so we were rendering the wrong
version.  This is a bit of a mess, and we should figure out if we can get off
of it.  However, any movement to a published version of the Tendermint crate
will likely be short-lived anyways, since we should move to ABCI++, and we'll
need a feature branch to do those changes.