### PR TITLE
guide: explain how to get the latest node id when joining testnet

### DIFF
--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -24,28 +24,31 @@ config	data
 config.toml	genesis.json	node_key.json
 ```
 
+The `genesis.json` file Tendermint generates needs to be replaced with the
+genesis file for the network you want to join.  The genesis JSON files for all
+of our testnets can be found [in our repository][testnets-repo], or downloaded
+directly from an existing node using the Tendermint RPC:
+```console
+curl -s http://testnet.penumbra.zone:26657/genesis | jq ".result.genesis" > \$HOME/.tendermint/config/genesis.json
+```
+
 Next you'll need to modify the persistent peers list to specify our primary
 testnet node as a permanent peer for your node. Open
 `\$HOME/.tendermint/config/config.toml` and find the `persistent-peers` line and
 add the testnet node:
-
 ```toml
-persistent-peers = "20eb3596354699d5b1952311f7cb4e133ad0b6c1@testnet.penumbra.zone:26656"
+persistent-peers = "NODE_ID@testnet.penumbra.zone:26656"
 ```
-
-The format is `NODE_ID@ADDRESS`.  The node ID of the primary testnet node may
-change, but the current node ID can be found with:
+The format is `NODE_ID@ADDRESS`.  You will need to replace `NODE_ID` with the
+identifier for the node you want to connect to.  On a production network, this
+might be stable, but our testnet nodes generate keys on deployment.  To find the
+current node ID, run:
 ```console
-curl http://testnet.penumbra.zone:26657/status | jq ".result.node_info.id"
+curl -s http://testnet.penumbra.zone:26657/status | jq ".result.node_info.id"
 ```
-If you don't have `jq` installed, you can just look for that entry in the returned JSON.
-
-Then you'll need to download our genesis JSON file and replace the automatically
-generated one.  You can find the genesis JSON files for all of our testnets [in
-our repository](https://github.com/penumbra-zone/penumbra/tree/main/testnets).
-
-The testnet directories are numbered in increasing order, find and download the
-latest JSON file and copy it to `\$HOME/.tendermint/config/genesis.json`.
+This command uses `jq` to extract the node ID from the response, but if you
+don't have `jq` installed, you can just look for that entry in the returned
+JSON.
 
 ## Starting your node
 
@@ -65,3 +68,5 @@ tendermint start
 ```
 
 You should now be participating in the network!
+
+[testnets-repo]: https://github.com/penumbra-zone/penumbra/tree/main/testnets


### PR DESCRIPTION
This way we don't have to constantly update the guide text.