### PR TITLE
pd: initial tokio-console integration

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+[build]
+# Enable Tokio's `tracing` support for `tokio-console`
+rustflags = ["--cfg", "tokio_unstable"]

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -41,7 +41,7 @@ tower = { version = "0.4", features = ["full"]}
 tracing = "0.1"
 structopt = "0.3"
 tonic = "0.6.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 pin-project = "1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -48,7 +48,7 @@ regex = "1.5"
 prost-types = "0.9"
 structopt = "0.3"
 tonic = "0.6.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
 pin-project = "1"
 futures = "0.3"
 serde_json = "1"
@@ -73,6 +73,7 @@ ibc-proto = "0.17.0"
 tendermint-light-client-verifier = "0.23.5"
 tempfile = "3.3.0"
 base64 = "0.13.0"
+console-subscriber = "0.1.4"
 
 [build-dependencies]
 vergen = "5"

--- a/pd/src/consensus/service.rs
+++ b/pd/src/consensus/service.rs
@@ -30,7 +30,9 @@ impl Consensus {
         };
         let (height_tx, height_rx) = watch::channel(initial_height);
 
-        tokio::spawn(Worker::new(storage, queue_rx, height_tx).await?.run());
+        tokio::task::Builder::new()
+            .name("consensus::Worker")
+            .spawn(Worker::new(storage, queue_rx, height_tx).await?.run());
 
         Ok((
             Self {

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -105,7 +105,7 @@ fn remote_addr(req: &http::Request<()>) -> Option<SocketAddr> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    console_subscriber::init();
     let opt = Opt::from_args();
 
     match opt.cmd {

--- a/pd/src/mempool/service.rs
+++ b/pd/src/mempool/service.rs
@@ -31,7 +31,9 @@ impl Mempool {
     ) -> anyhow::Result<Self> {
         let (queue_tx, queue_rx) = mpsc::channel(10);
 
-        tokio::spawn(Worker::new(storage, queue_rx, height_rx).await?.run());
+        tokio::task::Builder::new()
+            .name("mempool::Worker")
+            .spawn(Worker::new(storage, queue_rx, height_rx).await?.run());
 
         Ok(Self {
             queue: PollSender::new(queue_tx),

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -25,7 +25,7 @@ bincode = "1.3.3"
 tokio = { version = "1", features = ["full"]}
 tower = { version = "0.4", features = ["full"]}
 tracing = "0.1"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 pin-project = "1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
This commit adds initial support for the [Tokio Console], using the
basic [`console_subscriber::init`] API.  This should not interfere with
the existing logging configuration using `tracing`, as
`console_subscriber::init` is essentially a superset of
`tracing_subscriber::fmt::init`. Note that the console filter
configuration does not interfere with the filter configuration for
logging.

The console endpoint is served on the default address,
http://127.0.0.1:6669/. 

## Future Work

Future commits will improve the console instrumentation by configuring
the console endpoint using `pd`'s command line arguments, adding the
filter reloading described in
https://github.com/penumbra-zone/penumbra/issues/13#issuecomment-1100969950,
and integrate Tokio Console with the existing Grafana setup, but this is
a working starting point.

## Examples

![image](https://user-images.githubusercontent.com/2796466/164990005-d8dd0f4d-5b86-48a3-b9d0-9ed0836bebc2.png)

Note that:
- Only the `pd=trace` filter setting is logged (tokio events are not
  logged)
- Named tasks show up in the console
- Blocking tasks (from rocksdb) are also displayed in the console

Closes #13


[Tokio Console]: https://docs.rs/tokio-console/latest/tokio_console/
[`console_subscriber::init`]: https://docs.rs/console-subscriber/latest/console_subscriber/fn.init.html



