### PR TITLE
pd: fail service if consensus worker task panics

### DIFF
--- a/pd/src/consensus/service.rs
+++ b/pd/src/consensus/service.rs
@@ -52,6 +52,16 @@ impl tower::Service<ConsensusRequest> for Consensus {
     }
 
     fn call(&mut self, req: ConsensusRequest) -> Self::Future {
+        // Check if the worker has terminated. We do this again in `call`
+        // because the worker may have terminated *after* `poll_ready` reserved
+        // a send permit.
+        if self.queue.is_closed() {
+            return async move {
+                Err(anyhow::anyhow!("consensus worker terminated or panicked").into())
+            }
+            .boxed();
+        }
+
         let span = req.create_span();
         let (tx, rx) = oneshot::channel();
 
@@ -63,6 +73,10 @@ impl tower::Service<ConsensusRequest> for Consensus {
             })
             .expect("called without `poll_ready`");
 
-        async move { Ok(rx.await.expect("worker error??")) }.boxed()
+        async move {
+            rx.await
+                .map_err(|_| anyhow::anyhow!("consensus worker terminated or panicked").into())
+        }
+        .boxed()
     }
 }


### PR DESCRIPTION
Currently, if the consensus worker task panics (or terminates
unexpectedly), the rest of the `pd` process will simply continue
running. This is because the consensus `Service` calls `.expect(...)` on
the oneshot reciever from the worker task, and the `tower_acbi` server
may spawn the response future in a background task whose panicking may
not be propagated. Additionally, it is possible that the `Service` may
be driven to readiness successfully before the worker panicked or
terminated. If this occurs, the message will be sent successfully, but
the worker task may never respond.

This branch should fix these issues by changing the consensus service
to:
1. proactively check if the worker is still there in `call`, and return
   a failed response future if the worker has died;
2. return a response future that completes with an error if the oneshot
   receiver is dropped, rather than panicking, which should ensure the
   request fails.

Hopefully, this means that `tower-acbi` will propagate the failure up to
the main function and terminate the application gracefully.