### PR TITLE
ibc: suppress warnings of unreachable patterns

### DIFF
--- a/ibc/src/lib.rs
+++ b/ibc/src/lib.rs
@@ -1,3 +1,8 @@
+// Many of the IBC message types are enums, where the number of variants differs
+// depending on the build configuration, meaning that the fallthrough case gets
+// marked as unreachable only when not building in test configuration.
+#![allow(unreachable_patterns)]
+
 mod client;
 mod ibcaction;
 

--- a/pd/src/components/ibc.rs
+++ b/pd/src/components/ibc.rs
@@ -1,3 +1,8 @@
+// Many of the IBC message types are enums, where the number of variants differs
+// depending on the build configuration, meaning that the fallthrough case gets
+// marked as unreachable only when not building in test configuration.
+#![allow(unreachable_patterns)]
+
 mod client;
 
 use crate::components::Component;


### PR DESCRIPTION
Many of the IBC message types are enums, where the number of variants differs depending on the build configuration, meaning that the fallthrough case gets marked as unreachable only when not building in test configuration.

Should these be marked `#[non_exhaustive]` upstream?