### PR TITLE
ci: add cargo update step to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
           cd ~/penumbra
           git checkout main
           git pull
+          cargo update
     - name: Delete existing state
       uses: appleboy/ssh-action@master
       with:


### PR DESCRIPTION
Maybe even better would be to nuke the local repo and clone it again?  Or maybe that's a pointer that we should have a less duct-tape-and-bailing-wire approach ahaha...