### PR TITLE
pd: fix vote tracking in staking component

### DIFF
--- a/pd/src/components/staking.rs
+++ b/pd/src/components/staking.rs
@@ -405,9 +405,9 @@ impl Staking {
                     .ok_or_else(|| anyhow!("missing uptime for active validator {}", v))?;
 
                 tracing::debug!(
-                    ?v,
                     ?voted,
                     num_missed_blocks = ?uptime.num_missed_blocks(),
+                    ?v,
                     ?params.missed_blocks_maximum,
                     "recorded vote info"
                 );


### PR DESCRIPTION
The first attempt at implementing this functionality in #678 ignored the
`signed_last_block` field that records whether or not a validator actually
voted.  This commit uses it, and testing locally shows that it records missed
blocks (upload a validator definition with a random consensus key, delegate to
it, watch its missed block counter increase...).