### PR TITLE
scaffold IBC connections component, add ConnectionOpenInit handling

### DIFF
--- a/ibc/src/client.rs
+++ b/ibc/src/client.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use ibc::core::ics24_host::identifier::ConnectionId;
 use ibc::{
     clients::ics07_tendermint::{
         client_state, consensus_state, consensus_state::ConsensusState as TendermintConsensusState,
@@ -209,6 +210,39 @@ impl From<VerifiedHeights> for pb::VerifiedHeights {
     fn from(d: VerifiedHeights) -> Self {
         Self {
             heights: d.heights.into_iter().map(|h| h.into()).collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ClientConnections {
+    pub connection_ids: Vec<ConnectionId>,
+}
+
+impl Protobuf<pb::ClientConnections> for ClientConnections {}
+
+impl TryFrom<pb::ClientConnections> for ClientConnections {
+    type Error = anyhow::Error;
+
+    fn try_from(msg: pb::ClientConnections) -> Result<Self, Self::Error> {
+        Ok(ClientConnections {
+            connection_ids: msg
+                .connections
+                .into_iter()
+                .map(|h| h.parse())
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+}
+
+impl From<ClientConnections> for pb::ClientConnections {
+    fn from(d: ClientConnections) -> Self {
+        Self {
+            connections: d
+                .connection_ids
+                .into_iter()
+                .map(|h| h.as_str().to_string())
+                .collect(),
         }
     }
 }

--- a/ibc/src/connection.rs
+++ b/ibc/src/connection.rs
@@ -1,0 +1,52 @@
+use ibc::core::ics03_connection::connection::ConnectionEnd;
+use penumbra_proto::{ibc as pb, Protobuf};
+
+#[derive(Debug, Clone)]
+pub struct ConnectionCounter(pub u64);
+
+impl Protobuf<pb::ConnectionCounter> for ConnectionCounter {}
+
+impl TryFrom<pb::ConnectionCounter> for ConnectionCounter {
+    type Error = anyhow::Error;
+
+    fn try_from(p: pb::ConnectionCounter) -> Result<Self, Self::Error> {
+        Ok(ConnectionCounter(p.counter))
+    }
+}
+
+impl From<ConnectionCounter> for pb::ConnectionCounter {
+    fn from(c: ConnectionCounter) -> Self {
+        pb::ConnectionCounter { counter: c.0 }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Connection(pub ConnectionEnd);
+
+impl Protobuf<pb::Connection> for Connection {}
+
+impl TryFrom<pb::Connection> for Connection {
+    type Error = anyhow::Error;
+
+    fn try_from(p: pb::Connection) -> Result<Self, Self::Error> {
+        let end = p
+            .connection_end
+            .ok_or_else(|| anyhow::anyhow!("connection end not set"))?;
+        let connection_end = ConnectionEnd::try_from(end)?;
+        Ok(Connection(connection_end))
+    }
+}
+
+impl From<Connection> for pb::Connection {
+    fn from(c: Connection) -> Self {
+        pb::Connection {
+            connection_end: Some(c.0.into()),
+        }
+    }
+}
+
+impl From<ConnectionEnd> for Connection {
+    fn from(c: ConnectionEnd) -> Self {
+        Connection(c)
+    }
+}

--- a/ibc/src/lib.rs
+++ b/ibc/src/lib.rs
@@ -4,7 +4,9 @@
 #![allow(unreachable_patterns)]
 
 mod client;
+mod connection;
 mod ibcaction;
 
-pub use client::{ClientCounter, ClientData, ConsensusState, VerifiedHeights};
+pub use client::{ClientConnections, ClientCounter, ClientData, ConsensusState, VerifiedHeights};
+pub use connection::{Connection, ConnectionCounter};
 pub use ibcaction::IBCAction;

--- a/pd/src/components/ibc.rs
+++ b/pd/src/components/ibc.rs
@@ -4,6 +4,7 @@
 #![allow(unreachable_patterns)]
 
 mod client;
+mod connection;
 
 use crate::components::Component;
 use crate::{genesis, Overlay};
@@ -16,6 +17,7 @@ use tracing::instrument;
 
 pub struct IBCComponent {
     client: client::ClientComponent,
+    connection: connection::ConnectionComponent,
 }
 
 #[async_trait]
@@ -23,23 +25,27 @@ impl Component for IBCComponent {
     #[instrument(name = "ibc", skip(overlay))]
     async fn new(overlay: Overlay) -> Self {
         let client = ClientComponent::new(overlay.clone()).await;
+        let connection = connection::ConnectionComponent::new(overlay.clone()).await;
 
-        Self { client }
+        Self { client, connection }
     }
 
     #[instrument(name = "ibc", skip(self, app_state))]
     async fn init_chain(&mut self, app_state: &genesis::AppState) {
         self.client.init_chain(app_state).await;
+        self.connection.init_chain(app_state).await;
     }
 
     #[instrument(name = "ibc", skip(self, begin_block))]
     async fn begin_block(&mut self, begin_block: &abci::request::BeginBlock) {
         self.client.begin_block(begin_block).await;
+        self.connection.begin_block(begin_block).await;
     }
 
     #[instrument(name = "ibc", skip(tx))]
     fn check_tx_stateless(tx: &Transaction) -> Result<()> {
         client::ClientComponent::check_tx_stateless(tx)?;
+        connection::ConnectionComponent::check_tx_stateless(tx)?;
 
         Ok(())
     }
@@ -47,6 +53,7 @@ impl Component for IBCComponent {
     #[instrument(name = "ibc", skip(self, tx))]
     async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()> {
         self.client.check_tx_stateful(tx).await?;
+        self.connection.check_tx_stateful(tx).await?;
 
         Ok(())
     }
@@ -54,10 +61,12 @@ impl Component for IBCComponent {
     #[instrument(name = "ibc", skip(self, tx))]
     async fn execute_tx(&mut self, tx: &Transaction) {
         self.client.execute_tx(tx).await;
+        self.connection.execute_tx(tx).await;
     }
 
     #[instrument(name = "ibc", skip(self, end_block))]
     async fn end_block(&mut self, end_block: &abci::request::EndBlock) {
         self.client.end_block(end_block).await;
+        self.connection.end_block(end_block).await;
     }
 }

--- a/pd/src/components/ibc/connection.rs
+++ b/pd/src/components/ibc/connection.rs
@@ -1,0 +1,221 @@
+use crate::{components::ibc::client::View as _, components::Component};
+use crate::{genesis, Overlay, OverlayExt};
+use anyhow::Result;
+use async_trait::async_trait;
+use ibc::core::ics03_connection::connection::{ConnectionEnd, State};
+use ibc::core::ics03_connection::msgs::conn_open_ack::MsgConnectionOpenAck;
+use ibc::core::ics03_connection::msgs::conn_open_confirm::MsgConnectionOpenConfirm;
+use ibc::core::ics03_connection::msgs::conn_open_init::MsgConnectionOpenInit;
+use ibc::core::ics03_connection::msgs::conn_open_try::MsgConnectionOpenTry;
+use ibc::core::ics03_connection::version::Version;
+use ibc::core::ics24_host::identifier::ConnectionId;
+use penumbra_ibc::{Connection, ConnectionCounter, IBCAction};
+use penumbra_proto::ibc::ibc_action::Action::{
+    ConnectionOpenAck, ConnectionOpenConfirm, ConnectionOpenInit, ConnectionOpenTry,
+};
+use penumbra_transaction::Transaction;
+use tendermint::abci;
+use tracing::instrument;
+
+pub struct ConnectionComponent {
+    overlay: Overlay,
+}
+
+#[async_trait]
+impl Component for ConnectionComponent {
+    #[instrument(name = "ibc_connection", skip(overlay))]
+    async fn new(overlay: Overlay) -> Self {
+        Self { overlay }
+    }
+
+    #[instrument(name = "ibc_connection", skip(self, _app_state))]
+    async fn init_chain(&mut self, _app_state: &genesis::AppState) {}
+
+    #[instrument(name = "ibc_connection", skip(self, _begin_block))]
+    async fn begin_block(&mut self, _begin_block: &abci::request::BeginBlock) {}
+
+    #[instrument(name = "ibc_connection", skip(tx))]
+    fn check_tx_stateless(tx: &Transaction) -> Result<()> {
+        for ibc_action in tx.ibc_actions() {
+            validate_ibc_action_stateless(ibc_action)?;
+        }
+
+        Ok(())
+    }
+
+    #[instrument(name = "ibc_connection", skip(self, tx))]
+    async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()> {
+        for ibc_action in tx.ibc_actions() {
+            self.validate_ibc_action_stateful(ibc_action).await?;
+        }
+        Ok(())
+    }
+
+    #[instrument(name = "ibc_connection", skip(self, tx))]
+    async fn execute_tx(&mut self, tx: &Transaction) {
+        for ibc_action in tx.ibc_actions() {
+            self.execute_ibc_action(ibc_action).await;
+        }
+    }
+
+    #[instrument(name = "ibc_connection", skip(self, _end_block))]
+    async fn end_block(&mut self, _end_block: &abci::request::EndBlock) {}
+}
+
+fn validate_ibc_action_stateless(ibc_action: &IBCAction) -> Result<(), anyhow::Error> {
+    match &ibc_action.action {
+        ConnectionOpenInit(msg) => {
+            let msg_connection_open_init = MsgConnectionOpenInit::try_from(msg.clone())?;
+
+            // check if the version is supported (we use the same versions as the cosmos SDK)
+            // TODO: should we be storing the compatible versions in our state instead?
+            let compatible_versions = vec![Version::default()];
+
+            if !compatible_versions.contains(&msg_connection_open_init.version) {
+                return Err(anyhow::anyhow!(
+                    "unsupported version: in ConnectionOpenInit",
+                ));
+            }
+
+            return Ok(());
+        }
+
+        ConnectionOpenTry(msg) => {
+            let _msg_connection_open_try = MsgConnectionOpenTry::try_from(msg.clone())?;
+        }
+
+        ConnectionOpenAck(msg) => {
+            let _msg_connection_open_ack = MsgConnectionOpenAck::try_from(msg.clone())?;
+        }
+
+        ConnectionOpenConfirm(msg) => {
+            let _msg_connection_open_confirm = MsgConnectionOpenConfirm::try_from(msg.clone())?;
+        }
+
+        _ => {}
+    }
+
+    Ok(())
+}
+
+impl ConnectionComponent {
+    async fn execute_ibc_action(&mut self, ibc_action: &IBCAction) {
+        match &ibc_action.action {
+            ConnectionOpenInit(msg) => {
+                let msg_connection_open_init =
+                    MsgConnectionOpenInit::try_from(msg.clone()).unwrap();
+                self.execute_connection_open_init(&msg_connection_open_init)
+                    .await;
+            }
+
+            ConnectionOpenTry(msg) => {
+                let _msg_connection_open_try = MsgConnectionOpenTry::try_from(msg.clone()).unwrap();
+            }
+
+            ConnectionOpenAck(msg) => {
+                let _msg_connection_open_ack = MsgConnectionOpenAck::try_from(msg.clone()).unwrap();
+            }
+
+            ConnectionOpenConfirm(msg) => {
+                let _msg_connection_open_confirm =
+                    MsgConnectionOpenConfirm::try_from(msg.clone()).unwrap();
+            }
+
+            _ => {}
+        }
+    }
+
+    async fn execute_connection_open_init(&mut self, msg: &MsgConnectionOpenInit) {
+        let connection_id =
+            ConnectionId::new(self.overlay.get_connection_counter().await.unwrap().0);
+
+        let compatible_versions = vec![Version::default()];
+
+        let new_connection_end = ConnectionEnd::new(
+            State::Init,
+            msg.client_id.clone(),
+            msg.counterparty.clone(),
+            compatible_versions,
+            msg.delay_period,
+        );
+
+        // commit the connection, this also increments the connection counter
+        self.overlay
+            .put_new_connection(&connection_id, new_connection_end.into())
+            .await
+            .unwrap();
+    }
+
+    async fn validate_ibc_action_stateful(&self, ibc_action: &IBCAction) -> Result<()> {
+        match &ibc_action.action {
+            ConnectionOpenInit(raw_msg) => {
+                // check that the client id exists
+                let msg = MsgConnectionOpenInit::try_from(raw_msg.clone())?;
+                self.overlay.get_client_data(&msg.client_id).await?;
+
+                return Ok(());
+            }
+
+            ConnectionOpenTry(msg) => {
+                let _msg_connection_open_try = MsgConnectionOpenTry::try_from(msg.clone())?;
+            }
+
+            ConnectionOpenAck(msg) => {
+                let _msg_connection_open_ack = MsgConnectionOpenAck::try_from(msg.clone())?;
+            }
+
+            ConnectionOpenConfirm(msg) => {
+                let _msg_connection_open_confirm = MsgConnectionOpenConfirm::try_from(msg.clone())?;
+            }
+
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+pub trait View: OverlayExt + Send + Sync {
+    async fn get_connection_counter(&self) -> Result<ConnectionCounter> {
+        self.get_domain("ibc/ics03-connection/connection_counter".into())
+            .await
+            .map(|counter| counter.unwrap_or(ConnectionCounter(0)))
+    }
+
+    async fn put_connection_counter(&self, counter: ConnectionCounter) {
+        self.put_domain("ibc/ics03-connection/connection_counter".into(), counter)
+            .await;
+    }
+
+    // puts a new connection into the state, updating the connections associated with the client,
+    // and incrementing the client counter.
+    async fn put_new_connection(
+        &mut self,
+        connection_id: &ConnectionId,
+        connection: Connection,
+    ) -> Result<()> {
+        self.put_domain(
+            format!(
+                "ibc/ics03-connection/connections/{}",
+                connection_id.as_str()
+            )
+            .into(),
+            connection.clone(),
+        )
+        .await;
+        let counter = self
+            .get_connection_counter()
+            .await
+            .unwrap_or(ConnectionCounter(0));
+        self.put_connection_counter(ConnectionCounter(counter.0 + 1))
+            .await;
+
+        self.add_connection_to_client(connection.0.client_id(), connection_id)
+            .await?;
+
+        return Ok(());
+    }
+}
+
+impl<T: OverlayExt + Send + Sync> View for T {}

--- a/proto/proto/ibc.proto
+++ b/proto/proto/ibc.proto
@@ -1,9 +1,13 @@
 syntax = "proto3";
 
 import "ibc/core/connection/v1/tx.proto";
+import "ibc/core/connection/v1/connection.proto";
+
 import "ibc/core/channel/v1/tx.proto";
+
 import "ibc/core/client/v1/tx.proto";
 import "ibc/core/client/v1/client.proto";
+
 import "google/protobuf/any.proto";
 
 package penumbra.ibc;
@@ -49,4 +53,16 @@ message ConsensusState {
 
 message VerifiedHeights {
   repeated .ibc.core.client.v1.Height heights = 1; 
+}
+
+message ConnectionCounter {
+  uint64 counter = 1;
+}
+
+message Connection {
+  .ibc.core.connection.v1.ConnectionEnd connectionEnd = 1;
+}
+
+message ClientConnections {
+  repeated string connections = 1;
 }


### PR DESCRIPTION
this PR scaffolds out an ibc connection handling component, and adds support for handling `ConnectionOpenInit`. Closes #640.