### PR TITLE
pd: make the BeginBlock span smaller

### DIFF
--- a/pd/src/request_ext.rs
+++ b/pd/src/request_ext.rs
@@ -16,8 +16,8 @@ impl RequestExt for ConsensusRequest {
         // Create a parent "abci" span. All of these spans are at error level, so they're always recorded.
         let p = error_span!("abci");
         match self {
-            ConsensusRequest::BeginBlock(BeginBlock { hash, header, .. }) => {
-                error_span!(parent: &p, "BeginBlock", height = ?header.height, hash = ?hex::encode(hash.as_ref()))
+            ConsensusRequest::BeginBlock(BeginBlock { header, .. }) => {
+                error_span!(parent: &p, "BeginBlock", height = ?header.height.value())
             }
             ConsensusRequest::DeliverTx(DeliverTx { tx }) => {
                 error_span!(parent: &p, "DeliverTx", txid = ?hex::encode(&Sha256::digest(tx.as_ref())))


### PR DESCRIPTION
It's not really useful to include the hash in the BeginBlock span, because the
other spans don't include it, so we don't have a way to filter all of the
processing of a block by its hash, and because Tendermint has finality, so it's
just as easy to identify a block by height as by hash.

Also, use a plain integer value in the span for consistency with the other messages.