### PR TITLE
Guide fixes

### DIFF
--- a/docs/guide/src/pcli/install.md
+++ b/docs/guide/src/pcli/install.md
@@ -16,7 +16,7 @@ depending on your distribution. For a bare-bones Ubuntu installation, you can
 run:
 
 ```bash
-sudo apt-get install build-essential pkg-config libssl-dev clang
+sudo apt-get install build-essential pkg-config libssl-dev
 ```
 
 #### macOS

--- a/docs/guide/src/pcli/install.md
+++ b/docs/guide/src/pcli/install.md
@@ -16,7 +16,7 @@ depending on your distribution. For a bare-bones Ubuntu installation, you can
 run:
 
 ```bash
-sudo apt-get install build-essential pkg-config libssl-dev
+sudo apt-get install build-essential pkg-config libssl-dev clang
 ```
 
 #### macOS

--- a/docs/guide/src/pd/build.md
+++ b/docs/guide/src/pd/build.md
@@ -3,7 +3,16 @@
 The node software `pd` is part of the same repository as `pcli`, so follow
 [those instructions](../pcli/install.md) to clone the repo and install dependencies.
 
+You may need to install some additional packages in order to build `pd`,
+depending on your distribution. For a bare-bones Ubuntu installation, you can
+run
+
+```bash
+sudo apt-get install clang
+```
+
 To build `pd`, run
+
 ```bash
 cargo build --release --bin pd
 ```

--- a/docs/guide/src/pd/join-testnet/validator.md
+++ b/docs/guide/src/pd/join-testnet/validator.md
@@ -64,6 +64,10 @@ By default `template-definition` will use a random consensus key that you won't 
   },
 ```
 
+Note: if you can't find `priv_validator_key.json`, assure that you have set
+`validator = true` in the Tendermint `config.toml`, as described above, and
+restarted Tendermint after doing so.
+
 #### Configuring funding streams
 
 Unlike the Cosmos SDK, which has validators specify a commission percentage that


### PR DESCRIPTION
This PR fixes a few minor issues in the validator guide.

- Makes dependency on `clang` explicit, as recommended in #659.
- ~~Drops `-n testnet-preview.penumbra.zone` from "Updating your validator" (most people will not want to use the preview deployment.~~ Someone beat me to this!
- Makes explicit that validators must restart Tendermint after setting `mode = validator` in the Tendermint config.