### PR TITLE
storage: rename Overlay to State

### DIFF
--- a/pd/src/components/app.rs
+++ b/pd/src/components/app.rs
@@ -6,7 +6,7 @@ use jmt::{RootHash, Version};
 use penumbra_chain::{genesis, params::ChainParams};
 use penumbra_component::Component;
 use penumbra_stake::Epoch;
-use penumbra_storage::{Overlay, OverlayExt, Storage};
+use penumbra_storage::{State, StateExt, Storage};
 use penumbra_transaction::Transaction;
 use tendermint::abci::{self, types::ValidatorUpdate};
 use tendermint::Time;
@@ -20,7 +20,7 @@ use super::{IBCComponent, ShieldedPool, Staking};
 /// it constructs the others and exposes a [`commit`](App::commit) that
 /// commits the changes to the persistent storage and resets its subcomponents.
 pub struct App {
-    overlay: Overlay,
+    state: State,
     shielded_pool: ShieldedPool,
     ibc: IBCComponent,
     staking: Staking,
@@ -31,16 +31,16 @@ impl App {
     /// returning the new root hash and storage version.
     ///
     /// This method also resets `self` as if it were constructed
-    /// as an empty overlay of the newly written state.
+    /// as an empty state over top of the newly written storage.
     #[instrument(skip(self, storage))]
     pub async fn commit(&mut self, storage: Storage) -> Result<(RootHash, Version)> {
-        // Commit the pending writes, clearing the overlay.
-        let (root_hash, version) = self.overlay.lock().await.commit(storage).await?;
-        tracing::debug!(?root_hash, version, "finished committing overlay");
+        // Commit the pending writes, clearing the state.
+        let (root_hash, version) = self.state.lock().await.commit(storage).await?;
+        tracing::debug!(?root_hash, version, "finished committing state");
         // Now re-instantiate all of the components:
-        self.staking = Staking::new(self.overlay.clone()).await;
-        self.ibc = IBCComponent::new(self.overlay.clone()).await;
-        self.shielded_pool = ShieldedPool::new(self.overlay.clone()).await;
+        self.staking = Staking::new(self.state.clone()).await;
+        self.ibc = IBCComponent::new(self.state.clone()).await;
+        self.shielded_pool = ShieldedPool::new(self.state.clone()).await;
 
         Ok((root_hash, version))
     }
@@ -53,14 +53,14 @@ impl App {
 
 #[async_trait]
 impl Component for App {
-    #[instrument(skip(overlay))]
-    async fn new(overlay: Overlay) -> Self {
-        let staking = Staking::new(overlay.clone()).await;
-        let ibc = IBCComponent::new(overlay.clone()).await;
-        let shielded_pool = ShieldedPool::new(overlay.clone()).await;
+    #[instrument(skip(state))]
+    async fn new(state: State) -> Self {
+        let staking = Staking::new(state.clone()).await;
+        let ibc = IBCComponent::new(state.clone()).await;
+        let shielded_pool = ShieldedPool::new(state.clone()).await;
 
         Self {
-            overlay,
+            state,
             shielded_pool,
             staking,
             ibc,
@@ -69,15 +69,15 @@ impl Component for App {
 
     #[instrument(skip(self, app_state))]
     async fn init_chain(&mut self, app_state: &genesis::AppState) {
-        self.overlay
+        self.state
             .put_chain_params(app_state.chain_params.clone())
             .await;
         // TODO: do we actually need to store the app state here?
-        self.overlay
+        self.state
             .put_domain(b"genesis/app_state".into(), app_state.clone())
             .await;
         // The genesis block height is 0
-        self.overlay.put_block_height(0).await;
+        self.state.put_block_height(0).await;
 
         self.staking.init_chain(app_state).await;
         self.ibc.init_chain(app_state).await;
@@ -89,11 +89,11 @@ impl Component for App {
     #[instrument(skip(self, begin_block))]
     async fn begin_block(&mut self, begin_block: &abci::request::BeginBlock) {
         // store the block height
-        self.overlay
+        self.state
             .put_block_height(begin_block.header.height.into())
             .await;
         // store the block time
-        self.overlay
+        self.state
             .put_block_timestamp(begin_block.header.time)
             .await;
 
@@ -145,7 +145,7 @@ impl Component for App {
 /// Note: the `get_` methods in this trait assume that the state store has been
 /// initialized, so they will error on an empty state.
 #[async_trait]
-pub trait View: OverlayExt {
+pub trait View: StateExt {
     /// Gets the chain parameters from the JMT.
     async fn get_chain_params(&self) -> Result<ChainParams> {
         self.get_domain(b"chain_params".into())
@@ -236,4 +236,4 @@ pub trait View: OverlayExt {
     }
 }
 
-impl<T: OverlayExt> View for T {}
+impl<T: StateExt> View for T {}

--- a/pd/src/components/ibc.rs
+++ b/pd/src/components/ibc.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use client::ClientComponent;
 use penumbra_chain::genesis;
 use penumbra_component::Component;
-use penumbra_storage::Overlay;
+use penumbra_storage::State;
 use penumbra_transaction::Transaction;
 use tendermint::abci;
 use tracing::instrument;
@@ -23,10 +23,10 @@ pub struct IBCComponent {
 
 #[async_trait]
 impl Component for IBCComponent {
-    #[instrument(name = "ibc", skip(overlay))]
-    async fn new(overlay: Overlay) -> Self {
-        let client = ClientComponent::new(overlay.clone()).await;
-        let connection = connection::ConnectionComponent::new(overlay.clone()).await;
+    #[instrument(name = "ibc", skip(state))]
+    async fn new(state: State) -> Self {
+        let client = ClientComponent::new(state.clone()).await;
+        let connection = connection::ConnectionComponent::new(state.clone()).await;
 
         Self { client, connection }
     }

--- a/pd/src/components/shielded_pool.rs
+++ b/pd/src/components/shielded_pool.rs
@@ -14,7 +14,7 @@ use penumbra_crypto::{
     note, Address, Note, Nullifier, One, Value,
 };
 use penumbra_stake::{Epoch, STAKING_TOKEN_ASSET_ID};
-use penumbra_storage::{Overlay, OverlayExt};
+use penumbra_storage::{State, StateExt};
 use penumbra_transaction::{action::output, Action, Transaction};
 use tendermint::abci;
 use tracing::instrument;
@@ -23,7 +23,7 @@ use super::{app::View as _, staking::View as _};
 
 // Stub component
 pub struct ShieldedPool {
-    overlay: Overlay,
+    state: State,
     note_commitment_tree: NoteCommitmentTree,
     /// The in-progress CompactBlock representation of the ShieldedPool changes
     compact_block: CompactBlock,
@@ -31,12 +31,12 @@ pub struct ShieldedPool {
 
 #[async_trait]
 impl Component for ShieldedPool {
-    #[instrument(name = "shielded_pool", skip(overlay))]
-    async fn new(overlay: Overlay) -> Self {
-        let note_commitment_tree = Self::get_nct(&overlay).await.unwrap();
+    #[instrument(name = "shielded_pool", skip(state))]
+    async fn new(state: State) -> Self {
+        let note_commitment_tree = Self::get_nct(&state).await.unwrap();
 
         Self {
-            overlay,
+            state,
             note_commitment_tree,
             compact_block: Default::default(),
         }
@@ -62,7 +62,7 @@ impl Component for ShieldedPool {
                 })
                 .unwrap();
 
-            self.overlay.register_denom(&denom).await.unwrap();
+            self.state.register_denom(&denom).await.unwrap();
             self.mint_note(
                 Value {
                     amount: allocation.amount,
@@ -164,14 +164,12 @@ impl Component for ShieldedPool {
     #[instrument(name = "shielded_pool", skip(self, tx))]
     async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()> {
         // TODO: rename transaction_body.merkle_root now that we have 2 merkle trees
-        self.overlay
+        self.state
             .check_claimed_anchor(&tx.transaction_body.merkle_root)
             .await?;
 
         for spent_nullifier in tx.spent_nullifiers() {
-            self.overlay
-                .check_nullifier_unspent(spent_nullifier)
-                .await?;
+            self.state.check_nullifier_unspent(spent_nullifier).await?;
         }
 
         // TODO: handle quarantine
@@ -200,7 +198,7 @@ impl Component for ShieldedPool {
             // We need to record the nullifier as spent in the JMT (to prevent
             // double spends), as well as in the CompactBlock (so that clients
             // can learn that their note was spent).
-            self.overlay.spend_nullifier(spent_nullifier, source).await;
+            self.state.spend_nullifier(spent_nullifier, source).await;
             self.compact_block.nullifiers.push(spent_nullifier);
         }
         //}
@@ -213,7 +211,7 @@ impl Component for ShieldedPool {
 
         // Handle any pending reward notes from the Staking component
         let notes = self
-            .overlay
+            .state
             .commission_amounts(self.compact_block.height)
             .await
             .unwrap()
@@ -224,7 +222,7 @@ impl Component for ShieldedPool {
         let source = NoteSource::FundingStreamReward {
             epoch_index: Epoch::from_height(
                 self.compact_block.height,
-                self.overlay.get_epoch_duration().await.unwrap(),
+                self.state.get_epoch_duration().await.unwrap(),
             )
             .index,
         };
@@ -313,7 +311,7 @@ impl ShieldedPool {
         let encrypted_note = note.encrypt(&esk);
 
         // Now record the note and update the total supply:
-        self.overlay
+        self.state
             .update_token_supply(&value.asset_id, value.amount as i64)
             .await?;
         self.add_note(
@@ -336,7 +334,7 @@ impl ShieldedPool {
         self.note_commitment_tree
             .append(&output_body.note_commitment);
         // 2. Record its source in the JMT
-        self.overlay
+        self.state
             .set_note_source(&output_body.note_commitment, source)
             .await;
         // 3. Finally, record it in the pending compact block.
@@ -346,11 +344,11 @@ impl ShieldedPool {
     #[instrument(skip(self))]
     async fn write_compactblock_and_nct(&mut self) -> Result<()> {
         // Write the CompactBlock:
-        self.overlay
+        self.state
             .set_compact_block(std::mem::take(&mut self.compact_block))
             .await;
         // and the note commitment tree data and anchor:
-        self.overlay
+        self.state
             .set_nct_anchor(self.compact_block.height, self.note_commitment_tree.root2())
             .await;
         self.put_nct().await?;
@@ -363,7 +361,7 @@ impl ShieldedPool {
     /// implementing one now.  When switching to the TCT we should revisit.
     async fn put_nct(&mut self) -> Result<()> {
         let nct_data = bincode::serialize(&self.note_commitment_tree)?;
-        self.overlay
+        self.state
             .lock()
             .await
             .put(b"shielded_pool/nct_data".into(), nct_data);
@@ -373,9 +371,9 @@ impl ShieldedPool {
     /// This is an associated function rather than a method,
     /// so that we can call it in the constructor to get the NCT.
     /// NOTE: we may not need that any more now that we can use an
-    /// Overlay on an empty database.
-    async fn get_nct(overlay: &Overlay) -> Result<NoteCommitmentTree> {
-        if let Ok(Some(bytes)) = overlay
+    /// State on an empty database.
+    async fn get_nct(state: &State) -> Result<NoteCommitmentTree> {
+        if let Ok(Some(bytes)) = state
             .lock()
             .await
             .get(b"shielded_pool/nct_data".into())
@@ -392,7 +390,7 @@ impl ShieldedPool {
 ///
 /// TODO: should this be split into Read and Write traits?
 #[async_trait]
-pub trait View: OverlayExt {
+pub trait View: StateExt {
     async fn token_supply(&self, asset_id: &asset::Id) -> Result<Option<u64>> {
         self.get_proto(format!("shielded_pool/assets/{}/token_supply", asset_id).into())
             .await
@@ -569,4 +567,4 @@ pub trait View: OverlayExt {
     }
 }
 
-impl<T: OverlayExt> View for T {}
+impl<T: StateExt> View for T {}

--- a/pd/src/components/staking.rs
+++ b/pd/src/components/staking.rs
@@ -8,11 +8,11 @@ use penumbra_proto::Protobuf;
 use penumbra_stake::{
     action::{Delegate, Undelegate},
     rate::{BaseRateData, RateData},
-    validator::{self, State, Validator},
+    validator::{self, Validator},
     CommissionAmount, CommissionAmounts, DelegationChanges, Epoch, IdentityKey, Uptime,
     STAKING_TOKEN_ASSET_ID,
 };
-use penumbra_storage::{Overlay, OverlayExt};
+use penumbra_storage::{State, StateExt};
 use penumbra_transaction::{Action, Transaction};
 use sha2::{Digest, Sha256};
 use tendermint::{
@@ -32,7 +32,7 @@ const MAX_VOTING_POWER: i64 = 1152921504606846975;
 
 // Staking component
 pub struct Staking {
-    overlay: Overlay,
+    state: State,
     /// Delegation changes accumulated over the course of this block, to be
     /// persisted at the end of the block for processing at the end of the next
     /// epoch.
@@ -48,7 +48,7 @@ impl Staking {
         let mut undelegations_by_validator = BTreeMap::<IdentityKey, Vec<Undelegate>>::new();
         for height in epoch_to_end.start_height().value()..=epoch_to_end.end_height().value() {
             let changes = self
-                .overlay
+                .state
                 .delegation_changes(height.try_into().unwrap())
                 .await?;
             for d in changes.delegations {
@@ -75,14 +75,14 @@ impl Staking {
                 .sum::<usize>(),
         );
 
-        let chain_params = self.overlay.get_chain_params().await?;
+        let chain_params = self.state.get_chain_params().await?;
         let unbonding_epochs = chain_params.unbonding_epochs;
         let active_validator_limit = chain_params.active_validator_limit;
 
         tracing::debug!("processing base rate");
         // We are transitioning to the next epoch, so set "cur_base_rate" to the previous "next_base_rate", and
         // update "next_base_rate".
-        let current_base_rate = self.overlay.next_base_rate().await?;
+        let current_base_rate = self.state.next_base_rate().await?;
 
         let next_base_rate = current_base_rate.next(chain_params.base_reward_rate);
 
@@ -91,22 +91,22 @@ impl Staking {
         tracing::debug!(?next_base_rate);
 
         // Update the base rates in the JMT:
-        self.overlay
+        self.state
             .set_base_rates(current_base_rate.clone(), next_base_rate.clone())
             .await;
 
         let mut commission_amounts = Vec::new();
-        let validator_list = self.overlay.validator_list().await?;
+        let validator_list = self.state.validator_list().await?;
         for v in &validator_list {
-            let validator = self.overlay.validator(v).await?.ok_or_else(|| {
+            let validator = self.state.validator(v).await?.ok_or_else(|| {
                 anyhow::anyhow!("validator had ID in validator_list but not found in JMT")
             })?;
             // The old epoch's "next rate" is now the "current rate".
-            let current_rate = self.overlay.next_validator_rate(v).await?.ok_or_else(|| {
+            let current_rate = self.state.next_validator_rate(v).await?.ok_or_else(|| {
                 anyhow::anyhow!("validator had ID in validator_list but rate not found in JMT")
             })?;
 
-            let validator_state = self.overlay.validator_state(v).await?.ok_or_else(|| {
+            let validator_state = self.state.validator_state(v).await?.ok_or_else(|| {
                 anyhow::anyhow!("validator had ID in validator_list but state not found in JMT")
             })?;
             tracing::debug!(?validator, "processing validator rate updates");
@@ -147,16 +147,16 @@ impl Staking {
             };
 
             // update the delegation token supply in the JMT
-            self.overlay
+            self.state
                 .update_token_supply(&v.delegation_token().id(), delegation_delta)
                 .await?;
             // update the staking token supply in the JMT
-            self.overlay
+            self.state
                 .update_token_supply(&STAKING_TOKEN_ASSET_ID, staking_delta)
                 .await?;
 
             let delegation_token_supply = self
-                .overlay
+                .state
                 .token_supply(&v.delegation_token().id())
                 .await?
                 .expect("delegation token should be known");
@@ -168,10 +168,10 @@ impl Staking {
 
             // Update the status of the validator within the validator set
             // with the newly starting epoch's calculated voting rate and power.
-            self.overlay
+            self.state
                 .set_validator_rates(v, current_rate.clone(), next_rate.clone())
                 .await;
-            self.overlay.set_validator_power(v, voting_power).await?;
+            self.state.set_validator_power(v, voting_power).await?;
 
             // Only Active validators produce commission rewards
             // The validator *may* drop out of Active state during the next epoch,
@@ -214,9 +214,9 @@ impl Staking {
 
         // Set the pending reward notes on the JMT for the current block height
         // so they can be processed by the ShieldedPool.
-        self.overlay
+        self.state
             .set_commission_amounts(
-                self.overlay.get_block_height().await?,
+                self.state.get_block_height().await?,
                 CommissionAmounts {
                     notes: commission_amounts,
                 },
@@ -242,14 +242,14 @@ impl Staking {
         }
 
         let mut validator_power_list = Vec::new();
-        for v in self.overlay.validator_list().await?.iter() {
+        for v in self.state.validator_list().await?.iter() {
             let power = self
-                .overlay
+                .state
                 .validator_power(v)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("validator missing power"))?;
             let state = self
-                .overlay
+                .state
                 .validator_state(v)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("validator missing state"))?;
@@ -279,15 +279,15 @@ impl Staking {
                 // on voting power and the delegation pool has a nonzero balance (meaning non-zero voting power),
                 // then the validator should be moved to the Active state.
                 if top_validators.contains(&vp.identity_key) && vp.power > 0 {
-                    self.overlay
+                    self.state
                         .set_validator_state(&vp.identity_key, validator::State::Active)
                         .await;
                     // Start tracking the validator's uptime as it becomes active
                     let uptime = Uptime::new(
-                        self.overlay.get_block_height().await?,
-                        self.overlay.signed_blocks_window_len().await? as usize,
+                        self.state.get_block_height().await?,
+                        self.state.signed_blocks_window_len().await? as usize,
                     );
-                    self.overlay
+                    self.state
                         .set_validator_uptime(&vp.identity_key, uptime)
                         .await;
                 }
@@ -297,10 +297,8 @@ impl Staking {
                 if !top_validators.contains(&vp.identity_key) {
                     // Unbonding the validator means that it can no longer participate
                     // in consensus, so its voting power is set to 0.
-                    self.overlay
-                        .set_validator_power(&vp.identity_key, 0)
-                        .await?;
-                    self.overlay
+                    self.state.set_validator_power(&vp.identity_key, 0).await?;
+                    self.state
                         .set_validator_state(
                             &vp.identity_key,
                             validator::State::Unbonding {
@@ -315,7 +313,7 @@ impl Staking {
             // and the validator is still in Unbonding state
             if let validator::State::Unbonding { unbonding_epoch } = vp.state {
                 if unbonding_epoch <= epoch_to_end.index {
-                    self.overlay
+                    self.state
                         .set_validator_state(&vp.identity_key, validator::State::Inactive)
                         .await;
                 }
@@ -331,21 +329,21 @@ impl Staking {
         // This isn't strictly necessary because tendermint technically expects
         // an update, however it is useful for debugging.
         let mut updates = Vec::new();
-        for v in self.overlay.validator_list().await?.iter() {
+        for v in self.state.validator_list().await?.iter() {
             let validator_state = self
-                .overlay
+                .state
                 .validator_state(v)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("validator state missing"))?;
             let validator = self
-                .overlay
+                .state
                 .validator(v)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("validator missing"))?;
 
             // Only active validators report power to tendermint. Other states
             // report a 0 power.
-            if validator_state != State::Active {
+            if validator_state != validator::State::Active {
                 updates.push(ValidatorUpdate {
                     pub_key: validator.consensus_key.clone(),
                     power: 0u32.into(),
@@ -354,7 +352,7 @@ impl Staking {
             }
 
             let power = self
-                .overlay
+                .state
                 .validator_power(v)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("validator missing power"))?;
@@ -375,8 +373,8 @@ impl Staking {
         // Note: this probably isn't the correct height for the LastCommitInfo,
         // which is about the *last* commit, but at least it'll be consistent,
         // which is all we need to count signatures.
-        let height = self.overlay.get_block_height().await?;
-        let params = self.overlay.get_chain_params().await?;
+        let height = self.state.get_block_height().await?;
+        let params = self.state.get_chain_params().await?;
 
         // Build a mapping from addresses (20-byte truncated SHA256(pubkey)) to vote statuses.
         let did_address_vote = last_commit_info
@@ -387,9 +385,9 @@ impl Staking {
 
         // Since we don't have a lookup from "addresses" to identity keys,
         // iterate over our app's validators, and match them up with the vote data.
-        for v in self.overlay.validator_list().await?.iter() {
+        for v in self.state.validator_list().await?.iter() {
             let info = self
-                .overlay
+                .state
                 .validator_info(v)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("validator missing status"))?;
@@ -403,7 +401,7 @@ impl Staking {
 
                 let voted = did_address_vote.get(&addr).cloned().unwrap_or(false);
                 let mut uptime = self
-                    .overlay
+                    .state
                     .validator_uptime(v)
                     .await?
                     .ok_or_else(|| anyhow!("missing uptime for active validator {}", v))?;
@@ -419,11 +417,11 @@ impl Staking {
                 uptime.mark_height_as_signed(height, voted).unwrap();
                 if uptime.num_missed_blocks() as u64 >= params.missed_blocks_maximum {
                     tracing::info!(?v, "slashing for downtime");
-                    self.overlay
+                    self.state
                         .slash_validator(info.validator, params.slashing_penalty_downtime_bps)
                         .await?;
                 } else {
-                    self.overlay.set_validator_uptime(v, uptime).await;
+                    self.state.set_validator_uptime(v, uptime).await;
                 }
             }
         }
@@ -434,20 +432,20 @@ impl Staking {
 
 #[async_trait]
 impl Component for Staking {
-    #[instrument(name = "staking", skip(overlay))]
-    async fn new(overlay: Overlay) -> Self {
+    #[instrument(name = "staking", skip(state))]
+    async fn new(state: State) -> Self {
         Self {
-            overlay,
+            state,
             delegation_changes: Default::default(),
         }
     }
 
     #[instrument(name = "staking", skip(self, app_state))]
     async fn init_chain(&mut self, app_state: &genesis::AppState) {
-        let starting_height = self.overlay.get_block_height().await.unwrap();
+        let starting_height = self.state.get_block_height().await.unwrap();
         let starting_epoch = Epoch::from_height(
             starting_height,
-            self.overlay.get_epoch_duration().await.unwrap(),
+            self.state.get_epoch_duration().await.unwrap(),
         );
         let epoch_index = starting_epoch.index;
 
@@ -464,7 +462,7 @@ impl Component for Staking {
             base_reward_rate: 0,
             base_exchange_rate: 1_0000_0000,
         };
-        self.overlay
+        self.state
             .set_base_rates(cur_base_rate.clone(), next_base_rate)
             .await;
 
@@ -514,7 +512,7 @@ impl Component for Staking {
                 .unwrap_or(0);
             let power = cur_rate_data.voting_power(total_delegation_tokens, &cur_base_rate);
 
-            self.overlay
+            self.state
                 .add_validator(
                     validator.clone(),
                     cur_rate_data,
@@ -526,7 +524,7 @@ impl Component for Staking {
                 .await
                 .unwrap();
             // We also need to start tracking uptime of the genesis validators:
-            self.overlay
+            self.state
                 .set_validator_uptime(
                     &validator.identity_key,
                     Uptime::new(0, app_state.chain_params.signed_blocks_window_len as usize),
@@ -536,7 +534,7 @@ impl Component for Staking {
 
         // Finally, record that there were no delegations in this block, so the data
         // isn't missing when we process the first epoch transition.
-        self.overlay
+        self.state
             .set_delegation_changes(0u32.into(), Default::default())
             .await;
     }
@@ -546,7 +544,7 @@ impl Component for Staking {
         // For each validator identified as byzantine by tendermint, update its
         // state to be slashed.
         for evidence in begin_block.byzantine_validators.iter() {
-            self.overlay
+            self.state
                 .slash_validator_by_evidence(evidence)
                 .await
                 .unwrap();
@@ -619,7 +617,7 @@ impl Component for Staking {
         let mut delegation_changes = BTreeMap::new();
         for d in tx.delegations() {
             let next_rate_data = self
-                .overlay
+                .state
                 .next_validator_rate(&d.validator_identity)
                 .await?
                 .ok_or_else(|| {
@@ -639,7 +637,7 @@ impl Component for Staking {
 
             // Check whether the delegation is for a slashed validator
             let validator_state = self
-                .overlay
+                .state
                 .validator_state(&d.validator_identity)
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("missing state for validator"))?;
@@ -682,7 +680,7 @@ impl Component for Staking {
         }
         for u in tx.undelegations() {
             let rate_data = self
-                .overlay
+                .state
                 .next_validator_rate(&u.validator_identity)
                 .await?
                 .ok_or_else(|| {
@@ -736,7 +734,7 @@ impl Component for Staking {
 
         // Check that the sequence numbers of updated validators are correct.
         for v in tx.validator_definitions() {
-            let existing_v = self.overlay.validator(&v.validator.identity_key).await?;
+            let existing_v = self.state.validator(&v.validator.identity_key).await?;
 
             if let Some(existing_v) = existing_v {
                 // This is an existing validator definition. Ensure that the highest
@@ -778,11 +776,11 @@ impl Component for Staking {
 
         // The validator definitions have been completely verified, so we can add them to the JMT
         let definitions = tx.validator_definitions().map(|v| v.to_owned());
-        let cur_epoch = self.overlay.get_current_epoch().await.unwrap();
+        let cur_epoch = self.state.get_current_epoch().await.unwrap();
 
         for v in definitions {
             if self
-                .overlay
+                .state
                 .validator(&v.validator.identity_key)
                 .await
                 .unwrap()
@@ -790,7 +788,7 @@ impl Component for Staking {
             {
                 // This is an existing validator definition.
                 // This means that only the Validator struct itself needs updating, not any rates/power/state.
-                self.overlay.update_validator(v.validator).await.unwrap();
+                self.state.update_validator(v.validator).await.unwrap();
             } else {
                 // This is a new validator definition.
                 // Set the default rates and state.
@@ -812,7 +810,7 @@ impl Component for Staking {
                     validator_exchange_rate: 1_0000_0000, // 1 represented as 1e8
                 };
 
-                self.overlay
+                self.state
                     .add_validator(
                         v.validator.clone(),
                         cur_rate_data,
@@ -831,7 +829,7 @@ impl Component for Staking {
     #[instrument(name = "staking", skip(self, end_block))]
     async fn end_block(&mut self, end_block: &abci::request::EndBlock) {
         // Write the delegation changes for this block.
-        self.overlay
+        self.state
             .set_delegation_changes(
                 end_block.height.try_into().unwrap(),
                 std::mem::take(&mut self.delegation_changes),
@@ -839,8 +837,8 @@ impl Component for Staking {
             .await;
 
         // If this is an epoch boundary, updated rates need to be calculated and set.
-        let cur_epoch = self.overlay.get_current_epoch().await.unwrap();
-        let cur_height = self.overlay.get_block_height().await.unwrap();
+        let cur_epoch = self.state.get_current_epoch().await.unwrap();
+        let cur_height = self.state.get_block_height().await.unwrap();
 
         if cur_epoch.is_epoch_end(cur_height) {
             self.end_epoch(cur_epoch).await.unwrap();
@@ -852,7 +850,7 @@ impl Component for Staking {
 ///
 /// TODO: should this be split into Read and Write traits?
 #[async_trait]
-pub trait View: OverlayExt {
+pub trait View: StateExt {
     async fn current_base_rate(&self) -> Result<BaseRateData> {
         self.get_domain("staking/base_rate/current".into())
             .await
@@ -1179,4 +1177,4 @@ pub trait View: OverlayExt {
     }
 }
 
-impl<T: OverlayExt + Send + Sync> View for T {}
+impl<T: StateExt + Send + Sync> View for T {}

--- a/pd/src/consensus/worker.rs
+++ b/pd/src/consensus/worker.rs
@@ -29,7 +29,7 @@ impl Worker {
         queue: mpsc::Receiver<Message>,
         height_tx: watch::Sender<block::Height>,
     ) -> Result<Self> {
-        let app = App::new(storage.overlay().await?).await;
+        let app = App::new(storage.state().await?).await;
 
         Ok(Self {
             queue,

--- a/pd/src/info.rs
+++ b/pd/src/info.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use futures::FutureExt;
-use penumbra_storage::{Overlay, Storage};
+use penumbra_storage::{State, Storage};
 use tendermint::abci::{self, response::Echo, InfoRequest, InfoResponse};
 use tower_abci::BoxError;
 use tracing::Instrument;
@@ -27,8 +27,8 @@ impl Info {
         Self { storage }
     }
 
-    async fn overlay_tonic(&self) -> Result<Overlay, tonic::Status> {
-        self.storage.overlay_tonic().await
+    async fn state_tonic(&self) -> Result<State, tonic::Status> {
+        self.storage.state_tonic().await
     }
 
     async fn info(&self, info: abci::request::Info) -> Result<abci::response::Info, anyhow::Error> {

--- a/pd/src/info/specific.rs
+++ b/pd/src/info/specific.rs
@@ -24,12 +24,12 @@ impl SpecificQuery for Info {
         &self,
         request: tonic::Request<NoteCommitment>,
     ) -> Result<tonic::Response<NoteSource>, Status> {
-        let overlay = self.overlay_tonic().await?;
+        let state = self.state_tonic().await?;
         let cm = request
             .into_inner()
             .try_into()
             .map_err(|_| Status::invalid_argument("invalid commitment"))?;
-        let source = overlay
+        let source = state
             .note_source(&cm)
             .await
             .map_err(|_| Status::unavailable("database error"))?
@@ -44,8 +44,8 @@ impl SpecificQuery for Info {
         &self,
         request: tonic::Request<ValidatorStatusRequest>,
     ) -> Result<tonic::Response<proto::stake::ValidatorStatus>, Status> {
-        let overlay = self.overlay_tonic().await?;
-        overlay.check_chain_id(&request.get_ref().chain_id).await?;
+        let state = self.state_tonic().await?;
+        state.check_chain_id(&request.get_ref().chain_id).await?;
 
         let id = request
             .into_inner()
@@ -54,7 +54,7 @@ impl SpecificQuery for Info {
             .try_into()
             .map_err(|_| Status::invalid_argument("invalid identity key"))?;
 
-        let status = overlay
+        let status = state
             .validator_status(&id)
             .await
             .map_err(|_| Status::unavailable("database error"))?
@@ -68,13 +68,13 @@ impl SpecificQuery for Info {
         &self,
         request: tonic::Request<proto::stake::IdentityKey>,
     ) -> Result<tonic::Response<proto::stake::RateData>, Status> {
-        let overlay = self.overlay_tonic().await?;
+        let state = self.state_tonic().await?;
         let identity_key = request
             .into_inner()
             .try_into()
             .map_err(|_| tonic::Status::invalid_argument("invalid identity key"))?;
 
-        let rate_data = overlay
+        let rate_data = state
             .next_validator_rate(&identity_key)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?

--- a/pd/src/mempool/worker.rs
+++ b/pd/src/mempool/worker.rs
@@ -25,7 +25,7 @@ impl Worker {
         queue: mpsc::Receiver<Message>,
         height_rx: watch::Receiver<block::Height>,
     ) -> Result<Self> {
-        let app = App::new(storage.overlay().await?).await;
+        let app = App::new(storage.state().await?).await;
 
         Ok(Self {
             queue,
@@ -59,7 +59,7 @@ impl Worker {
                     if let Ok(()) = change {
                         let height = self.height_rx.borrow().value();
                         tracing::info!(?height, "resetting ephemeral mempool state");
-                        self.app = App::new(self.storage.overlay().await?).await;
+                        self.app = App::new(self.storage.state().await?).await;
                     } else {
                         tracing::info!("consensus worker shut down, shutting down mempool worker");
                         // The consensus worker shut down, we should too.

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -6,7 +6,7 @@ use tokio::sync::Mutex;
 mod overlay_ext;
 mod storage;
 
-pub use overlay_ext::OverlayExt;
+pub use overlay_ext::StateExt;
 pub use storage::Storage;
 
-pub type Overlay = Arc<Mutex<WriteOverlay<Storage>>>;
+pub type State = Arc<Mutex<WriteOverlay<Storage>>>;


### PR DESCRIPTION
This is a better word, because instead of giving an implementation detail
("it's an overlay over the persistent storage"), it gives the semantics: "it's
an instance of the application state".

(There should be additional documentation, but this commit just does the name change).

This was on the way to #709, but I split it out since there's a potential complication on that effort in re: transaction structuring, and it's better to not risk a delay in merging broad-touching refactoring.