### PR TITLE
pd: unify gRPC services

### DIFF
--- a/docker-compose.multinode.override.yml
+++ b/docker-compose.multinode.override.yml
@@ -37,8 +37,7 @@ services:
         ipv4_address: 192.167.10.20
     ports:
       - "27658:26658"
-      - "27666:26666"
-      - "27667:26667"
+      - "8080:8080"
 
   # The Tendermint node
   tendermint-node1:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,7 @@ services:
         ipv4_address: 192.167.10.10
     ports:
       - "26658:26658"
-      - "26666:26666"
-      - "26667:26667"
+      - "8080:8080"
 
   # The Tendermint node
   tendermint-node0:

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -26,15 +26,12 @@ pub struct Opt {
     /// The address of the pd+tendermint node.
     #[structopt(short, long, default_value = "testnet.penumbra.zone")]
     pub node: String,
-    /// The port to use to speak to tendermint.
-    #[structopt(short, long, default_value = "26657")]
-    pub rpc_port: u16,
-    /// The port to use to speak to pd's light wallet server.
-    #[structopt(short, long, default_value = "26666")]
-    pub oblivious_query_port: u16,
-    /// The port to use to speak to pd's thin wallet server.
-    #[structopt(short, long, default_value = "26667")]
-    pub specific_query_port: u16,
+    /// The port to use to speak to tendermint's RPC server.
+    #[structopt(long, default_value = "26657")]
+    pub tendermint_port: u16,
+    /// The port to use to speak to pd's gRPC server.
+    #[structopt(long, default_value = "8080")]
+    pub pd_port: u16,
     #[structopt(subcommand)]
     pub cmd: Command,
     /// The location of the wallet file [default: platform appdata directory]

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -22,7 +22,7 @@ impl Opt {
         let client = reqwest::Client::new();
         let req_id: u8 = rand::thread_rng().gen();
         let rsp: serde_json::Value = client
-            .post(format!(r#"http://{}:{}"#, self.node, self.rpc_port))
+            .post(format!(r#"http://{}:{}"#, self.node, self.tendermint_port))
             .json(&serde_json::json!(
                 {
                     "method": "broadcast_tx_sync",
@@ -74,7 +74,7 @@ impl Opt {
         let client = reqwest::Client::new();
         let req_id: u8 = rand::thread_rng().gen();
         let rsp: serde_json::Value = client
-            .post(format!(r#"http://{}:{}"#, self.node, self.rpc_port))
+            .post(format!(r#"http://{}:{}"#, self.node, self.tendermint_port))
             .json(&serde_json::json!(
                 {
                     "method": "broadcast_tx_async",
@@ -93,17 +93,14 @@ impl Opt {
     }
 
     pub async fn specific_client(&self) -> Result<SpecificQueryClient<Channel>, anyhow::Error> {
-        SpecificQueryClient::connect(format!("http://{}:{}", self.node, self.specific_query_port))
+        SpecificQueryClient::connect(format!("http://{}:{}", self.node, self.pd_port))
             .await
             .map_err(Into::into)
     }
 
     pub async fn oblivious_client(&self) -> Result<ObliviousQueryClient<Channel>, anyhow::Error> {
-        ObliviousQueryClient::connect(format!(
-            "http://{}:{}",
-            self.node, self.oblivious_query_port
-        ))
-        .await
-        .map_err(Into::into)
+        ObliviousQueryClient::connect(format!("http://{}:{}", self.node, self.pd_port))
+            .await
+            .map_err(Into::into)
     }
 }


### PR DESCRIPTION
We currently have two different client RPC endpoints in `pd` for no real
reason, other than that I don't think I realized that it was possible to have
multiple gRPC services on one endpoint when I wrote the original skeleton code,
and then we just copied that structure forward.

This commit unifies them onto a single service on port 8080.