### PR TITLE
update to upstream tendermint 0.24.0-pre.1

### DIFF
--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -39,11 +39,8 @@ jobs:
           # - published crates are excluded
           # Doing this in one go is useful because the JSON file with search
           # indexes is overwritten on each cargo doc invocation.
-          # (The version specifier for tendermint avoids ambiguity from multiple
-          # package versions but will break in the future).
-          # NOTE: make sure we're rendering the version of the tendermint crate that has ABCI support (?? this is a mess)
           cargo doc --no-deps \
-            -p tendermint:0.23.0 \
+            -p tendermint \
             -p tower-abci \
             -p incrementalmerkletree \
             -p jmt \

--- a/component/Cargo.toml
+++ b/component/Cargo.toml
@@ -10,5 +10,5 @@ penumbra-storage = { path = "../storage" }
 penumbra-transaction = { path = "../transaction" }
 penumbra-chain = { path = "../chain" }
 async-trait = "0.1.52"
-tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "master" }
+tendermint = "0.24.0-pre.1"
 anyhow = "1"

--- a/ibc/Cargo.toml
+++ b/ibc/Cargo.toml
@@ -9,15 +9,14 @@ edition = "2021"
 # Workspace dependencies
 penumbra-crypto = { path = "../crypto" }
 penumbra-proto = { path = "../proto" } 
-tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "master" }
+tendermint = "0.24.0-pre.1"
 
 # External dependencies
-#ibc-proto = { path = "../../ibc-rs/proto" }
 prost-types = "0.9"
-tendermint-proto = "0.23.5"
-ibc-proto = "0.17.0"
+tendermint-proto = "0.24.0-pre.1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 anyhow = "1"
 async-trait = "0.1.52"
-ibc = "0.13.0"
+ibc = { git = "https://github.com/penumbra-zone/ibc-rs.git", branch = "with-tendermintrs-24" }
+ibc-proto = { git = "https://github.com/penumbra-zone/ibc-rs.git", branch = "with-tendermintrs-24" }

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -22,10 +22,10 @@ penumbra-wallet = { path = "../wallet" }
 
 # Penumbra dependencies
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
-tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "master" }
+tendermint = "0.24.0-pre.1"
 # External dependencies
 ark-ff = "0.3"
-ed25519-consensus = "2"
+ed25519-consensus = "1.2" # 1.2 required because tendermint 0.24.0-pre.1 uses it
 futures = "0.3"
 async-stream = "0.2"
 bincode = "1.3.3"

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -24,14 +24,14 @@ penumbra-component = { path = "../component" }
 
 # Penumbra dependencies
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
-tower-abci = { git = "https://github.com/penumbra-zone/tower-abci/" }
-tendermint-config = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "master" }
-tendermint-proto = "0.23.5" 
-tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "master" }
+tower-abci = { git = "https://github.com/penumbra-zone/tower-abci/", branch =  "with-tendermintrs-24" }
 jmt = { git = "https://github.com/penumbra-zone/jellyfish-merkle.git", branch = "main" }
 
 
 # External dependencies
+tendermint-config = "0.24.0-pre.1"
+tendermint-proto = "0.24.0-pre.1"
+tendermint = "0.24.0-pre.1"
 ark-ff = "0.3"
 evmap = "10"
 async-stream = "0.2"
@@ -65,14 +65,13 @@ rand_core = { version = "0.6.3", features = ["getrandom"] }
 metrics = "0.18.0"
 metrics-exporter-prometheus = { version = "0.8.0", features = ["http-listener"] }
 http = "0.2"
-ed25519-consensus = "2"
+ed25519-consensus = "1.2"
 async-trait = "0.1.52"
 once_cell = "1.7.2"
 rocksdb = "0.18.0"
-#ibc = { path = "../../ibc-rs/modules" }
-ibc = "0.13.0"
-ibc-proto = "0.17.0"
-tendermint-light-client-verifier = "0.23.5"
+ibc = { git = "https://github.com/penumbra-zone/ibc-rs.git", branch = "with-tendermintrs-24" }
+ibc-proto = { git = "https://github.com/penumbra-zone/ibc-rs.git", branch = "with-tendermintrs-24" }
+tendermint-light-client-verifier = "0.24.0-pre.1"
 tempfile = "3.3.0"
 base64 = "0.13.0"
 console-subscriber = "0.1.4"

--- a/pd/src/components/ibc/connection.rs
+++ b/pd/src/components/ibc/connection.rs
@@ -77,7 +77,11 @@ fn validate_ibc_action_stateless(ibc_action: &IbcAction) -> Result<(), anyhow::E
             // TODO: should we be storing the compatible versions in our state instead?
             let compatible_versions = vec![Version::default()];
 
-            if !compatible_versions.contains(&msg_connection_open_init.version) {
+            if !compatible_versions.contains(
+                &msg_connection_open_init
+                    .version
+                    .ok_or_else(|| anyhow::anyhow!("invalid version"))?,
+            ) {
                 return Err(anyhow::anyhow!(
                     "unsupported version: in ConnectionOpenInit",
                 ));

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -14,12 +14,12 @@ hex = "0.4"
 anyhow = "1.0"
 subtle-encoding = "0.5"
 bech32 = "0.8"
-ibc-proto = "0.17.0"
+ibc-proto = { git = "https://github.com/penumbra-zone/ibc-rs.git", branch = "with-tendermintrs-24" }
 prost-types = "0.9"
 
 [build-dependencies]
 prost = "0.9"
 prost-types = "0.9"
 prost-build = "0.9"
-ibc-proto = "0.17.0"
+ibc-proto = { git = "https://github.com/penumbra-zone/ibc-rs.git", branch = "with-tendermintrs-24" }
 tonic-build = "0.6"

--- a/stake/Cargo.toml
+++ b/stake/Cargo.toml
@@ -18,7 +18,7 @@ penumbra-proto = { path = "../proto" }
 penumbra-transaction = { path = "../transaction" }
 
 # Penumbra dependencies
-tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs.git", branch = "master" }
+tendermint = "0.24.0-pre.1"
 # External dependencies
 anyhow = "1"
 serde_json = "1"


### PR DESCRIPTION
this PR unifies the version of tendermint-rs that we are using to `0.24.0-pre.1`, across ibc-rs and the main penumbra crates.