### PR TITLE
storage: replace State Mutex with RwLock

### DIFF
--- a/pd/src/components/app.rs
+++ b/pd/src/components/app.rs
@@ -35,7 +35,7 @@ impl App {
     #[instrument(skip(self, storage))]
     pub async fn commit(&mut self, storage: Storage) -> Result<(RootHash, Version)> {
         // Commit the pending writes, clearing the state.
-        let (root_hash, version) = self.state.lock().await.commit(storage).await?;
+        let (root_hash, version) = self.state.write().await.commit(storage).await?;
         tracing::debug!(?root_hash, version, "finished committing state");
         // Now re-instantiate all of the components:
         self.staking = Staking::new(self.state.clone()).await;

--- a/pd/src/components/shielded_pool.rs
+++ b/pd/src/components/shielded_pool.rs
@@ -362,7 +362,7 @@ impl ShieldedPool {
     async fn put_nct(&mut self) -> Result<()> {
         let nct_data = bincode::serialize(&self.note_commitment_tree)?;
         self.state
-            .lock()
+            .write()
             .await
             .put(b"shielded_pool/nct_data".into(), nct_data);
         Ok(())
@@ -374,7 +374,7 @@ impl ShieldedPool {
     /// State on an empty database.
     async fn get_nct(state: &State) -> Result<NoteCommitmentTree> {
         if let Ok(Some(bytes)) = state
-            .lock()
+            .read()
             .await
             .get(b"shielded_pool/nct_data".into())
             .await

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use jmt::WriteOverlay;
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 
 mod overlay_ext;
 mod storage;
@@ -9,4 +9,4 @@ mod storage;
 pub use overlay_ext::StateExt;
 pub use storage::Storage;
 
-pub type State = Arc<Mutex<WriteOverlay<Storage>>>;
+pub type State = Arc<RwLock<WriteOverlay<Storage>>>;

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -7,7 +7,7 @@ use jmt::{
     WriteOverlay,
 };
 use rocksdb::DB;
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 use tracing::{instrument, Span};
 
 use crate::State;
@@ -49,7 +49,7 @@ impl Storage {
             .unwrap_or(WriteOverlay::<Storage>::PRE_GENESIS_VERSION);
 
         tracing::debug!("creating state for version {}", version);
-        Ok(Arc::new(Mutex::new(WriteOverlay::new(
+        Ok(Arc::new(RwLock::new(WriteOverlay::new(
             self.clone(),
             version,
         ))))


### PR DESCRIPTION
This commit changes the `State` typedef to use an `RwLock` instead of a
`Mutex`.  This allows concurrent read access to a shared `State`, which means
(because of the split between validation and execution in the `Component`
trait) that we can execute the `check_tx_stateful` methods of every `Component`
concurrently, even in the serial `consensus::Worker`.