### PR TITLE
ibc: implement connection open ack and connectionOpenConfirm handling

### DIFF
--- a/pd/src/components/ibc/connection.rs
+++ b/pd/src/components/ibc/connection.rs
@@ -406,6 +406,16 @@ impl ConnectionComponent {
             ));
         }
 
+        // verify the provided client state
+        let provided_cs = msg
+            .client_state
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("client state not provided in MsgConnectionOpenTry"))?;
+
+        let height = self.state.get_block_height().await?;
+        let chain_id = self.state.get_chain_id().await?;
+        validate_penumbra_client_state(provided_cs, &chain_id, height)?;
+
         let connection = self
             .state
             .get_connection(&msg.connection_id)
@@ -442,7 +452,7 @@ impl ConnectionComponent {
             connection.client_id(),
             msg.proofs.clone(),
             msg.client_state.as_ref().ok_or_else(|| {
-                anyhow::anyhow!("client state not provided in MsgConnectionOpenTry")
+                anyhow::anyhow!("client state not provided in MsgConnectionOpenAck")
             })?,
             counterparty
                 .connection_id()

--- a/pd/src/components/ibc/connection.rs
+++ b/pd/src/components/ibc/connection.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use ibc::core::ics02_client::client_consensus::ConsensusState;
 use ibc::core::ics02_client::client_def::AnyClient;
 use ibc::core::ics02_client::client_def::ClientDef;
+use ibc::core::ics02_client::client_state::AnyClientState;
 use ibc::core::ics02_client::client_state::ClientState;
 use ibc::core::ics03_connection::connection::Counterparty;
 use ibc::core::ics03_connection::connection::{ConnectionEnd, State as ConnectionState};
@@ -12,7 +13,9 @@ use ibc::core::ics03_connection::msgs::conn_open_confirm::MsgConnectionOpenConfi
 use ibc::core::ics03_connection::msgs::conn_open_init::MsgConnectionOpenInit;
 use ibc::core::ics03_connection::msgs::conn_open_try::MsgConnectionOpenTry;
 use ibc::core::ics03_connection::version::{pick_version, Version};
+use ibc::core::ics24_host::identifier::ClientId;
 use ibc::core::ics24_host::identifier::ConnectionId;
+use ibc::proofs::Proofs;
 use ibc::Height as IBCHeight;
 use penumbra_chain::genesis;
 use penumbra_component::Component;
@@ -193,6 +196,84 @@ impl ConnectionComponent {
             .unwrap();
     }
 
+    async fn verify_connection_proofs(
+        &self,
+        client_id: &ClientId,
+        msg_proofs: Proofs,
+        msg_client_state: &AnyClientState,
+        counterparty_connection_id: &ConnectionId,
+        counterparty: Counterparty,
+        expected_conn: ConnectionEnd,
+    ) -> Result<()> {
+        // get the stored client state for the counterparty
+        let stored_client_state = self.state.get_client_data(client_id).await?.client_state.0;
+
+        // check if the client is frozen
+        // TODO: should we also check if the client is expired here?
+        if stored_client_state.is_frozen() {
+            return Err(anyhow::anyhow!("client is frozen"));
+        }
+
+        // get the stored consensus state for the counterparty
+        let stored_consensus_state = self
+            .state
+            .get_verified_consensus_state(msg_proofs.height(), client_id.clone())
+            .await?
+            .0;
+
+        let client_def = AnyClient::from_client_type(stored_client_state.client_type());
+
+        // PROOF VERIFICATION
+        // 1. verify that the counterparty chain committed the expected_conn to its state
+        client_def.verify_connection_state(
+            &stored_client_state,
+            msg_proofs.height(),
+            counterparty.prefix(),
+            msg_proofs.object_proof(),
+            stored_consensus_state.root(),
+            &counterparty_connection_id,
+            &expected_conn,
+        )?;
+
+        // 2. verify that the counterparty chain committed the correct ClientState (that was
+        //    provided in the msg)
+        client_def.verify_client_full_state(
+            &stored_client_state,
+            msg_proofs.height(),
+            counterparty.prefix(),
+            msg_proofs.client_proof().as_ref().ok_or_else(|| {
+                anyhow::anyhow!("client proof not provided in the connectionOpenTry")
+            })?,
+            stored_consensus_state.root(),
+            counterparty.client_id(),
+            msg_client_state,
+        )?;
+
+        let cons_proof = msg_proofs.consensus_proof().ok_or_else(|| {
+            anyhow::anyhow!("consensus proof not provided in the connectionOpenTry")
+        })?;
+        let expected_consensus = self
+            .state
+            .get_penumbra_consensus_state(cons_proof.height())
+            .await?
+            .0;
+
+        // 3. verify that the counterparty chain stored the correct consensus state of Penumbra at
+        //    the given consensus height
+        client_def.verify_client_consensus_state(
+            &stored_client_state,
+            msg_proofs.height(),
+            counterparty.prefix(),
+            cons_proof.proof(),
+            stored_consensus_state.root(),
+            counterparty.client_id(),
+            cons_proof.height(),
+            &expected_consensus,
+        )?;
+
+        Ok(())
+    }
+
     async fn validate_connection_open_try(
         &self,
         msg: &MsgConnectionOpenTry,
@@ -264,27 +345,6 @@ impl ConnectionComponent {
         }
         pick_version(supported_versions, msg.counterparty_versions.clone())?;
 
-        // get the stored client state for the counterparty
-        let stored_client_state = self
-            .state
-            .get_client_data(&msg.client_id)
-            .await?
-            .client_state
-            .0;
-
-        // check if the client is frozen
-        // TODO: should we also check if the client is expired here?
-        if stored_client_state.is_frozen() {
-            return Err(anyhow::anyhow!("client is frozen"));
-        }
-
-        // get the stored consensus state for the counterparty
-        let stored_consensus_state = self
-            .state
-            .get_verified_consensus_state(msg.proofs.height(), msg.client_id.clone())
-            .await?
-            .0;
-
         // get the connection ID of the counterparty
         let counterparty_connection_id = msg
             .counterparty
@@ -292,57 +352,81 @@ impl ConnectionComponent {
             .clone()
             .ok_or_else(|| anyhow::anyhow!("connection id for counterparty not provided"))?;
 
-        let client_def = AnyClient::from_client_type(stored_client_state.client_type());
-
         // PROOF VERIFICATION
-        // 1. verify that the counterparty chain committed the expected_conn to its state
-        client_def.verify_connection_state(
-            &stored_client_state,
-            msg.proofs.height(),
-            msg.counterparty.prefix(),
-            msg.proofs.object_proof(),
-            stored_consensus_state.root(),
+        self.verify_connection_proofs(
+            &msg.client_id,
+            msg.proofs.clone(),
+            msg.client_state.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("client state not provided in MsgConnectionOpenTry")
+            })?,
             &counterparty_connection_id,
-            &expected_conn,
-        )?;
+            msg.counterparty.clone(),
+            expected_conn,
+        )
+        .await?;
 
-        // 2. verify that the counterparty chain committed the correct ClientState (that was
-        //    provided in the msg)
-        client_def.verify_client_full_state(
-            &stored_client_state,
-            msg.proofs.height(),
-            msg.counterparty.prefix(),
-            msg.proofs.client_proof().as_ref().ok_or_else(|| {
-                anyhow::anyhow!("client proof not provided in the connectionOpenTry")
-            })?,
-            stored_consensus_state.root(),
-            msg.counterparty.client_id(),
-            &msg.client_state.clone().ok_or_else(|| {
-                anyhow::anyhow!("client state not provided in the connectionOpenTry")
-            })?,
-        )?;
+        Ok(())
+    }
 
-        let cons_proof = msg.proofs.consensus_proof().ok_or_else(|| {
-            anyhow::anyhow!("consensus proof not provided in the connectionOpenTry")
-        })?;
-        let expected_consensus = self
+    async fn validate_connection_open_ack(
+        &self,
+        msg: &MsgConnectionOpenAck,
+    ) -> Result<(), anyhow::Error> {
+        // verify the consensus height is correct
+        if msg.consensus_height()
+            > IBCHeight::zero().with_revision_height(self.state.get_block_height().await?)
+        {
+            return Err(anyhow::anyhow!(
+                "consensus height is greater than the current block height",
+            ));
+        }
+
+        let connection = self
             .state
-            .get_penumbra_consensus_state(cons_proof.height())
+            .get_connection(&msg.connection_id)
             .await?
+            .ok_or_else(|| anyhow::anyhow!("no connection with the given ID"))?
             .0;
 
-        // 3. verify that the counterparty chain stored the correct consensus state of Penumbra at
-        //    the given consensus height
-        client_def.verify_client_consensus_state(
-            &stored_client_state,
-            msg.proofs.height(),
-            msg.counterparty.prefix(),
-            cons_proof.proof(),
-            stored_consensus_state.root(),
-            msg.counterparty.client_id(),
-            cons_proof.height(),
-            &expected_consensus,
-        )?;
+        let state_is_consistent = connection.state_matches(&ConnectionState::Init)
+            && connection.versions().contains(&msg.version)
+            || connection.state_matches(&ConnectionState::TryOpen)
+                && connection.versions().get(0).eq(&Some(&msg.version));
+
+        if !state_is_consistent {
+            return Err(anyhow::anyhow!("connection is not in the correct state"));
+        }
+
+        // set the connection id of the counterparty
+        let prev_counterparty = connection.counterparty();
+        let counterparty = Counterparty::new(
+            prev_counterparty.client_id().clone(),
+            Some(msg.connection_id.clone()),
+            prev_counterparty.prefix().clone(),
+        );
+
+        let expected_conn = ConnectionEnd::new(
+            ConnectionState::TryOpen,
+            counterparty.client_id().clone(),
+            counterparty.clone(),
+            vec![msg.version.clone()],
+            connection.delay_period(),
+        );
+
+        // PROOF VERIFICATION
+        self.verify_connection_proofs(
+            connection.client_id(),
+            msg.proofs.clone(),
+            msg.client_state.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("client state not provided in MsgConnectionOpenTry")
+            })?,
+            counterparty
+                .connection_id()
+                .ok_or_else(|| anyhow::anyhow!("connection id for counterparty not provided"))?,
+            counterparty.clone(),
+            expected_conn,
+        )
+        .await?;
 
         Ok(())
     }
@@ -362,8 +446,9 @@ impl ConnectionComponent {
                 self.validate_connection_open_try(&msg).await?;
             }
 
-            Some(ConnectionOpenAck(msg)) => {
-                let _msg_connection_open_ack = MsgConnectionOpenAck::try_from(msg.clone())?;
+            Some(ConnectionOpenAck(raw_msg)) => {
+                let msg = MsgConnectionOpenAck::try_from(raw_msg.clone())?;
+                self.validate_connection_open_ack(&msg).await?;
             }
 
             Some(ConnectionOpenConfirm(msg)) => {


### PR DESCRIPTION
this implements the connectionOpenAck and connectionOpenConfirm phase of the IBC connection handshake. This should complete the connection handshake work, though it is still untested

closes #641