### PR TITLE
wallet-next: scaffold the wallet server state machine

### DIFF
--- a/proto/proto/wallet.proto
+++ b/proto/proto/wallet.proto
@@ -15,10 +15,10 @@ import "crypto.proto";
 // data).  (TODO: refine this)
 service WalletProtocol {
     // Get current status of chain sync
-    rpc Status(crypto.FullViewingKeyHash) returns (StatusResult);
+    rpc Status(StatusRequest) returns (StatusResponse);
 
     // Queries for notes.
-    rpc Notes(NoteRequest) returns (stream NoteRecord);
+    rpc Notes(NotesRequest) returns (stream NoteRecord);
 
     // Returns authentication paths for the given note commitments.
     //
@@ -29,8 +29,14 @@ service WalletProtocol {
     rpc AuthPaths(AuthPathsRequest) returns (AuthPathsResponse);
 }
 
+// Requests sync status of the wallet service.
+message StatusRequest {
+    // Identifies the FVK for the notes to query.
+    crypto.FullViewingKeyHash fvk_hash = 1;
+}
+
 // Returns the status of the wallet server and whether it is synchronized with the chain state.
-message StatusResult {
+message StatusResponse {
     /// Whether the wallet service is synchronized with the chain state.
     bool synchronized = 1;
     // The height reported by the full node
@@ -59,7 +65,7 @@ message NoteRecord {
 //
 // This message uses the fact that all proto fields are optional
 // to allow various filtering on the returned notes.
-message NoteRequest {
+message NotesRequest {
     // Identifies the FVK for the notes to query.
     crypto.FullViewingKeyHash fvk_hash = 1;
 

--- a/wallet-next/Cargo.toml
+++ b/wallet-next/Cargo.toml
@@ -35,6 +35,7 @@ tonic = "0.6.1"
 bincode = "1.3.3"
 bytes = { version = "1", features = ["serde"] }
 prost = "0.9"
+futures = "0.3"
 
 [build-dependencies]
 anyhow = "1"

--- a/wallet-next/src/lib.rs
+++ b/wallet-next/src/lib.rs
@@ -1,6 +1,11 @@
 mod note_record;
+mod service;
 mod storage;
 mod sync;
+mod worker;
+
+use worker::Worker;
 
 pub use note_record::NoteRecord;
+pub use service::WalletService;
 pub use storage::Storage;

--- a/wallet-next/src/service.rs
+++ b/wallet-next/src/service.rs
@@ -1,0 +1,90 @@
+use std::pin::Pin;
+
+use penumbra_proto::{
+    crypto as pbc,
+    wallet::{self as pb, wallet_protocol_server::WalletProtocol},
+};
+use tonic::async_trait;
+
+use crate::{Storage, Worker};
+
+/// A service that synchronizes private chain state and responds to queries
+/// about it.
+///
+/// The [`WalletService`] implements the Tonic-derived [`WalletProtocol`] trait,
+/// so it can be used as a gRPC server, or called directly.  It spawns a task
+/// internally that performs synchronization and scanning.  The
+/// [`WalletService`] can be cloned; each clone will read from the same shared
+/// state, but there will only be a single scanning task.
+#[derive(Clone)]
+pub struct WalletService {
+    storage: Storage,
+    // TODO: add a way for the WalletService to poll the state of its worker task, to determine if it failed
+    // this probably looks like a handle for the task, wrapped in an arc'd mutex or something
+    // error_slot: Arc<Mutex<Option<anyhow::Error>>>,
+    // TODO: add a way for the WalletService to signal the worker that it should shut down
+    // this probably looks like an Arc<oneshot::Sender<()>> or something,
+    // where the receiver is held by the worker and the worker checks if it's closed (=> all sender handles dropped)
+}
+
+impl WalletService {
+    /// Constructs a new [`WalletService`], spawning a sync task internally.
+    ///
+    /// To create multiple [`WalletService`]s, clone the [`WalletService`] returned
+    /// by this method, rather than calling it multiple times.  That way, each clone
+    /// will be backed by the same scanning task, rather than each spawning its own.
+    pub fn new(storage: Storage) -> Self {
+        let worker = Worker::new(storage.clone());
+        tokio::spawn(worker.run());
+
+        Self { storage }
+    }
+
+    async fn check_fvk(&self, fvk: Option<&pbc::FullViewingKeyHash>) -> Result<(), tonic::Status> {
+        // TODO: check the fvk against the Storage
+        // Takes an Option to avoid making the caller handle missing fields,
+        // should error on None or wrong FVK hash
+        Ok(())
+    }
+
+    async fn check_worker(&self) -> Result<(), tonic::Status> {
+        // TODO: check whether the worker is still alive, else fail, when we have a way to do that
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl WalletProtocol for WalletService {
+    type NotesStream =
+        Pin<Box<dyn futures::Stream<Item = Result<pb::NoteRecord, tonic::Status>> + Send>>;
+
+    async fn status(
+        &self,
+        request: tonic::Request<pb::StatusRequest>,
+    ) -> Result<tonic::Response<pb::StatusResponse>, tonic::Status> {
+        self.check_worker().await?;
+        self.check_fvk(request.get_ref().fvk_hash.as_ref()).await?;
+
+        todo!()
+    }
+
+    async fn notes(
+        &self,
+        request: tonic::Request<pb::NotesRequest>,
+    ) -> Result<tonic::Response<Self::NotesStream>, tonic::Status> {
+        self.check_worker().await?;
+        self.check_fvk(request.get_ref().fvk_hash.as_ref()).await?;
+
+        todo!()
+    }
+
+    async fn auth_paths(
+        &self,
+        request: tonic::Request<pb::AuthPathsRequest>,
+    ) -> Result<tonic::Response<pb::AuthPathsResponse>, tonic::Status> {
+        self.check_worker().await?;
+        self.check_fvk(request.get_ref().fvk_hash.as_ref()).await?;
+
+        todo!()
+    }
+}

--- a/wallet-next/src/storage.rs
+++ b/wallet-next/src/storage.rs
@@ -3,8 +3,9 @@ use penumbra_crypto::merkle::NoteCommitmentTree;
 use penumbra_proto::{crypto::FullViewingKey, Message, Protobuf};
 use sqlx::{query, Pool, Sqlite};
 
+#[derive(Clone)]
 pub struct Storage {
-    pub(super) pool: Pool<Sqlite>,
+    pool: Pool<Sqlite>,
 }
 
 impl Storage {
@@ -31,6 +32,7 @@ impl Storage {
 
         Ok(result[0].height.map(|h| h as u64))
     }
+
     pub async fn chain_params(&self) -> anyhow::Result<ChainParams> {
         let result = query!(
             r#"
@@ -44,6 +46,7 @@ impl Storage {
 
         ChainParams::decode(result[0].bytes.as_ref().unwrap().as_slice())
     }
+
     pub async fn full_viewing_key(&self) -> anyhow::Result<FullViewingKey> {
         let result = query!(
             r#"
@@ -59,6 +62,7 @@ impl Storage {
             result[0].bytes.as_ref().unwrap().as_slice(),
         )?)
     }
+
     pub async fn note_commitment_tree(&self) -> anyhow::Result<NoteCommitmentTree> {
         let result = query!(
             r#"

--- a/wallet-next/src/worker.rs
+++ b/wallet-next/src/worker.rs
@@ -1,13 +1,16 @@
 use crate::Storage;
+use penumbra_proto::client::oblivious::oblivious_query_client::ObliviousQueryClient;
+use tonic::transport::Channel;
 
 pub struct Worker {
     storage: Storage,
+    client: ObliviousQueryClient<Channel>,
     // TODO: notifications (see TODOs on WalletService)
 }
 
 impl Worker {
-    pub fn new(storage: Storage) -> Self {
-        Self { storage }
+    pub fn new(storage: Storage, client: ObliviousQueryClient<Channel>) -> Self {
+        Self { storage, client }
     }
 
     pub async fn sync_to_latest(&self) -> Result<u64, anyhow::Error> {

--- a/wallet-next/src/worker.rs
+++ b/wallet-next/src/worker.rs
@@ -1,0 +1,27 @@
+use crate::Storage;
+
+pub struct Worker {
+    storage: Storage,
+    // TODO: notifications (see TODOs on WalletService)
+}
+
+impl Worker {
+    pub fn new(storage: Storage) -> Self {
+        Self { storage }
+    }
+
+    pub async fn sync_to_latest(&self) -> Result<u64, anyhow::Error> {
+        // Do a single sync run, up to whatever the latest block height is
+        todo!()
+    }
+
+    pub async fn run(self) -> Result<(), anyhow::Error> {
+        loop {
+            self.sync_to_latest().await?;
+
+            // TODO 1: randomize sleep interval within some range?
+            // TODO 2: use websockets to be notified on new block
+            tokio::time::sleep(std::time::Duration::from_millis(1729)).await;
+        }
+    }
+}


### PR DESCRIPTION
This commit scaffolds the basic wallet server state machine, which uses a
pub-sub architecture mediated by SQLite:

- a single `Worker` task runs indefinitely, scanning the chain, and writing the
  results to SQLite;
- any number of `WalletService` readers can serve gRPC requests.

Along the way, tidy the proto files slightly for consistency.

Closes #613 