### PR TITLE
ibc: refactor connection handshake validation

### DIFF
--- a/ibc/src/component/client/stateful.rs
+++ b/ibc/src/component/client/stateful.rs
@@ -34,7 +34,7 @@ pub mod update_client {
 
             // Optimization: reject duplicate updates instead of verifying them.
             if self
-                .update_is_already_committed(&client_data.client_id, &untrusted_header)
+                .update_is_already_committed(&client_data.client_id, untrusted_header)
                 .await?
             {
                 // If the update is already committed, return an error to reject a duplicate update.
@@ -43,8 +43,8 @@ pub mod update_client {
                 ));
             }
 
-            header_revision_matches_client_state(&trusted_client_state, &untrusted_header)?;
-            header_height_is_consistent(&untrusted_header)?;
+            header_revision_matches_client_state(&trusted_client_state, untrusted_header)?;
+            header_height_is_consistent(untrusted_header)?;
 
             // The (still untrusted) header uses the `trusted_height` field to
             // specify the trusted anchor data it is extending.
@@ -65,14 +65,14 @@ pub mod update_client {
                 .map_err(|_| anyhow::anyhow!("invalid header height"))?;
 
             let trusted_validator_set =
-                verify_header_validator_set(&untrusted_header, &last_trusted_consensus_state)?;
+                verify_header_validator_set(untrusted_header, &last_trusted_consensus_state)?;
 
             // Now we build the trusted and untrusted states to feed to the Tendermint light client.
 
             let trusted_state = TrustedBlockState {
                 header_time: last_trusted_consensus_state.timestamp,
                 height: trusted_height,
-                next_validators: &trusted_validator_set,
+                next_validators: trusted_validator_set,
                 next_validators_hash: last_trusted_consensus_state.next_validators_hash,
             };
 

--- a/ibc/src/component/connection.rs
+++ b/ibc/src/component/connection.rs
@@ -3,7 +3,6 @@ use async_trait::async_trait;
 use ibc::core::ics02_client::client_consensus::ConsensusState;
 use ibc::core::ics02_client::client_def::AnyClient;
 use ibc::core::ics02_client::client_def::ClientDef;
-use ibc::core::ics02_client::client_state::AnyClientState;
 use ibc::core::ics02_client::client_state::ClientState;
 use ibc::core::ics03_connection::connection::Counterparty;
 use ibc::core::ics03_connection::connection::{ConnectionEnd, State as ConnectionState};
@@ -12,9 +11,7 @@ use ibc::core::ics03_connection::msgs::conn_open_confirm::MsgConnectionOpenConfi
 use ibc::core::ics03_connection::msgs::conn_open_init::MsgConnectionOpenInit;
 use ibc::core::ics03_connection::msgs::conn_open_try::MsgConnectionOpenTry;
 use ibc::core::ics03_connection::version::{pick_version, Version};
-use ibc::core::ics24_host::identifier::ClientId;
 use ibc::core::ics24_host::identifier::ConnectionId;
-use ibc::proofs::Proofs;
 use ibc::Height as IBCHeight;
 use penumbra_chain::{genesis, View as _};
 use penumbra_component::Component;
@@ -34,6 +31,9 @@ use crate::{
     validate_penumbra_client_state, Connection, ConnectionCounter, COMMITMENT_PREFIX,
     SUPPORTED_VERSIONS,
 };
+
+mod stateful;
+mod stateless;
 
 pub struct ConnectionComponent {
     state: State,
@@ -55,7 +55,26 @@ impl Component for ConnectionComponent {
     #[instrument(name = "ibc_connection", skip(tx))]
     fn check_tx_stateless(tx: &Transaction) -> Result<()> {
         for ibc_action in tx.ibc_actions() {
-            validate_ibc_action_stateless(ibc_action)?;
+            match &ibc_action.action {
+                Some(ConnectionOpenInit(msg)) => {
+                    use stateless::connection_open_init::*;
+                    let msg = MsgConnectionOpenInit::try_from(msg.clone())?;
+
+                    version_is_supported(&msg)?;
+                }
+                Some(ConnectionOpenTry(msg)) => {
+                    let _ = MsgConnectionOpenTry::try_from(msg.clone())?;
+                }
+                Some(ConnectionOpenAck(msg)) => {
+                    let _ = MsgConnectionOpenAck::try_from(msg.clone())?;
+                }
+
+                Some(ConnectionOpenConfirm(msg)) => {
+                    let _ = MsgConnectionOpenConfirm::try_from(msg.clone())?;
+                }
+
+                _ => {}
+            }
         }
 
         Ok(())
@@ -64,8 +83,35 @@ impl Component for ConnectionComponent {
     #[instrument(name = "ibc_connection", skip(self, tx))]
     async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()> {
         for ibc_action in tx.ibc_actions() {
-            self.validate_ibc_action_stateful(ibc_action).await?;
+            match &ibc_action.action {
+                Some(ConnectionOpenInit(msg)) => {
+                    use stateful::connection_open_init::ConnectionOpenInitCheck;
+                    let msg = MsgConnectionOpenInit::try_from(msg.clone())?;
+
+                    self.state.validate(&msg).await?;
+                }
+                Some(ConnectionOpenTry(msg)) => {
+                    use stateful::connection_open_try::ConnectionOpenTryCheck;
+                    let msg = MsgConnectionOpenTry::try_from(msg.clone())?;
+
+                    self.state.validate(&msg).await?;
+                }
+                Some(ConnectionOpenAck(msg)) => {
+                    use stateful::connection_open_ack::ConnectionOpenAckCheck;
+                    let msg = MsgConnectionOpenAck::try_from(msg.clone())?;
+
+                    self.state.validate(&msg).await?;
+                }
+                Some(ConnectionOpenConfirm(msg)) => {
+                    use stateful::connection_open_confirm::ConnectionOpenConfirmCheck;
+                    let msg = MsgConnectionOpenConfirm::try_from(msg.clone())?;
+
+                    self.state.validate(&msg).await?;
+                }
+                _ => {}
+            }
         }
+
         Ok(())
     }
 
@@ -80,44 +126,6 @@ impl Component for ConnectionComponent {
     async fn end_block(&mut self, _end_block: &abci::request::EndBlock) {}
 }
 
-fn validate_ibc_action_stateless(ibc_action: &IbcAction) -> Result<(), anyhow::Error> {
-    match &ibc_action.action {
-        Some(ConnectionOpenInit(msg)) => {
-            let msg_connection_open_init = MsgConnectionOpenInit::try_from(msg.clone())?;
-
-            // check if the version is supported (we use the same versions as the cosmos SDK)
-            // TODO: should we be storing the compatible versions in our state instead?
-            if !SUPPORTED_VERSIONS.contains(
-                &msg_connection_open_init
-                    .version
-                    .ok_or_else(|| anyhow::anyhow!("invalid version"))?,
-            ) {
-                return Err(anyhow::anyhow!(
-                    "unsupported version: in ConnectionOpenInit",
-                ));
-            }
-
-            return Ok(());
-        }
-
-        // process a notice of a connection attempt on a counterparty chain
-        Some(ConnectionOpenTry(msg)) => {
-            let _ = MsgConnectionOpenTry::try_from(msg.clone())?;
-        }
-
-        Some(ConnectionOpenAck(msg)) => {
-            let _msg_connection_open_ack = MsgConnectionOpenAck::try_from(msg.clone())?;
-        }
-
-        Some(ConnectionOpenConfirm(msg)) => {
-            let _msg_connection_open_confirm = MsgConnectionOpenConfirm::try_from(msg.clone())?;
-        }
-
-        _ => {}
-    }
-
-    Ok(())
-}
 impl ConnectionComponent {
     async fn execute_ibc_action(&mut self, ibc_action: &IbcAction) {
         match &ibc_action.action {
@@ -237,348 +245,6 @@ impl ConnectionComponent {
             .put_new_connection(&new_connection_id, new_conn.into())
             .await
             .unwrap();
-    }
-
-    async fn verify_connection_proofs(
-        &self,
-        client_id: &ClientId,
-        msg_proofs: Proofs,
-        msg_client_state: &AnyClientState,
-        counterparty_connection_id: &ConnectionId,
-        counterparty: Counterparty,
-        expected_conn: ConnectionEnd,
-    ) -> Result<()> {
-        // get the stored client state for the counterparty
-        let stored_client_state = self.state.get_client_data(client_id).await?.client_state.0;
-
-        // check if the client is frozen
-        // TODO: should we also check if the client is expired here?
-        if stored_client_state.is_frozen() {
-            return Err(anyhow::anyhow!("client is frozen"));
-        }
-
-        // get the stored consensus state for the counterparty
-        let stored_consensus_state = self
-            .state
-            .get_verified_consensus_state(msg_proofs.height(), client_id.clone())
-            .await?
-            .0;
-
-        let client_def = AnyClient::from_client_type(stored_client_state.client_type());
-
-        // PROOF VERIFICATION
-        // 1. verify that the counterparty chain committed the expected_conn to its state
-        client_def.verify_connection_state(
-            &stored_client_state,
-            msg_proofs.height(),
-            counterparty.prefix(),
-            msg_proofs.object_proof(),
-            stored_consensus_state.root(),
-            &counterparty_connection_id,
-            &expected_conn,
-        )?;
-
-        // 2. verify that the counterparty chain committed the correct ClientState (that was
-        //    provided in the msg)
-        client_def.verify_client_full_state(
-            &stored_client_state,
-            msg_proofs.height(),
-            counterparty.prefix(),
-            msg_proofs.client_proof().as_ref().ok_or_else(|| {
-                anyhow::anyhow!("client proof not provided in the connectionOpenTry")
-            })?,
-            stored_consensus_state.root(),
-            counterparty.client_id(),
-            msg_client_state,
-        )?;
-
-        let cons_proof = msg_proofs.consensus_proof().ok_or_else(|| {
-            anyhow::anyhow!("consensus proof not provided in the connectionOpenTry")
-        })?;
-        let expected_consensus = self
-            .state
-            .get_penumbra_consensus_state(cons_proof.height())
-            .await?
-            .0;
-
-        // 3. verify that the counterparty chain stored the correct consensus state of Penumbra at
-        //    the given consensus height
-        client_def.verify_client_consensus_state(
-            &stored_client_state,
-            msg_proofs.height(),
-            counterparty.prefix(),
-            cons_proof.proof(),
-            stored_consensus_state.root(),
-            counterparty.client_id(),
-            cons_proof.height(),
-            &expected_consensus,
-        )?;
-
-        Ok(())
-    }
-
-    async fn validate_connection_open_try(
-        &self,
-        msg: &MsgConnectionOpenTry,
-    ) -> Result<(), anyhow::Error> {
-        // verify the consensus height is correct
-        if msg.consensus_height()
-            > IBCHeight::zero().with_revision_height(self.state.get_block_height().await?)
-        {
-            return Err(anyhow::anyhow!(
-                "consensus height is greater than the current block height",
-            ));
-        }
-
-        //
-        // TODO: store our earliest non-pruned block height and check against the consensus height
-        //
-
-        // verify the provided client state
-        let provided_cs = msg
-            .client_state
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("client state not provided in MsgConnectionOpenTry"))?;
-
-        let height = self.state.get_block_height().await?;
-        let chain_id = self.state.get_chain_id().await?;
-        validate_penumbra_client_state(provided_cs, &chain_id, height)?;
-
-        let mut previous_conn: Option<ConnectionEnd> = None;
-        if let Some(prev_conn_id) = &msg.previous_connection_id {
-            // check that we have a valid connection with the given ID
-            let prev_connection = self
-                .state
-                .get_connection(prev_conn_id)
-                .await?
-                .ok_or_else(|| anyhow::anyhow!("no connection with the given ID"))?
-                .0;
-
-            // check that the existing connection matches the incoming connectionOpenTry
-            if !(prev_connection.state_matches(&ConnectionState::Init)
-                && prev_connection.counterparty_matches(&msg.counterparty)
-                && prev_connection.client_id_matches(&msg.client_id)
-                && prev_connection.delay_period() == msg.delay_period)
-            {
-                return Err(anyhow::anyhow!(
-                    "connection with the given ID is not in the correct state",
-                ));
-            }
-            previous_conn = Some(prev_connection);
-        }
-
-        // expected_conn is the conn that we expect to have been committed to on the counterparty
-        // chain
-        let expected_conn = ConnectionEnd::new(
-            ConnectionState::Init,
-            msg.counterparty.client_id().clone(),
-            Counterparty::new(
-                msg.client_id.clone(),
-                None,
-                COMMITMENT_PREFIX.as_bytes().to_vec().try_into().unwrap(),
-            ),
-            msg.counterparty_versions.clone(),
-            msg.delay_period,
-        );
-
-        // perform version intersection
-        let mut supported_versions = SUPPORTED_VERSIONS.clone();
-        if let Some(prev_conn) = previous_conn {
-            supported_versions = prev_conn.versions().to_vec();
-        }
-        pick_version(supported_versions, msg.counterparty_versions.clone())?;
-
-        // get the connection ID of the counterparty
-        let counterparty_connection_id = msg
-            .counterparty
-            .connection_id
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("connection id for counterparty not provided"))?;
-
-        // PROOF VERIFICATION
-        self.verify_connection_proofs(
-            &msg.client_id,
-            msg.proofs.clone(),
-            msg.client_state.as_ref().ok_or_else(|| {
-                anyhow::anyhow!("client state not provided in MsgConnectionOpenTry")
-            })?,
-            &counterparty_connection_id,
-            msg.counterparty.clone(),
-            expected_conn,
-        )
-        .await?;
-
-        Ok(())
-    }
-
-    async fn validate_connection_open_ack(
-        &self,
-        msg: &MsgConnectionOpenAck,
-    ) -> Result<(), anyhow::Error> {
-        // verify the consensus height is correct
-        if msg.consensus_height()
-            > IBCHeight::zero().with_revision_height(self.state.get_block_height().await?)
-        {
-            return Err(anyhow::anyhow!(
-                "consensus height is greater than the current block height",
-            ));
-        }
-
-        // verify the provided client state
-        let provided_cs = msg
-            .client_state
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("client state not provided in MsgConnectionOpenTry"))?;
-
-        let height = self.state.get_block_height().await?;
-        let chain_id = self.state.get_chain_id().await?;
-        validate_penumbra_client_state(provided_cs, &chain_id, height)?;
-
-        let connection = self
-            .state
-            .get_connection(&msg.connection_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("no connection with the given ID"))?
-            .0;
-
-        let state_is_consistent = connection.state_matches(&ConnectionState::Init)
-            && connection.versions().contains(&msg.version)
-            || connection.state_matches(&ConnectionState::TryOpen)
-                && connection.versions().get(0).eq(&Some(&msg.version));
-
-        if !state_is_consistent {
-            return Err(anyhow::anyhow!("connection is not in the correct state"));
-        }
-
-        // we are the counterparty here
-        let counterparty = Counterparty::new(
-            connection.client_id().clone(),
-            Some(msg.counterparty_connection_id.clone()),
-            COMMITMENT_PREFIX.as_bytes().to_vec().try_into().unwrap(),
-        );
-
-        let expected_conn = ConnectionEnd::new(
-            ConnectionState::TryOpen,
-            connection.counterparty().client_id().clone(),
-            counterparty.clone(),
-            vec![msg.version.clone()],
-            connection.delay_period(),
-        );
-
-        // PROOF VERIFICATION
-        self.verify_connection_proofs(
-            connection.client_id(),
-            msg.proofs.clone(),
-            msg.client_state.as_ref().ok_or_else(|| {
-                anyhow::anyhow!("client state not provided in MsgConnectionOpenAck")
-            })?,
-            counterparty
-                .connection_id()
-                .ok_or_else(|| anyhow::anyhow!("connection id for counterparty not provided"))?,
-            counterparty.clone(),
-            expected_conn,
-        )
-        .await?;
-
-        Ok(())
-    }
-
-    async fn validate_connection_open_confirm(&self, msg: &MsgConnectionOpenConfirm) -> Result<()> {
-        let connection = self
-            .state
-            .get_connection(&msg.connection_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("no connection with the given ID"))?
-            .0;
-
-        if !connection.state_matches(&ConnectionState::TryOpen) {
-            return Err(anyhow::anyhow!("connection is not in the correct state"));
-        }
-
-        let expected_conn = ConnectionEnd::new(
-            ConnectionState::Open,
-            connection.counterparty().client_id().clone(),
-            Counterparty::new(
-                connection.client_id().clone(),
-                Some(msg.connection_id.clone()),
-                COMMITMENT_PREFIX.as_bytes().to_vec().try_into().unwrap(),
-            ),
-            connection.versions().to_vec(),
-            connection.delay_period(),
-        );
-
-        // get the stored client state for the counterparty
-        let stored_client_state = self
-            .state
-            .get_client_data(connection.client_id())
-            .await?
-            .client_state
-            .0;
-
-        // check if the client is frozen
-        // TODO: should we also check if the client is expired here?
-        if stored_client_state.is_frozen() {
-            return Err(anyhow::anyhow!("client is frozen"));
-        }
-
-        // get the stored consensus state for the counterparty
-        let stored_consensus_state = self
-            .state
-            .get_verified_consensus_state(msg.proofs.height(), connection.client_id().clone())
-            .await?
-            .0;
-
-        let client_def = AnyClient::from_client_type(stored_client_state.client_type());
-
-        // PROOF VERIFICATION
-        // note: here we only verify connection state inclusion, not client state or consensus
-        // state.
-        // 1. verify that the counterparty chain committed the expected_conn to its state
-        client_def.verify_connection_state(
-            &stored_client_state,
-            msg.proofs.height(),
-            connection.counterparty().prefix(),
-            msg.proofs.object_proof(),
-            stored_consensus_state.root(),
-            connection
-                .counterparty()
-                .connection_id()
-                .ok_or_else(|| anyhow::anyhow!("invalid counterparty"))?,
-            &expected_conn,
-        )?;
-
-        Ok(())
-    }
-
-    async fn validate_ibc_action_stateful(&self, ibc_action: &IbcAction) -> Result<()> {
-        match &ibc_action.action {
-            Some(ConnectionOpenInit(raw_msg)) => {
-                // check that the client id exists
-                let msg = MsgConnectionOpenInit::try_from(raw_msg.clone())?;
-                self.state.get_client_data(&msg.client_id).await?;
-
-                return Ok(());
-            }
-
-            Some(ConnectionOpenTry(raw_msg)) => {
-                let msg = MsgConnectionOpenTry::try_from(raw_msg.clone())?;
-                self.validate_connection_open_try(&msg).await?;
-            }
-
-            Some(ConnectionOpenAck(raw_msg)) => {
-                let msg = MsgConnectionOpenAck::try_from(raw_msg.clone())?;
-                self.validate_connection_open_ack(&msg).await?;
-            }
-
-            Some(ConnectionOpenConfirm(raw_msg)) => {
-                let msg = MsgConnectionOpenConfirm::try_from(raw_msg.clone())?;
-                self.validate_connection_open_confirm(&msg).await?;
-            }
-
-            _ => {}
-        }
-
-        Ok(())
     }
 }
 

--- a/ibc/src/component/connection/stateful.rs
+++ b/ibc/src/component/connection/stateful.rs
@@ -1,0 +1,496 @@
+pub mod connection_open_init {
+    use super::super::*;
+
+    #[async_trait]
+    pub trait ConnectionOpenInitCheck: StateExt {
+        async fn validate(&self, msg: &MsgConnectionOpenInit) -> anyhow::Result<()> {
+            // check that the client with the specified ID exists
+            self.get_client_data(&msg.client_id).await?;
+
+            Ok(())
+        }
+    }
+
+    impl<T: StateExt> ConnectionOpenInitCheck for T {}
+}
+
+pub mod connection_open_confirm {
+    use super::super::*;
+
+    #[async_trait]
+    pub trait ConnectionOpenConfirmCheck: StateExt + inner::Inner {
+        // Validate a ConnectionOpenConfirm message, completing the IBC connection handshake.
+        //
+        // Verify that we have a connection in the correct state (TRYOPEN), and that the
+        // counterparty has committed a connection with the expected state (OPEN) to their state
+        // store.
+        //
+        // Here we are Chain B.
+        // CHAINS:          (A, B)
+        // PRIOR STATE:     (OPEN, TRYOPEN)
+        // POSTERIOR STATE: (OPEN, OPEN)
+        async fn validate(&self, msg: &MsgConnectionOpenConfirm) -> anyhow::Result<()> {
+            // verify that a connection with the provided ID exists and is in the correct state
+            // (TRYOPEN)
+            let connection = self.verify_previous_connection(msg).await?;
+
+            let expected_conn = ConnectionEnd::new(
+                ConnectionState::Open,
+                connection.counterparty().client_id().clone(),
+                Counterparty::new(
+                    connection.client_id().clone(),
+                    Some(msg.connection_id.clone()),
+                    COMMITMENT_PREFIX.as_bytes().to_vec().try_into().unwrap(),
+                ),
+                connection.versions().to_vec(),
+                connection.delay_period(),
+            );
+
+            // get the trusted client state for the counterparty
+            let trusted_client_state = self
+                .get_client_data(connection.client_id())
+                .await?
+                .client_state
+                .0;
+
+            // check if the client is frozen
+            // TODO: should we also check if the client is expired here?
+            if trusted_client_state.is_frozen() {
+                return Err(anyhow::anyhow!("client is frozen"));
+            }
+
+            // get the stored consensus state for the counterparty
+            let trusted_consensus_state = self
+                .get_verified_consensus_state(msg.proofs.height(), connection.client_id().clone())
+                .await?
+                .0;
+
+            let client_def = AnyClient::from_client_type(trusted_client_state.client_type());
+
+            // PROOF VERIFICATION
+            // note: here we only verify connection state inclusion, not client state or consensus
+            // state.
+            //
+            // 1. verify that the counterparty chain committed the expected_conn to its state
+            client_def.verify_connection_state(
+                &trusted_client_state,
+                msg.proofs.height(),
+                connection.counterparty().prefix(),
+                msg.proofs.object_proof(),
+                trusted_consensus_state.root(),
+                connection
+                    .counterparty()
+                    .connection_id()
+                    .ok_or_else(|| anyhow::anyhow!("invalid counterparty"))?,
+                &expected_conn,
+            )?;
+
+            Ok(())
+        }
+    }
+    mod inner {
+        use super::*;
+
+        #[async_trait]
+        pub trait Inner: StateExt {
+            async fn verify_previous_connection(
+                &self,
+                msg: &MsgConnectionOpenConfirm,
+            ) -> anyhow::Result<ConnectionEnd> {
+                let connection = self
+                    .get_connection(&msg.connection_id)
+                    .await?
+                    .ok_or_else(|| anyhow::anyhow!("connection not found"))?
+                    .0;
+
+                if !connection.state_matches(&ConnectionState::TryOpen) {
+                    return Err(anyhow::anyhow!("connection not in correct state"));
+                } else {
+                    Ok(connection)
+                }
+            }
+        }
+        impl<T: StateExt> Inner for T {}
+    }
+    impl<T: StateExt> ConnectionOpenConfirmCheck for T {}
+}
+
+pub mod connection_open_ack {
+    use super::super::*;
+
+    #[async_trait]
+    pub trait ConnectionOpenAckCheck: StateExt + inner::Inner {
+        // Validate a ConnectionOpenAck message, which is sent to us by a counterparty chain that
+        // has committed a Connection to us expected to be in the TRYOPEN state. Before executing a
+        // ConnectionOpenAck, we must have a prior connection to this chain in the INIT state.
+        //
+        // In order to verify a ConnectionOpenAck, we need to check that the counterparty chain has
+        // committed a _valid_ Penumbra consensus state, that the counterparty chain has committed
+        // the expected Connection to its state (in the TRYOPEN state) with the expected version,
+        // and that the counterparty has committed a correct Penumbra client state to its state.
+        //
+        // Here we are Chain A.
+        // CHAINS:          (A, B)
+        // PRIOR STATE:     (INIT, TRYOPEN)
+        // POSTERIOR STATE: (OPEN, TRYOPEN)
+        async fn validate(&self, msg: &MsgConnectionOpenAck) -> anyhow::Result<()> {
+            // verify that the consensus height is correct
+            self.consensus_height_is_correct(msg).await?;
+
+            // verify that the client state is well formed
+            self.penumbra_client_state_is_well_formed(msg).await?;
+
+            // verify the previous connection that we're ACKing is in the correct state
+            let connection = self.verify_previous_connection(msg).await?;
+
+            // verify that the counterparty committed a TRYOPEN connection with us as the
+            // counterparty
+            let penumbra_counterparty = Counterparty::new(
+                connection.client_id().clone(),
+                Some(msg.counterparty_connection_id.clone()),
+                COMMITMENT_PREFIX.as_bytes().to_vec().try_into().unwrap(),
+            );
+
+            // the connection we expect the counterparty to have committed
+            let expected_conn = ConnectionEnd::new(
+                ConnectionState::TryOpen,
+                connection.counterparty().client_id().clone(),
+                penumbra_counterparty.clone(),
+                vec![msg.version.clone()],
+                connection.delay_period(),
+            );
+
+            // get the stored client state for the counterparty
+            let trusted_client_state = self
+                .get_client_data(connection.client_id())
+                .await?
+                .client_state
+                .0;
+
+            // check if the client is frozen
+            // TODO: should we also check if the client is expired here?
+            if trusted_client_state.is_frozen() {
+                return Err(anyhow::anyhow!("client is frozen"));
+            }
+
+            // get the stored consensus state for the counterparty
+            let trusted_consensus_state = self
+                .get_verified_consensus_state(msg.proofs.height(), connection.client_id().clone())
+                .await?
+                .0;
+
+            let client_def = AnyClient::from_client_type(trusted_client_state.client_type());
+
+            // PROOF VERIFICATION
+            // 1. verify that the counterparty chain committed the expected_conn to its state
+            client_def.verify_connection_state(
+                &trusted_client_state,
+                msg.proofs.height(),
+                penumbra_counterparty.prefix(),
+                msg.proofs.object_proof(),
+                trusted_consensus_state.root(),
+                penumbra_counterparty
+                    .connection_id
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("no connection id"))?,
+                &expected_conn,
+            )?;
+
+            // 2. verify that the counterparty chain committed the correct ClientState (that was
+            //    provided in the msg)
+            client_def.verify_client_full_state(
+                &trusted_client_state,
+                msg.proofs.height(),
+                penumbra_counterparty.prefix(),
+                msg.proofs.client_proof().as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("client proof not provided in the connectionOpenTry")
+                })?,
+                trusted_consensus_state.root(),
+                penumbra_counterparty.client_id(),
+                msg.client_state.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("client state not provided in the connectionOpenTry")
+                })?,
+            )?;
+
+            let cons_proof = msg.proofs.consensus_proof().ok_or_else(|| {
+                anyhow::anyhow!("consensus proof not provided in the connectionOpenTry")
+            })?;
+            let expected_consensus = self
+                .get_penumbra_consensus_state(cons_proof.height())
+                .await?
+                .0;
+
+            // 3. verify that the counterparty chain stored the correct consensus state of Penumbra at
+            //    the given consensus height
+            client_def.verify_client_consensus_state(
+                &trusted_client_state,
+                msg.proofs.height(),
+                penumbra_counterparty.prefix(),
+                cons_proof.proof(),
+                trusted_consensus_state.root(),
+                penumbra_counterparty.client_id(),
+                cons_proof.height(),
+                &expected_consensus,
+            )?;
+
+            Ok(())
+        }
+    }
+    mod inner {
+        use super::*;
+
+        #[async_trait]
+        pub trait Inner: StateExt {
+            async fn consensus_height_is_correct(
+                &self,
+                msg: &MsgConnectionOpenAck,
+            ) -> anyhow::Result<()> {
+                if msg.consensus_height()
+                    > IBCHeight::zero().with_revision_height(self.get_block_height().await?)
+                {
+                    return Err(anyhow::anyhow!(
+                        "consensus height is greater than the current block height",
+                    ));
+                }
+
+                Ok(())
+            }
+            async fn penumbra_client_state_is_well_formed(
+                &self,
+                msg: &MsgConnectionOpenAck,
+            ) -> anyhow::Result<()> {
+                let height = self.get_block_height().await?;
+                let chain_id = self.get_chain_id().await?;
+                validate_penumbra_client_state(
+                    msg.client_state
+                        .clone()
+                        .ok_or_else(|| anyhow::anyhow!("no client state provided"))?,
+                    &chain_id,
+                    height,
+                )?;
+
+                Ok(())
+            }
+            async fn verify_previous_connection(
+                &self,
+                msg: &MsgConnectionOpenAck,
+            ) -> anyhow::Result<ConnectionEnd> {
+                let connection = self
+                    .get_connection(&msg.connection_id)
+                    .await?
+                    .ok_or_else(|| anyhow::anyhow!("no connection with the specified ID exists"))?
+                    .0;
+
+                // see
+                // https://github.com/cosmos/ibc/blob/master/spec/core/ics-003-connection-semantics/README.md
+                // for this validation logic
+                let state_is_consistent = connection.state_matches(&ConnectionState::Init)
+                    && connection.versions().contains(&msg.version)
+                    || connection.state_matches(&ConnectionState::TryOpen)
+                        && connection.versions().get(0).eq(&Some(&msg.version));
+
+                if !state_is_consistent {
+                    return Err(anyhow::anyhow!("connection is not in the correct state"));
+                } else {
+                    Ok(connection)
+                }
+            }
+        }
+        impl<T: StateExt> Inner for T {}
+    }
+    impl<T: StateExt> ConnectionOpenAckCheck for T {}
+}
+
+pub mod connection_open_try {
+    use super::super::*;
+
+    #[async_trait]
+    pub trait ConnectionOpenTryCheck: StateExt + inner::Inner {
+        // Validate a ConnectionOpenTry message, which is sent to us by a counterparty chain that
+        // has committed a Connection to us in an INIT state on its chain. Before executing a
+        // ConnectionOpenTry message, we have no knowledge about the connection: our counterparty
+        // is in INIT state, and we are in none state. After executing ConnectionOpenTry, our
+        // counterparty is in INIT state, and we are in TRYOPEN state.
+        //
+        // In order to verify a ConnectionOpenTry, we need to check that the counterparty chain has
+        // committed a _valid_ Penumbra consensus state, that the counterparty chain has committed
+        // the expected Connection to its state (in the INIT state), and that the counterparty has
+        // committed a correct Penumbra client state to its state.
+        //
+        // Here we are Chain B.
+        // CHAINS:          (A, B)
+        // PRIOR STATE:     (INIT, none)
+        // POSTERIOR STATE: (INIT, TRYOPEN)
+        async fn validate(&self, msg: &MsgConnectionOpenTry) -> anyhow::Result<()> {
+            // verify that the consensus height is correct
+            self.consensus_height_is_correct(msg).await?;
+
+            // verify that the client state (which is a Penumbra client) is well-formed for a
+            // penumbra client.
+            self.penumbra_client_state_is_well_formed(msg).await?;
+
+            // if this msg provides a previous_connection_id to resume from, then check that the
+            // provided previous connection ID is valid
+            let previous_connection = self.check_previous_connection(msg).await?;
+
+            // perform version intersection
+            let supported_versions = previous_connection
+                .map(|c| c.versions().to_vec())
+                .unwrap_or_else(|| SUPPORTED_VERSIONS.clone());
+
+            pick_version(supported_versions, msg.counterparty_versions.clone())?;
+
+            // expected_conn is the conn that we expect to have been committed to on the counterparty
+            // chain
+            let expected_conn = ConnectionEnd::new(
+                ConnectionState::Init,
+                msg.counterparty.client_id().clone(),
+                Counterparty::new(
+                    msg.client_id.clone(),
+                    None,
+                    COMMITMENT_PREFIX.as_bytes().to_vec().try_into().unwrap(),
+                ),
+                msg.counterparty_versions.clone(),
+                msg.delay_period,
+            );
+
+            // get the stored client state for the counterparty
+            let trusted_client_state = self.get_client_data(&msg.client_id).await?.client_state.0;
+
+            // check if the client is frozen
+            // TODO: should we also check if the client is expired here?
+            if trusted_client_state.is_frozen() {
+                return Err(anyhow::anyhow!("client is frozen"));
+            }
+
+            // get the stored consensus state for the counterparty
+            let trusted_consensus_state = self
+                .get_verified_consensus_state(msg.proofs.height(), msg.client_id.clone())
+                .await?
+                .0;
+            let client_def = AnyClient::from_client_type(trusted_client_state.client_type());
+
+            // PROOF VERIFICATION
+            // 1. verify that the counterparty chain committed the expected_conn to its state
+            client_def.verify_connection_state(
+                &trusted_client_state,
+                msg.proofs.height(),
+                msg.counterparty.prefix(),
+                msg.proofs.object_proof(),
+                trusted_consensus_state.root(),
+                msg.counterparty
+                    .connection_id
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("counterparty connection id is not set"))?,
+                &expected_conn,
+            )?;
+
+            // 2. verify that the counterparty chain committed the correct ClientState (that was
+            //    provided in the msg)
+            client_def.verify_client_full_state(
+                &trusted_client_state,
+                msg.proofs.height(),
+                msg.counterparty.prefix(),
+                msg.proofs.client_proof().as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("client proof not provided in the connectionOpenTry")
+                })?,
+                trusted_consensus_state.root(),
+                msg.counterparty.client_id(),
+                msg.client_state.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("client state not provided in the connectionOpenTry")
+                })?,
+            )?;
+
+            let cons_proof = msg.proofs.consensus_proof().ok_or_else(|| {
+                anyhow::anyhow!("consensus proof not provided in the connectionOpenTry")
+            })?;
+            let expected_consensus = self
+                .get_penumbra_consensus_state(cons_proof.height())
+                .await?
+                .0;
+
+            // 3. verify that the counterparty chain stored the correct consensus state of Penumbra at
+            //    the given consensus height
+            client_def.verify_client_consensus_state(
+                &trusted_client_state,
+                msg.proofs.height(),
+                msg.counterparty.prefix(),
+                cons_proof.proof(),
+                trusted_consensus_state.root(),
+                msg.counterparty.client_id(),
+                cons_proof.height(),
+                &expected_consensus,
+            )?;
+
+            Ok(())
+        }
+    }
+    mod inner {
+        use super::*;
+
+        #[async_trait]
+        pub trait Inner: StateExt {
+            async fn consensus_height_is_correct(
+                &self,
+                msg: &MsgConnectionOpenTry,
+            ) -> anyhow::Result<()> {
+                if msg.consensus_height()
+                    > IBCHeight::zero().with_revision_height(self.get_block_height().await?)
+                {
+                    return Err(anyhow::anyhow!(
+                        "consensus height is greater than the current block height",
+                    ));
+                }
+
+                Ok(())
+            }
+            async fn penumbra_client_state_is_well_formed(
+                &self,
+                msg: &MsgConnectionOpenTry,
+            ) -> anyhow::Result<()> {
+                let height = self.get_block_height().await?;
+                let chain_id = self.get_chain_id().await?;
+                validate_penumbra_client_state(
+                    msg.client_state
+                        .clone()
+                        .ok_or_else(|| anyhow::anyhow!("no client state provided"))?,
+                    &chain_id,
+                    height,
+                )?;
+
+                Ok(())
+            }
+            async fn check_previous_connection(
+                &self,
+                msg: &MsgConnectionOpenTry,
+            ) -> anyhow::Result<Option<ConnectionEnd>> {
+                if let Some(prev_conn_id) = &msg.previous_connection_id {
+                    // check that we have a valid connection with the given ID
+                    let prev_connection = self
+                        .get_connection(prev_conn_id)
+                        .await?
+                        .ok_or_else(|| anyhow::anyhow!("no connection with the given ID"))?
+                        .0;
+
+                    // check that the existing connection matches the incoming connectionOpenTry
+                    if !(prev_connection.state_matches(&ConnectionState::Init)
+                        && prev_connection.counterparty_matches(&msg.counterparty)
+                        && prev_connection.client_id_matches(&msg.client_id)
+                        && prev_connection.delay_period() == msg.delay_period)
+                    {
+                        return Err(anyhow::anyhow!(
+                            "connection with the given ID is not in the correct state",
+                        ));
+                    }
+                    return Ok(Some(prev_connection));
+                } else {
+                    return Ok(None);
+                }
+            }
+        }
+
+        impl<T: StateExt> Inner for T {}
+    }
+
+    impl<T: StateExt> ConnectionOpenTryCheck for T {}
+}

--- a/ibc/src/component/connection/stateless.rs
+++ b/ibc/src/component/connection/stateless.rs
@@ -1,0 +1,19 @@
+pub mod connection_open_init {
+    use super::super::*;
+
+    pub fn version_is_supported(msg: &MsgConnectionOpenInit) -> anyhow::Result<()> {
+        // check if the version is supported (we use the same versions as the cosmos SDK)
+        // TODO: should we be storing the compatible versions in our state instead?
+        if !SUPPORTED_VERSIONS.contains(
+            msg.version
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("invalid version"))?,
+        ) {
+            return Err(anyhow::anyhow!(
+                "unsupported version: in ConnectionOpenInit",
+            ));
+        } else {
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
Similarly to #774 , this PR refactors IBC connection handshake validation into new `stateful` and `stateless` modules, and adds documentation for the IBC handshake.