### PR TITLE
Fix grafana mount path

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -39,7 +39,7 @@ services:
       - '3000'
     volumes:
       - "grafana_configs:/etc/grafana"
-      - "grafana_dashboards:/var/lib/grafana/dashboards"
+      - "grafana_data:/var/lib/grafana"
     networks:
       - monitoring
     depends_on:


### PR DESCRIPTION
The docker-compose wasn't persisting the main grafana data directory, causing data loss on container restart.