### PR TITLE
shielded_pool: improved tracing for component

### DIFF
--- a/shielded-pool/src/component.rs
+++ b/shielded-pool/src/component.rs
@@ -322,9 +322,9 @@ impl ShieldedPool {
         Ok(())
     }
 
-    #[instrument(skip(self, source, output_body))]
+    #[instrument(skip(self, source, output_body), fields(note_commitment = ?output_body.note_commitment))]
     async fn add_note(&mut self, output_body: output::Body, source: NoteSource) {
-        tracing::debug!(commitment = ?output_body.note_commitment, "appending to NCT in component");
+        tracing::debug!("adding note");
         // 1. Insert it into the NCT
         self.note_commitment_tree
             .append(&output_body.note_commitment);
@@ -530,8 +530,9 @@ pub trait View: StateExt {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self, source))]
     async fn spend_nullifier(&self, nullifier: Nullifier, source: NoteSource) {
+        tracing::debug!("marking as spent");
         self.put_proto(
             format!("shielded_pool/spent_nullifiers/{}", nullifier).into(),
             // We don't use the value for validity checks, but writing the source


### PR DESCRIPTION
This produces nice output like
```
2022-05-07T04:04:04.563526Z DEBUG abci:DeliverTx{txid="dd1f840a773cf1fd8925742d65b3cb231539f90d34c1873eca34c04ee274bacf"}:check_tx_stateful:shielded_pool: penumbra_shielded_pool::component: anchor is valid anchor=merkle::Root("878945de86c5006abab1817b130b783783a4c934382902324882709cd6fbfa02") anchor_height=0
2022-05-07T04:04:04.565083Z DEBUG abci:DeliverTx{txid="dd1f840a773cf1fd8925742d65b3cb231539f90d34c1873eca34c04ee274bacf"}:execute_tx:shielded_pool:add_note{note_commitment=note::Commitment(bebb9f09d17cdbf08a54a758882fbc56e7d53922e7536bf6597133f6c8fc9709)}: penumbra_shielded_pool::component: adding note
2022-05-07T04:04:04.565534Z DEBUG abci:DeliverTx{txid="dd1f840a773cf1fd8925742d65b3cb231539f90d34c1873eca34c04ee274bacf"}:execute_tx:shielded_pool:spend_nullifier{nullifier=Nullifier("e31455d5ab93d17b4ad655997a21d47a7dcdbdd756781a94c65e2c8d2fc44208")}: penumbra_shielded_pool::component: marking as spent
2022-05-07T04:04:04.565556Z DEBUG abci:DeliverTx{txid="dd1f840a773cf1fd8925742d65b3cb231539f90d34c1873eca34c04ee274bacf"}:execute_tx:shielded_pool:spend_nullifier{nullifier=Nullifier("ace7901ce7feb8231217958c641a066637d3b508e477867dae1d0dae4e3bca01")}: penumbra_shielded_pool::component: marking as spent
```