### PR TITLE
use correct ICS3 state paths, connectionEnd encoding

### DIFF
--- a/ibc/src/component/client.rs
+++ b/ibc/src/component/client.rs
@@ -36,7 +36,10 @@ use tendermint_light_client_verifier::{
 };
 use tracing::instrument;
 
-use crate::{ClientConnections, ClientCounter, ClientData, ConsensusState, VerifiedHeights};
+use crate::{
+    ClientConnections, ClientCounter, ClientData, ConsensusState, VerifiedHeights,
+    COMMITMENT_PREFIX,
+};
 
 mod stateful;
 mod stateless;
@@ -549,7 +552,8 @@ pub trait View: StateExt {
         let mut connections = self
             .get_domain(
                 format!(
-                    "ibc/ics02-client/clients/{}/connections",
+                    "{}/clients/{}/connections",
+                    COMMITMENT_PREFIX,
                     hex::encode(client_id.as_bytes())
                 )
                 .into(),
@@ -561,7 +565,8 @@ pub trait View: StateExt {
 
         self.put_domain(
             format!(
-                "ibc/ics02-client/clients/{}/connections",
+                "{}/clients/{}/connections",
+                COMMITMENT_PREFIX,
                 hex::encode(client_id.as_bytes())
             )
             .into(),

--- a/ibc/src/component/connection.rs
+++ b/ibc/src/component/connection.rs
@@ -282,7 +282,8 @@ pub trait View: StateExt + Send + Sync {
     ) -> Result<()> {
         self.put_domain(
             format!(
-                "ibc/ics03-connection/connections/{}",
+                "{}/connections/{}",
+                COMMITMENT_PREFIX,
                 connection_id.as_str()
             )
             .into(),
@@ -305,7 +306,8 @@ pub trait View: StateExt + Send + Sync {
     async fn get_connection(&self, connection_id: &ConnectionId) -> Result<Option<Connection>> {
         self.get_domain(
             format!(
-                "ibc/ics03-connection/connections/{}",
+                "{}/connections/{}",
+                COMMITMENT_PREFIX,
                 connection_id.as_str()
             )
             .into(),
@@ -316,7 +318,8 @@ pub trait View: StateExt + Send + Sync {
     async fn update_connection(&self, connection_id: &ConnectionId, connection: Connection) {
         self.put_domain(
             format!(
-                "ibc/ics03-connection/connections/{}",
+                "{}/connections/{}",
+                COMMITMENT_PREFIX,
                 connection_id.as_str()
             )
             .into(),

--- a/ibc/src/connection.rs
+++ b/ibc/src/connection.rs
@@ -1,5 +1,6 @@
 use ibc::core::ics03_connection::connection::ConnectionEnd;
 use ibc::core::ics03_connection::version::Version;
+use ibc_proto::ibc::core::connection::v1::ConnectionEnd as RawConnectionEnd;
 use once_cell::sync::Lazy;
 use penumbra_proto::{ibc as pb, Protobuf};
 
@@ -25,25 +26,20 @@ impl From<ConnectionCounter> for pb::ConnectionCounter {
 #[derive(Debug, Clone)]
 pub struct Connection(pub ConnectionEnd);
 
-impl Protobuf<pb::Connection> for Connection {}
+impl Protobuf<RawConnectionEnd> for Connection {}
 
-impl TryFrom<pb::Connection> for Connection {
+impl TryFrom<RawConnectionEnd> for Connection {
     type Error = anyhow::Error;
 
-    fn try_from(p: pb::Connection) -> Result<Self, Self::Error> {
-        let end = p
-            .connection_end
-            .ok_or_else(|| anyhow::anyhow!("connection end not set"))?;
-        let connection_end = ConnectionEnd::try_from(end)?;
+    fn try_from(p: RawConnectionEnd) -> Result<Self, Self::Error> {
+        let connection_end = ConnectionEnd::try_from(p)?;
         Ok(Connection(connection_end))
     }
 }
 
-impl From<Connection> for pb::Connection {
+impl From<Connection> for RawConnectionEnd {
     fn from(c: Connection) -> Self {
-        pb::Connection {
-            connection_end: Some(c.0.into()),
-        }
+        c.0.into()
     }
 }
 

--- a/proto/proto/ibc.proto
+++ b/proto/proto/ibc.proto
@@ -60,10 +60,6 @@ message ConnectionCounter {
   uint64 counter = 1;
 }
 
-message Connection {
-  .ibc.core.connection.v1.ConnectionEnd connectionEnd = 1;
-}
-
 message ClientConnections {
   repeated string connections = 1;
 }


### PR DESCRIPTION
This PR updates the connection component to use the canonical state paths as specified in ICS3, and the canonical protobuf encoding for `ConnectionEnd`.