### PR TITLE
Use bootstrap-peers rather than persistent-peers

### DIFF
--- a/docs/guide/src/pd/join-testnet/fullnode.md
+++ b/docs/guide/src/pd/join-testnet/fullnode.md
@@ -28,12 +28,12 @@ curl -s http://testnet.penumbra.zone:26657/genesis | jq ".result.genesis" > \$HO
 ```
 The response data is nested, so we use `jq` to grab a specific key.
 
-Next you'll need to modify the persistent peers list to specify our primary
-testnet node as a permanent peer for your node. Open
-`\$HOME/.tendermint/config/config.toml` and find the `persistent-peers` line and
+Next you'll need to modify the bootstrap peers list to specify our primary
+testnet node as the initial peer for your node. Open
+`\$HOME/.tendermint/config/config.toml` and find the `bootstrap-peers` line and
 add the testnet node:
 ```toml
-persistent-peers = "NODE_ID@testnet.penumbra.zone:26656"
+bootstrap-peers = "NODE_ID@testnet.penumbra.zone:26656"
 ```
 The format is `NODE_ID@ADDRESS`.  You will need to replace `NODE_ID` with the
 identifier for the node you want to connect to.  On a production network, this

--- a/testnets/tm_config_template.toml
+++ b/testnets/tm_config_template.toml
@@ -223,10 +223,10 @@ seeds = ""
 # Comma separated list of peers to be added to the peer store
 # on startup. Either BootstrapPeers or PersistentPeers are
 # needed for peer discovery
-bootstrap-peers = ""
+bootstrap-peers = "{}"
 
 # Comma separated list of nodes to keep persistent connections to
-persistent-peers = "{}"
+persistent-peers = ""
 
 # UPNP port forwarding
 upnp = false


### PR DESCRIPTION
`persistent-peers` is designed for persistent connections like validator <> sentry node and ignores backoffs. `bootstrap-peers` is the correct configuration to use for normal validators.