### PR TITLE
remove wrapper types for IBC domain types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,6 +2669,7 @@ dependencies = [
  "penumbra-proto",
  "penumbra-storage",
  "penumbra-transaction",
+ "prost 0.9.0",
  "prost-types 0.9.0",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,6 +2688,7 @@ dependencies = [
  "bech32",
  "bytes",
  "hex",
+ "ibc",
  "ibc-proto",
  "prost 0.9.0",
  "prost-build",

--- a/ibc/Cargo.toml
+++ b/ibc/Cargo.toml
@@ -28,6 +28,7 @@ once_cell = "1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 anyhow = "1"
+prost = "0.9"
 async-trait = "0.1.52"
 ibc = { git = "https://github.com/penumbra-zone/ibc-rs.git", branch = "with-tendermintrs-24" }
 ibc-proto = { git = "https://github.com/penumbra-zone/ibc-rs.git", branch = "with-tendermintrs-24" }

--- a/ibc/src/client.rs
+++ b/ibc/src/client.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use ibc::core::ics02_client::trust_threshold::TrustThreshold;
 use ibc::core::ics23_commitment::specs::ProofSpecs;
 use ibc::core::ics24_host::identifier::ChainId;
@@ -9,11 +7,8 @@ use ibc::{
     clients::ics07_tendermint::{
         client_state, consensus_state, consensus_state::ConsensusState as TendermintConsensusState,
     },
-    core::{
-        ics02_client::{
-            client_consensus::AnyConsensusState, client_state::AnyClientState, height::Height,
-        },
-        ics24_host::identifier::ClientId,
+    core::ics02_client::{
+        client_consensus::AnyConsensusState, client_state::AnyClientState, height::Height,
     },
 };
 use penumbra_proto::{ibc as pb, Protobuf};
@@ -130,71 +125,6 @@ impl From<ConsensusState> for pb::ConsensusState {
                         .expect("encoding to `Any` from `ConsensusState::Tendermint`"),
                 }),
             },
-        }
-    }
-}
-
-/// ClientData encapsulates the data that represents an ICS-02 client, stored in the Penumbra
-/// state.
-#[derive(Clone, Debug)]
-pub struct ClientData {
-    pub client_id: ClientId,
-    pub client_state: ClientState,
-    pub processed_time: String,
-    pub processed_height: u64,
-}
-
-impl ClientData {
-    pub fn new(
-        client_id: ClientId,
-        client_state: AnyClientState,
-        processed_time: String,
-        processed_height: u64,
-    ) -> Self {
-        ClientData {
-            client_id,
-            client_state: ClientState(client_state),
-            processed_time,
-            processed_height,
-        }
-    }
-    pub fn with_new_client_state(
-        &self,
-        new_client_state: AnyClientState,
-        new_processed_time: String,
-        new_processed_height: u64,
-    ) -> Self {
-        ClientData {
-            client_id: self.client_id.clone(),
-            client_state: ClientState(new_client_state),
-            processed_time: new_processed_time,
-            processed_height: new_processed_height,
-        }
-    }
-}
-
-impl Protobuf<pb::ClientData> for ClientData {}
-
-impl TryFrom<pb::ClientData> for ClientData {
-    type Error = anyhow::Error;
-
-    fn try_from(msg: pb::ClientData) -> Result<Self, Self::Error> {
-        Ok(ClientData {
-            client_id: ClientId::from_str(&msg.client_id)?,
-            client_state: ClientState::try_from(msg.client_state.unwrap())?,
-            processed_time: msg.processed_time,
-            processed_height: msg.processed_height,
-        })
-    }
-}
-
-impl From<ClientData> for pb::ClientData {
-    fn from(d: ClientData) -> Self {
-        Self {
-            client_id: d.client_id.to_string(),
-            client_state: Some(d.client_state.into()),
-            processed_time: d.processed_time,
-            processed_height: d.processed_height,
         }
     }
 }

--- a/ibc/src/client.rs
+++ b/ibc/src/client.rs
@@ -1,22 +1,10 @@
 use ibc::core::ics02_client::trust_threshold::TrustThreshold;
+use ibc::core::ics02_client::{client_state::AnyClientState, height::Height};
 use ibc::core::ics23_commitment::specs::ProofSpecs;
 use ibc::core::ics24_host::identifier::ChainId;
 use ibc::core::ics24_host::identifier::ConnectionId;
 use ibc::downcast;
-use ibc::{
-    clients::ics07_tendermint::{
-        client_state, consensus_state, consensus_state::ConsensusState as TendermintConsensusState,
-    },
-    core::ics02_client::{
-        client_consensus::AnyConsensusState, client_state::AnyClientState, height::Height,
-    },
-};
 use penumbra_proto::{ibc as pb, Protobuf};
-use tendermint_proto::Protobuf as TmProtobuf;
-
-pub const TENDERMINT_CLIENT_STATE_TYPE_URL: &str = "/ibc.lightclients.tendermint.v1.ClientState";
-pub const TENDERMINT_CONSENSUS_STATE_TYPE_URL: &str =
-    "/ibc.lightclients.tendermint.v1.ConsensusState";
 
 #[derive(Clone, Debug)]
 pub struct ClientCounter(pub u64);
@@ -34,98 +22,6 @@ impl TryFrom<pb::ClientCounter> for ClientCounter {
 impl From<ClientCounter> for pb::ClientCounter {
     fn from(c: ClientCounter) -> Self {
         pb::ClientCounter { counter: c.0 }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ClientState(pub AnyClientState);
-
-impl Protobuf<prost_types::Any> for ClientState {}
-
-impl TryFrom<prost_types::Any> for ClientState {
-    type Error = anyhow::Error;
-
-    fn try_from(raw: prost_types::Any) -> Result<Self, Self::Error> {
-        match raw.type_url.as_str() {
-            TENDERMINT_CLIENT_STATE_TYPE_URL => Ok(ClientState(AnyClientState::Tendermint(
-                client_state::ClientState::decode_vec(&raw.value)
-                    .map_err(|_| anyhow::anyhow!("could not decode tendermint client state"))?,
-            ))),
-
-            _ => Err(anyhow::anyhow!("unknown client type: {}", raw.type_url)),
-        }
-    }
-}
-
-impl From<ClientState> for prost_types::Any {
-    fn from(value: ClientState) -> Self {
-        match value {
-            ClientState(AnyClientState::Tendermint(value)) => prost_types::Any {
-                type_url: TENDERMINT_CLIENT_STATE_TYPE_URL.to_string(),
-                value: value
-                    .encode_vec()
-                    .expect("encoding to `Any` from `ClientState::Tendermint`"),
-            },
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ConsensusState(pub AnyConsensusState);
-
-impl ConsensusState {
-    pub fn as_tendermint(&self) -> Result<TendermintConsensusState, anyhow::Error> {
-        match &self.0 {
-            AnyConsensusState::Tendermint(state) => Ok(state.clone()),
-            _ => return Err(anyhow::anyhow!("not a tendermint consensus state")),
-        }
-    }
-}
-
-impl From<TendermintConsensusState> for ConsensusState {
-    fn from(value: TendermintConsensusState) -> Self {
-        ConsensusState(AnyConsensusState::Tendermint(value))
-    }
-}
-
-impl Protobuf<pb::ConsensusState> for ConsensusState {}
-
-impl TryFrom<pb::ConsensusState> for ConsensusState {
-    type Error = anyhow::Error;
-
-    fn try_from(raw: pb::ConsensusState) -> Result<Self, Self::Error> {
-        let state = raw
-            .consensus_state
-            .ok_or_else(|| anyhow::anyhow!("missing consensus state"))?;
-        match state.type_url.as_str() {
-            TENDERMINT_CONSENSUS_STATE_TYPE_URL => {
-                Ok(ConsensusState(AnyConsensusState::Tendermint(
-                    consensus_state::ConsensusState::decode_vec(&state.value).map_err(|_| {
-                        anyhow::anyhow!("could not decode tendermint consensus state")
-                    })?,
-                )))
-            }
-
-            _ => Err(anyhow::anyhow!(
-                "unknown consensus state type: {}",
-                state.type_url
-            )),
-        }
-    }
-}
-
-impl From<ConsensusState> for pb::ConsensusState {
-    fn from(value: ConsensusState) -> Self {
-        match value {
-            ConsensusState(AnyConsensusState::Tendermint(value)) => pb::ConsensusState {
-                consensus_state: Some(prost_types::Any {
-                    type_url: TENDERMINT_CONSENSUS_STATE_TYPE_URL.to_string(),
-                    value: value
-                        .encode_vec()
-                        .expect("encoding to `Any` from `ConsensusState::Tendermint`"),
-                }),
-            },
-        }
     }
 }
 

--- a/ibc/src/component/client.rs
+++ b/ibc/src/component/client.rs
@@ -39,7 +39,7 @@ use tendermint_light_client_verifier::{
 };
 use tracing::instrument;
 
-use crate::{ClientConnections, ClientCounter, ConsensusState, VerifiedHeights, COMMITMENT_PREFIX};
+use crate::{ClientConnections, ClientCounter, VerifiedHeights, COMMITMENT_PREFIX};
 
 mod stateful;
 mod stateless;
@@ -83,7 +83,7 @@ impl Component for Ics2Client {
         let height = Height::new(revision_number, begin_block.header.height.into());
 
         self.state
-            .put_penumbra_consensus_state(height, cs.into())
+            .put_penumbra_consensus_state(height, AnyConsensusState::Tendermint(cs))
             .await;
     }
 
@@ -209,7 +209,7 @@ impl Ics2Client {
             .put_verified_consensus_state(
                 tm_header.height(),
                 msg_update_client.client_id.clone(),
-                ConsensusState(AnyConsensusState::Tendermint(next_tm_consensus_state)),
+                AnyConsensusState::Tendermint(next_tm_consensus_state),
             )
             .await
             .unwrap();
@@ -240,7 +240,7 @@ impl Ics2Client {
             .put_verified_consensus_state(
                 msg_create_client.client_state.latest_height(),
                 client_id,
-                ConsensusState(msg_create_client.consensus_state),
+                msg_create_client.consensus_state,
             )
             .await
             .unwrap();
@@ -274,7 +274,11 @@ impl Ics2Client {
             .await
             .ok()
         {
-            let stored_cs_state_tm = stored_cs_state.as_tendermint().unwrap();
+            let stored_cs_state_tm = downcast!(stored_cs_state => AnyConsensusState::Tendermint)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("stored consensus state is not a Tendermint consensus state")
+                })
+                .unwrap();
             if stored_cs_state_tm == verified_consensus_state {
                 return (trusted_client_state, verified_consensus_state);
             } else {
@@ -306,7 +310,11 @@ impl Ics2Client {
         // case 1: if we have a verified consensus state previous to this header, verify that this
         // header's timestamp is greater than or equal to the stored consensus state's timestamp
         if let Some(prev_state) = prev_consensus_state {
-            let prev_state_tm = prev_state.as_tendermint().unwrap();
+            let prev_state_tm = downcast!(prev_state => AnyConsensusState::Tendermint)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("stored consensus state is not a Tendermint consensus state")
+                })
+                .unwrap();
             if !(verified_header.signed_header.header().time >= prev_state_tm.timestamp) {
                 return (
                     trusted_client_state
@@ -320,7 +328,11 @@ impl Ics2Client {
         // case 2: if we have a verified consensus state with higher block height than this header,
         // verify that this header's timestamp is less than or equal to this header's timestamp.
         if let Some(next_state) = next_consensus_state {
-            let next_state_tm = next_state.as_tendermint().unwrap();
+            let next_state_tm = downcast!(next_state => AnyConsensusState::Tendermint)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("stored consensus state is not a Tendermint consensus state")
+                })
+                .unwrap();
             if !(verified_header.signed_header.header().time <= next_state_tm.timestamp) {
                 return (
                     trusted_client_state
@@ -413,7 +425,7 @@ pub trait View: StateExt {
     }
 
     // returns the ConsensusState for the penumbra chain (this chain) at the given height
-    async fn get_penumbra_consensus_state(&self, height: Height) -> Result<ConsensusState> {
+    async fn get_penumbra_consensus_state(&self, height: Height) -> Result<AnyConsensusState> {
         // NOTE: this is an implementation detail of the Penumbra ICS2 implementation, so
         // it's not in the same path namespace.
         self.get_domain(format!("penumbra_consensus_states/{}", height).into())
@@ -422,7 +434,11 @@ pub trait View: StateExt {
     }
 
     // returns the ConsensusState for the penumbra chain (this chain) at the given height
-    async fn put_penumbra_consensus_state(&self, height: Height, consensus_state: ConsensusState) {
+    async fn put_penumbra_consensus_state(
+        &self,
+        height: Height,
+        consensus_state: AnyConsensusState,
+    ) {
         // NOTE: this is an implementation detail of the Penumbra ICS2 implementation, so
         // it's not in the same path namespace.
         self.put_domain(
@@ -436,7 +452,7 @@ pub trait View: StateExt {
         &self,
         height: Height,
         client_id: ClientId,
-    ) -> Result<ConsensusState> {
+    ) -> Result<AnyConsensusState> {
         self.get_domain(
             format!(
                 "{}/{}/consensusStates/{}",
@@ -452,7 +468,7 @@ pub trait View: StateExt {
         &mut self,
         height: Height,
         client_id: ClientId,
-        consensus_state: ConsensusState,
+        consensus_state: AnyConsensusState,
     ) -> Result<()> {
         self.put_domain(
             format!(
@@ -486,7 +502,7 @@ pub trait View: StateExt {
         &self,
         client_id: &ClientId,
         height: Height,
-    ) -> Result<Option<ConsensusState>> {
+    ) -> Result<Option<AnyConsensusState>> {
         let mut verified_heights =
             self.get_verified_heights(client_id)
                 .await?
@@ -517,7 +533,7 @@ pub trait View: StateExt {
         &self,
         client_id: &ClientId,
         height: Height,
-    ) -> Result<Option<ConsensusState>> {
+    ) -> Result<Option<AnyConsensusState>> {
         let mut verified_heights =
             self.get_verified_heights(client_id)
                 .await?

--- a/ibc/src/component/connection.rs
+++ b/ibc/src/component/connection.rs
@@ -28,8 +28,7 @@ use tracing::instrument;
 
 use crate::component::client::View as _;
 use crate::{
-    validate_penumbra_client_state, Connection, ConnectionCounter, COMMITMENT_PREFIX,
-    SUPPORTED_VERSIONS,
+    validate_penumbra_client_state, ConnectionCounter, COMMITMENT_PREFIX, SUPPORTED_VERSIONS,
 };
 
 mod stateful;
@@ -174,8 +173,7 @@ impl ConnectionComponent {
             .await
             .unwrap()
             .ok_or_else(|| anyhow::anyhow!("no connection with the given ID"))
-            .unwrap()
-            .0;
+            .unwrap();
 
         connection.set_state(ConnectionState::Open);
 
@@ -190,8 +188,7 @@ impl ConnectionComponent {
             .get_connection(&msg.connection_id)
             .await
             .unwrap()
-            .unwrap()
-            .0;
+            .unwrap();
 
         let prev_counterparty = connection.counterparty();
         let counterparty = Counterparty::new(
@@ -278,7 +275,7 @@ pub trait View: StateExt + Send + Sync {
     async fn put_new_connection(
         &mut self,
         connection_id: &ConnectionId,
-        connection: Connection,
+        connection: ConnectionEnd,
     ) -> Result<()> {
         self.put_domain(
             format!(
@@ -297,13 +294,13 @@ pub trait View: StateExt + Send + Sync {
         self.put_connection_counter(ConnectionCounter(counter.0 + 1))
             .await;
 
-        self.add_connection_to_client(connection.0.client_id(), connection_id)
+        self.add_connection_to_client(connection.client_id(), connection_id)
             .await?;
 
         return Ok(());
     }
 
-    async fn get_connection(&self, connection_id: &ConnectionId) -> Result<Option<Connection>> {
+    async fn get_connection(&self, connection_id: &ConnectionId) -> Result<Option<ConnectionEnd>> {
         self.get_domain(
             format!(
                 "{}/connections/{}",
@@ -315,7 +312,7 @@ pub trait View: StateExt + Send + Sync {
         .await
     }
 
-    async fn update_connection(&self, connection_id: &ConnectionId, connection: Connection) {
+    async fn update_connection(&self, connection_id: &ConnectionId, connection: ConnectionEnd) {
         self.put_domain(
             format!(
                 "{}/connections/{}",

--- a/ibc/src/component/connection/stateful.rs
+++ b/ibc/src/component/connection/stateful.rs
@@ -98,8 +98,7 @@ pub mod connection_open_confirm {
                 let connection = self
                     .get_connection(&msg.connection_id)
                     .await?
-                    .ok_or_else(|| anyhow::anyhow!("connection not found"))?
-                    .0;
+                    .ok_or_else(|| anyhow::anyhow!("connection not found"))?;
 
                 if !connection.state_matches(&ConnectionState::TryOpen) {
                     return Err(anyhow::anyhow!("connection not in correct state"));
@@ -276,8 +275,7 @@ pub mod connection_open_ack {
                 let connection = self
                     .get_connection(&msg.connection_id)
                     .await?
-                    .ok_or_else(|| anyhow::anyhow!("no connection with the specified ID exists"))?
-                    .0;
+                    .ok_or_else(|| anyhow::anyhow!("no connection with the specified ID exists"))?;
 
                 // see
                 // https://github.com/cosmos/ibc/blob/master/spec/core/ics-003-connection-semantics/README.md
@@ -467,8 +465,7 @@ pub mod connection_open_try {
                     let prev_connection = self
                         .get_connection(prev_conn_id)
                         .await?
-                        .ok_or_else(|| anyhow::anyhow!("no connection with the given ID"))?
-                        .0;
+                        .ok_or_else(|| anyhow::anyhow!("no connection with the given ID"))?;
 
                     // check that the existing connection matches the incoming connectionOpenTry
                     if !(prev_connection.state_matches(&ConnectionState::Init)

--- a/ibc/src/component/connection/stateful.rs
+++ b/ibc/src/component/connection/stateful.rs
@@ -5,7 +5,8 @@ pub mod connection_open_init {
     pub trait ConnectionOpenInitCheck: StateExt {
         async fn validate(&self, msg: &MsgConnectionOpenInit) -> anyhow::Result<()> {
             // check that the client with the specified ID exists
-            self.get_client_data(&msg.client_id).await?;
+            self.get_client_state(&msg.client_id).await?;
+            self.get_client_type(&msg.client_id).await?;
 
             Ok(())
         }
@@ -47,11 +48,7 @@ pub mod connection_open_confirm {
             );
 
             // get the trusted client state for the counterparty
-            let trusted_client_state = self
-                .get_client_data(connection.client_id())
-                .await?
-                .client_state
-                .0;
+            let trusted_client_state = self.get_client_state(connection.client_id()).await?;
 
             // check if the client is frozen
             // TODO: should we also check if the client is expired here?
@@ -158,11 +155,7 @@ pub mod connection_open_ack {
             );
 
             // get the stored client state for the counterparty
-            let trusted_client_state = self
-                .get_client_data(connection.client_id())
-                .await?
-                .client_state
-                .0;
+            let trusted_client_state = self.get_client_state(connection.client_id()).await?;
 
             // check if the client is frozen
             // TODO: should we also check if the client is expired here?
@@ -351,7 +344,7 @@ pub mod connection_open_try {
             );
 
             // get the stored client state for the counterparty
-            let trusted_client_state = self.get_client_data(&msg.client_id).await?.client_state.0;
+            let trusted_client_state = self.get_client_state(&msg.client_id).await?;
 
             // check if the client is frozen
             // TODO: should we also check if the client is expired here?

--- a/ibc/src/component/connection/stateful.rs
+++ b/ibc/src/component/connection/stateful.rs
@@ -59,8 +59,7 @@ pub mod connection_open_confirm {
             // get the stored consensus state for the counterparty
             let trusted_consensus_state = self
                 .get_verified_consensus_state(msg.proofs.height(), connection.client_id().clone())
-                .await?
-                .0;
+                .await?;
 
             let client_def = AnyClient::from_client_type(trusted_client_state.client_type());
 
@@ -166,8 +165,7 @@ pub mod connection_open_ack {
             // get the stored consensus state for the counterparty
             let trusted_consensus_state = self
                 .get_verified_consensus_state(msg.proofs.height(), connection.client_id().clone())
-                .await?
-                .0;
+                .await?;
 
             let client_def = AnyClient::from_client_type(trusted_client_state.client_type());
 
@@ -207,8 +205,7 @@ pub mod connection_open_ack {
             })?;
             let expected_consensus = self
                 .get_penumbra_consensus_state(cons_proof.height())
-                .await?
-                .0;
+                .await?;
 
             // 3. verify that the counterparty chain stored the correct consensus state of Penumbra at
             //    the given consensus height
@@ -355,8 +352,8 @@ pub mod connection_open_try {
             // get the stored consensus state for the counterparty
             let trusted_consensus_state = self
                 .get_verified_consensus_state(msg.proofs.height(), msg.client_id.clone())
-                .await?
-                .0;
+                .await?;
+
             let client_def = AnyClient::from_client_type(trusted_client_state.client_type());
 
             // PROOF VERIFICATION
@@ -395,8 +392,7 @@ pub mod connection_open_try {
             })?;
             let expected_consensus = self
                 .get_penumbra_consensus_state(cons_proof.height())
-                .await?
-                .0;
+                .await?;
 
             // 3. verify that the counterparty chain stored the correct consensus state of Penumbra at
             //    the given consensus height

--- a/ibc/src/connection.rs
+++ b/ibc/src/connection.rs
@@ -1,6 +1,4 @@
-use ibc::core::ics03_connection::connection::ConnectionEnd;
 use ibc::core::ics03_connection::version::Version;
-use ibc_proto::ibc::core::connection::v1::ConnectionEnd as RawConnectionEnd;
 use once_cell::sync::Lazy;
 use penumbra_proto::{ibc as pb, Protobuf};
 
@@ -20,32 +18,6 @@ impl TryFrom<pb::ConnectionCounter> for ConnectionCounter {
 impl From<ConnectionCounter> for pb::ConnectionCounter {
     fn from(c: ConnectionCounter) -> Self {
         pb::ConnectionCounter { counter: c.0 }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct Connection(pub ConnectionEnd);
-
-impl Protobuf<RawConnectionEnd> for Connection {}
-
-impl TryFrom<RawConnectionEnd> for Connection {
-    type Error = anyhow::Error;
-
-    fn try_from(p: RawConnectionEnd) -> Result<Self, Self::Error> {
-        let connection_end = ConnectionEnd::try_from(p)?;
-        Ok(Connection(connection_end))
-    }
-}
-
-impl From<Connection> for RawConnectionEnd {
-    fn from(c: Connection) -> Self {
-        c.0.into()
-    }
-}
-
-impl From<ConnectionEnd> for Connection {
-    fn from(c: ConnectionEnd) -> Self {
-        Connection(c)
     }
 }
 

--- a/ibc/src/lib.rs
+++ b/ibc/src/lib.rs
@@ -8,7 +8,7 @@ mod component;
 mod connection;
 
 pub use client::{
-    validate_penumbra_client_state, ClientConnections, ClientCounter, ClientData, ConsensusState,
+    validate_penumbra_client_state, ClientConnections, ClientCounter, ConsensusState,
     VerifiedHeights,
 };
 pub use component::IBCComponent;

--- a/ibc/src/lib.rs
+++ b/ibc/src/lib.rs
@@ -8,8 +8,7 @@ mod component;
 mod connection;
 
 pub use client::{
-    validate_penumbra_client_state, ClientConnections, ClientCounter, ConsensusState,
-    VerifiedHeights,
+    validate_penumbra_client_state, ClientConnections, ClientCounter, VerifiedHeights,
 };
 pub use component::IBCComponent;
 pub use connection::{ConnectionCounter, SUPPORTED_VERSIONS};

--- a/ibc/src/lib.rs
+++ b/ibc/src/lib.rs
@@ -12,6 +12,6 @@ pub use client::{
     VerifiedHeights,
 };
 pub use component::IBCComponent;
-pub use connection::{Connection, ConnectionCounter, SUPPORTED_VERSIONS};
+pub use connection::{ConnectionCounter, SUPPORTED_VERSIONS};
 
 pub static COMMITMENT_PREFIX: &str = "penumbra-ibc-commitment";

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -14,6 +14,7 @@ hex = "0.4"
 anyhow = "1.0"
 subtle-encoding = "0.5"
 bech32 = "0.8"
+ibc = { git = "https://github.com/penumbra-zone/ibc-rs.git", branch = "with-tendermintrs-24" }
 ibc-proto = { git = "https://github.com/penumbra-zone/ibc-rs.git", branch = "with-tendermintrs-24" }
 prost-types = "0.9"
 

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -64,10 +64,12 @@ pub mod ibc {
     use crate::Protobuf;
     use ibc_proto::google::protobuf::Any;
     use ibc_proto::ibc::core::connection::v1::ConnectionEnd as RawConnectionEnd;
+    use ibc_rs::core::ics02_client::client_consensus::AnyConsensusState;
     use ibc_rs::core::ics03_connection::connection::ConnectionEnd;
 
     impl Protobuf<RawConnectionEnd> for ConnectionEnd {}
     impl Protobuf<Any> for AnyClientState {}
+    impl Protobuf<Any> for AnyConsensusState {}
 }
 
 /// Wallet protocol structures.

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -1,4 +1,4 @@
-//! Protobuf definitions for Penumbra.
+//! Protobuf definitions for Penumbra.o
 //!
 //! This crate only contains the `.proto` files and the Rust types generated
 //! from them.  These types only handle parsing the wire format; validation
@@ -56,6 +56,14 @@ pub mod client {
 /// IBC protocol structures.
 pub mod ibc {
     tonic::include_proto!("penumbra.ibc");
+
+    extern crate ibc as ibc_rs;
+
+    use crate::Protobuf;
+    use ibc_proto::ibc::core::connection::v1::ConnectionEnd as RawConnectionEnd;
+    use ibc_rs::core::ics03_connection::connection::ConnectionEnd;
+
+    impl Protobuf<RawConnectionEnd> for ConnectionEnd {}
 }
 
 /// Wallet protocol structures.

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -59,11 +59,15 @@ pub mod ibc {
 
     extern crate ibc as ibc_rs;
 
+    use ibc_rs::core::ics02_client::client_state::AnyClientState;
+
     use crate::Protobuf;
+    use ibc_proto::google::protobuf::Any;
     use ibc_proto::ibc::core::connection::v1::ConnectionEnd as RawConnectionEnd;
     use ibc_rs::core::ics03_connection::connection::ConnectionEnd;
 
     impl Protobuf<RawConnectionEnd> for ConnectionEnd {}
+    impl Protobuf<Any> for AnyClientState {}
 }
 
 /// Wallet protocol structures.


### PR DESCRIPTION
This PR removes our wrapper types for the IBC domain types, and instead does `impl Protobuf` directly in the proto crate on the IBC types. Also, the state paths for client related data have been brought into spec with ICS2.