### PR TITLE
storage: create database and column families if they are missing

### DIFF
--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -6,7 +6,7 @@ use jmt::{
     storage::{Node, NodeBatch, NodeKey, TreeReader, TreeWriter},
     WriteOverlay,
 };
-use rocksdb::DB;
+use rocksdb::{Options, DB};
 use tokio::sync::RwLock;
 use tracing::{instrument, Span};
 
@@ -25,8 +25,12 @@ impl Storage {
             .spawn_blocking(move || {
                 span.in_scope(|| {
                     tracing::info!(?path, "opening rocksdb");
+                    let mut opts = Options::default();
+                    opts.create_if_missing(true);
+                    opts.create_missing_column_families(true);
+
                     Ok(Self(Arc::new(DB::open_cf(
-                        &Default::default(),
+                        &opts,
                         path,
                         ["default", "nct"],
                     )?)))


### PR DESCRIPTION
when we changed how we use the RocksDB API, from `open_default` to `open_cf`, we removed the create_if_missing and create_missing_column_families flag, which exist by default in `open_default`. this was causing our smoke test and the IBC test to fail.