### PR TITLE
crypto: rename `transaction::output::Body` to `crypto::NotePayload`

### DIFF
--- a/chain/src/sync.rs
+++ b/chain/src/sync.rs
@@ -2,9 +2,8 @@ use std::convert::TryFrom;
 
 use anyhow::Result;
 use bytes::Bytes;
-use penumbra_crypto::{FieldExt, Nullifier};
+use penumbra_crypto::{FieldExt, NotePayload, Nullifier};
 use penumbra_proto::{chain as pb, Protobuf};
-use penumbra_transaction::action::output;
 use serde::{Deserialize, Serialize};
 
 // Domain type for CompactBlock.
@@ -14,7 +13,7 @@ use serde::{Deserialize, Serialize};
 pub struct CompactBlock {
     pub height: u64,
     // Output bodies describing new notes.
-    pub outputs: Vec<output::Body>,
+    pub note_payloads: Vec<NotePayload>,
     // Nullifiers identifying spent notes.
     pub nullifiers: Vec<Nullifier>,
 }
@@ -25,7 +24,7 @@ impl From<CompactBlock> for pb::CompactBlock {
     fn from(cb: CompactBlock) -> Self {
         pb::CompactBlock {
             height: cb.height,
-            outputs: cb.outputs.into_iter().map(Into::into).collect(),
+            note_payloads: cb.note_payloads.into_iter().map(Into::into).collect(),
             nullifiers: cb
                 .nullifiers
                 .into_iter()
@@ -41,11 +40,11 @@ impl TryFrom<pb::CompactBlock> for CompactBlock {
     fn try_from(value: pb::CompactBlock) -> Result<Self, Self::Error> {
         Ok(CompactBlock {
             height: value.height,
-            outputs: value
-                .outputs
+            note_payloads: value
+                .note_payloads
                 .into_iter()
-                .map(output::Body::try_from)
-                .collect::<Result<Vec<output::Body>>>()?,
+                .map(NotePayload::try_from)
+                .collect::<Result<Vec<NotePayload>>>()?,
             nullifiers: value
                 .nullifiers
                 .into_iter()

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -13,6 +13,7 @@ pub mod keys;
 pub mod memo;
 pub mod merkle;
 pub mod note;
+mod note_payload;
 mod nullifier;
 mod prf;
 pub mod proofs;
@@ -24,6 +25,7 @@ pub use delegation_token::DelegationToken;
 pub use identity_key::IdentityKey;
 pub use keys::FullViewingKey;
 pub use note::Note;
+pub use note_payload::NotePayload;
 pub use nullifier::Nullifier;
 pub use value::Value;
 

--- a/crypto/src/note_payload.rs
+++ b/crypto/src/note_payload.rs
@@ -1,0 +1,54 @@
+use anyhow::Error;
+use bytes::Bytes;
+use penumbra_proto::{crypto as pb, Protobuf};
+use serde::{Deserialize, Serialize};
+
+use crate::{ka, note};
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(try_from = "pb::NotePayload", into = "pb::NotePayload")]
+pub struct NotePayload {
+    pub note_commitment: note::Commitment,
+    pub ephemeral_key: ka::Public,
+    pub encrypted_note: [u8; note::NOTE_CIPHERTEXT_BYTES],
+}
+
+impl std::fmt::Debug for NotePayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("output::Body")
+            .field("note_commitment", &self.note_commitment)
+            .field("ephemeral_key", &self.ephemeral_key)
+            .field("encrypted_note", &"...")
+            .finish()
+    }
+}
+
+impl Protobuf<pb::NotePayload> for NotePayload {}
+
+impl From<NotePayload> for pb::NotePayload {
+    fn from(msg: NotePayload) -> Self {
+        pb::NotePayload {
+            note_commitment: Some(msg.note_commitment.into()),
+            ephemeral_key: Bytes::copy_from_slice(&msg.ephemeral_key.0),
+            encrypted_note: Bytes::copy_from_slice(&msg.encrypted_note),
+        }
+    }
+}
+
+impl TryFrom<pb::NotePayload> for NotePayload {
+    type Error = Error;
+
+    fn try_from(proto: pb::NotePayload) -> anyhow::Result<Self, Self::Error> {
+        Ok(NotePayload {
+            note_commitment: proto
+                .note_commitment
+                .ok_or_else(|| anyhow::anyhow!("missing note commitment"))?
+                .try_into()?,
+            ephemeral_key: ka::Public::try_from(&proto.ephemeral_key[..])
+                .map_err(|_| anyhow::anyhow!("output body malformed"))?,
+            encrypted_note: proto.encrypted_note[..]
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("output body malformed"))?,
+        })
+    }
+}

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
         ".penumbra.transaction",
         // The byte fields in a compact block will also be converted to fixed-size
         // byte arrays and then discarded.
-        ".penumbra.chain.CompactOutput",
+        ".penumbra.crypto.NotePayload",
         ".penumbra.chain.CompactBlock",
     ]);
 
@@ -109,6 +109,7 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.crypto.Note", SERDE_TRANSPARENT),
     (".penumbra.crypto.NoteCommitment", SERIALIZE),
     (".penumbra.crypto.NoteCommitment", SERDE_TRANSPARENT),
+    (".penumbra.crypto.NotePayload", SERIALIZE),
     (".penumbra.crypto.AssetId", SERIALIZE),
     (".penumbra.crypto.AssetId", SERDE_TRANSPARENT),
     (".penumbra.crypto.Value", SERIALIZE),
@@ -136,7 +137,6 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.chain.NoteSource", SERDE_TRANSPARENT),
     (".penumbra.chain.GenesisAppState", SERIALIZE),
     (".penumbra.chain.GenesisAllocation", SERIALIZE),
-    (".penumbra.transaction.OutputBody", SERIALIZE),
     (".penumbra.wallet.NoteRecord", SERIALIZE),
 ];
 

--- a/proto/proto/chain.proto
+++ b/proto/proto/chain.proto
@@ -3,7 +3,6 @@ package penumbra.chain;
 option go_package = "github.com/penumbra-zone/penumbra/proto/go-proto";
 
 import "crypto.proto";
-import "transaction.proto";
 import "stake.proto";
 
 // Global chain configuration data, such as chain ID, epoch duration, etc.
@@ -49,8 +48,8 @@ message AssetInfo {
 // Contains the minimum data needed to update client state.
 message CompactBlock {
   uint64 height = 1;
-  // OutputBodies describing new notes.
-  repeated transaction.OutputBody outputs = 2;
+  // NotePayloads describing new notes.
+  repeated crypto.NotePayload note_payloads = 2;
   // Nullifiers identifying spent notes.
   repeated bytes nullifiers = 3;
 }

--- a/proto/proto/crypto.proto
+++ b/proto/proto/crypto.proto
@@ -68,6 +68,18 @@ message Nullifier {
     bytes inner = 1;
 }
 
+// The body of an output description, including only the minimal
+// data required to scan and process the output.
+message NotePayload {
+  // The note commitment for the output note. 32 bytes.
+  NoteCommitment note_commitment = 1;
+  // The encoding of an ephemeral public key. 32 bytes.
+  bytes ephemeral_key = 2;
+  // An encryption of the newly created note.
+  // 132 = 1(type) + 11(d) + 8(amount) + 32(asset_id) + 32(rcm) + 32(pk_d) + 16(MAC) bytes.
+  bytes encrypted_note = 3;
+}
+
 // An authentication path from a note commitment to the root of the note commitment tree.
 //
 // TODO: update this when migrating to TCT

--- a/proto/proto/transaction.proto
+++ b/proto/proto/transaction.proto
@@ -68,7 +68,7 @@ message SpendBody {
 // Creates a new shielded note.
 message Output {
   // The minimal data required to scan and process the new output note.
-  OutputBody body = 1;
+  crypto.NotePayload note_payload = 1;
   // A commitment to the value of the output note. 32 bytes.
   bytes cv = 2;
   // An encrypted memo. 528 bytes.
@@ -78,16 +78,4 @@ message Output {
   bytes ovk_wrapped_key = 4;
   // The output proof. 192 bytes.
   bytes zkproof = 5;
-}
-
-// The body of an output description, including only the minimal
-// data required to scan and process the output.
-message OutputBody {
-  // The note commitment for the output note. 32 bytes.
-  crypto.NoteCommitment note_commitment = 1;
-  // The encoding of an ephemeral public key. 32 bytes.
-  bytes ephemeral_key = 2;
-  // An encryption of the newly created note.
-  // 132 = 1(type) + 11(d) + 8(amount) + 32(asset_id) + 32(rcm) + 32(pk_d) + 16(MAC) bytes.
-  bytes encrypted_note = 3;
 }

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -7,12 +7,12 @@ use decaf377::FieldExt;
 use penumbra_crypto::{
     merkle,
     rdsa::{Binding, Signature, VerificationKey, VerificationKeyBytes},
-    Fr, Nullifier, Value, STAKING_TOKEN_ASSET_ID,
+    Fr, NotePayload, Nullifier, Value, STAKING_TOKEN_ASSET_ID,
 };
 use penumbra_proto::{ibc as pb_ibc, stake as pbs, transaction as pbt, Message, Protobuf};
 
 use crate::{
-    action::{output, Delegate, Undelegate},
+    action::{Delegate, Undelegate},
     Action,
 };
 
@@ -114,13 +114,13 @@ impl Transaction {
         })
     }
 
-    pub fn output_bodies(&self) -> Vec<output::Body> {
+    pub fn note_payloads(&self) -> Vec<NotePayload> {
         self.transaction_body
             .actions
             .iter()
             .filter_map(|action| {
                 if let Action::Output(output) = action {
-                    Some(output.body.clone())
+                    Some(output.note_payload.clone())
                 } else {
                     None
                 }

--- a/wallet-next/src/sync.rs
+++ b/wallet-next/src/sync.rs
@@ -2,9 +2,8 @@ use penumbra_chain::CompactBlock;
 use penumbra_crypto::Nullifier;
 use penumbra_crypto::{
     merkle::{Frontier, Tree},
-    FullViewingKey, Note,
+    FullViewingKey, Note, NotePayload,
 };
-use penumbra_transaction::action::output;
 
 use crate::NoteRecord;
 
@@ -17,23 +16,23 @@ pub struct ScanResult {
     pub height: u64,
 }
 
-#[tracing::instrument(skip(fvk, outputs, nullifiers))]
+#[tracing::instrument(skip(fvk, note_commitment_tree, note_payloads, nullifiers))]
 pub fn scan_block(
     fvk: &FullViewingKey,
     note_commitment_tree: &mut penumbra_crypto::merkle::NoteCommitmentTree,
     CompactBlock {
         height,
-        outputs,
+        note_payloads,
         nullifiers,
     }: CompactBlock,
 ) -> ScanResult {
     let mut new_notes: Vec<NoteRecord> = Vec::new();
 
-    for output::Body {
+    for NotePayload {
         note_commitment,
         ephemeral_key,
         encrypted_note,
-    } in outputs.into_iter()
+    } in note_payloads
     {
         // Unconditionally insert the note commitment into the merkle tree
         tracing::debug!(?note_commitment, "appending to note commitment tree");


### PR DESCRIPTION
We use this structure in multiple places in the codebase, and it's
self-contained (being the minimal data payload needed to identify and scan a
new note).  So moving it into the `crypto` crate makes sense.

More importantly, it frees up the name `OutputBody` for other use.  In order to
have a useful signing/custody protocol, we need to classify transaction data
into *authorizing data* (which describes the actions that signatures authorize)
and *effecting data* (which effects those actions, but is not necessary to
authorize, e.g., proof data).  Then we'll want to have a protocol that allows
us to bundle up only the authorizing data and send it to a signer, who signs an
authorization hash (a renamed sighash) of the authorization data.  However,
this means that we want to pull apart the proto structures into chunks, where
each chunk has only authorizing /or/ effecting data.  To do /that/, it'd be
useful to be able to describe an `OutputBody`, which the `NotePayload` isn't
really.

Since the `NotePayload` is used much more widely than the other transaction
structures, splitting this out as a pre-change means that we can increase the
isolation of the remaining transaction structure refactoring from the rest of
the codebase.