### PR TITLE
pd: ensure components have shared state

### DIFF
--- a/pd/src/consensus/worker.rs
+++ b/pd/src/consensus/worker.rs
@@ -11,7 +11,7 @@ use tendermint::{
     block,
 };
 use tokio::sync::{mpsc, watch};
-use tracing::Instrument;
+use tracing::{instrument, Instrument};
 
 use super::Message;
 use crate::App;
@@ -24,6 +24,7 @@ pub struct Worker {
 }
 
 impl Worker {
+    #[instrument(skip(storage, queue, height_tx), name = "consensus::Worker::new")]
     pub async fn new(
         storage: Storage,
         queue: mpsc::Receiver<Message>,

--- a/pd/src/mempool/worker.rs
+++ b/pd/src/mempool/worker.rs
@@ -7,7 +7,7 @@ use penumbra_storage::Storage;
 use penumbra_transaction::Transaction;
 use tendermint::block;
 use tokio::sync::{mpsc, watch};
-use tracing::Instrument;
+use tracing::{instrument, Instrument};
 
 use super::Message;
 use crate::App;
@@ -20,6 +20,7 @@ pub struct Worker {
 }
 
 impl Worker {
+    #[instrument(skip(storage, queue, height_rx), name = "mempool::Worker::new")]
     pub async fn new(
         storage: Storage,
         queue: mpsc::Receiver<Message>,

--- a/shielded-pool/src/component.rs
+++ b/shielded-pool/src/component.rs
@@ -12,7 +12,7 @@ use penumbra_crypto::{
     merkle::{self, Frontier, NoteCommitmentTree, TreeExt},
     note, Address, Note, NotePayload, Nullifier, One, Value, STAKING_TOKEN_ASSET_ID,
 };
-use penumbra_storage::{State, StateExt, Storage};
+use penumbra_storage::{State, StateExt};
 use penumbra_transaction::{Action, Transaction};
 use tendermint::abci;
 use tracing::instrument;
@@ -28,12 +28,10 @@ pub struct ShieldedPool {
 }
 
 impl ShieldedPool {
-    #[instrument(name = "shielded_pool", skip(storage))]
-    pub async fn new(storage: Storage) -> Self {
-        let note_commitment_tree = storage.get_nct().await.unwrap();
-
+    #[instrument(name = "shielded_pool", skip(state, note_commitment_tree))]
+    pub async fn new(state: State, note_commitment_tree: NoteCommitmentTree) -> Self {
         Self {
-            state: storage.state().await.unwrap(),
+            state,
             note_commitment_tree,
             compact_block: Default::default(),
         }


### PR DESCRIPTION
This commit fixes a bug introduced in #796, which removed the `new` method from
the `Component` trait, in order to be able to "sideload" a copy of the note
commitment tree kept in a sidecar part of the underlying storage, rather than
in the (merklized) application state.

In that change, the `ShieldedPool` component was changed to take a raw
`Storage`, rather than a `State`, so that it would be able to read the NCT out
on its own.  But it's important that all of the components use the *same*
shared state, rather than each creating their own fork off of the version
currently in persistent storage.

Co-Authored-By: Ava Howell <ava@penumbra.zone>