### PR TITLE
Bubble up errors in wallet service/worker, shut down worker when service shuts down

### DIFF
--- a/docs/guide/src/dev/sqlx.md
+++ b/docs/guide/src/dev/sqlx.md
@@ -8,17 +8,19 @@ nothing extra is required to build.
 However, when editing the wallet server's database code, it's necessary to work
 with a development database:
 
-1.  The database structure is defined in the `migrations/` directory of the
+1.  You'll need `sqlx-cli` installed with the correct features:
+`cargo install sqlx-cli --features sqlite`
+2.  The database structure is defined in the `migrations/` directory of the
 wallet server crate.
-2.  Set the `DATABASE_URL` environment variable to point to the SQLite location.
+3.  Set the `DATABASE_URL` environment variable to point to the SQLite location.
     For instance,
     ```
     export DATABASE_URL="sqlite:///tmp/pwalletd-dev-db.sqlite"
     ```
     will set the shell environment variable to the same one set in the project's
     `.vscode/settings.json`.
-3.  From the `wallet-next` directory, run `cargo sqlx database setup` to create
+4.  From the `wallet-next` directory, run `cargo sqlx database setup` to create
 the database and run migrations.
-4.  From the `wallet-next` directory, run
+5.  From the `wallet-next` directory, run
 `cargo sqlx prepare -- --lib=penumbra-wallet-next`
 to regenerate the `sqlx-data.json` file that allows offline compilation.

--- a/docs/guide/src/dev/sqlx.md
+++ b/docs/guide/src/dev/sqlx.md
@@ -22,5 +22,5 @@ wallet server crate.
 4.  From the `wallet-next` directory, run `cargo sqlx database setup` to create
 the database and run migrations.
 5.  From the `wallet-next` directory, run
-`cargo sqlx prepare -- --lib=penumbra-wallet-next`
+`cargo sqlx prepare -- --lib penumbra-wallet-next`
 to regenerate the `sqlx-data.json` file that allows offline compilation.

--- a/wallet-next/src/service.rs
+++ b/wallet-next/src/service.rs
@@ -101,6 +101,7 @@ impl WalletService {
         }
 
         // TODO: check whether the worker is still alive, else fail, when we have a way to do that
+        // (if the worker is to crash without setting the error_slot, the service should die as well)
 
         Ok(())
     }


### PR DESCRIPTION
Closes #758, this will cause any errors occurring in the wallet workers to be bubbled up to the wallet service, as well as adds an `mpsc` channel between the worker and the wallet services, so that the worker can shut down when the services halt.