### PR TITLE
Use `get_block_height` as canonical source of block height

### DIFF
--- a/shielded-pool/src/component.rs
+++ b/shielded-pool/src/component.rs
@@ -222,8 +222,8 @@ impl Component for ShieldedPool {
         //}
     }
 
-    #[instrument(name = "shielded_pool", skip(self, end_block))]
-    async fn end_block(&mut self, end_block: &abci::request::EndBlock) {
+    #[instrument(name = "shielded_pool", skip(self, _end_block))]
+    async fn end_block(&mut self, _end_block: &abci::request::EndBlock) {
         // Get the current block height
         let height = self
             .state

--- a/shielded-pool/src/component.rs
+++ b/shielded-pool/src/component.rs
@@ -287,6 +287,8 @@ impl Component for ShieldedPool {
         )
         .is_epoch_end(height)
         {
+            tracing::debug!(?height, "end of epoch");
+
             // TODO: replace this with an `expect!` when this is consensus-critical
             if let Err(e) = self.tiered_commitment_tree.end_epoch() {
                 tracing::error!(error = ?e, "failed to end epoch in TCT");

--- a/shielded-pool/src/component.rs
+++ b/shielded-pool/src/component.rs
@@ -95,13 +95,7 @@ impl Component for ShieldedPool {
     }
 
     #[instrument(name = "shielded_pool", skip(self, _begin_block))]
-    async fn begin_block(&mut self, _begin_block: &abci::request::BeginBlock) {
-        self.compact_block.height = self
-            .state
-            .get_block_height()
-            .await
-            .expect("block height must be set");
-    }
+    async fn begin_block(&mut self, _begin_block: &abci::request::BeginBlock) {}
 
     #[instrument(name = "shielded_pool", skip(tx))]
     fn check_tx_stateless(tx: &Transaction) -> Result<()> {
@@ -231,6 +225,9 @@ impl Component for ShieldedPool {
             .await
             .expect("block height must be set");
 
+        // Set the height of the compact block
+        self.compact_block.height = height;
+
         // Handle any pending reward notes from the Staking component
         let notes = self
             .state
@@ -284,7 +281,7 @@ impl Component for ShieldedPool {
             }
         }
 
-        tracing::debug!(tct_root = %self.tiered_commitment_tree.root(), "tct root");
+        tracing::debug!(?height, tct_root = %self.tiered_commitment_tree.root(), "tct root");
 
         self.write_compactblock_and_nct().await.unwrap();
     }

--- a/shielded-pool/src/component.rs
+++ b/shielded-pool/src/component.rs
@@ -88,11 +88,8 @@ impl Component for ShieldedPool {
             .unwrap();
         }
 
-        self.compact_block.height = self
-            .state
-            .get_block_height()
-            .await
-            .expect("block height must be set");
+        // Hard-coded to zero because we are in the genesis block
+        self.compact_block.height = 0;
 
         self.write_compactblock_and_nct().await.unwrap();
     }
@@ -233,14 +230,6 @@ impl Component for ShieldedPool {
             .get_block_height()
             .await
             .expect("block height must be set");
-
-        if height != (end_block.height as u64) {
-            tracing::error!(
-                "end block height {} does not match current height {}",
-                end_block.height,
-                height
-            );
-        }
 
         // Handle any pending reward notes from the Staking component
         let notes = self
@@ -415,7 +404,7 @@ impl ShieldedPool {
     async fn write_compactblock_and_nct(&mut self) -> Result<()> {
         // Extract the compact block, resetting it
         let compact_block = std::mem::take(&mut self.compact_block);
-        let height = compact_block.height;
+        let height = self.state.get_block_height().await?;
 
         // Write the CompactBlock:
         self.state.set_compact_block(compact_block).await;

--- a/wallet/src/state.rs
+++ b/wallet/src/state.rs
@@ -837,6 +837,8 @@ impl ClientState {
         )
         .is_epoch_end(height)
         {
+            tracing::debug!(?height, "end of epoch");
+
             // TODO: replace this with an `expect!` when this is consensus-critical
             if let Err(e) = self.tiered_commitment_tree.end_epoch() {
                 tracing::error!(error = ?e, "failed to end epoch in TCT");


### PR DESCRIPTION
Previously there were a couple subtle order-of-execution bugs in the shielded pool because we sourced height from the under-construction `CompactBlock`. This PR uniformly uses `get_block_height` throughout the shielded pool to get the height, and it sets it in the compact block immediately upon begin-block. Log messages indicate that the height now correctly reflects the increasing sequence of blocks.