### PR TITLE
Add `chain params` and `chain_info` `pcli` commands

### DIFF
--- a/pcli/src/command.rs
+++ b/pcli/src/command.rs
@@ -2,6 +2,7 @@ use structopt::StructOpt;
 
 mod addr;
 mod balance;
+mod chain;
 mod stake;
 mod temp;
 mod tx;
@@ -10,6 +11,7 @@ mod wallet;
 
 pub use addr::AddrCmd;
 pub use balance::BalanceCmd;
+pub use chain::ChainCmd;
 pub use stake::StakeCmd;
 pub use temp::TmpCmd;
 pub use tx::TxCmd;
@@ -35,6 +37,8 @@ pub enum Command {
     Validator(ValidatorCmd),
     /// Manages delegations and undelegations.
     Stake(StakeCmd),
+    /// View chain data.
+    Chain(ChainCmd),
     /// Temporary commands for migrating address formats.
     Tmp(TmpCmd),
 }
@@ -51,6 +55,7 @@ impl Command {
             Command::Validator(cmd) => cmd.needs_sync(),
             Command::Stake(cmd) => cmd.needs_sync(),
             Command::Tmp(cmd) => cmd.needs_sync(),
+            Command::Chain(cmd) => cmd.needs_sync(),
         }
     }
 }

--- a/pcli/src/command/chain.rs
+++ b/pcli/src/command/chain.rs
@@ -1,0 +1,104 @@
+use std::{fs::File, io::BufReader, path::PathBuf, str::FromStr};
+
+use anyhow::{anyhow, Context as _, Result};
+use comfy_table::Table;
+use directories::ProjectDirs;
+use penumbra_crypto::keys::{SeedPhrase, SpendSeed};
+use penumbra_wallet::{ClientState, Wallet};
+use rand_core::OsRng;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use structopt::StructOpt;
+
+use crate::ClientStateFile;
+
+#[derive(Debug, StructOpt)]
+pub enum ChainCmd {
+    /// Display chain parameters.
+    Params,
+    /// Display information about the current chain state.
+    Info {
+        /// If true, will also display chain parameters.
+        #[structopt(short, long)]
+        verbose: bool,
+    },
+}
+
+impl ChainCmd {
+    /// Determine if this command requires a network sync before it executes.
+    pub fn needs_sync(&self) -> bool {
+        // Always true, though strictly not necessary until chain parameters are
+        // determined by consensus.
+        true
+    }
+
+    pub async fn exec(&self, state: &ClientStateFile) -> Result<()> {
+        match self {
+            ChainCmd::Params => {
+                let params = match state.chain_params() {
+                    Some(params) => params,
+                    None => {
+                        // This indicates that the sync failed.
+                        return Err(anyhow!("chain parameters not available"));
+                    }
+                };
+                println!("Chain Parameters: ");
+                let mut table = Table::new();
+                table
+                    .set_header(vec!["Parameter", "Value"])
+                    .add_row(vec!["Chain ID", &params.chain_id])
+                    .add_row(vec![
+                        "Epoch Duration",
+                        &format!("{}", params.epoch_duration),
+                    ])
+                    .add_row(vec![
+                        "Unbonding Epochs",
+                        &format!("{}", params.unbonding_epochs),
+                    ])
+                    .add_row(vec![
+                        "Active Validator Limit",
+                        &format!("{}", params.active_validator_limit),
+                    ])
+                    .add_row(vec![
+                        "Base Reward Rate (bps of bps)",
+                        &format!("{}", params.base_reward_rate),
+                    ])
+                    .add_row(vec![
+                        "Slashing Penalty (Misbehavior) (bps)",
+                        &format!("{}", params.slashing_penalty_misbehavior_bps),
+                    ])
+                    .add_row(vec![
+                        "Slashing Penalty (Downtime) (bps)",
+                        &format!("{}", params.slashing_penalty_downtime_bps),
+                    ])
+                    .add_row(vec![
+                        "Signed Blocks Window (blocks)",
+                        &format!("{}", params.signed_blocks_window_len),
+                    ])
+                    .add_row(vec![
+                        "Missed Blocks Max",
+                        &format!("{}", params.missed_blocks_maximum),
+                    ])
+                    .add_row(vec!["IBC Enabled", &format!("{}", params.ibc_enabled)])
+                    .add_row(vec![
+                        "Inbound ICS-20 Enabled",
+                        &format!("{}", params.inbound_ics20_transfers_enabled),
+                    ])
+                    .add_row(vec![
+                        "Outbound ICS-20 Enabled",
+                        &format!("{}", params.outbound_ics20_transfers_enabled),
+                    ]);
+
+                println!("{}", table);
+                // println!("  Chain ID: {}", params.chain_id);
+                // println!("  Epoch Duration: {}", params.epoch_duration);
+                // println!("  Unbonding Epochs: {}", params.unbonding_epochs);
+                // println!("  Active Validator Limit: {}", params.unbonding_epochs);
+                // tracing::debug!(?params, "exec");
+            }
+            ChainCmd::Info { verbose } => {}
+        };
+
+        Ok(())
+    }
+}

--- a/pcli/src/command/chain.rs
+++ b/pcli/src/command/chain.rs
@@ -1,16 +1,11 @@
-use std::{fs::File, io::BufReader, path::PathBuf, str::FromStr};
-
-use anyhow::{anyhow, Context as _, Result};
-use comfy_table::Table;
-use directories::ProjectDirs;
-use penumbra_crypto::keys::{SeedPhrase, SpendSeed};
-use penumbra_wallet::{ClientState, Wallet};
-use rand_core::OsRng;
-use serde::Deserialize;
-use sha2::{Digest, Sha256};
+use anyhow::{anyhow, Result};
+use comfy_table::{presets, Table};
+use futures::TryStreamExt;
+use penumbra_chain::Epoch;
+use penumbra_stake::validator;
 use structopt::StructOpt;
 
-use crate::ClientStateFile;
+use crate::{ClientStateFile, Opt};
 
 #[derive(Debug, StructOpt)]
 pub enum ChainCmd {
@@ -24,6 +19,17 @@ pub enum ChainCmd {
     },
 }
 
+struct Stats {
+    current_block_height: u64,
+    current_epoch: u64,
+    total_validators: u64,
+    active_validators: u64,
+    inactive_validators: u64,
+    jailed_validators: u64,
+    tombstoned_validators: u64,
+    disabled_validators: u64,
+}
+
 impl ChainCmd {
     /// Determine if this command requires a network sync before it executes.
     pub fn needs_sync(&self) -> bool {
@@ -32,71 +38,179 @@ impl ChainCmd {
         true
     }
 
-    pub async fn exec(&self, state: &ClientStateFile) -> Result<()> {
+    pub async fn print_chain_params(&self, state: &ClientStateFile) -> Result<()> {
+        let params = match state.chain_params() {
+            Some(params) => params,
+            None => {
+                // This indicates that the sync failed.
+                return Err(anyhow!("chain parameters not available"));
+            }
+        };
+
+        println!("Chain Parameters:");
+        let mut table = Table::new();
+        table.load_preset(presets::NOTHING);
+        table
+            .set_header(vec!["", ""])
+            .add_row(vec!["Chain ID", &params.chain_id])
+            .add_row(vec![
+                "Epoch Duration",
+                &format!("{}", params.epoch_duration),
+            ])
+            .add_row(vec![
+                "Unbonding Epochs",
+                &format!("{}", params.unbonding_epochs),
+            ])
+            .add_row(vec![
+                "Active Validator Limit",
+                &format!("{}", params.active_validator_limit),
+            ])
+            .add_row(vec![
+                "Base Reward Rate (bps of bps)",
+                &format!("{}", params.base_reward_rate),
+            ])
+            .add_row(vec![
+                "Slashing Penalty (Misbehavior) (bps)",
+                &format!("{}", params.slashing_penalty_misbehavior_bps),
+            ])
+            .add_row(vec![
+                "Slashing Penalty (Downtime) (bps)",
+                &format!("{}", params.slashing_penalty_downtime_bps),
+            ])
+            .add_row(vec![
+                "Signed Blocks Window (blocks)",
+                &format!("{}", params.signed_blocks_window_len),
+            ])
+            .add_row(vec![
+                "Missed Blocks Max",
+                &format!("{}", params.missed_blocks_maximum),
+            ])
+            .add_row(vec!["IBC Enabled", &format!("{}", params.ibc_enabled)])
+            .add_row(vec![
+                "Inbound ICS-20 Enabled",
+                &format!("{}", params.inbound_ics20_transfers_enabled),
+            ])
+            .add_row(vec![
+                "Outbound ICS-20 Enabled",
+                &format!("{}", params.outbound_ics20_transfers_enabled),
+            ]);
+
+        println!("{}", table);
+
+        Ok(())
+    }
+
+    pub async fn get_stats(&self, opt: &Opt, state: &ClientStateFile) -> Result<Stats> {
+        use penumbra_proto::client::oblivious::ValidatorInfoRequest;
+
+        let mut client = opt.oblivious_client().await?;
+
+        let current_block_height = state.last_block_height().unwrap_or_default();
+        let epoch_duration = state
+            .chain_params()
+            .expect("chain params unavailable")
+            .epoch_duration;
+        let current_epoch = Epoch::from_height(current_block_height, epoch_duration).index;
+
+        // Fetch validators.
+        let validators = client
+            .validator_info(ValidatorInfoRequest {
+                show_inactive: true,
+                chain_id: state.chain_id().unwrap_or_default(),
+            })
+            .await?
+            .into_inner()
+            .try_collect::<Vec<_>>()
+            .await?
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<validator::Info>, _>>()?;
+
+        let total_validators = validators.len() as u64;
+        let active_validators = validators
+            .iter()
+            .filter(|v| v.status.state == validator::State::Active)
+            .count() as u64;
+        let inactive_validators = validators
+            .iter()
+            .filter(|v| v.status.state == validator::State::Inactive)
+            .count() as u64;
+        let jailed_validators = validators
+            .iter()
+            .filter(|v| v.status.state == validator::State::Jailed)
+            .count() as u64;
+        let tombstoned_validators = validators
+            .iter()
+            .filter(|v| v.status.state == validator::State::Tombstoned)
+            .count() as u64;
+        let disabled_validators = validators
+            .iter()
+            .filter(|v| v.status.state == validator::State::Disabled)
+            .count() as u64;
+
+        Ok(Stats {
+            current_block_height,
+            current_epoch,
+            total_validators,
+            active_validators,
+            inactive_validators,
+            jailed_validators,
+            tombstoned_validators,
+            disabled_validators,
+        })
+    }
+
+    pub async fn exec(&self, opt: &Opt, state: &ClientStateFile) -> Result<()> {
         match self {
             ChainCmd::Params => {
-                let params = match state.chain_params() {
-                    Some(params) => params,
-                    None => {
-                        // This indicates that the sync failed.
-                        return Err(anyhow!("chain parameters not available"));
-                    }
-                };
-                println!("Chain Parameters: ");
+                self.print_chain_params(state).await?;
+            }
+            // TODO: we could implement this as an RPC call using the metrics
+            // subsystems once #829 is complete
+            ChainCmd::Info { verbose } => {
+                if *verbose {
+                    self.print_chain_params(state).await?;
+                }
+
+                let stats = self.get_stats(opt, state).await?;
+
+                println!("Chain Info:");
                 let mut table = Table::new();
+                table.load_preset(presets::NOTHING);
                 table
-                    .set_header(vec!["Parameter", "Value"])
-                    .add_row(vec!["Chain ID", &params.chain_id])
+                    .set_header(vec!["", ""])
                     .add_row(vec![
-                        "Epoch Duration",
-                        &format!("{}", params.epoch_duration),
+                        "Current Block Height",
+                        &format!("{}", stats.current_block_height),
+                    ])
+                    .add_row(vec!["Current Epoch", &format!("{}", stats.current_epoch)])
+                    .add_row(vec![
+                        "Total Validators",
+                        &format!("{}", stats.total_validators),
                     ])
                     .add_row(vec![
-                        "Unbonding Epochs",
-                        &format!("{}", params.unbonding_epochs),
+                        "Active Validators",
+                        &format!("{}", stats.active_validators),
                     ])
                     .add_row(vec![
-                        "Active Validator Limit",
-                        &format!("{}", params.active_validator_limit),
+                        "Inactive Validators",
+                        &format!("{}", stats.inactive_validators),
                     ])
                     .add_row(vec![
-                        "Base Reward Rate (bps of bps)",
-                        &format!("{}", params.base_reward_rate),
+                        "Jailed Validators",
+                        &format!("{}", stats.jailed_validators),
                     ])
                     .add_row(vec![
-                        "Slashing Penalty (Misbehavior) (bps)",
-                        &format!("{}", params.slashing_penalty_misbehavior_bps),
+                        "Tombstoned Validators",
+                        &format!("{}", stats.tombstoned_validators),
                     ])
                     .add_row(vec![
-                        "Slashing Penalty (Downtime) (bps)",
-                        &format!("{}", params.slashing_penalty_downtime_bps),
-                    ])
-                    .add_row(vec![
-                        "Signed Blocks Window (blocks)",
-                        &format!("{}", params.signed_blocks_window_len),
-                    ])
-                    .add_row(vec![
-                        "Missed Blocks Max",
-                        &format!("{}", params.missed_blocks_maximum),
-                    ])
-                    .add_row(vec!["IBC Enabled", &format!("{}", params.ibc_enabled)])
-                    .add_row(vec![
-                        "Inbound ICS-20 Enabled",
-                        &format!("{}", params.inbound_ics20_transfers_enabled),
-                    ])
-                    .add_row(vec![
-                        "Outbound ICS-20 Enabled",
-                        &format!("{}", params.outbound_ics20_transfers_enabled),
+                        "Disabled Validators",
+                        &format!("{}", stats.disabled_validators),
                     ]);
 
                 println!("{}", table);
-                // println!("  Chain ID: {}", params.chain_id);
-                // println!("  Epoch Duration: {}", params.epoch_duration);
-                // println!("  Unbonding Epochs: {}", params.unbonding_epochs);
-                // println!("  Active Validator Limit: {}", params.unbonding_epochs);
-                // tracing::debug!(?params, "exec");
             }
-            ChainCmd::Info { verbose } => {}
         };
 
         Ok(())

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -93,6 +93,7 @@ async fn main() -> Result<()> {
         Command::Validator(cmd) => cmd.exec(&opt, &mut state).await?,
         Command::Stake(cmd) => cmd.exec(&opt, &mut state).await?,
         Command::Tmp(cmd) => cmd.exec().await?,
+        Command::Chain(cmd) => cmd.exec(&state).await?,
     }
 
     Ok(())

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -93,7 +93,7 @@ async fn main() -> Result<()> {
         Command::Validator(cmd) => cmd.exec(&opt, &mut state).await?,
         Command::Stake(cmd) => cmd.exec(&opt, &mut state).await?,
         Command::Tmp(cmd) => cmd.exec().await?,
-        Command::Chain(cmd) => cmd.exec(&state).await?,
+        Command::Chain(cmd) => cmd.exec(&opt, &state).await?,
     }
 
     Ok(())


### PR DESCRIPTION
This implements new `pcli chain params` and `pcli chain info` commands.

`pcli chain params` prints the current chain parameters.

`pcli chain info` prints some summary information about the chain. Maybe this would be better off implemented in the general state query interface later on.

Closes #759 