### PR TITLE
Pass epoch duration to sync_to_latest in sync.rs

### DIFF
--- a/wallet-next/src/sync.rs
+++ b/wallet-next/src/sync.rs
@@ -23,6 +23,7 @@ pub fn scan_block(
         note_payloads,
         nullifiers,
     }: CompactBlock,
+    epoch_duration: u64,
 ) -> ScanResult {
     let mut new_notes: Vec<NoteRecord> = Vec::new();
 
@@ -74,7 +75,7 @@ pub fn scan_block(
         .expect("ending the block must succed");
 
     // If we've also reached the end of the epoch, end the epoch in the commitment tree
-    if Epoch::from_height(height, todo!("get epoch duration")).is_epoch_end(height) {
+    if Epoch::from_height(height, epoch_duration).is_epoch_end(height) {
         tracing::debug!(?height, "end of epoch");
         note_commitment_tree
             .end_epoch()

--- a/wallet-next/src/worker.rs
+++ b/wallet-next/src/worker.rs
@@ -46,6 +46,8 @@ impl Worker {
             .map(|h| h + 1)
             .unwrap_or(0);
 
+        let epoch_duration = self.storage.chain_params().await?.epoch_duration;
+
         let mut stream = self
             .client
             .compact_block_range(tonic::Request::new(CompactBlockRangeRequest {
@@ -57,7 +59,8 @@ impl Worker {
             .into_inner();
 
         while let Some(block) = stream.message().await? {
-            let scan_result = scan_block(&self.fvk, &mut self.nct, block.try_into()?);
+            let scan_result =
+                scan_block(&self.fvk, &mut self.nct, block.try_into()?, epoch_duration);
 
             self.storage
                 .record_block(scan_result, &mut self.nct)


### PR DESCRIPTION
Closes #843 by calling chain_params() from the wallet worker to retrieve the stored epoch_duration
