### PR TITLE
Use env var for Caddyfile domains

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Update git repository
       uses: appleboy/ssh-action@master
       with:
-        host: ${{ secrets.TESTNET_PREVIEW_HOST }}
+        host: ${{ secrets.TESTNET_HOST }}
         username: ${{ secrets.TUNNEL_USERNAME }}
         key: ${{ secrets.ID_ED25519 }}
         port: ${{ secrets.TUNNEL_PORT }}
@@ -31,7 +31,7 @@ jobs:
     - name: Delete existing state
       uses: appleboy/ssh-action@master
       with:
-        host: ${{ secrets.TESTNET_PREVIEW_HOST }}
+        host: ${{ secrets.TESTNET_HOST }}
         username: ${{ secrets.TUNNEL_USERNAME }}
         key: ${{ secrets.ID_ED25519 }}
         port: ${{ secrets.TUNNEL_PORT }}
@@ -42,7 +42,7 @@ jobs:
     - name: Generate testnet
       uses: appleboy/ssh-action@master
       with:
-        host: ${{ secrets.TESTNET_PREVIEW_HOST }}
+        host: ${{ secrets.TESTNET_HOST }}
         username: ${{ secrets.TUNNEL_USERNAME }}
         key: ${{ secrets.ID_ED25519 }}
         port: ${{ secrets.TUNNEL_PORT }}
@@ -54,7 +54,7 @@ jobs:
       uses: appleboy/ssh-action@master
       timeout-minutes: 30
       with:
-        host: ${{ secrets.TESTNET_PREVIEW_HOST }}
+        host: ${{ secrets.TESTNET_HOST }}
         username: ${{ secrets.TUNNEL_USERNAME }}
         key: ${{ secrets.ID_ED25519 }}
         port: ${{ secrets.TUNNEL_PORT }}

--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -5,9 +5,9 @@
     # Optional staging lets encrypt for testing. Comment out for production.
     # acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
 }
-testnet.penumbra.zone {
+{$TESTNET_HOST:localhost} {
     reverse_proxy grafana:3000
 }
-www.testnet.penumbra.zone {
-    redir https://testnet.penumbra.zone{uri}
+www.{$TESTNET_HOST:localhost} {
+    redir https://{$TESTNET_HOST:localhost}{uri}
 }


### PR DESCRIPTION
This should fix the inaccessibility of testnet-preview's grafana instance.