### PR TITLE
Conditionally enable console-subscriber with a console-subscriber feature

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,7 +8,7 @@ services:
       [
         "bash",
         "-c",
-        "pd start --host 0.0.0.0 -r /pd/rocksdb"
+        "pd start --host 0.0.0.0 -r /pd/rocksdb --no-console"
       ]
     logging:
       driver: "json-file"


### PR DESCRIPTION
`console-subscriber` seems to cause OOM errors when `pd` runs long enough, and at any rate, we don't want it enabled on our production deployments.

This PR adds a default feature to enable `console-subscriber` so developers building locally will keep behaving as expected. The prod Dockerfiles have been updated to disable default features on the `pd` crate, and will use the regular tracing subscriber instead.