### PR TITLE
Add additional PD metrics for staking and TCT

### DIFF
--- a/stake/src/component.rs
+++ b/stake/src/component.rs
@@ -210,7 +210,7 @@ impl Staking {
 
                 Ok(())
             }
-            (cur_state @ (Inactive | Jailed), Disabled) => {
+            (Inactive | Jailed, Disabled) => {
                 // We don't really have to do anything here; we're just
                 // recording that the validator was disabled, so delegations to
                 // it are not allowed.

--- a/stake/src/metrics.rs
+++ b/stake/src/metrics.rs
@@ -29,9 +29,9 @@ pub fn register_metrics() {
     describe_gauge!(TOMBSTONED_VALIDATORS, "The number of tombstoned validators");
 }
 
-pub const MISSED_BLOCKS: &str = "penumbra_pd_missed_blocks";
-pub const ACTIVE_VALIDATORS: &str = "penumbra_pd_active_validators";
-pub const INACTIVE_VALIDATORS: &str = "penumbra_pd_inactive_validators";
-pub const JAILED_VALIDATORS: &str = "penumbra_pd_jailed_validators";
-pub const DISABLED_VALIDATORS: &str = "penumbra_pd_disabled_validators";
-pub const TOMBSTONED_VALIDATORS: &str = "penumbra_pd_tombstoned_validators";
+pub const MISSED_BLOCKS: &str = "penumbra_stake_missed_blocks";
+pub const ACTIVE_VALIDATORS: &str = "penumbra_stake_validators_active_validators";
+pub const DISABLED_VALIDATORS: &str = "penumbra_stake_validators_disabled_validators";
+pub const INACTIVE_VALIDATORS: &str = "penumbra_stake_validators_inactive_validators";
+pub const JAILED_VALIDATORS: &str = "penumbra_stake_validators_jailed_validators";
+pub const TOMBSTONED_VALIDATORS: &str = "penumbra_stake_validators_tombstoned_validators";

--- a/stake/src/metrics.rs
+++ b/stake/src/metrics.rs
@@ -15,15 +15,23 @@ pub use metrics::*;
 
 /// Registers all metrics used by this crate.
 pub fn register_metrics() {
-    /*
-    // Sample code for reference -- delete when adding the first metric
-    register_counter!(MEMPOOL_CHECKTX_TOTAL);
-    describe_counter!(
-        MEMPOOL_CHECKTX_TOTAL,
-        "The total number of checktx requests made to the mempool"
-    );
-     */
+    register_gauge!(MISSED_BLOCKS);
+    describe_gauge!(MISSED_BLOCKS, "The number of missed blocks per validator");
+    register_gauge!(ACTIVE_VALIDATORS);
+    describe_gauge!(ACTIVE_VALIDATORS, "The number of active validators");
+    register_gauge!(INACTIVE_VALIDATORS);
+    describe_gauge!(INACTIVE_VALIDATORS, "The number of inactive validators");
+    register_gauge!(JAILED_VALIDATORS);
+    describe_gauge!(JAILED_VALIDATORS, "The number of jailed validators");
+    register_gauge!(DISABLED_VALIDATORS);
+    describe_gauge!(DISABLED_VALIDATORS, "The number of disabled validators");
+    register_gauge!(TOMBSTONED_VALIDATORS);
+    describe_gauge!(TOMBSTONED_VALIDATORS, "The number of tombstoned validators");
 }
 
-// Sample code for reference -- delete when adding the first metric
-// pub const MEMPOOL_CHECKTX_TOTAL: &str = "penumbra_pd_mempool_checktx_total";
+pub const MISSED_BLOCKS: &str = "penumbra_pd_missed_blocks";
+pub const ACTIVE_VALIDATORS: &str = "penumbra_pd_active_validators";
+pub const INACTIVE_VALIDATORS: &str = "penumbra_pd_inactive_validators";
+pub const JAILED_VALIDATORS: &str = "penumbra_pd_jailed_validators";
+pub const DISABLED_VALIDATORS: &str = "penumbra_pd_disabled_validators";
+pub const TOMBSTONED_VALIDATORS: &str = "penumbra_pd_tombstoned_validators";

--- a/stake/src/metrics.rs
+++ b/stake/src/metrics.rs
@@ -30,8 +30,8 @@ pub fn register_metrics() {
 }
 
 pub const MISSED_BLOCKS: &str = "penumbra_stake_missed_blocks";
-pub const ACTIVE_VALIDATORS: &str = "penumbra_stake_validators_active_validators";
-pub const DISABLED_VALIDATORS: &str = "penumbra_stake_validators_disabled_validators";
-pub const INACTIVE_VALIDATORS: &str = "penumbra_stake_validators_inactive_validators";
-pub const JAILED_VALIDATORS: &str = "penumbra_stake_validators_jailed_validators";
-pub const TOMBSTONED_VALIDATORS: &str = "penumbra_stake_validators_tombstoned_validators";
+pub const ACTIVE_VALIDATORS: &str = "penumbra_stake_validators_active";
+pub const DISABLED_VALIDATORS: &str = "penumbra_stake_validators_disabled";
+pub const INACTIVE_VALIDATORS: &str = "penumbra_stake_validators_inactive";
+pub const JAILED_VALIDATORS: &str = "penumbra_stake_validators_jailed";
+pub const TOMBSTONED_VALIDATORS: &str = "penumbra_stake_validators_tombstoned";

--- a/storage/src/metrics.rs
+++ b/storage/src/metrics.rs
@@ -19,4 +19,4 @@ pub fn register_metrics() {
     describe_gauge!(TCT_SIZE_BYTES, "The size of the serialized TCT in bytes");
 }
 
-pub const TCT_SIZE_BYTES: &str = "penumbra_pd_tct_size_bytes";
+pub const TCT_SIZE_BYTES: &str = "penumbra_storage_tct_size_bytes";

--- a/storage/src/metrics.rs
+++ b/storage/src/metrics.rs
@@ -15,15 +15,8 @@ pub use metrics::*;
 
 /// Registers all metrics used by this crate.
 pub fn register_metrics() {
-    /*
-    // Sample code for reference -- delete when adding the first metric
-    register_counter!(MEMPOOL_CHECKTX_TOTAL);
-    describe_counter!(
-        MEMPOOL_CHECKTX_TOTAL,
-        "The total number of checktx requests made to the mempool"
-    );
-     */
+    register_gauge!(TCT_SIZE_BYTES);
+    describe_gauge!(TCT_SIZE_BYTES, "The size of the serialized TCT in bytes");
 }
 
-// Sample code for reference -- delete when adding the first metric
-// pub const MEMPOOL_CHECKTX_TOTAL: &str = "penumbra_pd_mempool_checktx_total";
+pub const TCT_SIZE_BYTES: &str = "penumbra_pd_tct_size_bytes";

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -1,19 +1,19 @@
 use std::{path::PathBuf, sync::Arc};
 
+use ::metrics::gauge;
 use anyhow::Result;
 use futures::future::BoxFuture;
 use jmt::{
     storage::{Node, NodeBatch, NodeKey, TreeReader, TreeWriter},
     WriteOverlay,
 };
-use metrics::gauge;
 use rocksdb::{Options, DB};
 use tokio::sync::RwLock;
 use tracing::{instrument, Span};
 
 use penumbra_tct as tct;
 
-use crate::{metrics::TCT_SIZE_BYTES, State};
+use crate::{metrics, State};
 
 #[derive(Clone, Debug)]
 pub struct Storage(Arc<DB>);
@@ -80,7 +80,7 @@ impl Storage {
         tracing::debug!("serializing TCT");
         let tct_data = bincode::serialize(tct)?;
         tracing::debug!(tct_bytes = tct_data.len(), "serialized TCT");
-        gauge!(TCT_SIZE_BYTES, tct_data.len() as f64);
+        gauge!(metrics::TCT_SIZE_BYTES, tct_data.len() as f64);
 
         let span = Span::current();
         tokio::task::Builder::new()

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -6,13 +6,14 @@ use jmt::{
     storage::{Node, NodeBatch, NodeKey, TreeReader, TreeWriter},
     WriteOverlay,
 };
+use metrics::gauge;
 use rocksdb::{Options, DB};
 use tokio::sync::RwLock;
 use tracing::{instrument, Span};
 
 use penumbra_tct as tct;
 
-use crate::State;
+use crate::{metrics::TCT_SIZE_BYTES, State};
 
 #[derive(Clone, Debug)]
 pub struct Storage(Arc<DB>);
@@ -79,6 +80,7 @@ impl Storage {
         tracing::debug!("serializing TCT");
         let tct_data = bincode::serialize(tct)?;
         tracing::debug!(tct_bytes = tct_data.len(), "serialized TCT");
+        gauge!(TCT_SIZE_BYTES, tct_data.len() as f64);
 
         let span = Span::current();
         tokio::task::Builder::new()


### PR DESCRIPTION
This introduces some simple metrics on validator state and TCT size.

One thing that wasn't clear was how we should handle the missed blocks metric. Missed blocks are only relevant for Active validators, so the metric is only updated for Active validators -- but if a validator transitions out of Active state, the metric won't be updated. Maybe it should be zeroed out if the validator transitions out of Active?

However that would mismatch the state machine code, which never resets the missed blocks counter, even if the validator goes disabled and then active again. I'm thinking we can try the metric as implemented and tweak if needed.