### PR TITLE
Correct flag in testnet instructions

### DIFF
--- a/docs/guide/src/pd/join-testnet/validator.md
+++ b/docs/guide/src/pd/join-testnet/validator.md
@@ -77,7 +77,7 @@ By default `template-definition` will use a random consensus key that you won't 
 ```
 
 Note: if you can't find `priv_validator_key.json`, assure that you have set
-`validator = true` in the Tendermint `config.toml`, as described above, and
+`mode = "validator"` in the Tendermint `config.toml`, as described above, and
 restarted Tendermint after doing so.
 
 #### Configuring funding streams


### PR DESCRIPTION
This PR fixes an incorrect flag for validator nodes listed in the docs.