### PR TITLE
Suggest removing RocksDB on Tendermint error

### DIFF
--- a/docs/guide/src/pd/join-testnet/fullnode.md
+++ b/docs/guide/src/pd/join-testnet/fullnode.md
@@ -77,6 +77,8 @@ tendermint start
 
 You should now be syncing from the network as a fullnode!
 
+## Common errors
+
 If you see an error like the following:
 
 ```
@@ -90,3 +92,18 @@ rm -rf \$HOME/.tendermint/data/ && \
 echo "{}" > \$HOME/.tendermint/data/priv_validator_state.json
 tendermint start
 ```
+
+If you get an error like the following:
+
+```
+Did you reset Tendermint without resetting your application's data?
+```
+
+when you run `tendermint start`, try removing RocksDB:
+
+
+```
+rm -r $HOME/.rocksdb
+```
+
+and restarting `pd`.


### PR DESCRIPTION
People may need to reset RocksDB when upgrading between testnets. This PR makes a suggestion to that effect.