### PR TITLE
Enumerate all error states explicitly, making match statement non-order-dependent

### DIFF
--- a/stake/src/component.rs
+++ b/stake/src/component.rs
@@ -283,9 +283,15 @@ impl Staking {
 
                 Ok(())
             }
-            (Tombstoned, _) => Err(anyhow::anyhow!("tombstoning is forever")),
-            (_, Active) => Err(anyhow::anyhow!("only inactive validator may become active")),
-            (_, Jailed) => Err(anyhow::anyhow!("only active validators may become jailed")),
+            (Jailed | Disabled, Active) => {
+                Err(anyhow::anyhow!("only inactive validator may become active"))
+            }
+            (Inactive | Jailed | Disabled, Jailed) => {
+                Err(anyhow::anyhow!("only active validators may become jailed"))
+            }
+            (Tombstoned, Inactive | Active | Jailed | Tombstoned | Disabled) => {
+                Err(anyhow::anyhow!("tombstoning is forever"))
+            }
         }
     }
 


### PR DESCRIPTION
This is a small edit with no semantic change intended, meant to prevent future changes to the ordering of clauses in the validator state transition function from causing unintended consequences. It uses `|`-patterns to enumerate all the illegal states that are caught for each error message returned.