### PR TITLE
Create MempoolService/ConsensusService spans

### DIFF
--- a/pd/src/consensus/service.rs
+++ b/pd/src/consensus/service.rs
@@ -13,6 +13,7 @@ use tendermint::{
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio_util::sync::PollSender;
 use tower_abci::BoxError;
+use tracing::error_span;
 
 use super::{Message, Worker};
 use crate::RequestExt;
@@ -66,6 +67,7 @@ impl tower::Service<ConsensusRequest> for Consensus {
         }
 
         let span = req.create_span();
+        let span = error_span!(parent: &span, "ConsensusService");
         let (tx, rx) = oneshot::channel();
 
         self.queue

--- a/pd/src/mempool/service.rs
+++ b/pd/src/mempool/service.rs
@@ -16,7 +16,7 @@ use tendermint::{
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio_util::sync::PollSender;
 use tower_abci::BoxError;
-use tracing::Instrument;
+use tracing::{error_span, Instrument};
 
 use super::{Message, Worker};
 use crate::metrics;
@@ -64,6 +64,7 @@ impl tower::Service<MempoolRequest> for Mempool {
             .boxed();
         }
         let span = req.create_span();
+        let span = error_span!(parent: &span, "MempoolService");
         let (tx, rx) = oneshot::channel();
 
         let MempoolRequest::CheckTx(CheckTxReq {


### PR DESCRIPTION
This should allow us to differentiate sources of metrics events.