### PR TITLE
Use shared NCT between ViewService and Worker

### DIFF
--- a/view/src/bin/pviewd.rs
+++ b/view/src/bin/pviewd.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![allow(clippy::clone_on_copy)]
 use anyhow::Result;
 use penumbra_crypto::FullViewingKey;


### PR DESCRIPTION
First part of #755. This wraps the NCT with `Arc<RwLock<>>` so it's shared between the `ViewService` and view `Worker`.