### PR TITLE
Spend proofs now only contain the note commitment in the proof itself

### DIFF
--- a/proto/proto/transparent_proofs.proto
+++ b/proto/proto/transparent_proofs.proto
@@ -13,7 +13,6 @@ message SpendProof {
   uint64 value_amount = 4;
   bytes value_asset_id = 5;
   bytes v_blinding = 6;
-  bytes note_commitment = 7;
   bytes note_blinding = 8;
   bytes spend_auth_randomizer = 9;
   bytes ak = 10;

--- a/transaction/src/plan/action/spend.rs
+++ b/transaction/src/plan/action/spend.rs
@@ -68,7 +68,6 @@ impl SpendPlan {
             pk_d: self.note.transmission_key(),
             value: self.note.value(),
             v_blinding: self.value_blinding,
-            note_commitment: self.note.commit(),
             note_blinding: self.note.note_blinding(),
             spend_auth_randomizer: self.randomizer,
             ak: *fvk.spend_verification_key(),


### PR DESCRIPTION
Resolves #859 by removing the possibility of mismatched note commitment and proof: now, the submitted note commitment proof is used as the source of the commitment being checked, which means that there is no redundancy to be exploited.