### PR TITLE
implement ABCI query interface for JMT

### DIFF
--- a/pd/src/info/specific.rs
+++ b/pd/src/info/specific.rs
@@ -100,7 +100,7 @@ impl SpecificQuery for Info {
 
         let req_inner = request.into_inner();
         let req_proof = req_inner.proof;
-        let req_key = req_inner.key_hash;
+        let req_key = req_inner.key;
 
         if req_proof == true {
             let (value, proof) = state
@@ -110,9 +110,13 @@ impl SpecificQuery for Info {
                 .await
                 .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
+            let commitment_proof = ics23::CommitmentProof {
+                proof: Some(ics23::commitment_proof::Proof::Exist(proof)),
+            };
+
             Ok(tonic::Response::new(KeyValueResponse {
                 value,
-                proof: Some(proof),
+                proof: Some(commitment_proof),
             }))
         } else {
             let value = state

--- a/proto/proto/client/specific.proto
+++ b/proto/proto/client/specific.proto
@@ -31,12 +31,14 @@ message ValidatorStatusRequest {
 message KeyValueRequest {
   // The expected chain id (empty string if no expectation).
   string chain_id = 1;
-  bytes key_hash = 2;
+  // the key to fetch from storage
+  bytes key = 2;
+  // whether to return a proof
   bool proof = 3;
 }
 
 message KeyValueResponse {
   bytes value = 1;
 
-  .ics23.ExistenceProof proof = 2;
+  .ics23.CommitmentProof proof = 2;
 }


### PR DESCRIPTION
this adds ABCI query handling to `pd`, currently only handling one path: `/jmt/key`, which queries the JMT state for an arbitrary key. The query response is a proto-encoded `KeyValueResponse` that contains the value as well as an ICS23 CommitmentProof of that value's inclusion.