### PR TITLE
update tendermint deployment to 0.35.5

### DIFF
--- a/docker-compose.multinode.override.yml
+++ b/docker-compose.multinode.override.yml
@@ -41,7 +41,7 @@ services:
 
   # The Tendermint node
   tendermint-node1:
-    image: "tendermint/tendermint:v0.35.4"
+    image: "tendermint/tendermint:v0.35.5"
     container_name: tendermint-node1
     ports:
       - "27656:26656"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   # The Tendermint node
   tendermint-node0:
-    image: "tendermint/tendermint:v0.35.4"
+    image: "tendermint/tendermint:v0.35.5"
     container_name: tendermint-node0
     ports:
       - "26656:26656"

--- a/docs/guide/src/dev/create-testnet.md
+++ b/docs/guide/src/dev/create-testnet.md
@@ -8,7 +8,7 @@ parameters of the network.  This has two parts:
 1. Tendermint-related data specifying parameters for the consensus engine;
 2. Penumbra-related data specifying the initial chain state.
 
-First, [install Tendermint][tm-install].  Be sure to install `v0.35.4`, rather
+First, [install Tendermint][tm-install].  Be sure to install `v0.35.5`, rather
 than `master`.
 
 Next, create the Tendermint config data with


### PR DESCRIPTION
0.35.5 contains a p2p-related fix and may improve stability on our testnets