### PR TITLE
view: add a streaming sync status RPC method.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,6 +3011,7 @@ dependencies = [
  "sqlx",
  "structopt",
  "tokio",
+ "tokio-stream",
  "tonic 0.6.2",
  "tracing",
  "tracing-subscriber 0.2.25",
@@ -4611,6 +4612,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]

--- a/proto/proto/view.proto
+++ b/proto/proto/view.proto
@@ -20,6 +20,9 @@ service ViewProtocol {
     // Get current status of chain sync
     rpc Status(StatusRequest) returns (StatusResponse);
 
+    // Stream sync status updates until the view service has caught up with the chain.
+    rpc StatusStream(StatusStreamRequest) returns (stream StatusStreamResponse);
+
     // Queries for notes.
     rpc Notes(NotesRequest) returns (stream NoteRecord);
 
@@ -42,15 +45,15 @@ service ViewProtocol {
 message ChainParamsRequest {
 }
 
-// Requests sync status of the view service.
-message StatusRequest {
-    // Identifies the FVK for the notes to query.
-    crypto.FullViewingKeyHash fvk_hash = 1;
-}
-
 // Requests all assets known to the view service.
 message AssetRequest {
     // For verification.
+    crypto.FullViewingKeyHash fvk_hash = 1;
+}
+
+// Requests sync status of the view service.
+message StatusRequest {
+    // Identifies the FVK for the notes to query.
     crypto.FullViewingKeyHash fvk_hash = 1;
 }
 
@@ -60,6 +63,18 @@ message StatusResponse {
     uint64 sync_height = 1;
     // Whether the view service is catching up with the chain state
     bool catching_up = 2;
+}
+
+// Requests streaming updates on the sync height until the view service is synchronized.
+message StatusStreamRequest {
+    // Identifies the FVK for the notes to query.
+    crypto.FullViewingKeyHash fvk_hash = 1;
+}
+
+// A streaming sync status update
+message StatusStreamResponse {
+    uint64 latest_known_block_height = 1;
+    uint64 sync_height = 2;
 }
 
 // A note plaintext with associated metadata about its status.

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -22,6 +22,7 @@ penumbra-transaction = { path = "../transaction" }
 
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "offline", "sqlite" ] }
 tokio = { version = "1.16", features = ["full"]}
+tokio-stream = { version =  "0.1.8", features = ["sync"] }
 anyhow = "1"
 directories = "4.0.1"
 rand_core = { version = "0.6.3", features = ["getrandom"] }

--- a/view/sqlx-data.json
+++ b/view/sqlx-data.json
@@ -1,17 +1,16 @@
 {
   "db": "SQLite",
   "00ebf9aa311283f814859965b74865091c6e9bca47f4d95985b2aa63d4e4ac2f": {
-    "query": "INSERT INTO full_viewing_key (bytes) VALUES (?)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Right": 1
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "INSERT INTO full_viewing_key (bytes) VALUES (?)"
   },
   "0c9654cf156210edda72a63b80ad55cc1cd772f6ab83660307167aa3d2e8b094": {
-    "query": "UPDATE notes SET height_spent = ? WHERE nullifier = ? RETURNING note_commitment",
     "describe": {
       "columns": [
         {
@@ -20,46 +19,46 @@
           "type_info": "Blob"
         }
       ],
-      "parameters": {
-        "Right": 2
-      },
       "nullable": [
         false
-      ]
-    }
-  },
-  "1766574ebf4edffed45f0167f734a5ea5167ef2ec4280ed9710b4e1ec3eeb362": {
-    "query": "INSERT INTO chain_params (bytes) VALUES (?)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": []
-    }
-  },
-  "1ace3043077b74682c94e9d1876858fd696a42eac8f7da07d5b4ec43b0d9fc3f": {
-    "query": "INSERT INTO sync_height (height) VALUES (?)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": []
-    }
-  },
-  "2547294717840bcb1bef870394b99cf275bcba98d005f1f18b03c7a3d93909e1": {
-    "query": "INSERT INTO assets\n                    (\n                        asset_id,\n                        denom\n                    )\n                    VALUES\n                    (\n                        ?,\n                        ?\n                    )",
-    "describe": {
-      "columns": [],
+      ],
       "parameters": {
         "Right": 2
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "UPDATE notes SET height_spent = ? WHERE nullifier = ? RETURNING note_commitment"
+  },
+  "1766574ebf4edffed45f0167f734a5ea5167ef2ec4280ed9710b4e1ec3eeb362": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "INSERT INTO chain_params (bytes) VALUES (?)"
+  },
+  "1ace3043077b74682c94e9d1876858fd696a42eac8f7da07d5b4ec43b0d9fc3f": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "INSERT INTO sync_height (height) VALUES (?)"
+  },
+  "2547294717840bcb1bef870394b99cf275bcba98d005f1f18b03c7a3d93909e1": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "INSERT INTO assets\n                    (\n                        asset_id,\n                        denom\n                    )\n                    VALUES\n                    (\n                        ?,\n                        ?\n                    )"
   },
   "3381f1580eeac4a2fab83b4d64ae259c964e88dd22872675232f829ebc52a335": {
-    "query": "SELECT *\n            FROM assets",
     "describe": {
       "columns": [
         {
@@ -73,37 +72,37 @@
           "type_info": "Text"
         }
       ],
-      "parameters": {
-        "Right": 0
-      },
       "nullable": [
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "SELECT *\n            FROM assets"
   },
   "4af503f633659f5e73d7e64f3fb1f1ab5e37299a25dadcd851f4ec86aea0a78b": {
-    "query": "UPDATE sync_height SET height = ?",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Right": 1
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "UPDATE sync_height SET height = ?"
   },
   "52159e7c73f1adfe3098fdd6c1141aade5f4372584a359302b0fe64051daefad": {
-    "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        height_spent,\n                        height_created,\n                        diversifier,\n                        amount,\n                        asset_id,\n                        transmission_key,\n                        blinding_factor,\n                        diversifier_index,\n                        nullifier,\n                        position\n                    )\n                    VALUES\n                    (\n                        ?,\n                        NULL,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?\n                    )",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Right": 10
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        height_spent,\n                        height_created,\n                        diversifier,\n                        amount,\n                        asset_id,\n                        transmission_key,\n                        blinding_factor,\n                        diversifier_index,\n                        nullifier,\n                        position\n                    )\n                    VALUES\n                    (\n                        ?,\n                        NULL,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?\n                    )"
   },
   "5342f12d217c5e7aaf374fa574fd26df465f95878c84ce5670336f7f78a23c9f": {
-    "query": "SELECT *\n            FROM notes\n            WHERE height_spent = ?\n            AND asset_id = ?\n            AND diversifier_index = ?",
     "describe": {
       "columns": [
         {
@@ -162,9 +161,6 @@
           "type_info": "Int64"
         }
       ],
-      "parameters": {
-        "Right": 3
-      },
       "nullable": [
         false,
         true,
@@ -177,11 +173,14 @@
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Right": 3
+      }
+    },
+    "query": "SELECT *\n            FROM notes\n            WHERE height_spent = ?\n            AND asset_id = ?\n            AND diversifier_index = ?"
   },
   "63aad4faac1ffefd5525595f9ca5a82186181368251da9fbacf65a4d48671a01": {
-    "query": "\n            SELECT bytes\n            FROM full_viewing_key\n            LIMIT 1\n            ",
     "describe": {
       "columns": [
         {
@@ -190,16 +189,16 @@
           "type_info": "Blob"
         }
       ],
-      "parameters": {
-        "Right": 0
-      },
       "nullable": [
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            SELECT bytes\n            FROM full_viewing_key\n            LIMIT 1\n            "
   },
   "6684105462e0bba65abb19049c13836941421a0ed4ac59c6355dccdcab50dca7": {
-    "query": "\n            SELECT height\n            FROM sync_height\n            ORDER BY height DESC\n            LIMIT 1\n        ",
     "describe": {
       "columns": [
         {
@@ -208,26 +207,26 @@
           "type_info": "Int64"
         }
       ],
-      "parameters": {
-        "Right": 0
-      },
       "nullable": [
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            SELECT height\n            FROM sync_height\n            ORDER BY height DESC\n            LIMIT 1\n        "
   },
   "b4a0b026cd41003d66ec3ff1f104d89aee4ff22f10f1e7d20aa59dab4354b6ed": {
-    "query": "UPDATE note_commitment_tree SET bytes = ?",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Right": 1
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "UPDATE note_commitment_tree SET bytes = ?"
   },
   "d437ce2946cba91cd0e4fa750f14d227c2caa78e6bd69ed475f7b0679914c897": {
-    "query": "\n            SELECT bytes\n            FROM note_commitment_tree\n            LIMIT 1\n            ",
     "describe": {
       "columns": [
         {
@@ -236,26 +235,26 @@
           "type_info": "Blob"
         }
       ],
-      "parameters": {
-        "Right": 0
-      },
       "nullable": [
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            SELECT bytes\n            FROM note_commitment_tree\n            LIMIT 1\n            "
   },
   "e61182e04d553075f4385fda82a0822a04a08b8ada8ac5b5d46154a4c2901626": {
-    "query": "INSERT INTO note_commitment_tree (bytes) VALUES (?)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Right": 1
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "INSERT INTO note_commitment_tree (bytes) VALUES (?)"
   },
   "efb5f4932197a38ca134b63d8ea5d2fad9145fb56d03a60351f15b5302905402": {
-    "query": "\n            SELECT bytes\n            FROM chain_params\n            LIMIT 1\n        ",
     "describe": {
       "columns": [
         {
@@ -264,12 +263,13 @@
           "type_info": "Blob"
         }
       ],
-      "parameters": {
-        "Right": 0
-      },
       "nullable": [
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            SELECT bytes\n            FROM chain_params\n            LIMIT 1\n        "
   }
 }

--- a/view/src/bin/pviewd.rs
+++ b/view/src/bin/pviewd.rs
@@ -5,13 +5,12 @@ use penumbra_crypto::FullViewingKey;
 use penumbra_proto::client::oblivious::oblivious_query_client::ObliviousQueryClient;
 use penumbra_proto::client::oblivious::ChainParamsRequest;
 use penumbra_proto::view::view_protocol_server::ViewProtocolServer;
-use penumbra_proto::view::StatusResponse;
 use penumbra_view::ViewService;
 use std::env;
 use std::str::FromStr;
 use structopt::StructOpt;
 use tonic::transport::Server;
-use tracing::instrument;
+
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "pviewd",


### PR DESCRIPTION
This commit does two things:

1. It provides the Worker with a way to notify subscribers when it's learned of a new block;
2. It adds a new RPC method, StatusStream, that streams those height updates to clients, closing the connection when the sync has finished.

This gives view clients a way to wait for the sync process to complete, while receiving progress information along the way.