### PR TITLE
crypto: eliminate SpendSeed

### DIFF
--- a/crypto/src/address.rs
+++ b/crypto/src/address.rs
@@ -190,14 +190,13 @@ mod tests {
     use rand_core::OsRng;
 
     use super::*;
-    use crate::keys::{SeedPhrase, SpendKey, SpendSeed};
+    use crate::keys::{SeedPhrase, SpendKey};
 
     #[test]
     fn test_address_encoding() {
         let mut rng = OsRng;
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk = SpendKey::new(spend_seed);
+        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let ivk = fvk.incoming();
         let (dest, _dtk_d) = ivk.payment_address(0u64.into());

--- a/crypto/src/keys.rs
+++ b/crypto/src/keys.rs
@@ -8,7 +8,7 @@ mod seed_phrase;
 pub use seed_phrase::SeedPhrase;
 
 mod spend;
-pub use spend::{SpendKey, SpendSeed, SPENDSEED_LEN_BYTES};
+pub use spend::{SpendKey, SpendKeyBytes, SPENDKEY_LEN_BYTES};
 
 mod fvk;
 mod ivk;

--- a/crypto/src/memo.rs
+++ b/crypto/src/memo.rs
@@ -100,15 +100,14 @@ mod tests {
     use rand_core::OsRng;
 
     use super::*;
-    use crate::keys::{SeedPhrase, SpendKey, SpendSeed};
+    use crate::keys::{SeedPhrase, SpendKey};
 
     #[test]
     fn test_memo_encryption_and_decryption() {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk = SpendKey::new(spend_seed);
+        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let ivk = fvk.incoming();
         let (dest, _dtk_d) = ivk.payment_address(0u64.into());

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -400,15 +400,14 @@ mod tests {
     use rand_core::OsRng;
 
     use super::*;
-    use crate::keys::{SeedPhrase, SpendKey, SpendSeed};
+    use crate::keys::{SeedPhrase, SpendKey};
 
     #[test]
     fn test_note_encryption_and_decryption() {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk = SpendKey::new(spend_seed);
+        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let ivk = fvk.incoming();
         let (dest, _dtk_d) = ivk.payment_address(0u64.into());
@@ -428,8 +427,7 @@ mod tests {
         assert_eq!(plaintext, note);
 
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk2 = SpendKey::new(spend_seed);
+        let sk2 = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk2 = sk2.full_viewing_key();
         let ivk2 = fvk2.incoming();
 

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -390,7 +390,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        keys::{SeedPhrase, SpendKey, SpendSeed},
+        keys::{SeedPhrase, SpendKey},
         note, Note, Value,
     };
 
@@ -399,8 +399,7 @@ mod tests {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk_recipient = SpendKey::new(spend_seed);
+        let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
         let (dest, _dtk_d) = ivk_recipient.payment_address(0u64.into());
@@ -433,8 +432,7 @@ mod tests {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk_recipient = SpendKey::new(spend_seed);
+        let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
         let (dest, _dtk_d) = ivk_recipient.payment_address(0u64.into());
@@ -478,8 +476,7 @@ mod tests {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk_recipient = SpendKey::new(spend_seed);
+        let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
         let (dest, _dtk_d) = ivk_recipient.payment_address(0u64.into());
@@ -513,8 +510,7 @@ mod tests {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk_recipient = SpendKey::new(spend_seed);
+        let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
         let (dest, _dtk_d) = ivk_recipient.payment_address(0u64.into());
@@ -552,8 +548,7 @@ mod tests {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk_recipient = SpendKey::new(spend_seed);
+        let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
         let (dest, _dtk_d) = ivk_recipient.payment_address(0u64.into());
@@ -586,8 +581,7 @@ mod tests {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk_sender = SpendKey::new(spend_seed);
+        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (sender, _dtk_d) = ivk_sender.payment_address(0u64.into());
@@ -632,8 +626,7 @@ mod tests {
     fn test_spend_proof_verification_merkle_path_integrity_failure() {
         let mut rng = OsRng;
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk_sender = SpendKey::new(spend_seed);
+        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (sender, _dtk_d) = ivk_sender.payment_address(0u64.into());
@@ -678,8 +671,7 @@ mod tests {
     fn test_spend_proof_verification_value_commitment_integrity_failure() {
         let mut rng = OsRng;
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk_sender = SpendKey::new(spend_seed);
+        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (sender, _dtk_d) = ivk_sender.payment_address(0u64.into());
@@ -723,8 +715,7 @@ mod tests {
     fn test_spend_proof_verification_nullifier_integrity_failure() {
         let mut rng = OsRng;
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk_sender = SpendKey::new(spend_seed);
+        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (sender, _dtk_d) = ivk_sender.payment_address(0u64.into());

--- a/pcli-next/src/main.rs
+++ b/pcli-next/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use penumbra_crypto::keys::{SeedPhrase, SpendKey, SpendSeed};
+use penumbra_crypto::keys::{SeedPhrase, SpendKey};
 use penumbra_custody::SoftHSM;
 use penumbra_proto::{
     client::oblivious::oblivious_query_client::ObliviousQueryClient,
@@ -18,7 +18,7 @@ use rand_core::OsRng;
 async fn main() -> Result<()> {
     // stub code to check that generics are well-formed in wallet-next
 
-    let sk = SpendKey::new(SpendSeed::from_seed_phrase(SeedPhrase::generate(OsRng), 0));
+    let sk = SpendKey::from_seed_phrase(SeedPhrase::generate(OsRng), 0);
     let fvk = sk.full_viewing_key().clone();
 
     let oq_client =

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -13,7 +13,7 @@ use anyhow::Context;
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusRecorder};
 use penumbra_chain::{genesis::Allocation, params::ChainParams};
 use penumbra_crypto::{
-    keys::{SpendKey, SpendSeed},
+    keys::{SpendKey, SpendKeyBytes},
     rdsa::{SigningKey, SpendAuth, VerificationKey},
     DelegationToken,
 };
@@ -321,7 +321,7 @@ async fn main() -> anyhow::Result<()> {
                 pub node_key_sk: tendermint::PrivateKey,
                 #[allow(unused_variables, dead_code)]
                 pub node_key_pk: tendermint::PublicKey,
-                pub validator_spendseed: SpendSeed,
+                pub validator_spendseed: SpendKeyBytes,
             }
             let mut validator_keys = Vec::<ValidatorKeys>::new();
             // Generate a keypair for each validator
@@ -332,7 +332,7 @@ async fn main() -> anyhow::Result<()> {
             );
             for _ in 0..num_validator_nodes {
                 // Create the spend key for this node.
-                let seed = SpendSeed(OsRng.gen());
+                let seed = SpendKeyBytes(OsRng.gen());
                 let spend_key = SpendKey::from(seed.clone());
 
                 // Create signing key and verification key for this node.

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -83,6 +83,7 @@ static AS_BECH32_IDENTITY_KEY: &str =
     r#"#[serde(with = "crate::serializers::bech32str::validator_identity_key")]"#;
 static AS_BECH32_ADDRESS: &str = r#"#[serde(with = "crate::serializers::bech32str::address")]"#;
 static AS_BECH32_ASSET_ID: &str = r#"#[serde(with = "crate::serializers::bech32str::asset_id")]"#;
+static AS_BECH32_SPEND_KEY: &str = r#"#[serde(with = "crate::serializers::bech32str::spend_key")]"#;
 static AS_BECH32_FULL_VIEWING_KEY: &str =
     r#"#[serde(with = "crate::serializers::bech32str::full_viewing_key")]"#;
 
@@ -120,6 +121,8 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.crypto.Asset", SERIALIZE),
     (".penumbra.crypto.MerkleRoot", SERIALIZE),
     (".penumbra.crypto.MerkleRoot", SERDE_TRANSPARENT),
+    (".penumbra.crypto.SpendKey", SERIALIZE),
+    (".penumbra.crypto.SpendKey", SERDE_TRANSPARENT),
     (".penumbra.crypto.FullViewingKey", SERIALIZE),
     (".penumbra.crypto.FullViewingKey", SERDE_TRANSPARENT),
     (".penumbra.crypto.FullViewingKeyHash", SERIALIZE),
@@ -158,6 +161,7 @@ static FIELD_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.crypto.AssetId.inner", AS_BECH32_ASSET_ID),
     (".penumbra.crypto.NoteCommitment.inner", AS_HEX),
     (".penumbra.crypto.MerkleRoot.inner", AS_HEX),
+    (".penumbra.crypto.SpendKey.inner", AS_BECH32_SPEND_KEY),
     (
         ".penumbra.crypto.FullViewingKey.inner",
         AS_BECH32_FULL_VIEWING_KEY,

--- a/proto/proto/crypto.proto
+++ b/proto/proto/crypto.proto
@@ -7,6 +7,10 @@ message Address {
     bytes inner = 1;
 }
 
+message SpendKey {
+    bytes inner = 1;
+}
+
 message FullViewingKey {
     bytes inner = 1;
 }

--- a/proto/src/serializers/bech32str.rs
+++ b/proto/src/serializers/bech32str.rs
@@ -142,8 +142,30 @@ pub mod asset_id {
 pub mod full_viewing_key {
     use super::*;
 
-    /// The Bech32 prefix used for asset IDs.
+    /// The Bech32 prefix used for full viewing keys.
     pub const BECH32_PREFIX: &str = "penumbrafullviewingkey";
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_bech32(deserializer, BECH32_PREFIX, Variant::Bech32m)
+    }
+
+    pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: AsRef<[u8]>,
+    {
+        serialize_bech32(value, serializer, BECH32_PREFIX, Variant::Bech32m)
+    }
+}
+
+pub mod spend_key {
+    use super::*;
+
+    /// The Bech32 prefix used for spend keys.
+    pub const BECH32_PREFIX: &str = "penumbraspendkey";
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
     where

--- a/transaction/src/auth_hash.rs
+++ b/transaction/src/auth_hash.rs
@@ -234,7 +234,7 @@ impl Undelegate {
 #[cfg(test)]
 mod tests {
     use penumbra_crypto::{
-        keys::{SeedPhrase, SpendKey, SpendSeed},
+        keys::{SeedPhrase, SpendKey},
         memo::MemoPlaintext,
         Note, Value, STAKING_TOKEN_ASSET_ID,
     };
@@ -255,8 +255,7 @@ mod tests {
     fn plan_auth_hash_matches_transaction_auth_hash() {
         let mut rng = OsRng;
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let sk = SpendKey::new(spend_seed);
+        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let (addr, _dtk) = fvk.incoming().payment_address(0u64.into());
 

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use penumbra_crypto::{
     fmd,
     keys::{
-        FullViewingKey, IncomingViewingKey, OutgoingViewingKey, SeedPhrase, SpendKey, SpendSeed,
+        FullViewingKey, IncomingViewingKey, OutgoingViewingKey, SeedPhrase, SpendKey, SpendKeyBytes,
     },
     Address, Note,
 };
@@ -25,8 +25,7 @@ impl Wallet {
     pub fn from_seed_phrase(seed_phrase: SeedPhrase) -> Self {
         // Currently we support a single spend authority per wallet. In the future,
         // we can derive multiple spend seeds from a single seed phrase.
-        let spend_seed = SpendSeed::from_seed_phrase(seed_phrase, 0);
-        let spend_key = SpendKey::new(spend_seed);
+        let spend_key = SpendKey::from_seed_phrase(seed_phrase, 0);
 
         Self {
             spend_key,
@@ -35,7 +34,7 @@ impl Wallet {
     }
 
     /// Imports a wallet from a legacy [`SpendSeed`].
-    pub fn import(spend_seed: SpendSeed) -> Self {
+    pub fn import(spend_seed: SpendKeyBytes) -> Self {
         let spend_key = spend_seed.into();
         Self {
             spend_key,
@@ -111,7 +110,7 @@ impl Wallet {
 }
 
 mod serde_helpers {
-    use penumbra_crypto::keys::SpendSeed;
+    use penumbra_crypto::keys::SpendKeyBytes;
     use serde_with::serde_as;
 
     use super::*;
@@ -128,7 +127,7 @@ mod serde_helpers {
         fn from(w: WalletHelper) -> Self {
             Self {
                 address_labels: w.address_labels,
-                spend_key: SpendKey::from(SpendSeed(w.spend_seed)),
+                spend_key: SpendKey::from(SpendKeyBytes(w.spend_seed)),
             }
         }
     }
@@ -137,7 +136,7 @@ mod serde_helpers {
         fn from(w: Wallet) -> Self {
             Self {
                 address_labels: w.address_labels,
-                spend_seed: w.spend_key.seed().clone().0,
+                spend_seed: w.spend_key.to_bytes().clone().0,
             }
         }
     }


### PR DESCRIPTION
The `SpendSeed` doesn't add anything to the API except complexity, because it's
exactly the same data as the `SpendKey` (in the sense that all of the
`SpendKey` data can be derived from it, and the `SpendKey` contains a copy of
the `SpendSeed`). It's really better thought of as a serialization detail.

This commit renames it to `SpendKeyBytes`, and eliminates most of its uses.  We
can't make it entirely hidden, because we need it to parse existing wallets.
But going forward, we should use the protoized format (introduced in this
commit) with Bech32 encoding.