### PR TITLE
pcli-next: print tx submissions

### DIFF
--- a/pcli-next/src/network.rs
+++ b/pcli-next/src/network.rs
@@ -18,12 +18,12 @@ impl Opt {
     /// node has accepted the transaction, and erroring otherwise.
     #[instrument(skip(self, transaction))]
     pub async fn submit_transaction(&self, transaction: &Transaction) -> Result<(), anyhow::Error> {
-        tracing::info!("pre-checking transaction...");
+        println!("pre-checking transaction...");
         use penumbra_component::Component;
         pd::App::check_tx_stateless(transaction)
             .context("transaction pre-submission checks failed")?;
 
-        tracing::info!("broadcasting transaction...");
+        println!("broadcasting transaction...");
 
         let client = reqwest::Client::new();
         let req_id: u8 = rand::thread_rng().gen();
@@ -52,6 +52,7 @@ impl Opt {
             .ok_or_else(|| anyhow::anyhow!("could not parse JSON response"))?;
 
         if code == 0 {
+            println!("transaction submitted successfully");
             Ok(())
         } else {
             let log = result


### PR DESCRIPTION
Now that we don't use `tracing` for progress output, we should be printing output to the user and only using `tracing` for debugging.