### PR TITLE
pd: add keep-alive to compact block streams

### DIFF
--- a/pcli/src/sync.rs
+++ b/pcli/src/sync.rs
@@ -17,6 +17,7 @@ pub async fn sync(opt: &Opt, state: &mut ClientStateFile) -> Result<()> {
             chain_id: state
                 .chain_id()
                 .ok_or_else(|| anyhow::anyhow!("missing chain_id"))?,
+            keep_alive: false,
         }))
         .await?
         .into_inner();

--- a/pd/src/info.rs
+++ b/pd/src/info.rs
@@ -6,7 +6,11 @@ use std::{
 
 use futures::FutureExt;
 use penumbra_storage::{State, Storage};
-use tendermint::abci::{self, response::Echo, InfoRequest, InfoResponse};
+use tendermint::{
+    abci::{self, response::Echo, InfoRequest, InfoResponse},
+    block,
+};
+use tokio::sync::watch;
 use tower_abci::BoxError;
 use tracing::Instrument;
 
@@ -20,11 +24,12 @@ const ABCI_INFO_VERSION: &str = env!("VERGEN_GIT_SEMVER");
 #[derive(Clone, Debug)]
 pub struct Info {
     storage: Storage,
+    height_rx: watch::Receiver<block::Height>,
 }
 
 impl Info {
-    pub fn new(storage: Storage) -> Self {
-        Self { storage }
+    pub fn new(storage: Storage, height_rx: watch::Receiver<block::Height>) -> Self {
+        Self { storage, height_rx }
     }
 
     async fn state_tonic(&self) -> Result<State, tonic::Status> {

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -148,8 +148,8 @@ async fn main() -> anyhow::Result<()> {
                 .context("Unable to initialize RocksDB storage")?;
 
             let (consensus, height_rx) = pd::Consensus::new(storage.clone()).await?;
-            let mempool = pd::Mempool::new(storage.clone(), height_rx).await?;
-            let info = pd::Info::new(storage.clone());
+            let mempool = pd::Mempool::new(storage.clone(), height_rx.clone()).await?;
+            let info = pd::Info::new(storage.clone(), height_rx);
             let snapshot = pd::Snapshot {};
 
             let abci_server = tokio::task::Builder::new().name("abci_server").spawn(

--- a/proto/proto/client/oblivious.proto
+++ b/proto/proto/client/oblivious.proto
@@ -30,7 +30,12 @@ message CompactBlockRangeRequest {
   // The start height of the range.
   uint64 start_height = 2;
   // The end height of the range.
+  //
+  // If unset, defaults to the latest block height.
   uint64 end_height = 3;
+  // If set, keep the connection alive past end_height,
+  // streaming new compact blocks as they are created.
+  bool keep_alive = 4;
 }
 
 // Requests the global configuration data for the chain.


### PR DESCRIPTION
This allows clients to leave connections open to pd, and to be notified
immediately whenever new blocks arrive, rather than having to periodically
poll.  This significantly improves the latency of checking sync readiness,
since if the full node is a block ahead, we don't need to wait a few seconds
for the worker to find out.