### PR TITLE
view: only commit to database on nonempty blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2989,6 +2989,7 @@ dependencies = [
  "futures",
  "hex",
  "metrics",
+ "parking_lot 0.12.0",
  "penumbra-chain",
  "penumbra-crypto",
  "penumbra-proto",

--- a/chain/src/sync.rs
+++ b/chain/src/sync.rs
@@ -18,6 +18,13 @@ pub struct CompactBlock {
     pub nullifiers: Vec<Nullifier>,
 }
 
+impl CompactBlock {
+    /// Returns true if the compact block is empty.
+    pub fn is_empty(&self) -> bool {
+        self.note_payloads.is_empty() && self.nullifiers.is_empty()
+    }
+}
+
 impl Protobuf<pb::CompactBlock> for CompactBlock {}
 
 impl From<CompactBlock> for pb::CompactBlock {

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -42,6 +42,7 @@ hex = "0.4"
 metrics = "0.18"
 async-stream = "0.2"
 reqwest = { version = "0.11", features = ["json"] }
+parking_lot = "0.12"
 
 [build-dependencies]
 vergen = "5"

--- a/view/src/worker.rs
+++ b/view/src/worker.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use crate::{sync::scan_block, Storage};
+use penumbra_chain::sync::CompactBlock;
 use penumbra_crypto::{Asset, FullViewingKey};
 use penumbra_proto::client::oblivious::{
     oblivious_query_client::ObliviousQueryClient, AssetListRequest, CompactBlockRangeRequest,
@@ -101,17 +102,30 @@ impl Worker {
             .into_inner();
 
         while let Some(block) = stream.message().await? {
+            let block = CompactBlock::try_from(block)?;
+
             // Lock the NCT only while processing this block.
-            let mut nct = self.nct.write().await;
+            let mut nct_guard = self.nct.write().await;
 
-            let scan_result = scan_block(&self.fvk, &mut nct, block.try_into()?, epoch_duration);
-            let height = scan_result.height;
+            if block.is_empty() {
+                // Optimization: if the block is empty, seal the in-memory NCT,
+                // and skip touching the database:
+                nct_guard.end_block().unwrap();
+                self.storage.record_empty_block(block.height).await?;
+            } else {
+                // Otherwise, scan the block and commit its changes:
+                let scan_result =
+                    scan_block(&self.fvk, &mut nct_guard, block.try_into()?, epoch_duration);
+                let height = scan_result.height;
 
-            self.storage.record_block(scan_result, &mut nct).await?;
-            // Notify all watchers of the new height we just recorded.
-            self.sync_height_tx.send(height)?;
+                self.storage
+                    .record_block(scan_result, &mut nct_guard)
+                    .await?;
+                // Notify all watchers of the new height we just recorded.
+                self.sync_height_tx.send(height)?;
+            }
             // Release the NCT RwLock
-            drop(nct);
+            drop(nct_guard);
 
             // Check if we should stop waiting for blocks to arrive, because the view
             // services are dropped and we're supposed to shut down.


### PR DESCRIPTION
The initial version of the view service's sync logic suffered from poor sync
performance as the size of the NCT grows, because it commits the full NCT to
the database on every block.  This causes a massive amount of disk traffic.

In the future, we'll avoid this by using incremental serialization of the NCT,
so that the data to serialize drops from being on the order of megabytes to on
the order of kilobytes.

In the meantime, this is an easy optimization for empty blocks: only commit
changes to the database when the block is nonempty.  Otherwise, if the block
was empty, there was no data to update, except the NCT, which is already
in-memory.

To actually implement this, we have to be a bit more careful, and also add an
in-memory cache for the `last_sync_height` field, update it when we "uncommit"
an empty block, and reset it when we commit a nonempty block.

Testing locally (without carefully measuring) seems to give a 4-5x speedup on
sync times.