### PR TITLE
Make the complete part of the TCT strict for hashes

### DIFF
--- a/tct-property-test/tests/witness.proptest-regressions
+++ b/tct-property-test/tests/witness.proptest-regressions
@@ -7,3 +7,5 @@
 cc 9b0b30e0127fda824382ef1c8f20ca26734bc82ced221d04d8c3e94c9e6e15c9 # shrinks to actions = [Insert(Forget, note::Commitment(c38d49528121961f75e5eee0470e33ec5dcc1f1faa07a3a1e4e45f6226383103))]
 cc 90fdae3a9ff02aca8bb97f9d92621cdc91400d7244757d98f9682bab4ce4cb19 # shrinks to actions = [Insert(Keep, note::Commitment(8e80f2bd163ff5d6c6996417d5b1952d91b9d64d2c13527f7bf7f402a763040d)), Insert(Keep, note::Commitment(8e80f2bd163ff5d6c6996417d5b1952d91b9d64d2c13527f7bf7f402a763040d))]
 cc 9e6ccd22e2c45933e6ebedf7dc1d4ea32a4252285c2b7cf44556d8e9d8595f9c # shrinks to actions = [Insert(Forget, note::Commitment(ca04ad4423b52682e4641fb4d0ec66df5f5f3d812f12f690b485e259c3f84709))]
+cc fff581e62e6c5c9419017e4152a13695bdf299fa110c1af6c970fb013f1d004a # shrinks to actions = [Insert(Keep, note::Commitment(ebb2f28fb7a61c457d2d91cbfc5650d66c55f64427910e4e98ad0d587bc7c711)), EndBlock]
+cc 8e1020c6c3c4f520d444c3e0e6202169e347d741a05737f8968c8a6e3fc2bce9 # shrinks to actions = [Insert(Keep, note::Commitment(51281de2836af0540a355b564737f898def524344ca0fa1097302fbc2a31f70a)), EndBlock]

--- a/tct/src/internal/complete/item.rs
+++ b/tct/src/internal/complete/item.rs
@@ -1,26 +1,28 @@
 use crate::prelude::*;
 
 /// A witnessed hash of a commitment at the true leaf of a complete tree.
-#[derive(Clone, Copy, PartialEq, Eq, Derivative, Serialize, Deserialize)]
-#[derivative(Debug = "transparent")]
-pub struct Item(Hash);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Derivative, Serialize, Deserialize)]
+pub struct Item {
+    hash: Hash,
+    commitment: Commitment,
+}
 
 impl Item {
     /// Create a new `Item` from a [`Hash`](struct@Hash).
-    pub fn new(hash: Hash) -> Self {
-        Self(hash)
+    pub fn new(hash: Hash, commitment: Commitment) -> Self {
+        Self { hash, commitment }
     }
 }
 
 impl GetHash for Item {
     #[inline]
     fn hash(&self) -> Hash {
-        self.0
+        self.hash
     }
 
     #[inline]
     fn cached_hash(&self) -> Option<Hash> {
-        Some(self.0)
+        Some(self.hash)
     }
 }
 
@@ -36,14 +38,14 @@ impl Witness for Item {
     #[inline]
     fn witness(&self, index: impl Into<u64>) -> Option<(AuthPath<Self>, Hash)> {
         debug_assert_eq!(index.into(), 0, "non-zero index when witnessing leaf");
-        Some((path::Leaf, self.0))
+        Some((path::Leaf, self.hash))
     }
 }
 
 impl ForgetOwned for Item {
     fn forget_owned(self, index: impl Into<u64>) -> (Insert<Self>, bool) {
         debug_assert_eq!(index.into(), 0, "non-zero index when forgetting leaf");
-        (Insert::Hash(self.0), true)
+        (Insert::Hash(self.hash), true)
     }
 }
 

--- a/tct/src/internal/complete/node.rs
+++ b/tct/src/internal/complete/node.rs
@@ -167,7 +167,13 @@ impl<Child: GetHash + ForgetOwned> ForgetOwned for Node<Child> {
 
         // Reconstruct the node from the children, or else (if all the children are hashes) hash
         // those hashes into a single node hash
-        let reconstructed = Self::from_children_or_else_hash(children);
+        let reconstructed = match Children::try_from(children) {
+            Ok(children) => Insert::Keep(Self {
+                children,
+                hash: self.hash,
+            }),
+            Err(_) => Insert::Hash(self.hash),
+        };
 
         (reconstructed, forgotten)
     }

--- a/tct/src/internal/complete/node.rs
+++ b/tct/src/internal/complete/node.rs
@@ -43,26 +43,6 @@ impl<'de, Child: Height + GetHash + Deserialize<'de>> Deserialize<'de> for Node<
 }
 
 impl<Child: GetHash + Height> Node<Child> {
-    pub(in super::super) fn from_siblings_and_focus_or_else_hash(
-        siblings: Three<Insert<Child>>,
-        focus: Insert<Child>,
-    ) -> Insert<Self> {
-        let one = || Insert::Hash(Hash::one());
-
-        // Push the focus into the siblings, and fill any empty children with the *ONE* hash, which
-        // causes the hash of a complete node to deliberately differ from that of a frontier node,
-        // which uses *ZERO* padding
-        Self::from_children_or_else_hash(match siblings.push(focus) {
-            Err([a, b, c, d]) => [a, b, c, d],
-            Ok(siblings) => match siblings.into_elems() {
-                IntoElems::_3([a, b, c]) => [a, b, c, one()],
-                IntoElems::_2([a, b]) => [a, b, one(), one()],
-                IntoElems::_1([a]) => [a, one(), one(), one()],
-                IntoElems::_0([]) => [one(), one(), one(), one()],
-            },
-        })
-    }
-
     pub(in super::super) fn from_children_or_else_hash(
         children: [Insert<Child>; 4],
     ) -> Insert<Self> {

--- a/tct/src/internal/complete/node/children.rs
+++ b/tct/src/internal/complete/node/children.rs
@@ -59,7 +59,7 @@ impl<Child: Debug> Debug for Children<Child> {
 }
 
 impl<Child: Height> Height for Children<Child> {
-    type Height = <Child as Height>::Height;
+    type Height = Succ<<Child as Height>::Height>;
 }
 
 impl<Child: Height + GetHash> GetHash for Children<Child> {

--- a/tct/src/internal/complete/node/children.rs
+++ b/tct/src/internal/complete/node/children.rs
@@ -58,6 +58,21 @@ impl<Child: Debug> Debug for Children<Child> {
     }
 }
 
+impl<Child: Height> Height for Children<Child> {
+    type Height = <Child as Height>::Height;
+}
+
+impl<Child: Height + GetHash> GetHash for Children<Child> {
+    fn hash(&self) -> Hash {
+        let [a, b, c, d] = self.children().map(|x| x.hash());
+        Hash::node(<Self as Height>::Height::HEIGHT, a, b, c, d)
+    }
+
+    fn cached_hash(&self) -> Option<Hash> {
+        None
+    }
+}
+
 impl<Child> TryFrom<[Insert<Child>; 4]> for Children<Child>
 where
     Child: Height,

--- a/tct/src/internal/complete/tier.rs
+++ b/tct/src/internal/complete/tier.rs
@@ -9,15 +9,15 @@ pub type Nested<Item> = N<N<N<N<N<N<N<N<L<Item>>>>>>>>>;
 
 /// A complete tier of the tiered commitment tree, being an 8-deep sparse quad-tree.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Tier<Item> {
+pub struct Tier<Item: GetHash + Height> {
     pub(in super::super) inner: Nested<Item>,
 }
 
-impl<Item: Height> Height for Tier<Item> {
+impl<Item: GetHash + Height> Height for Tier<Item> {
     type Height = <Nested<Item> as Height>::Height;
 }
 
-impl<Item: Height + GetHash> GetHash for Tier<Item> {
+impl<Item: GetHash + Height> GetHash for Tier<Item> {
     #[inline]
     fn hash(&self) -> Hash {
         self.inner.hash()

--- a/tct/src/internal/complete/top.rs
+++ b/tct/src/internal/complete/top.rs
@@ -4,15 +4,15 @@ use complete::Nested;
 
 /// A complete top-level tier of the tiered commitment tree, being an 8-deep sparse quad-tree.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Top<Item> {
+pub struct Top<Item: GetHash + Height> {
     pub(in super::super) inner: Nested<Item>,
 }
 
-impl<Item: Height> Height for Top<Item> {
+impl<Item: GetHash + Height> Height for Top<Item> {
     type Height = <Nested<Item> as Height>::Height;
 }
 
-impl<Item: Height + GetHash> GetHash for Top<Item> {
+impl<Item: GetHash + Height> GetHash for Top<Item> {
     #[inline]
     fn hash(&self) -> Hash {
         self.inner.hash()
@@ -24,7 +24,7 @@ impl<Item: Height + GetHash> GetHash for Top<Item> {
     }
 }
 
-impl<Item> From<complete::Tier<Item>> for Top<Item> {
+impl<Item: GetHash + Height> From<complete::Tier<Item>> for Top<Item> {
     fn from(tier: complete::Tier<Item>) -> Self {
         Top { inner: tier.inner }
     }

--- a/tct/src/internal/frontier/node.rs
+++ b/tct/src/internal/frontier/node.rs
@@ -147,16 +147,10 @@ where
                 // We didn't have enough room to add another sibling, so we return a complete node
                 // as a carry, to be propagated up above us and added to some ancestor segment's
                 // siblings, along with the item we couldn't insert
-                Err(children) => {
-                    Err(Full {
-                        item,
-                        // Implicitly, we only hash the children together when we're pruning them
-                        // (because otherwise we would lose that informtion); if at least one child
-                        // and its sibling hashes/subtrees is preserved in a `Complete` node, then
-                        // we defer calculating the node hash until looking up an authentication path
-                        complete: complete::Node::from_children_or_else_hash(children),
-                    })
-                }
+                Err(children) => Err(Full {
+                    item,
+                    complete: complete::Node::from_children_or_else_hash(children),
+                }),
             },
         }
     }

--- a/tct/src/internal/frontier/tier.rs
+++ b/tct/src/internal/frontier/tier.rs
@@ -317,7 +317,7 @@ mod test {
 
     #[test]
     fn check_inner_size() {
-        static_assertions::assert_eq_size!(Tier<Tier<Tier<frontier::Item>>>, [u8; 64]);
+        static_assertions::assert_eq_size!(Tier<Tier<Tier<frontier::Item>>>, [u8; 56]);
     }
 
     #[test]

--- a/tct/src/lib.rs
+++ b/tct/src/lib.rs
@@ -128,7 +128,7 @@ mod test {
 
     #[test]
     fn check_eternity_size() {
-        static_assertions::assert_eq_size!(Tree, [u8; 608]);
+        static_assertions::assert_eq_size!(Tree, [u8; 600]);
     }
 
     #[test]


### PR DESCRIPTION
The only place where laziness actually improves the efficiency of the TCT is along the frontier, because we may overwrite a node's hash without ever making use of it. However, it is not necessary in the complete portion of the tree, because for each internal node, it will either (a) be evaluated when computing the root, or (b) be explicitly forgotten before that time, which requires computing its hash. This change has several benefits:

1. we save space on each node in the internal complete tree structure, because we don't need a `parking_lot::Mutex` to synchronize, and
2. we have a fixed upper bound on the time it takes to compute a root of a tree, regardless of how long it has been since the root was last computed.

This changeset also adds the `Commitment` to the bottom-most leaves of the tree, which implicitly establishes a reverse-index from position to commitment: that change is necessary for incremental serialization to produce the list of newly added commitments.