### PR TITLE
Patch for setting `pcli addr show` default to 0

### DIFF
--- a/pcli/src/command/addr.rs
+++ b/pcli/src/command/addr.rs
@@ -8,6 +8,8 @@ pub enum AddrCmd {
     /// Show the address with the given index.
     Show {
         /// The index of the address to show.
+        /// Default to 0
+        #[structopt(default_value = "0")]
         index: u64,
         /// If true, emits only the address and not the (local) label for it.
         #[structopt(short, long)]


### PR DESCRIPTION
Updated addr.rs to make use of `0` for the default value of puli command, `pcli addr show` fixes #941