### PR TITLE
Test tct-property-test using release build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,11 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --exclude penumbra-tct-property-test
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release -p penumbra-tct-property-test
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --exclude penumbra-tct-property-test
+          args: --workspace --exclude penumbra-tct-property-test
       - uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
The property tests crate for the TCT takes some time to run, because it does a lot of hashing; this PR speeds it up by running it in release mode. This decreases the total CI time spent in the test suite from 15 minutes to 9 minutes.