### PR TITLE
Add ABCI event recording capability to penumbra Components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ dependencies = [
  "penumbra-chain",
  "penumbra-transaction",
  "tendermint",
+ "tokio",
  "tonic 0.6.2",
 ]
 

--- a/component/Cargo.toml
+++ b/component/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tokio = { version = "1.16", features = ["full", "tracing"]}
 penumbra-transaction = { path = "../transaction" }
 penumbra-chain = { path = "../chain" }
 async-trait = "0.1.52"

--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -2,7 +2,37 @@ use anyhow::Result;
 use async_trait::async_trait;
 use penumbra_chain::genesis;
 use penumbra_transaction::Transaction;
+use std::sync::Arc;
+use std::sync::Mutex;
 use tendermint::abci;
+
+#[derive(Clone)]
+pub struct Context {
+    inner: Arc<Mutex<Option<Vec<abci::Event>>>>,
+}
+
+impl Context {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Some(Vec::new()))),
+        }
+    }
+    pub fn record(&self, e: abci::Event) {
+        self.inner
+            .lock()
+            .expect("record called after into_events")
+            .as_mut()
+            .unwrap()
+            .push(e);
+    }
+    pub fn into_events(self) -> Vec<abci::Event> {
+        self.inner
+            .lock()
+            .expect("into_events called after record")
+            .take()
+            .unwrap()
+    }
+}
 
 /// A component of the Penumbra application.
 ///
@@ -82,11 +112,11 @@ pub trait Component: Sized {
     /// This method should only be called immediately after [`Component::new`].
     /// This method need not be called before [`Component::execute_tx`] (e.g.,
     /// in order to simulate executing a transaction in the mempool).
-    async fn begin_block(&mut self, begin_block: &abci::request::BeginBlock);
+    async fn begin_block(&mut self, ctx: Context, begin_block: &abci::request::BeginBlock);
 
     /// Performs all of this component's stateless validity checks on the given
     /// [`Transaction`].
-    fn check_tx_stateless(tx: &Transaction) -> Result<()>;
+    fn check_tx_stateless(ctx: Context, tx: &Transaction) -> Result<()>;
 
     /// Performs all of this component's stateful validity checks on the given
     /// [`Transaction`].
@@ -96,7 +126,7 @@ pub trait Component: Sized {
     /// This method should only be called on transactions that have been
     /// checked with [`Component::check_tx_stateless`].
     /// This method can be called before [`Component::begin_block`].
-    async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()>;
+    async fn check_tx_stateful(&self, ctx: Context, tx: &Transaction) -> Result<()>;
 
     /// Executes the given [`Transaction`] against the current state.
     ///
@@ -105,7 +135,7 @@ pub trait Component: Sized {
     /// This method should only be called immediately following a successful
     /// invocation of [`Component::check_tx_stateful`] on the same transaction.
     /// This method can be called before [`Component::begin_block`].
-    async fn execute_tx(&mut self, tx: &Transaction);
+    async fn execute_tx(&mut self, ctx: Context, tx: &Transaction);
 
     /// Ends the block, optionally inspecting the ABCI
     /// [`EndBlock`](abci::request::EndBlock) request, and performing any batch
@@ -115,5 +145,5 @@ pub trait Component: Sized {
     ///
     /// This method should only be called after [`Component::begin_block`].
     /// No methods should be called following this method.
-    async fn end_block(&mut self, end_block: &abci::request::EndBlock);
+    async fn end_block(&mut self, ctx: Context, end_block: &abci::request::EndBlock);
 }

--- a/ibc/src/component/channel.rs
+++ b/ibc/src/component/channel.rs
@@ -24,7 +24,7 @@ use ibc::core::ics04_channel::packet::Packet;
 use ibc::core::ics24_host::identifier::ChannelId;
 use ibc::core::ics24_host::identifier::PortId;
 use penumbra_chain::genesis;
-use penumbra_component::Component;
+use penumbra_component::{Component, Context};
 use penumbra_proto::ibc::ibc_action::Action::{
     Acknowledgement, ChannelCloseConfirm, ChannelCloseInit, ChannelOpenAck, ChannelOpenConfirm,
     ChannelOpenInit, ChannelOpenTry, RecvPacket, Timeout,
@@ -54,11 +54,11 @@ impl Component for ICS4Channel {
     #[instrument(name = "ics4_channel", skip(self, _app_state))]
     async fn init_chain(&mut self, _app_state: &genesis::AppState) {}
 
-    #[instrument(name = "ics4_channel", skip(self, _begin_block))]
-    async fn begin_block(&mut self, _begin_block: &abci::request::BeginBlock) {}
+    #[instrument(name = "ics4_channel", skip(self, _ctx, _begin_block))]
+    async fn begin_block(&mut self, _ctx: Context, _begin_block: &abci::request::BeginBlock) {}
 
-    #[instrument(name = "ics4_channel", skip(tx))]
-    fn check_tx_stateless(tx: &Transaction) -> Result<()> {
+    #[instrument(name = "ics4_channel", skip(_ctx, tx))]
+    fn check_tx_stateless(_ctx: Context, tx: &Transaction) -> Result<()> {
         // Each stateless check is a distinct function in an appropriate submodule,
         // so that we can easily add new stateless checks and see a birds' eye view
         // of all of the checks we're performing.
@@ -115,8 +115,8 @@ impl Component for ICS4Channel {
         Ok(())
     }
 
-    #[instrument(name = "ics4_channel", skip(self, tx))]
-    async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()> {
+    #[instrument(name = "ics4_channel", skip(self, _ctx, tx))]
+    async fn check_tx_stateful(&self, _ctx: Context, tx: &Transaction) -> Result<()> {
         for ibc_action in tx.ibc_actions() {
             match &ibc_action.action {
                 Some(ChannelOpenInit(msg)) => {
@@ -181,8 +181,8 @@ impl Component for ICS4Channel {
         Ok(())
     }
 
-    #[instrument(name = "ics4_channel", skip(self, tx))]
-    async fn execute_tx(&mut self, tx: &Transaction) {
+    #[instrument(name = "ics4_channel", skip(self, _ctx, tx))]
+    async fn execute_tx(&mut self, _ctx: Context, tx: &Transaction) {
         for ibc_action in tx.ibc_actions() {
             match &ibc_action.action {
                 Some(ChannelOpenInit(msg)) => {
@@ -246,8 +246,8 @@ impl Component for ICS4Channel {
         }
     }
 
-    #[instrument(name = "ics4_channel", skip(self, _end_block))]
-    async fn end_block(&mut self, _end_block: &abci::request::EndBlock) {}
+    #[instrument(name = "ics4_channel", skip(self, _ctx, _end_block))]
+    async fn end_block(&mut self, _ctx: Context, _end_block: &abci::request::EndBlock) {}
 }
 
 #[async_trait]

--- a/ibc/src/component/client.rs
+++ b/ibc/src/component/client.rs
@@ -25,7 +25,7 @@ use ibc::{
     },
 };
 use penumbra_chain::{genesis, View as _};
-use penumbra_component::Component;
+use penumbra_component::{Component, Context};
 use penumbra_proto::ibc::{
     ibc_action::Action::{CreateClient, UpdateClient},
     IbcAction,
@@ -67,8 +67,8 @@ impl Component for Ics2Client {
         self.state.put_client_counter(ClientCounter(0)).await;
     }
 
-    #[instrument(name = "ics2_client", skip(self, begin_block))]
-    async fn begin_block(&mut self, begin_block: &abci::request::BeginBlock) {
+    #[instrument(name = "ics2_client", skip(self, _ctx, begin_block))]
+    async fn begin_block(&mut self, _ctx: Context, begin_block: &abci::request::BeginBlock) {
         // In BeginBlock, we want to save a copy of our consensus state to our
         // own state tree, so that when we get a message from our
         // counterparties, we can verify that they are committing the correct
@@ -89,8 +89,8 @@ impl Component for Ics2Client {
             .await;
     }
 
-    #[instrument(name = "ics2_client", skip(tx))]
-    fn check_tx_stateless(tx: &Transaction) -> Result<()> {
+    #[instrument(name = "ics2_client", skip(_ctx, tx))]
+    fn check_tx_stateless(_ctx: Context, tx: &Transaction) -> Result<()> {
         // Each stateless check is a distinct function in an appropriate submodule,
         // so that we can easily add new stateless checks and see a birds' eye view
         // of all of the checks we're performing.
@@ -118,8 +118,8 @@ impl Component for Ics2Client {
         Ok(())
     }
 
-    #[instrument(name = "ics2_client", skip(self, tx))]
-    async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()> {
+    #[instrument(name = "ics2_client", skip(self, _ctx, tx))]
+    async fn check_tx_stateful(&self, _ctx: Context, tx: &Transaction) -> Result<()> {
         for ibc_action in tx.ibc_actions() {
             match &ibc_action.action {
                 Some(CreateClient(msg)) => {
@@ -139,16 +139,16 @@ impl Component for Ics2Client {
         Ok(())
     }
 
-    #[instrument(name = "ics2_client", skip(self, tx))]
-    async fn execute_tx(&mut self, tx: &Transaction) {
+    #[instrument(name = "ics2_client", skip(self, _ctx, tx))]
+    async fn execute_tx(&mut self, _ctx: Context, tx: &Transaction) {
         // Handle any IBC actions found in the transaction.
         for ibc_action in tx.ibc_actions() {
             self.execute_ibc_action(ibc_action).await;
         }
     }
 
-    #[instrument(name = "ics2_client", skip(self, _end_block))]
-    async fn end_block(&mut self, _end_block: &abci::request::EndBlock) {}
+    #[instrument(name = "ics2_client", skip(self, _ctx, _end_block))]
+    async fn end_block(&mut self, _ctx: Context, _end_block: &abci::request::EndBlock) {}
 }
 
 impl Ics2Client {

--- a/ibc/src/component/connection.rs
+++ b/ibc/src/component/connection.rs
@@ -18,7 +18,7 @@ use ibc::core::ics03_connection::version::{pick_version, Version};
 use ibc::core::ics24_host::identifier::ConnectionId;
 use ibc::Height as IBCHeight;
 use penumbra_chain::{genesis, View as _};
-use penumbra_component::Component;
+use penumbra_component::{Component, Context};
 use penumbra_proto::ibc::{
     ibc_action::Action::{
         ConnectionOpenAck, ConnectionOpenConfirm, ConnectionOpenInit, ConnectionOpenTry,
@@ -52,11 +52,11 @@ impl Component for ConnectionComponent {
     #[instrument(name = "ibc_connection", skip(self, _app_state))]
     async fn init_chain(&mut self, _app_state: &genesis::AppState) {}
 
-    #[instrument(name = "ibc_connection", skip(self, _begin_block))]
-    async fn begin_block(&mut self, _begin_block: &abci::request::BeginBlock) {}
+    #[instrument(name = "ibc_connection", skip(self, _ctx, _begin_block))]
+    async fn begin_block(&mut self, _ctx: Context, _begin_block: &abci::request::BeginBlock) {}
 
-    #[instrument(name = "ibc_connection", skip(tx))]
-    fn check_tx_stateless(tx: &Transaction) -> Result<()> {
+    #[instrument(name = "ibc_connection", skip(_ctx, tx))]
+    fn check_tx_stateless(_ctx: Context, tx: &Transaction) -> Result<()> {
         for ibc_action in tx.ibc_actions() {
             match &ibc_action.action {
                 Some(ConnectionOpenInit(msg)) => {
@@ -95,8 +95,8 @@ impl Component for ConnectionComponent {
         Ok(())
     }
 
-    #[instrument(name = "ibc_connection", skip(self, tx))]
-    async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()> {
+    #[instrument(name = "ibc_connection", skip(self, _ctx, tx))]
+    async fn check_tx_stateful(&self, _ctx: Context, tx: &Transaction) -> Result<()> {
         for ibc_action in tx.ibc_actions() {
             match &ibc_action.action {
                 Some(ConnectionOpenInit(msg)) => {
@@ -130,15 +130,15 @@ impl Component for ConnectionComponent {
         Ok(())
     }
 
-    #[instrument(name = "ibc_connection", skip(self, tx))]
-    async fn execute_tx(&mut self, tx: &Transaction) {
+    #[instrument(name = "ibc_connection", skip(self, _ctx, tx))]
+    async fn execute_tx(&mut self, _ctx: Context, tx: &Transaction) {
         for ibc_action in tx.ibc_actions() {
             self.execute_ibc_action(ibc_action).await;
         }
     }
 
-    #[instrument(name = "ibc_connection", skip(self, _end_block))]
-    async fn end_block(&mut self, _end_block: &abci::request::EndBlock) {}
+    #[instrument(name = "ibc_connection", skip(self, _ctx, _end_block))]
+    async fn end_block(&mut self, _ctx: Context, _end_block: &abci::request::EndBlock) {}
 }
 
 impl ConnectionComponent {

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -1,4 +1,5 @@
-use anyhow::Context;
+use anyhow::Context as _;
+use penumbra_component::Context;
 use penumbra_proto::{
     client::{
         oblivious::oblivious_query_client::ObliviousQueryClient,
@@ -20,7 +21,8 @@ impl Opt {
     pub async fn submit_transaction(&self, transaction: &Transaction) -> Result<(), anyhow::Error> {
         println!("pre-checking transaction...");
         use penumbra_component::Component;
-        pd::App::check_tx_stateless(transaction)
+        let ctx = Context::new();
+        pd::App::check_tx_stateless(ctx.clone(), transaction)
             .context("transaction pre-submission checks failed")?;
 
         println!("broadcasting transaction...");

--- a/shielded-pool/src/component.rs
+++ b/shielded-pool/src/component.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeSet;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Context as _, Result};
 use ark_ff::PrimeField;
 use async_trait::async_trait;
 use decaf377::{Fq, Fr};
 use penumbra_chain::{genesis, sync::CompactBlock, Epoch, KnownAssets, NoteSource, View as _};
-use penumbra_component::Component;
+use penumbra_component::{Component, Context};
 use penumbra_crypto::{
     asset::{self, Asset, Denom},
     ka, note, Address, Note, NotePayload, Nullifier, One, Value, STAKING_TOKEN_ASSET_ID,
@@ -87,11 +87,11 @@ impl Component for ShieldedPool {
         self.write_compactblock_and_nct().await.unwrap();
     }
 
-    #[instrument(name = "shielded_pool", skip(self, _begin_block))]
-    async fn begin_block(&mut self, _begin_block: &abci::request::BeginBlock) {}
+    #[instrument(name = "shielded_pool", skip(self, _ctx, _begin_block))]
+    async fn begin_block(&mut self, _ctx: Context, _begin_block: &abci::request::BeginBlock) {}
 
-    #[instrument(name = "shielded_pool", skip(tx))]
-    fn check_tx_stateless(tx: &Transaction) -> Result<()> {
+    #[instrument(name = "shielded_pool", skip(_ctx, tx))]
+    fn check_tx_stateless(_ctx: Context, tx: &Transaction) -> Result<()> {
         // TODO: add a check that ephemeral_key is not identity to prevent scanning dos attack ?
         let auth_hash = tx.transaction_body().auth_hash();
 
@@ -153,8 +153,8 @@ impl Component for ShieldedPool {
         Ok(())
     }
 
-    #[instrument(name = "shielded_pool", skip(self, tx))]
-    async fn check_tx_stateful(&self, tx: &Transaction) -> Result<()> {
+    #[instrument(name = "shielded_pool", skip(self, _ctx, tx))]
+    async fn check_tx_stateful(&self, _ctx: Context, tx: &Transaction) -> Result<()> {
         // TODO: rename transaction_body.merkle_root now that we have 2 merkle trees
         self.state.check_claimed_anchor(&tx.anchor).await?;
 
@@ -166,8 +166,8 @@ impl Component for ShieldedPool {
         Ok(())
     }
 
-    #[instrument(name = "shielded_pool", skip(self, tx))]
-    async fn execute_tx(&mut self, tx: &Transaction) {
+    #[instrument(name = "shielded_pool", skip(self, _ctx, tx))]
+    async fn execute_tx(&mut self, _ctx: Context, tx: &Transaction) {
         let _should_quarantine = tx
             .transaction_body
             .actions
@@ -194,8 +194,8 @@ impl Component for ShieldedPool {
         //}
     }
 
-    #[instrument(name = "shielded_pool", skip(self, _end_block))]
-    async fn end_block(&mut self, _end_block: &abci::request::EndBlock) {
+    #[instrument(name = "shielded_pool", skip(self, _ctx, _end_block))]
+    async fn end_block(&mut self, _ctx: Context, _end_block: &abci::request::EndBlock) {
         // Get the current block height
         let height = self.height().await;
 


### PR DESCRIPTION
this PR implements part of #936 , adding a `Context`, threading it through the component api, and reporting events back to ABCI responses. Currently, no events are created, just the context functionality itself.