### PR TITLE
Add an NCT divergence check mode to `pcli`

### DIFF
--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -11,6 +11,10 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+nct-divergence-check = ["penumbra-view/nct-divergence-check"]
+
 [dependencies]
 # Workspace dependencies
 penumbra-proto = { path = "../proto" }

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -114,20 +114,14 @@ async fn main() -> Result<()> {
         main_inner(opt, wallet.spend_key, fvk, view, custody).await
     } else {
         // Use an in-memory view service.
-        let mut oc_client = opt.oblivious_client().await?;
-        let view_storage = penumbra_view::Storage::load_or_initialize(
+        let view_service = ViewService::load_or_initialize(
             view_path
                 .to_str()
                 .ok_or_else(|| anyhow::anyhow!("Non-UTF8 view path"))?
                 .to_string(),
             &fvk,
-            &mut oc_client,
-        )
-        .await?;
-        let view_service = ViewService::new(
-            view_storage,
-            oc_client,
             opt.node.clone(),
+            opt.pd_port,
             opt.tendermint_port,
         )
         .await?;

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -11,6 +11,12 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+# When this feature is enabled, the view worker will request every single
+# NCT root, to pinpoint exactly where any NCT root divergence occurs.
+nct-divergence-check = []
+
 [dependencies]
 # Workspace dependencies
 penumbra-proto = { path = "../proto" }

--- a/view/src/bin/pviewd.rs
+++ b/view/src/bin/pviewd.rs
@@ -57,11 +57,12 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
     let opt = Opt::from_args();
 
-    let mut client =
-        ObliviousQueryClient::connect(format!("http://{}:{}", opt.node, opt.pd_port)).await?;
-
     match opt.cmd {
         Command::Init { full_viewing_key } => {
+            let mut client =
+                ObliviousQueryClient::connect(format!("http://{}:{}", opt.node, opt.pd_port))
+                    .await?;
+
             let params = client
                 .chain_params(tonic::Request::new(ChainParamsRequest {
                     chain_id: String::new(),
@@ -84,7 +85,8 @@ async fn main() -> Result<()> {
 
             let storage = penumbra_view::Storage::load(opt.sqlite_path).await?;
 
-            let service = ViewService::new(storage, client, opt.node, opt.tendermint_port).await?;
+            let service =
+                ViewService::new(storage, opt.node, opt.pd_port, opt.tendermint_port).await?;
 
             tokio::spawn(
                 Server::builder()


### PR DESCRIPTION
This PR adds an `nct-divergence-check` Cargo feature to `pcli` that causes
the view service worker to explicitly request each and every anchor from `pd`,
then check it against the computed root at that sync height.

Currently, it detects a divergence at height 1472:
```
2022-06-07T22:09:54.503222Z  INFO penumbra_view::worker: nct roots match height=1470 actual_root=Root(25a39ec6e2b5e165a2de6e3e9eb48f1f29667a58809a609ac21df6e336cc2f04) expected_root=Root(25a39ec6e2b5e165a2de6e3e9eb48f1f29667a58809a609ac21df6e336cc2f04)
2022-06-07T22:09:54.528923Z  INFO penumbra_view::worker: nct roots match height=1471 actual_root=Root(92737fbdf5f7788f7c135fd0291a79fa960cb11e3e30923fa48382763866e20f) expected_root=Root(92737fbdf5f7788f7c135fd0291a79fa960cb11e3e30923fa48382763866e20f)
2022-06-07T22:09:54.542236Z DEBUG scan_block{height=1472 block_root=Root(1) epoch_root=None epoch_duration=40}: penumbra_view::sync: tct root tct_root=f55041e221b85fdf99e02c0c1262d5dfd08e3ce384
[42s] ██████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░    1472/11281   34/s ETA: 4m
2022-06-07T22:09:54.556760Z ERROR penumbra_view::worker: e=NCT divergence detected at height 1472: expected 82a48ea8875d7dce343ff719a6ee095d003e8d30adc8de687282759ea6ec720f, got f55041e221b85fdf99e02c0c1262d5dfd08e3ce3842824c8545a468e360c150e
2022-06-07T22:09:54.557070Z ERROR penumbra_view::worker: e=NCT divergence detected at height 1472: expected 82a48ea8875d7dce343ff719a6ee095d003e8d30adc8de687282759ea6ec720f, got f55041e221b85fdf99e02c0c1262d5dfd08e3ce3842824c8545a468e360c150e
```