### PR TITLE
Unconditionally end the epoch if needed regardless of block acceleration

### DIFF
--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -11,6 +11,10 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+nct-divergence-check = ["penumbra-view/nct-divergence-check"]
+
 [dependencies]
 # Workspace dependencies
 penumbra-proto = { path = "../proto" }

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -114,20 +114,14 @@ async fn main() -> Result<()> {
         main_inner(opt, wallet.spend_key, fvk, view, custody).await
     } else {
         // Use an in-memory view service.
-        let mut oc_client = opt.oblivious_client().await?;
-        let view_storage = penumbra_view::Storage::load_or_initialize(
+        let view_service = ViewService::load_or_initialize(
             view_path
                 .to_str()
                 .ok_or_else(|| anyhow::anyhow!("Non-UTF8 view path"))?
                 .to_string(),
             &fvk,
-            &mut oc_client,
-        )
-        .await?;
-        let view_service = ViewService::new(
-            view_storage,
-            oc_client,
             opt.node.clone(),
+            opt.pd_port,
             opt.tendermint_port,
         )
         .await?;

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -11,6 +11,12 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+# When this feature is enabled, the view worker will request every single
+# NCT root, to pinpoint exactly where any NCT root divergence occurs.
+nct-divergence-check = []
+
 [dependencies]
 # Workspace dependencies
 penumbra-proto = { path = "../proto" }

--- a/view/src/bin/pviewd.rs
+++ b/view/src/bin/pviewd.rs
@@ -57,11 +57,12 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
     let opt = Opt::from_args();
 
-    let mut client =
-        ObliviousQueryClient::connect(format!("http://{}:{}", opt.node, opt.pd_port)).await?;
-
     match opt.cmd {
         Command::Init { full_viewing_key } => {
+            let mut client =
+                ObliviousQueryClient::connect(format!("http://{}:{}", opt.node, opt.pd_port))
+                    .await?;
+
             let params = client
                 .chain_params(tonic::Request::new(ChainParamsRequest {
                     chain_id: String::new(),
@@ -84,7 +85,8 @@ async fn main() -> Result<()> {
 
             let storage = penumbra_view::Storage::load(opt.sqlite_path).await?;
 
-            let service = ViewService::new(storage, client, opt.node, opt.tendermint_port).await?;
+            let service =
+                ViewService::new(storage, opt.node, opt.pd_port, opt.tendermint_port).await?;
 
             tokio::spawn(
                 Server::builder()

--- a/view/src/sync.rs
+++ b/view/src/sync.rs
@@ -112,14 +112,14 @@ pub fn scan_block(
         note_commitment_tree
             .end_block()
             .expect("ending the block must succed");
+    }
 
-        // If we've also reached the end of the epoch, end the epoch in the commitment tree
-        if Epoch::from_height(height, epoch_duration).is_epoch_end(height) {
-            tracing::debug!(?height, "end of epoch");
-            note_commitment_tree
-                .end_epoch()
-                .expect("ending the epoch must succeed");
-        }
+    // If we've also reached the end of the epoch, end the epoch in the commitment tree
+    if Epoch::from_height(height, epoch_duration).is_epoch_end(height) {
+        tracing::debug!(?height, "end of epoch");
+        note_commitment_tree
+            .end_epoch()
+            .expect("ending the epoch must succeed");
     }
 
     // Print the TCT root for debugging


### PR DESCRIPTION
Implementing block-level acceleration accidentally left the epoch finalization code inside the branch where block acceleration is not engaged. It should happen always.