### PR TITLE
pcli: Erase gRPC service types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,6 +2604,7 @@ dependencies = [
  "fslock",
  "futures",
  "hex",
+ "http-body",
  "indicatif",
  "jmt",
  "pd",

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -64,6 +64,7 @@ rand = "0.8"
 rand_chacha = "0.3.1"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 indicatif = "0.16"
+http-body = "0.4.5"
 
 [build-dependencies]
 vergen = "5"

--- a/pcli/src/box_grpc_svc.rs
+++ b/pcli/src/box_grpc_svc.rs
@@ -1,0 +1,53 @@
+use bytes::Bytes;
+use http_body::{combinators::UnsyncBoxBody, Body};
+use tonic::{
+    body::BoxBody as ReqBody,
+    codegen::http as grpc,
+    transport::{self, Endpoint},
+};
+use tower::{util::UnsyncBoxService, Service, ServiceBuilder};
+
+/// A type-erased gRPC service.
+pub(crate) type BoxGrpcService =
+    UnsyncBoxService<grpc::Request<ReqBody>, grpc::Response<RspBody>, BoxError>;
+
+pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// A type-erased gRPC response [`Body`].
+pub(crate) type RspBody = UnsyncBoxBody<Bytes, BoxError>;
+
+/// Connects to the provided tonic [`Endpoint`], returning a [`BoxGrpcService`].
+pub(crate) async fn connect(ep: Endpoint) -> anyhow::Result<BoxGrpcService> {
+    let conn = ep.connect().await?;
+    let svc = ServiceBuilder::new()
+        .map_response(|rsp: grpc::Response<transport::Body>| rsp.map(box_rsp_body))
+        .map_err(BoxError::from)
+        .service(conn);
+    Ok(UnsyncBoxService::new(svc))
+}
+
+/// Constructs a [`BoxGrpcService`] by erasing the type of an `S`-typed local
+/// (in-process) service instance.
+pub(crate) fn local<S, B>(svc: S) -> BoxGrpcService
+where
+    S: Service<grpc::Request<ReqBody>, Response = grpc::Response<B>> + 'static,
+    BoxError: From<S::Error> + From<B::Error>,
+    S::Error: 'static,
+    B: Body<Data = Bytes> + Send + 'static,
+{
+    let svc = ServiceBuilder::new()
+        .map_response(|rsp: grpc::Response<B>| rsp.map(box_rsp_body))
+        .map_err(BoxError::from)
+        .service(svc);
+    UnsyncBoxService::new(svc)
+}
+
+/// Erases a response body's `Error` type, returning a `RspBody`.
+fn box_rsp_body<B>(body: B) -> RspBody
+where
+    B: Body<Data = Bytes> + Send + 'static,
+    BoxError: From<B::Error>,
+    B::Error: 'static,
+{
+    body.map_err(BoxError::from).boxed_unsync()
+}


### PR DESCRIPTION
`pcli` may use either an in-process view/custody service, or be
configured to talk to an out-of-process view or custody daemon. This
means that the types of the `tower::Service` given to the `tonic` client
for these services may differ depending on how `pcli` is configured.
Currently, this is handled by splitting out half of the `main` function
into a separate function and making it generic, which is kind of
unfortunate.

This branch adds a `box_grpc_svc` module in `pcli`, with utilities for
type-erasing a local or remote gRPC service. It changes the view service
constructed in `main` to use these utilities and removes the (now
unnecessary) `main_inner`. The `box_grpc_service` module could also be
used to do the same for a custody service, once a standalone custody
daemon is implemented.

I also went ahead and factored out the construction of the view service
into a method on `Opts`, which I thought seemed a bit nicer.

Closes #986