### PR TITLE
Replace use of `structopt` with `clap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,13 +711,48 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+dependencies = [
  "atty",
  "bitflags",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2 1.0.39",
+ "quote 1.0.18",
+ "syn 1.0.95",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -844,7 +879,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -1017,7 +1052,7 @@ dependencies = [
  "ident_case",
  "proc-macro2 1.0.39",
  "quote 1.0.18",
- "strsim 0.10.0",
+ "strsim",
  "syn 1.0.95",
 ]
 
@@ -2511,6 +2546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +2638,7 @@ dependencies = [
  "bincode",
  "blake2b_simd 0.5.11",
  "bytes",
+ "clap 3.1.18",
  "comfy-table",
  "decaf377",
  "directories",
@@ -2626,7 +2668,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.9.9",
- "structopt",
  "tendermint",
  "tokio",
  "tokio-stream",
@@ -2651,6 +2692,7 @@ dependencies = [
  "blake2b_simd 0.5.11",
  "bytes",
  "chrono",
+ "clap 3.1.18",
  "console-subscriber",
  "csv",
  "decaf377",
@@ -2685,7 +2727,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.9.9",
- "structopt",
  "tempfile",
  "tendermint",
  "tendermint-config",
@@ -2990,6 +3031,7 @@ dependencies = [
  "async-stream 0.2.1",
  "bincode",
  "bytes",
+ "clap 3.1.18",
  "directories",
  "futures",
  "hex",
@@ -3008,7 +3050,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sqlx",
- "structopt",
  "tokio",
  "tokio-stream",
  "tonic 0.6.2",
@@ -4186,39 +4227,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
-]
 
 [[package]]
 name = "strum"
@@ -4437,6 +4448,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4454,6 +4474,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -5012,12 +5038,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -49,7 +49,6 @@ tokio-stream = "0.1"
 tokio-util = "0.6"
 tower = { version = "0.4", features = ["full"]}
 tracing = "0.1"
-structopt = "0.3"
 tonic = "0.6.1"
 tracing-subscriber = "0.3"
 pin-project = "1"
@@ -65,6 +64,7 @@ rand_chacha = "0.3.1"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 indicatif = "0.16"
 http-body = "0.4.5"
+clap = { version = "3", features = ["derive"] }
 
 [build-dependencies]
 vergen = "5"

--- a/pcli/src/command.rs
+++ b/pcli/src/command.rs
@@ -1,5 +1,3 @@
-use structopt::StructOpt;
-
 mod addr;
 mod balance;
 mod chain;
@@ -18,13 +16,16 @@ pub use tx::TxCmd;
 pub use validator::ValidatorCmd;
 pub use wallet::WalletCmd;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum Command {
     /// Creates a transaction.
+    #[clap(subcommand)]
     Tx(TxCmd),
     /// Manages the wallet state.
+    #[clap(subcommand)]
     Wallet(WalletCmd),
     /// Manages addresses.
+    #[clap(subcommand)]
     Addr(AddrCmd),
     /// Synchronizes the client, privately scanning the chain state.
     ///
@@ -34,16 +35,20 @@ pub enum Command {
     /// Displays the current wallet balance.
     Balance(BalanceCmd),
     /// Manages a validator.
+    #[clap(subcommand)]
     Validator(ValidatorCmd),
     /// Manages delegations and undelegations.
+    #[clap(subcommand)]
     Stake(StakeCmd),
     /// Queries the public chain state.
     ///
     /// This command has two modes: it can be used to query raw bytes of
     /// arbitrary keys with the `key` subcommand, or it can be used to query
     /// typed data with a subcommand for a particular component.
+    #[clap(subcommand)]
     Q(QueryCmd),
     /// View chain data.
+    #[clap(subcommand)]
     Chain(ChainCmd),
 }
 

--- a/pcli/src/command/addr.rs
+++ b/pcli/src/command/addr.rs
@@ -1,18 +1,17 @@
 use anyhow::Result;
 use comfy_table::{presets, Table};
 use penumbra_crypto::FullViewingKey;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum AddrCmd {
     /// Show the address with the given index.
     Show {
         /// The index of the address to show.
         /// Default to 0
-        #[structopt(default_value = "0")]
+        #[clap(default_value = "0")]
         index: u64,
         /// If true, emits only the address and not the (local) label for it.
-        #[structopt(short, long)]
+        #[clap(short, long)]
         addr_only: bool,
     },
 }

--- a/pcli/src/command/balance.rs
+++ b/pcli/src/command/balance.rs
@@ -2,17 +2,15 @@ use anyhow::Result;
 use comfy_table::{presets, Table};
 use penumbra_crypto::{keys::DiversifierIndex, FullViewingKey, Value};
 use penumbra_view::ViewClient;
-use structopt::StructOpt;
-
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Args)]
 pub struct BalanceCmd {
     /// If set, breaks down balances by address.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub by_address: bool,
-    #[structopt(long)]
+    #[clap(long)]
     /// If set, does not attempt to synchronize the wallet before printing the balance.
     pub offline: bool,
-    #[structopt(long)]
+    #[clap(long)]
     /// If set, prints the value of each note individually.
     pub by_note: bool,
 }

--- a/pcli/src/command/chain.rs
+++ b/pcli/src/command/chain.rs
@@ -5,20 +5,19 @@ use penumbra_chain::Epoch;
 use penumbra_component::stake::validator;
 use penumbra_crypto::FullViewingKey;
 use penumbra_view::ViewClient;
-use structopt::StructOpt;
 
 // TODO: remove this subcommand and merge into `pcli q`
 
 use crate::Opt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum ChainCmd {
     /// Display chain parameters.
     Params,
     /// Display information about the current chain state.
     Info {
         /// If true, will also display chain parameters.
-        #[structopt(short, long)]
+        #[clap(short, long)]
         verbose: bool,
     },
 }

--- a/pcli/src/command/query.rs
+++ b/pcli/src/command/query.rs
@@ -1,11 +1,10 @@
 use anyhow::Result;
 use jmt::KeyHash;
 use penumbra_proto::Protobuf;
-use structopt::StructOpt;
 
 use crate::Opt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum QueryCmd {
     /// Queries an arbitrary key.
     Key {
@@ -13,10 +12,11 @@ pub enum QueryCmd {
         key: String,
     },
     /// Queries shielded pool data.
+    #[clap(subcommand)]
     ShieldedPool(ShieldedPool),
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum ShieldedPool {
     /// Queries the note commitment tree anchor for a given height.
     Anchor {

--- a/pcli/src/command/stake.rs
+++ b/pcli/src/command/stake.rs
@@ -12,24 +12,23 @@ use penumbra_proto::client::oblivious::ValidatorInfoRequest;
 use penumbra_view::ViewClient;
 use penumbra_wallet::{build_transaction, plan};
 use rand_core::OsRng;
-use structopt::StructOpt;
 
 use crate::Opt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum StakeCmd {
     /// Deposit stake into a validator's delegation pool.
     Delegate {
         /// The identity key of the validator to delegate to.
-        #[structopt(long)]
+        #[clap(long)]
         to: String,
         /// The amount of stake to delegate.
         amount: String,
         /// The transaction fee (paid in upenumbra).
-        #[structopt(long, default_value = "0")]
+        #[clap(long, default_value = "0")]
         fee: u64,
         /// Optional. Only spend funds originally received by the given address index.
-        #[structopt(long)]
+        #[clap(long)]
         source: Option<u64>,
     },
     /// Withdraw stake from a validator's delegation pool.
@@ -37,27 +36,27 @@ pub enum StakeCmd {
         /// The amount of delegation tokens to undelegate.
         amount: String,
         /// The transaction fee (paid in upenumbra).
-        #[structopt(long, default_value = "0")]
+        #[clap(long, default_value = "0")]
         fee: u64,
         /// Optional. Only spend funds originally received by the given address index.
-        #[structopt(long)]
+        #[clap(long)]
         source: Option<u64>,
     },
     /// Redelegate stake from one validator's delegation pool to another.
     Redelegate {
         /// The identity key of the validator to withdraw delegation from.
-        #[structopt(long)]
+        #[clap(long)]
         from: String,
         /// The identity key of the validator to delegate to.
-        #[structopt(long)]
+        #[clap(long)]
         to: String,
         /// The amount of stake to delegate.
         amount: String,
         /// The transaction fee (paid in upenumbra).
-        #[structopt(long, default_value = "0")]
+        #[clap(long, default_value = "0")]
         fee: u64,
         /// Optional. Only spend funds originally received by the given address index.
-        #[structopt(long)]
+        #[clap(long)]
         source: Option<u64>,
     },
     /// Display this wallet's delegations and their value.
@@ -65,10 +64,10 @@ pub enum StakeCmd {
     /// Display all of the validators participating in the chain.
     ListValidators {
         /// Whether to show validators that are not currently part of the consensus set.
-        #[structopt(short = "i", long)]
+        #[clap(short = 'i', long)]
         show_inactive: bool,
         /// Whether to show detailed validator info.
-        #[structopt(short, long)]
+        #[clap(short, long)]
         detailed: bool,
     },
 }

--- a/pcli/src/command/tx.rs
+++ b/pcli/src/command/tx.rs
@@ -4,27 +4,26 @@ use penumbra_custody::CustodyClient;
 use penumbra_view::ViewClient;
 use penumbra_wallet::{build_transaction, plan};
 use rand_core::OsRng;
-use structopt::StructOpt;
 
 use crate::Opt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum TxCmd {
     /// Send transaction to the node.
     Send {
         /// The destination address to send funds to.
-        #[structopt(long)]
+        #[clap(long)]
         to: String,
         /// The amounts to send, written as typed values 1.87penumbra, 12cubes, etc.
         values: Vec<String>,
         /// The transaction fee (paid in upenumbra).
-        #[structopt(long, default_value = "0")]
+        #[clap(long, default_value = "0")]
         fee: u64,
         /// Optional. Only spend funds originally received by the given address index.
-        #[structopt(long)]
+        #[clap(long)]
         source: Option<u64>,
         /// Optional. Set the transaction's memo field to the provided text.
-        #[structopt(long)]
+        #[clap(long)]
         memo: Option<String>,
     },
     /// Sweeps small notes of the same denomination into a few larger notes.

--- a/pcli/src/command/validator.rs
+++ b/pcli/src/command/validator.rs
@@ -9,24 +9,23 @@ use penumbra_proto::{stake::Validator as ProtoValidator, Message};
 use penumbra_view::ViewClient;
 use penumbra_wallet::{build_transaction, plan};
 use rand_core::OsRng;
-use structopt::StructOpt;
 
 use crate::Opt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum ValidatorCmd {
     /// Display the validator identity key derived from this wallet's spend seed.
     Identity,
     /// Create a ValidatorDefinition transaction to create or update a validator.
     UploadDefinition {
         /// The JSON file containing the ValidatorDefinition to upload
-        #[structopt(long)]
+        #[clap(long)]
         file: String,
         /// The transaction fee (paid in upenumbra).
-        #[structopt(long, default_value = "0")]
+        #[clap(long, default_value = "0")]
         fee: u64,
         /// Optional. Only spend funds originally received by the given address index.
-        #[structopt(long)]
+        #[clap(long)]
         source: Option<u64>,
     },
     /// Generates a template validator definition for editing.
@@ -35,13 +34,13 @@ pub enum ValidatorCmd {
     /// identity key derived from this wallet's seed phrase.
     TemplateDefinition {
         /// The JSON file to write the template to.
-        #[structopt(long)]
+        #[clap(long)]
         file: String,
     },
     /// Fetches a validator's current definition and saves it to a file.
     FetchDefinition {
         /// The JSON file to write the template to.
-        #[structopt(long)]
+        #[clap(long)]
         file: String,
         /// The identity key of the validator to fetch.
         identity_key: String,

--- a/pcli/src/command/wallet.rs
+++ b/pcli/src/command/wallet.rs
@@ -5,11 +5,10 @@ use directories::ProjectDirs;
 use penumbra_crypto::keys::SeedPhrase;
 use rand_core::OsRng;
 use sha2::{Digest, Sha256};
-use structopt::StructOpt;
 
 use crate::Wallet;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum WalletCmd {
     /// Import from an existing seed phrase.
     ImportFromPhrase {

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use clap::Parser;
 use directories::ProjectDirs;
 use futures::StreamExt;
 use penumbra_crypto::{keys::SpendKey, FullViewingKey};
@@ -19,7 +20,6 @@ use penumbra_proto::{
     view::{view_protocol_client::ViewProtocolClient, view_protocol_server::ViewProtocolServer},
 };
 use penumbra_view::{ViewClient, ViewService};
-use structopt::StructOpt;
 
 mod box_grpc_svc;
 mod command;
@@ -35,29 +35,29 @@ const VIEW_FILE_NAME: &'static str = "pcli-view.sqlite";
 
 use command::*;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "pcli",
     about = "The Penumbra command-line interface.",
     version = env!("VERGEN_GIT_SEMVER"),
 )]
 pub struct Opt {
     /// The address of the pd+tendermint node.
-    #[structopt(short, long, default_value = "testnet.penumbra.zone")]
+    #[clap(short, long, default_value = "testnet.penumbra.zone")]
     pub node: String,
     /// The port to use to speak to tendermint's RPC server.
-    #[structopt(long, default_value = "26657")]
+    #[clap(long, default_value = "26657")]
     pub tendermint_port: u16,
     /// The port to use to speak to pd's gRPC server.
-    #[structopt(long, default_value = "8080")]
+    #[clap(long, default_value = "8080")]
     pub pd_port: u16,
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: Command,
     /// The directory to store the wallet and view data in [default: platform appdata directory]
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub data_path: Option<String>,
     /// If set, use a remote view service instead of local synchronization.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub view_address: Option<SocketAddr>,
 }
 
@@ -102,7 +102,7 @@ async fn main() -> Result<()> {
     }
 
     tracing_subscriber::fmt::init();
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let default_data_dir = ProjectDirs::from("zone", "penumbra", "pcli")
         .context("Failed to get platform data dir")?

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -56,7 +56,6 @@ tower = { version = "0.4", features = ["full"]}
 tracing = "0.1"
 regex = "1.5"
 prost-types = "0.9"
-structopt = "0.3"
 tonic = "0.6.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
 pin-project = "1"
@@ -85,6 +84,7 @@ base64 = "0.13.0"
 console-subscriber = "0.1.6"
 metrics-tracing-context = "0.10.0"
 metrics-util = "0.11.1"
+clap = { version = "3", features = ["derive"] }
 
 [build-dependencies]
 vergen = "5"

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -35,7 +35,6 @@ rand = "0.8"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 serde_with = { version = "1.11", features = ["hex"] }
-structopt = "0.3"
 tracing = "0.1"
 tracing-subscriber = "0.2"
 tonic = "0.6.1"
@@ -48,6 +47,7 @@ metrics = "0.18"
 async-stream = "0.2"
 reqwest = { version = "0.11", features = ["json"] }
 parking_lot = "0.12"
+clap = { version = "3", features = ["derive"] }
 
 [build-dependencies]
 vergen = "5"

--- a/view/src/bin/pviewd.rs
+++ b/view/src/bin/pviewd.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "256"]
 #![allow(clippy::clone_on_copy)]
 use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
 use penumbra_crypto::FullViewingKey;
 use penumbra_proto::client::oblivious::oblivious_query_client::ObliviousQueryClient;
 use penumbra_proto::client::oblivious::ChainParamsRequest;
@@ -8,34 +9,33 @@ use penumbra_proto::view::view_protocol_server::ViewProtocolServer;
 use penumbra_view::ViewService;
 use std::env;
 use std::str::FromStr;
-use structopt::StructOpt;
 use tonic::transport::Server;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "pviewd",
     about = "The Penumbra view daemon.",
     version = env!("VERGEN_GIT_SEMVER"),
 )]
 struct Opt {
     /// Command to run.
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     cmd: Command,
     /// The path used to store the state database.
-    #[structopt(short, long, default_value = "pviewd-db.sqlite")]
+    #[clap(short, long, default_value = "pviewd-db.sqlite")]
     sqlite_path: String,
     /// The address of the pd+tendermint node.
-    #[structopt(short, long, default_value = "testnet.penumbra.zone")]
+    #[clap(short, long, default_value = "testnet.penumbra.zone")]
     node: String,
     /// The port to use to speak to tendermint's RPC server.
-    #[structopt(long, default_value = "26657")]
+    #[clap(long, default_value = "26657")]
     tendermint_port: u16,
     /// The port to use to speak to pd's gRPC server.
-    #[structopt(long, default_value = "8080")]
+    #[clap(long, default_value = "8080")]
     pd_port: u16,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 enum Command {
     /// Initialize the view service with a full viewing key.
     Init {
@@ -45,17 +45,17 @@ enum Command {
     /// Start the view service.
     Start {
         /// Bind the view service to this host.
-        #[structopt(short, long, default_value = "127.0.0.1")]
+        #[clap(short, long, default_value = "127.0.0.1")]
         host: String,
         /// Bind the view gRPC server to this port.
-        #[structopt(long, default_value = "8081")]
+        #[clap(long, default_value = "8081")]
         view_port: u16,
     },
 }
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     match opt.cmd {
         Command::Init { full_viewing_key } => {


### PR DESCRIPTION
The `structopt` crate is a wrapper around a previous version of `clap`.
Now, this functionality is provided by `clap` v3. This commit updates
`pcli` and `pd` to use `clap` v3 rather than `structopt`.