### PR TITLE
pcli: path handling improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,6 +614,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
+
+[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,6 +2644,7 @@ dependencies = [
  "bincode",
  "blake2b_simd 0.5.11",
  "bytes",
+ "camino",
  "clap 3.1.18",
  "comfy-table",
  "decaf377",

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -65,6 +65,7 @@ rand_core = { version = "0.6.3", features = ["getrandom"] }
 indicatif = "0.16"
 http-body = "0.4.5"
 clap = { version = "3", features = ["derive"] }
+camino = "1"
 
 [build-dependencies]
 vergen = "5"

--- a/pcli/src/command/wallet.rs
+++ b/pcli/src/command/wallet.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, str::FromStr};
+use std::str::FromStr;
 
 use anyhow::{anyhow, Result};
 use directories::ProjectDirs;
@@ -57,7 +57,8 @@ impl WalletCmd {
         Ok(())
     }
 
-    pub fn exec(&self, data_dir: PathBuf) -> Result<()> {
+    pub fn exec(&self, data_dir: impl AsRef<camino::Utf8Path>) -> Result<()> {
+        let data_dir = data_dir.as_ref();
         match self {
             WalletCmd::Generate => {
                 let seed_phrase = SeedPhrase::generate(&mut OsRng);
@@ -86,16 +87,16 @@ impl WalletCmd {
                 let wallet_path = data_dir.join(crate::CUSTODY_FILE_NAME);
                 if wallet_path.is_file() {
                     std::fs::remove_file(&wallet_path)?;
-                    println!("Deleted wallet file at {}", wallet_path.display());
+                    println!("Deleted wallet file at {}", wallet_path);
                 } else if wallet_path.exists() {
                     return Err(anyhow!(
                             "Expected wallet file at {} but found something that is not a file; refusing to delete it",
-                            wallet_path.display()
+                            wallet_path
                         ));
                 } else {
                     return Err(anyhow!(
                         "No wallet exists at {}, so it cannot be deleted",
-                        wallet_path.display()
+                        wallet_path
                     ));
                 }
             }
@@ -104,16 +105,16 @@ impl WalletCmd {
                 let view_path = data_dir.join(crate::VIEW_FILE_NAME);
                 if view_path.is_file() {
                     std::fs::remove_file(&view_path)?;
-                    println!("Deleted view data at {}", view_path.display());
+                    println!("Deleted view data at {}", view_path);
                 } else if view_path.exists() {
                     return Err(anyhow!(
                             "Expected view data at {} but found something that is not a file; refusing to delete it",
-                            view_path.display()
+                            view_path
                         ));
                 } else {
                     return Err(anyhow!(
                         "No view data exists at {}, so it cannot be deleted",
-                        view_path.display()
+                        view_path
                     ));
                 }
             }

--- a/pcli/src/legacy.rs
+++ b/pcli/src/legacy.rs
@@ -7,7 +7,13 @@ use serde::{Deserialize, Serialize};
 pub const WALLET_FILE_NAME: &'static str = "penumbra_wallet.json";
 
 /// Migrate from a legacy wallet to the current wallet format.
-pub fn migrate(legacy_wallet_path: &Path, custody_path: &Path) -> anyhow::Result<()> {
+pub fn migrate(
+    legacy_wallet_path: impl AsRef<Path>,
+    custody_path: impl AsRef<Path>,
+) -> anyhow::Result<()> {
+    let legacy_wallet_path = legacy_wallet_path.as_ref();
+    let custody_path = custody_path.as_ref();
+
     tracing::info!("Migrating legacy wallet to new wallet format");
     let legacy_wallet: ClientState =
         serde_json::from_slice(std::fs::read(legacy_wallet_path)?.as_slice())?;


### PR DESCRIPTION
Currently, the default data directory is not specified in a `clap`
attribute, but instead determined in `main` after the CLI arguments are
parsed. This is rather unfortunate, because it means that `clap` will
not display the actual data path in the help text, and we have to do
extra path construction after parsing the arguments.

This commit changes `pcli` to specify the default data dir path in
`#[clap(..., default_value_t = ...)]`. This way, the actual default
value is displayed in the help text rather than just saying "[default:
platform appdata directory]".

This required changing the path to be a `camino::Utf8PathBuf`, rather
than a `std::path::PathBuf`. Camino provides a variant of
`Path`/`PathBuf` which is guaranteed to always contain valid UTF-8
(which paths *should* be on any reasonable modern system). Because of
this, it can implement `fmt::Display` directly, rather than requiring
`path.display()` like `std`'s path types. This was required as `clap`
needs the default value to implement `Display`.

Now, the help text looks like this:
```
OPTIONS:
    -d, --data-path <DATA_PATH>
            The directory to store the wallet and view data in [default:
            /home/eliza/.local/share/pcli]
```

Depends on https://github.com/penumbra-zone/penumbra/pull/989