### PR TITLE
fix: break once the sync to latest_known_block_height is complete

### DIFF
--- a/view/src/service.rs
+++ b/view/src/service.rs
@@ -294,7 +294,7 @@ impl ViewProtocol for ViewService {
                     latest_known_block_height,
                     sync_height,
                 };
-                if sync_height == latest_known_block_height {
+                if sync_height >= latest_known_block_height {
                     break;
                 }
             }

--- a/view/src/worker.rs
+++ b/view/src/worker.rs
@@ -140,6 +140,7 @@ impl Worker {
         while let Some(block) = stream.message().await? {
             let block = CompactBlock::try_from(block)?;
             let height = block.height;
+            dbg!(height);
 
             // Lock the NCT only while processing this block.
             let mut nct_guard = self.nct.write().await;
@@ -212,7 +213,7 @@ impl Worker {
                 // If the sync returns `Ok` then it means we're shutting down.
                 Ok(()) => return Ok(()),
                 Err(e) => {
-                    tracing::error!(?e);
+                    tracing::warn!(?e);
                     error_count += 1;
                     // Retry a few times and then give up.
                     if error_count > 3 {


### PR DESCRIPTION
Closes #932

I've turned down the error level in `view/src/worker.rs:216` to warn because when the `break` is hit here it was causing a spurious error reported to the user (i.e. when running without RUST_LOG)

This was tested against testnet-preview