### PR TITLE
pcli: refactor away from passing `Opt` into everything

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,6 +3038,7 @@ dependencies = [
  "async-stream 0.2.1",
  "bincode",
  "bytes",
+ "camino",
  "clap 3.1.18",
  "directories",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,6 +2683,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber 0.3.11",
+ "url",
  "vergen",
 ]
 

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -66,6 +66,7 @@ indicatif = "0.16"
 http-body = "0.4.5"
 clap = { version = "3", features = ["derive", "env"] }
 camino = "1"
+url = "2"
 
 [build-dependencies]
 vergen = "5"

--- a/pcli/src/command/chain.rs
+++ b/pcli/src/command/chain.rs
@@ -3,7 +3,6 @@ use comfy_table::{presets, Table};
 use futures::TryStreamExt;
 use penumbra_chain::Epoch;
 use penumbra_component::stake::validator;
-use penumbra_crypto::FullViewingKey;
 use penumbra_view::ViewClient;
 
 // TODO: remove this subcommand and merge into `pcli q`
@@ -158,20 +157,20 @@ impl ChainCmd {
         })
     }
 
-    pub async fn exec<V: ViewClient>(&self, app: &mut App) -> Result<()> {
+    pub async fn exec(&self, app: &mut App) -> Result<()> {
         match self {
             ChainCmd::Params => {
-                self.print_chain_params(view).await?;
+                self.print_chain_params(&mut app.view).await?;
             }
             // TODO: we could implement this as an RPC call using the metrics
             // subsystems once #829 is complete
             // OR (hdevalence): fold it into pcli q
             ChainCmd::Info { verbose } => {
                 if *verbose {
-                    self.print_chain_params(view).await?;
+                    self.print_chain_params(&mut app.view).await?;
                 }
 
-                let stats = self.get_stats(opt, fvk, view).await?;
+                let stats = self.get_stats(app).await?;
 
                 println!("Chain Info:");
                 let mut table = Table::new();

--- a/pcli/src/command/chain.rs
+++ b/pcli/src/command/chain.rs
@@ -8,7 +8,7 @@ use penumbra_view::ViewClient;
 
 // TODO: remove this subcommand and merge into `pcli q`
 
-use crate::Opt;
+use crate::App;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum ChainCmd {
@@ -97,15 +97,12 @@ impl ChainCmd {
         Ok(())
     }
 
-    pub async fn get_stats<V: ViewClient>(
-        &self,
-        opt: &Opt,
-        fvk: &FullViewingKey,
-        view: &mut V,
-    ) -> Result<Stats> {
+    pub async fn get_stats(&self, app: &mut App) -> Result<Stats> {
         use penumbra_proto::client::oblivious::ValidatorInfoRequest;
 
-        let mut client = opt.oblivious_client().await?;
+        let mut client = app.oblivious_client().await?;
+        let fvk = &app.fvk;
+        let view: &mut dyn ViewClient = &mut app.view;
 
         let current_block_height = view.status(fvk.hash()).await?.sync_height;
         let chain_params = view.chain_params().await?;
@@ -161,12 +158,7 @@ impl ChainCmd {
         })
     }
 
-    pub async fn exec<V: ViewClient>(
-        &self,
-        opt: &Opt,
-        fvk: &FullViewingKey,
-        view: &mut V,
-    ) -> Result<()> {
+    pub async fn exec<V: ViewClient>(&self, app: &mut App) -> Result<()> {
         match self {
             ChainCmd::Params => {
                 self.print_chain_params(view).await?;

--- a/pcli/src/command/query.rs
+++ b/pcli/src/command/query.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use jmt::KeyHash;
 use penumbra_proto::Protobuf;
 
-use crate::Opt;
+use crate::App;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum QueryCmd {
@@ -26,8 +26,8 @@ pub enum ShieldedPool {
 }
 
 impl QueryCmd {
-    pub async fn exec(&self, opt: &Opt) -> Result<()> {
-        let mut client = opt.specific_client().await?;
+    pub async fn exec(&self, app: &mut App) -> Result<()> {
+        let mut client = app.specific_client().await?;
 
         let key_hash = self.key_hash();
 

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -89,9 +89,9 @@ async fn main() -> Result<()> {
 
     let mut opt = Opt::parse();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(std::mem::take(&mut opt.trace_filter))
-        .init();
+    // Initialize tracing here, rather than when converting into an `App`, so
+    // that tracing is set up even for wallet commands that don't build the `App`.
+    opt.init_tracing();
 
     // The wallet command takes the data dir directly, since it may need to
     // create the client state, so handle it specially here so that we can have

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -1,75 +1,33 @@
 // Rust analyzer complains without this (but rustc is happy regardless)
 #![recursion_limit = "256"]
 #![allow(clippy::clone_on_copy)]
-use std::net::SocketAddr;
-
-use anyhow::{Context, Result};
-use camino::Utf8PathBuf;
+use anyhow::Result;
 use clap::Parser;
-use directories::ProjectDirs;
 use futures::StreamExt;
 use penumbra_crypto::FullViewingKey;
-use penumbra_custody::SoftHSM;
 use penumbra_proto::{
-    custody::{
-        custody_protocol_client::CustodyProtocolClient,
-        custody_protocol_server::CustodyProtocolServer,
-    },
-    view::{view_protocol_client::ViewProtocolClient, view_protocol_server::ViewProtocolServer},
+    custody::custody_protocol_client::CustodyProtocolClient,
+    view::view_protocol_client::ViewProtocolClient,
 };
-use penumbra_view::{ViewClient, ViewService};
-use tracing_subscriber::EnvFilter;
+use penumbra_view::ViewClient;
 use url::Url;
 
 mod box_grpc_svc;
 mod command;
 mod legacy;
 mod network;
+mod opt;
 mod wallet;
 mod warning;
 
+use opt::Opt;
 use wallet::Wallet;
-
-const CUSTODY_FILE_NAME: &'static str = "custody.json";
-const VIEW_FILE_NAME: &'static str = "pcli-view.sqlite";
 
 use box_grpc_svc::BoxGrpcService;
 use command::*;
 
-#[derive(Debug, Parser)]
-#[clap(
-    name = "pcli",
-    about = "The Penumbra command-line interface.",
-    version = env!("VERGEN_GIT_SEMVER"),
-)]
-struct Opt {
-    /// The hostname of the pd+tendermint node.
-    #[clap(
-        short,
-        long,
-        default_value = "testnet.penumbra.zone",
-        env = "PENUMBRA_NODE_HOSTNAME",
-        parse(try_from_str = url::Host::parse)
-    )]
-    node: url::Host,
-    /// The port to use to speak to tendermint's RPC server.
-    #[clap(long, default_value_t = 26657, env = "PENUMBRA_TENDERMINT_PORT")]
-    tendermint_port: u16,
-    /// The port to use to speak to pd's gRPC server.
-    #[clap(long, default_value_t = 8080, env = "PENUMBRA_PD_PORT")]
-    pd_port: u16,
-    #[clap(subcommand)]
-    cmd: Command,
-    /// The directory to store the wallet and view data in.
-    #[clap(short, long, default_value_t = default_data_dir())]
-    data_path: Utf8PathBuf,
-    /// If set, use a remote view service instead of local synchronization.
-    #[clap(short, long, env = "PENUMBRA_VIEW_ADDRESS")]
-    view_address: Option<SocketAddr>,
-    /// The filter for `pcli`'s log messages.
-    #[clap( long, default_value_t = EnvFilter::new("warn"), env = "RUST_LOG")]
-    trace_filter: EnvFilter,
-}
+const CUSTODY_FILE_NAME: &'static str = "custody.json";
+const VIEW_FILE_NAME: &'static str = "pcli-view.sqlite";
 
 #[derive(Debug)]
 pub struct App {
@@ -84,52 +42,6 @@ pub struct App {
 impl App {
     pub fn view(&mut self) -> &mut impl ViewClient {
         &mut self.view
-    }
-
-    async fn from_opts(opts: &Opt) -> Result<Self> {
-        // Create the data directory if it is missing.
-        std::fs::create_dir_all(&opts.data_path).context("Failed to create data directory")?;
-
-        let custody_path = opts.data_path.join(CUSTODY_FILE_NAME);
-        let legacy_wallet_path = opts.data_path.join(legacy::WALLET_FILE_NAME);
-
-        // Try to auto-migrate the legacy wallet file to the new location, if:
-        // - the legacy wallet file exists
-        // - the new wallet file does not exist
-        if legacy_wallet_path.exists() && !custody_path.exists() {
-            legacy::migrate(&legacy_wallet_path, &custody_path.as_path())?;
-        }
-
-        // Build the custody service...
-        let wallet = Wallet::load(custody_path)?;
-        let soft_hsm = SoftHSM::new(vec![wallet.spend_key.clone()]);
-        let custody_svc = CustodyProtocolServer::new(soft_hsm);
-        let custody = CustodyProtocolClient::new(box_grpc_svc::local(custody_svc));
-
-        let fvk = wallet.spend_key.full_viewing_key().clone();
-
-        // ...and the view service...
-        let view = opts.view_client(&fvk).await?;
-
-        let mut tendermint_url = format!("http://{}", opts.node)
-            .parse::<Url>()
-            .with_context(|| format!("Invalid node URL: {}", opts.node))?;
-        let mut pd_url = tendermint_url.clone();
-        pd_url
-            .set_port(Some(opts.pd_port))
-            .expect("pd URL will not be `file://`");
-        tendermint_url
-            .set_port(Some(opts.tendermint_port))
-            .expect("tendermint URL will not be `file://`");
-
-        Ok(Self {
-            view,
-            custody,
-            fvk,
-            wallet,
-            pd_url,
-            tendermint_url,
-        })
     }
 
     async fn sync(&mut self) -> Result<()> {
@@ -168,49 +80,6 @@ impl App {
     }
 }
 
-impl Opt {
-    /// Constructs a [`ViewProtocolClient`] based on the command-line options.
-    async fn view_client(
-        &self,
-        fvk: &FullViewingKey,
-    ) -> Result<ViewProtocolClient<BoxGrpcService>> {
-        let svc = if let Some(address) = self.view_address {
-            // Use a remote view service.
-            tracing::info!(%address, "using remote view service");
-
-            let ep = tonic::transport::Endpoint::new(format!("http://{}", address))?;
-            box_grpc_svc::connect(ep).await?
-        } else {
-            // Use an in-memory view service.
-            let path = self.data_path.join(VIEW_FILE_NAME);
-            tracing::info!(%path, "using local view service");
-
-            let svc = ViewService::load_or_initialize(
-                path,
-                &fvk,
-                self.node.to_string(),
-                self.pd_port,
-                self.tendermint_port,
-            )
-            .await?;
-
-            // Now build the view and custody clients, doing gRPC with ourselves
-            let svc = ViewProtocolServer::new(svc);
-            box_grpc_svc::local(svc)
-        };
-
-        Ok(ViewProtocolClient::new(svc))
-    }
-}
-
-fn default_data_dir() -> Utf8PathBuf {
-    let path = ProjectDirs::from("zone", "penumbra", "pcli")
-        .expect("Failed to get platform data dir")
-        .data_dir()
-        .to_path_buf();
-    Utf8PathBuf::from_path_buf(path).expect("Platform default data dir was not UTF-8")
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     // Display a warning message to the user so they don't get upset when all their tokens are lost.
@@ -232,9 +101,9 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let mut app = App::from_opts(&opt).await?;
+    let (mut app, cmd) = opt.into_app().await?;
 
-    if opt.cmd.needs_sync() {
+    if cmd.needs_sync() {
         app.sync().await?;
     }
 
@@ -242,7 +111,7 @@ async fn main() -> Result<()> {
     // make sure to be compatible with client for remote view service, with different
     // concrete type
 
-    match &opt.cmd {
+    match &cmd {
         Command::Wallet(_) => unreachable!("wallet command already executed"),
         Command::Sync => {
             // We have already synchronized the wallet above, so we can just return.

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -42,7 +42,7 @@ use command::*;
     about = "The Penumbra command-line interface.",
     version = env!("VERGEN_GIT_SEMVER"),
 )]
-pub struct Opt {
+struct Opt {
     /// The hostname of the pd+tendermint node.
     #[clap(
         short,
@@ -51,24 +51,24 @@ pub struct Opt {
         env = "PENUMBRA_NODE_HOSTNAME",
         parse(try_from_str = url::Host::parse)
     )]
-    pub node: url::Host,
+    node: url::Host,
     /// The port to use to speak to tendermint's RPC server.
     #[clap(long, default_value_t = 26657, env = "PENUMBRA_TENDERMINT_PORT")]
-    pub tendermint_port: u16,
+    tendermint_port: u16,
     /// The port to use to speak to pd's gRPC server.
     #[clap(long, default_value_t = 8080, env = "PENUMBRA_PD_PORT")]
-    pub pd_port: u16,
+    pd_port: u16,
     #[clap(subcommand)]
-    pub cmd: Command,
+    cmd: Command,
     /// The directory to store the wallet and view data in.
     #[clap(short, long, default_value_t = default_data_dir())]
-    pub data_path: Utf8PathBuf,
+    data_path: Utf8PathBuf,
     /// If set, use a remote view service instead of local synchronization.
     #[clap(short, long, env = "PENUMBRA_VIEW_ADDRESS")]
-    pub view_address: Option<SocketAddr>,
+    view_address: Option<SocketAddr>,
     /// The filter for `pcli`'s log messages.
     #[clap( long, default_value_t = EnvFilter::new("warn"), env = "RUST_LOG")]
-    pub trace_filter: EnvFilter,
+    trace_filter: EnvFilter,
 }
 
 #[derive(Debug)]

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -12,9 +12,9 @@ use rand::Rng;
 use tonic::transport::Channel;
 use tracing::instrument;
 
-use crate::Opt;
+use crate::App;
 
-impl Opt {
+impl App {
     /// Submits a transaction to the network, returning `Ok` only when the remote
     /// node has accepted the transaction, and erroring otherwise.
     #[instrument(skip(self, transaction))]
@@ -30,7 +30,7 @@ impl Opt {
         let client = reqwest::Client::new();
         let req_id: u8 = rand::thread_rng().gen();
         let rsp: serde_json::Value = client
-            .post(format!(r#"http://{}:{}"#, self.node, self.tendermint_port))
+            .post(self.tendermint_url.clone())
             .json(&serde_json::json!(
                 {
                     "method": "broadcast_tx_sync",
@@ -83,7 +83,7 @@ impl Opt {
         let client = reqwest::Client::new();
         let req_id: u8 = rand::thread_rng().gen();
         let rsp: serde_json::Value = client
-            .post(format!(r#"http://{}:{}"#, self.node, self.tendermint_port))
+            .post(self.tendermint_url.clone())
             .json(&serde_json::json!(
                 {
                     "method": "broadcast_tx_async",
@@ -102,13 +102,13 @@ impl Opt {
     }
 
     pub async fn specific_client(&self) -> Result<SpecificQueryClient<Channel>, anyhow::Error> {
-        SpecificQueryClient::connect(format!("http://{}:{}", self.node, self.pd_port))
+        SpecificQueryClient::connect(self.pd_url.as_ref().to_owned())
             .await
             .map_err(Into::into)
     }
 
     pub async fn oblivious_client(&self) -> Result<ObliviousQueryClient<Channel>, anyhow::Error> {
-        ObliviousQueryClient::connect(format!("http://{}:{}", self.node, self.pd_port))
+        ObliviousQueryClient::connect(self.pd_url.as_ref().to_owned())
             .await
             .map_err(Into::into)
     }

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -1,4 +1,4 @@
-use anyhow::Context as _;
+use anyhow::{Context as _, Result};
 use penumbra_component::Context;
 use penumbra_proto::{
     client::{
@@ -7,14 +7,37 @@ use penumbra_proto::{
     },
     Protobuf,
 };
-use penumbra_transaction::Transaction;
+use penumbra_transaction::{plan::TransactionPlan, Transaction};
 use rand::Rng;
+use rand_core::OsRng;
+use std::future::Future;
 use tonic::transport::Channel;
 use tracing::instrument;
 
 use crate::App;
 
 impl App {
+    pub async fn build_and_submit_transaction(
+        &mut self,
+        plan: TransactionPlan,
+    ) -> anyhow::Result<()> {
+        let tx = self.build_transaction(plan).await?;
+        self.submit_transaction(&tx).await
+    }
+
+    fn build_transaction<'a>(
+        &'a mut self,
+        plan: TransactionPlan,
+    ) -> impl Future<Output = Result<Transaction>> + 'a {
+        penumbra_wallet::build_transaction(
+            &self.fvk,
+            &mut self.view,
+            &mut self.custody,
+            OsRng,
+            plan,
+        )
+    }
+
     /// Submits a transaction to the network, returning `Ok` only when the remote
     /// node has accepted the transaction, and erroring otherwise.
     #[instrument(skip(self, transaction))]

--- a/pcli/src/opt.rs
+++ b/pcli/src/opt.rs
@@ -54,10 +54,16 @@ pub struct Opt {
     view_address: Option<SocketAddr>,
     /// The filter for `pcli`'s log messages.
     #[clap( long, default_value_t = EnvFilter::new("warn"), env = "RUST_LOG")]
-    pub trace_filter: EnvFilter,
+    trace_filter: EnvFilter,
 }
 
 impl Opt {
+    pub fn init_tracing(&mut self) {
+        tracing_subscriber::fmt()
+            .with_env_filter(std::mem::take(&mut self.trace_filter))
+            .init();
+    }
+
     pub async fn into_app(self) -> Result<(App, Command)> {
         // Create the data directory if it is missing.
         std::fs::create_dir_all(&self.data_path).context("Failed to create data directory")?;

--- a/pcli/src/opt.rs
+++ b/pcli/src/opt.rs
@@ -1,0 +1,148 @@
+use crate::{
+    box_grpc_svc::{self, BoxGrpcService},
+    legacy,
+    wallet::Wallet,
+    App, Command,
+};
+use anyhow::{Context, Result};
+use camino::Utf8PathBuf;
+use clap::Parser;
+use directories::ProjectDirs;
+use penumbra_crypto::FullViewingKey;
+use penumbra_custody::SoftHSM;
+use penumbra_proto::{
+    custody::{
+        custody_protocol_client::CustodyProtocolClient,
+        custody_protocol_server::CustodyProtocolServer,
+    },
+    view::{view_protocol_client::ViewProtocolClient, view_protocol_server::ViewProtocolServer},
+};
+use penumbra_view::ViewService;
+use std::net::SocketAddr;
+use tracing_subscriber::EnvFilter;
+use url::Url;
+
+#[derive(Debug, Parser)]
+#[clap(
+    name = "pcli",
+    about = "The Penumbra command-line interface.",
+    version = env!("VERGEN_GIT_SEMVER"),
+)]
+pub struct Opt {
+    /// The hostname of the pd+tendermint node.
+    #[clap(
+        short,
+        long,
+        default_value = "testnet.penumbra.zone",
+        env = "PENUMBRA_NODE_HOSTNAME",
+        parse(try_from_str = url::Host::parse)
+    )]
+    node: url::Host,
+    /// The port to use to speak to tendermint's RPC server.
+    #[clap(long, default_value_t = 26657, env = "PENUMBRA_TENDERMINT_PORT")]
+    tendermint_port: u16,
+    /// The port to use to speak to pd's gRPC server.
+    #[clap(long, default_value_t = 8080, env = "PENUMBRA_PD_PORT")]
+    pd_port: u16,
+    #[clap(subcommand)]
+    pub cmd: Command,
+    /// The directory to store the wallet and view data in.
+    #[clap(short, long, default_value_t = default_data_dir())]
+    pub data_path: Utf8PathBuf,
+    /// If set, use a remote view service instead of local synchronization.
+    #[clap(short, long, env = "PENUMBRA_VIEW_ADDRESS")]
+    view_address: Option<SocketAddr>,
+    /// The filter for `pcli`'s log messages.
+    #[clap( long, default_value_t = EnvFilter::new("warn"), env = "RUST_LOG")]
+    pub trace_filter: EnvFilter,
+}
+
+impl Opt {
+    pub async fn into_app(self) -> Result<(App, Command)> {
+        // Create the data directory if it is missing.
+        std::fs::create_dir_all(&self.data_path).context("Failed to create data directory")?;
+
+        let custody_path = self.data_path.join(crate::CUSTODY_FILE_NAME);
+        let legacy_wallet_path = self.data_path.join(legacy::WALLET_FILE_NAME);
+
+        // Try to auto-migrate the legacy wallet file to the new location, if:
+        // - the legacy wallet file exists
+        // - the new wallet file does not exist
+        if legacy_wallet_path.exists() && !custody_path.exists() {
+            legacy::migrate(&legacy_wallet_path, &custody_path.as_path())?;
+        }
+
+        // Build the custody service...
+        let wallet = Wallet::load(custody_path)?;
+        let soft_hsm = SoftHSM::new(vec![wallet.spend_key.clone()]);
+        let custody_svc = CustodyProtocolServer::new(soft_hsm);
+        let custody = CustodyProtocolClient::new(box_grpc_svc::local(custody_svc));
+
+        let fvk = wallet.spend_key.full_viewing_key().clone();
+
+        // ...and the view service...
+        let view = self.view_client(&fvk).await?;
+
+        let mut tendermint_url = format!("http://{}", self.node)
+            .parse::<Url>()
+            .with_context(|| format!("Invalid node URL: {}", self.node))?;
+        let mut pd_url = tendermint_url.clone();
+        pd_url
+            .set_port(Some(self.pd_port))
+            .expect("pd URL will not be `file://`");
+        tendermint_url
+            .set_port(Some(self.tendermint_port))
+            .expect("tendermint URL will not be `file://`");
+
+        let app = App {
+            view,
+            custody,
+            fvk,
+            wallet,
+            pd_url,
+            tendermint_url,
+        };
+        Ok((app, self.cmd))
+    }
+
+    /// Constructs a [`ViewProtocolClient`] based on the command-line options.
+    async fn view_client(
+        &self,
+        fvk: &FullViewingKey,
+    ) -> Result<ViewProtocolClient<BoxGrpcService>> {
+        let svc = if let Some(address) = self.view_address {
+            // Use a remote view service.
+            tracing::info!(%address, "using remote view service");
+
+            let ep = tonic::transport::Endpoint::new(format!("http://{}", address))?;
+            box_grpc_svc::connect(ep).await?
+        } else {
+            // Use an in-memory view service.
+            let path = self.data_path.join(crate::VIEW_FILE_NAME);
+            tracing::info!(%path, "using local view service");
+
+            let svc = ViewService::load_or_initialize(
+                path,
+                &fvk,
+                self.node.to_string(),
+                self.pd_port,
+                self.tendermint_port,
+            )
+            .await?;
+
+            // Now build the view and custody clients, doing gRPC with ourselves
+            let svc = ViewProtocolServer::new(svc);
+            box_grpc_svc::local(svc)
+        };
+
+        Ok(ViewProtocolClient::new(svc))
+    }
+}
+
+fn default_data_dir() -> Utf8PathBuf {
+    let path = ProjectDirs::from("zone", "penumbra", "pcli")
+        .expect("Failed to get platform data dir")
+        .data_dir()
+        .to_path_buf();
+    Utf8PathBuf::from_path_buf(path).expect("Platform default data dir was not UTF-8")
+}

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -48,6 +48,7 @@ async-stream = "0.2"
 reqwest = { version = "0.11", features = ["json"] }
 parking_lot = "0.12"
 clap = { version = "3", features = ["derive"] }
+camino = "1"
 
 [build-dependencies]
 vergen = "5"

--- a/view/src/bin/pviewd.rs
+++ b/view/src/bin/pviewd.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "256"]
 #![allow(clippy::clone_on_copy)]
 use anyhow::{Context, Result};
+use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand};
 use penumbra_crypto::FullViewingKey;
 use penumbra_proto::client::oblivious::oblivious_query_client::ObliviousQueryClient;
@@ -23,7 +24,7 @@ struct Opt {
     cmd: Command,
     /// The path used to store the state database.
     #[clap(short, long, default_value = "pviewd-db.sqlite")]
-    sqlite_path: String,
+    sqlite_path: Utf8PathBuf,
     /// The address of the pd+tendermint node.
     #[clap(short, long, default_value = "testnet.penumbra.zone")]
     node: String,
@@ -72,7 +73,7 @@ async fn main() -> Result<()> {
                 .try_into()?;
 
             penumbra_view::Storage::initialize(
-                opt.sqlite_path,
+                opt.sqlite_path.as_path(),
                 FullViewingKey::from_str(full_viewing_key.as_ref())
                     .context("The provided string is not a valid FullViewingKey")?,
                 params,

--- a/view/src/service.rs
+++ b/view/src/service.rs
@@ -5,6 +5,7 @@ use std::{
 
 use anyhow::anyhow;
 use async_stream::try_stream;
+use camino::Utf8Path;
 use futures::stream::{StreamExt, TryStreamExt};
 use penumbra_crypto::{
     asset,
@@ -53,7 +54,7 @@ pub struct ViewService {
 impl ViewService {
     /// Convenience method that calls [`Storage::load_or_initialize`] and then [`Self::new`].
     pub async fn load_or_initialize(
-        storage_path: String,
+        storage_path: impl AsRef<Utf8Path>,
         fvk: &FullViewingKey,
         node: String,
         pd_port: u16,


### PR DESCRIPTION
The `Opt` type in `pcli` represents the parsed command line arguments.
Currently, it's passed into most subcommands' `exec` methods, along with
a bunch of other stuff that's constructed in `main`. This is kind of
unfortunate, since there are a number of singletons we want to construct
a _single_ time based on the values in `Opt` (such as the `view` service
client).

This branch refactors `pcli` to add an `App` type that contains the
actual values necessary to run the application, which are constructed
based on the CLI arguments in the `Opt` type. Most of the fields on
`Opt` are made private, and `Opt` is moved into its own submodule of
`main`. This way, the *only* thing that an `Opt` value can be used for
is constructing an `App` value, and checking which subcommand should be
run.