### PR TITLE
View quarantine v2

### DIFF
--- a/proto/build.rs
+++ b/proto/build.rs
@@ -145,6 +145,7 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.chain.Quarantined", SERIALIZE),
     (".penumbra.chain.QuarantinedPerValidator", SERIALIZE),
     (".penumbra.view.NoteRecord", SERIALIZE),
+    (".penumbra.view.QuarantinedNoteRecord", SERIALIZE),
     (".penumbra.transaction.TransactionPlan", SERIALIZE),
     (".penumbra.transaction.Fee", SERIALIZE),
     (".penumbra.transaction.ActionPlan", SERIALIZE),

--- a/proto/proto/view.proto
+++ b/proto/proto/view.proto
@@ -23,8 +23,11 @@ service ViewProtocol {
     // Stream sync status updates until the view service has caught up with the chain.
     rpc StatusStream(StatusStreamRequest) returns (stream StatusStreamResponse);
 
-    // Queries for notes.
+    // Queries for notes that have been accepted by the chain.
     rpc Notes(NotesRequest) returns (stream NoteRecord);
+
+    // Queries for notes that have been quarantined until the end of an unbonding period.
+    rpc QuarantinedNotes(QuarantinedNotesRequest) returns (stream QuarantinedNoteRecord);
 
     // Returns authentication paths for the given note commitments.
     //
@@ -132,4 +135,26 @@ message WitnessRequest {
 
     // The note commitments to obtain auth paths for.
     repeated crypto.NoteCommitment note_commitments = 2;
+}
+
+// The plaintext of a note that has been quarantined until the end of an unbonding period.
+message QuarantinedNoteRecord {
+    // The note commitment, identifying the note.
+    crypto.NoteCommitment note_commitment = 1;
+    // The note plaintext itself.
+    crypto.Note note = 2;
+    // A precomputed decryption of the note's diversifier index.
+    crypto.DiversifierIndex diversifier_index = 3;
+    // The height at which the note was created.
+    uint64 height_created = 4;
+    // The epoch at which the note will exit quarantine, if unbonding is not interrupted by slashing.
+    uint64 unbonding_epoch = 5;
+    // The validator identity the quarantining is bound to.
+    crypto.IdentityKey identity_key = 6;
+}
+
+// A query for quarantined notes known by the view service.
+message QuarantinedNotesRequest {
+    // Identifies the FVK for the notes to query.
+    crypto.FullViewingKeyHash fvk_hash = 1;
 }

--- a/view/migrations/20220415094212_init.sql
+++ b/view/migrations/20220415094212_init.sql
@@ -5,6 +5,7 @@ CREATE TABLE sync_height (height BIGINT NOT NULL);
 CREATE TABLE note_commitment_tree (bytes BLOB NOT NULL);
 
 -- Minimal data required for balance tracking
+-- Meant to represent notes which have been accepted into the note set
 CREATE TABLE notes (
     note_commitment         BLOB PRIMARY KEY NOT NULL,
     height_spent            BIGINT, --null if unspent, otherwise spent at height_spent 
@@ -39,4 +40,38 @@ CREATE INDEX nullifier_idx on notes ( nullifier );
 CREATE TABLE assets (
     asset_id BLOB PRIMARY KEY NOT NULL,
     denom    TEXT NOT NULL
+);
+
+CREATE TABLE quarantined_notes (
+    note_commitment         BLOB PRIMARY KEY NOT NULL,
+    height_created          BIGINT NOT NULL,
+    -- note contents themselves:
+    diversifier             BLOB NOT NULL,
+    amount                  BIGINT NOT NULL,
+    asset_id                BLOB NOT NULL,
+    transmission_key        BLOB NOT NULL,
+    blinding_factor         BLOB NOT NULL,
+    -- precomputed decryption of the diversifier
+    diversifier_index       BLOB NOT NULL,
+    -- the quarantine status of the note
+    unbonding_epoch         BIGINT NOT NULL,
+    identity_key            BLOB NOT NULL
+);
+
+CREATE INDEX quarantined_notes_idx ON quarantined_notes (
+    identity_key,       -- first by identity key
+    unbonding_epoch,    -- then by unbonding epoch
+    diversifier_index,  -- then filter by account
+    amount,             -- then by amount
+    height_created      -- we don't really care about this, except informationally
+);
+
+-- Nullifiers and identity keys added here in the event of a provisional spend (height_spent updated in notes table, then provisionality of that spend is recorded here)
+CREATE TABLE quarantined_nullifiers (
+    nullifier               BLOB PRIMARY KEY NOT NULL,
+    identity_key            BLOB NOT NULL
+);
+
+CREATE INDEX identity_key_idx ON quarantined_nullifiers (
+    identity_key
 );

--- a/view/sqlx-data.json
+++ b/view/sqlx-data.json
@@ -1,17 +1,16 @@
 {
   "db": "SQLite",
   "00ebf9aa311283f814859965b74865091c6e9bca47f4d95985b2aa63d4e4ac2f": {
-    "query": "INSERT INTO full_viewing_key (bytes) VALUES (?)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Right": 1
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "INSERT INTO full_viewing_key (bytes) VALUES (?)"
   },
   "0c9654cf156210edda72a63b80ad55cc1cd772f6ab83660307167aa3d2e8b094": {
-    "query": "UPDATE notes SET height_spent = ? WHERE nullifier = ? RETURNING note_commitment",
     "describe": {
       "columns": [
         {
@@ -20,46 +19,46 @@
           "type_info": "Blob"
         }
       ],
-      "parameters": {
-        "Right": 2
-      },
       "nullable": [
         false
-      ]
-    }
-  },
-  "1766574ebf4edffed45f0167f734a5ea5167ef2ec4280ed9710b4e1ec3eeb362": {
-    "query": "INSERT INTO chain_params (bytes) VALUES (?)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": []
-    }
-  },
-  "1ace3043077b74682c94e9d1876858fd696a42eac8f7da07d5b4ec43b0d9fc3f": {
-    "query": "INSERT INTO sync_height (height) VALUES (?)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Right": 1
-      },
-      "nullable": []
-    }
-  },
-  "2547294717840bcb1bef870394b99cf275bcba98d005f1f18b03c7a3d93909e1": {
-    "query": "INSERT INTO assets\n                    (\n                        asset_id,\n                        denom\n                    )\n                    VALUES\n                    (\n                        ?,\n                        ?\n                    )",
-    "describe": {
-      "columns": [],
+      ],
       "parameters": {
         "Right": 2
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "UPDATE notes SET height_spent = ? WHERE nullifier = ? RETURNING note_commitment"
+  },
+  "1766574ebf4edffed45f0167f734a5ea5167ef2ec4280ed9710b4e1ec3eeb362": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "INSERT INTO chain_params (bytes) VALUES (?)"
+  },
+  "1ace3043077b74682c94e9d1876858fd696a42eac8f7da07d5b4ec43b0d9fc3f": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "INSERT INTO sync_height (height) VALUES (?)"
+  },
+  "2547294717840bcb1bef870394b99cf275bcba98d005f1f18b03c7a3d93909e1": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "INSERT INTO assets\n                    (\n                        asset_id,\n                        denom\n                    )\n                    VALUES\n                    (\n                        ?,\n                        ?\n                    )"
   },
   "3381f1580eeac4a2fab83b4d64ae259c964e88dd22872675232f829ebc52a335": {
-    "query": "SELECT *\n            FROM assets",
     "describe": {
       "columns": [
         {
@@ -73,37 +72,37 @@
           "type_info": "Text"
         }
       ],
-      "parameters": {
-        "Right": 0
-      },
       "nullable": [
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "SELECT *\n            FROM assets"
   },
   "4af503f633659f5e73d7e64f3fb1f1ab5e37299a25dadcd851f4ec86aea0a78b": {
-    "query": "UPDATE sync_height SET height = ?",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Right": 1
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "UPDATE sync_height SET height = ?"
   },
   "52159e7c73f1adfe3098fdd6c1141aade5f4372584a359302b0fe64051daefad": {
-    "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        height_spent,\n                        height_created,\n                        diversifier,\n                        amount,\n                        asset_id,\n                        transmission_key,\n                        blinding_factor,\n                        diversifier_index,\n                        nullifier,\n                        position\n                    )\n                    VALUES\n                    (\n                        ?,\n                        NULL,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?\n                    )",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Right": 10
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        height_spent,\n                        height_created,\n                        diversifier,\n                        amount,\n                        asset_id,\n                        transmission_key,\n                        blinding_factor,\n                        diversifier_index,\n                        nullifier,\n                        position\n                    )\n                    VALUES\n                    (\n                        ?,\n                        NULL,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?\n                    )"
   },
   "63aad4faac1ffefd5525595f9ca5a82186181368251da9fbacf65a4d48671a01": {
-    "query": "\n            SELECT bytes\n            FROM full_viewing_key\n            LIMIT 1\n            ",
     "describe": {
       "columns": [
         {
@@ -112,16 +111,16 @@
           "type_info": "Blob"
         }
       ],
-      "parameters": {
-        "Right": 0
-      },
       "nullable": [
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            SELECT bytes\n            FROM full_viewing_key\n            LIMIT 1\n            "
   },
   "6684105462e0bba65abb19049c13836941421a0ed4ac59c6355dccdcab50dca7": {
-    "query": "\n            SELECT height\n            FROM sync_height\n            ORDER BY height DESC\n            LIMIT 1\n        ",
     "describe": {
       "columns": [
         {
@@ -130,26 +129,26 @@
           "type_info": "Int64"
         }
       ],
-      "parameters": {
-        "Right": 0
-      },
       "nullable": [
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            SELECT height\n            FROM sync_height\n            ORDER BY height DESC\n            LIMIT 1\n        "
   },
   "b4a0b026cd41003d66ec3ff1f104d89aee4ff22f10f1e7d20aa59dab4354b6ed": {
-    "query": "UPDATE note_commitment_tree SET bytes = ?",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Right": 1
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "UPDATE note_commitment_tree SET bytes = ?"
   },
   "d437ce2946cba91cd0e4fa750f14d227c2caa78e6bd69ed475f7b0679914c897": {
-    "query": "\n            SELECT bytes\n            FROM note_commitment_tree\n            LIMIT 1\n            ",
     "describe": {
       "columns": [
         {
@@ -158,26 +157,26 @@
           "type_info": "Blob"
         }
       ],
-      "parameters": {
-        "Right": 0
-      },
       "nullable": [
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            SELECT bytes\n            FROM note_commitment_tree\n            LIMIT 1\n            "
   },
   "e61182e04d553075f4385fda82a0822a04a08b8ada8ac5b5d46154a4c2901626": {
-    "query": "INSERT INTO note_commitment_tree (bytes) VALUES (?)",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Right": 1
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "INSERT INTO note_commitment_tree (bytes) VALUES (?)"
   },
   "efb5f4932197a38ca134b63d8ea5d2fad9145fb56d03a60351f15b5302905402": {
-    "query": "\n            SELECT bytes\n            FROM chain_params\n            LIMIT 1\n        ",
     "describe": {
       "columns": [
         {
@@ -186,12 +185,13 @@
           "type_info": "Blob"
         }
       ],
-      "parameters": {
-        "Right": 0
-      },
       "nullable": [
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Right": 0
+      }
+    },
+    "query": "\n            SELECT bytes\n            FROM chain_params\n            LIMIT 1\n        "
   }
 }

--- a/view/sqlx-data.json
+++ b/view/sqlx-data.json
@@ -102,6 +102,16 @@
     },
     "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        height_spent,\n                        height_created,\n                        diversifier,\n                        amount,\n                        asset_id,\n                        transmission_key,\n                        blinding_factor,\n                        diversifier_index,\n                        nullifier,\n                        position\n                    )\n                    VALUES\n                    (\n                        ?,\n                        NULL,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?\n                    )"
   },
+  "58e7cd62f2177d2bd0fa3b34c8be3495c9a0d8e331f846b56bf7c756a534ea64": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "DELETE FROM quarantined_notes WHERE note_commitment = ?"
+  },
   "63aad4faac1ffefd5525595f9ca5a82186181368251da9fbacf65a4d48671a01": {
     "describe": {
       "columns": [
@@ -138,6 +148,44 @@
     },
     "query": "\n            SELECT height\n            FROM sync_height\n            ORDER BY height DESC\n            LIMIT 1\n        "
   },
+  "8ecf6591d5fcf8d364e7457ef4b5d927d9c079c23e633dc4475d6c2c60192c8f": {
+    "describe": {
+      "columns": [
+        {
+          "name": "nullifier",
+          "ordinal": 0,
+          "type_info": "Blob"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "DELETE FROM quarantined_nullifiers WHERE identity_key = ? RETURNING nullifier"
+  },
+  "a2d77e7ce1b2de126dc78eb2439260219847f082340db4912a9e71f78f00c2d6": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 10
+      }
+    },
+    "query": "INSERT INTO quarantined_notes\n                    (\n                        note_commitment,\n                        height_created,\n                        diversifier,\n                        amount,\n                        asset_id,\n                        transmission_key,\n                        blinding_factor,\n                        diversifier_index,\n                        unbonding_epoch,\n                        identity_key\n                    )\n                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+  },
+  "a43839bc75670a52de169be6a9c36aa8da0b2efe8c56d68e4e4cd437d63cc2cb": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "DELETE FROM quarantined_nullifiers WHERE nullifier = ?"
+  },
   "b4a0b026cd41003d66ec3ff1f104d89aee4ff22f10f1e7d20aa59dab4354b6ed": {
     "describe": {
       "columns": [],
@@ -147,6 +195,36 @@
       }
     },
     "query": "UPDATE note_commitment_tree SET bytes = ?"
+  },
+  "b8c80b31e23d061d621a5486b84e80b4a4b4fa409bf4510b5ad301ef54a66101": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "DELETE FROM quarantined_notes WHERE identity_key = ?"
+  },
+  "ce4148ecb83f1152688735c4b12d807dcab0d61c96dffefefc8c560315623534": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "INSERT INTO quarantined_nullifiers\n                        (\n                            identity_key,\n                            nullifier\n                        )\n                    VALUES (?, ?)"
+  },
+  "cf12e2860eec12aa6161588cf1dd6d7053e6d3ab678ec095c5322fd4b81b9db4": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "UPDATE notes SET height_spent = NULL WHERE nullifier = ?"
   },
   "d437ce2946cba91cd0e4fa750f14d227c2caa78e6bd69ed475f7b0679914c897": {
     "describe": {

--- a/view/src/lib.rs
+++ b/view/src/lib.rs
@@ -4,6 +4,7 @@
 mod client;
 mod metrics;
 mod note_record;
+mod quarantined_note_record;
 mod service;
 mod status;
 mod storage;
@@ -15,6 +16,7 @@ use worker::Worker;
 pub use crate::metrics::register_metrics;
 pub use client::ViewClient;
 pub use note_record::NoteRecord;
+pub use quarantined_note_record::QuarantinedNoteRecord;
 pub use service::ViewService;
 pub use status::StatusStreamResponse;
 pub use storage::Storage;

--- a/view/src/quarantined_note_record.rs
+++ b/view/src/quarantined_note_record.rs
@@ -1,0 +1,165 @@
+use penumbra_crypto::{
+    asset,
+    ka::Public,
+    keys::{Diversifier, DiversifierIndex},
+    note, FieldExt, Fq, IdentityKey, Note, Value,
+};
+use penumbra_proto::{view as pb, Protobuf};
+
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
+
+/// Corresponds to the QuarantinedNoteRecord proto
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(
+    try_from = "pb::QuarantinedNoteRecord",
+    into = "pb::QuarantinedNoteRecord"
+)]
+pub struct QuarantinedNoteRecord {
+    pub note_commitment: note::Commitment,
+    pub note: Note,
+    pub diversifier_index: DiversifierIndex,
+    pub height_created: u64,
+    pub unbonding_epoch: u64,
+    pub identity_key: IdentityKey,
+}
+
+impl Protobuf<pb::QuarantinedNoteRecord> for QuarantinedNoteRecord {}
+impl From<QuarantinedNoteRecord> for pb::QuarantinedNoteRecord {
+    fn from(v: QuarantinedNoteRecord) -> Self {
+        pb::QuarantinedNoteRecord {
+            note_commitment: Some(v.note_commitment.into()),
+            note: Some(v.note.into()),
+            diversifier_index: Some(v.diversifier_index.into()),
+            height_created: v.height_created,
+            unbonding_epoch: v.unbonding_epoch,
+            identity_key: Some(v.identity_key.into()),
+        }
+    }
+}
+
+impl TryFrom<pb::QuarantinedNoteRecord> for QuarantinedNoteRecord {
+    type Error = anyhow::Error;
+    fn try_from(v: pb::QuarantinedNoteRecord) -> Result<Self, Self::Error> {
+        Ok(QuarantinedNoteRecord {
+            note_commitment: v
+                .note_commitment
+                .ok_or_else(|| anyhow::anyhow!("missing note commitment"))?
+                .try_into()?,
+            note: v
+                .note
+                .ok_or_else(|| anyhow::anyhow!("missing note"))?
+                .try_into()?,
+            diversifier_index: v
+                .diversifier_index
+                .ok_or_else(|| anyhow::anyhow!("missing diversifier index"))?
+                .try_into()?,
+            height_created: v.height_created,
+            unbonding_epoch: v.unbonding_epoch,
+            identity_key: v
+                .identity_key
+                .ok_or_else(|| anyhow::anyhow!("missing identity key"))?
+                .try_into()?,
+        })
+    }
+}
+
+impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for QuarantinedNoteRecord {
+    fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
+        // This is not a fun time.
+        // Mostly on account of sqlx::Error.
+
+        let diversifier =
+            Diversifier::try_from(row.get::<'r, &[u8], _>("diversifier")).map_err(|e| {
+                sqlx::Error::ColumnDecode {
+                    index: "diversifier".to_string(),
+                    source: e.into(),
+                }
+            })?;
+
+        let diversifier_index = DiversifierIndex::try_from(
+            row.get::<'r, &[u8], _>("diversifier_index"),
+        )
+        .map_err(|e| sqlx::Error::ColumnDecode {
+            index: "diversifier_index".to_string(),
+            source: e.into(),
+        })?;
+
+        let transmission_key = Public(
+            <[u8; 32]>::try_from(row.get::<'r, &[u8], _>("transmission_key")).map_err(|e| {
+                sqlx::Error::ColumnDecode {
+                    index: "transmission_key".to_string(),
+                    source: e.into(),
+                }
+            })?,
+        );
+
+        let amount = row.get::<'r, i64, _>("amount") as u64;
+
+        let asset_id = asset::Id(
+            Fq::from_bytes(
+                <[u8; 32]>::try_from(row.get::<'r, &[u8], _>("asset_id")).map_err(|e| {
+                    sqlx::Error::ColumnDecode {
+                        index: "asset_id".to_string(),
+                        source: e.into(),
+                    }
+                })?,
+            )
+            .map_err(|e| sqlx::Error::ColumnDecode {
+                index: "asset_id".to_string(),
+                source: e.into(),
+            })?,
+        );
+
+        let note_blinding = Fq::from_bytes(
+            <[u8; 32]>::try_from(row.get::<'r, &[u8], _>("blinding_factor")).map_err(|e| {
+                sqlx::Error::ColumnDecode {
+                    index: "blinding_factor".to_string(),
+                    source: e.into(),
+                }
+            })?,
+        )
+        .map_err(|e| sqlx::Error::ColumnDecode {
+            index: "blinding_factor".to_string(),
+            source: e.into(),
+        })?;
+
+        let note_commitment = note::Commitment::try_from(
+            row.get::<'r, &[u8], _>("note_commitment"),
+        )
+        .map_err(|e| sqlx::Error::ColumnDecode {
+            index: "note_commitment".to_string(),
+            source: e.into(),
+        })?;
+
+        let height_created = row.get::<'r, i64, _>("height_created") as u64;
+
+        let identity_key =
+            IdentityKey::decode(row.get::<'r, &[u8], _>("identity_key")).map_err(|e| {
+                sqlx::Error::ColumnDecode {
+                    index: "identity_key".to_string(),
+                    source: e.into(),
+                }
+            })?;
+
+        let unbonding_epoch = row.get::<'r, i64, _>("unbonding_epoch") as u64;
+
+        let value = Value { amount, asset_id };
+        let note =
+            Note::from_parts(diversifier, transmission_key, value, note_blinding).map_err(|e| {
+                sqlx::Error::ColumnDecode {
+                    index: "note".to_string(),
+                    source: e.into(),
+                }
+            })?;
+
+        Ok(QuarantinedNoteRecord {
+            note_commitment,
+            note,
+            diversifier_index,
+            height_created,
+            unbonding_epoch,
+            identity_key,
+        })
+    }
+}

--- a/view/src/service.rs
+++ b/view/src/service.rs
@@ -355,9 +355,11 @@ impl ViewProtocol for ViewService {
         self.check_worker().await?;
         self.check_fvk(request.get_ref().fvk_hash.as_ref()).await?;
 
-        let notes = self.storage.quarantined_notes().await.map_err(|e| {
-            tonic::Status::unavailable(format!("database error: {}", e.to_string()))
-        })?;
+        let notes = self
+            .storage
+            .quarantined_notes()
+            .await
+            .map_err(|e| tonic::Status::unavailable(format!("database error: {}", e)))?;
 
         let stream = try_stream! {
             for note in notes {
@@ -368,7 +370,7 @@ impl ViewProtocol for ViewService {
         Ok(tonic::Response::new(
             stream
                 .map_err(|e: anyhow::Error| {
-                    tonic::Status::unavailable(format!("database error: {}", e.to_string()))
+                    tonic::Status::unavailable(format!("database error: {}", e))
                 })
                 .boxed(),
         ))

--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -85,7 +85,7 @@ impl Storage {
         // Create the SQLite database
         sqlx::Sqlite::create_database(storage_path.as_str());
 
-        let pool = Pool::<Sqlite>::connect(&storage_path.as_str()).await?;
+        let pool = Pool::<Sqlite>::connect(storage_path.as_str()).await?;
 
         // Run migrations
         sqlx::migrate!().run(&pool).await?;

--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -17,7 +17,7 @@ use std::{num::NonZeroU64, sync::Arc};
 use tct::Commitment;
 use tokio::sync::broadcast;
 
-use crate::{sync::ScanResult, NoteRecord};
+use crate::{sync::ScanResult, NoteRecord, QuarantinedNoteRecord};
 
 #[derive(Clone)]
 pub struct Storage {
@@ -337,6 +337,14 @@ impl Storage {
         }
 
         Ok(output)
+    }
+
+    pub async fn quarantined_notes(&self) -> anyhow::Result<Vec<QuarantinedNoteRecord>> {
+        let result = sqlx::query_as::<_, QuarantinedNoteRecord>("SELECT * FROM quarantined_notes")
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok(result)
     }
 
     pub async fn record_asset(&self, asset: Asset) -> anyhow::Result<()> {


### PR DESCRIPTION
Closes #1009 and #1011.

TODO:

- [x] Make `QuarantinedNoteRecord` proto type and domain type
- [x] Update scanning & sync logic to handle quarantining
- [x] Add RPC to view service that works like existing note RPC, but for quarantined notes
- [x] Use RPC to display quarantined notes in `pcli` (#1011)