### PR TITLE
add IBC "app handlers", router for IBC events, ICS20 Transfer scaffold

### DIFF
--- a/component/src/ibc/component/channel.rs
+++ b/component/src/ibc/component/channel.rs
@@ -128,54 +128,63 @@ impl Component for ICS4Channel {
                     let msg = MsgChannelOpenInit::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
+                    self.app_handler.chan_open_init_check(&msg).await?;
                 }
                 Some(ChannelOpenTry(msg)) => {
                     use stateful::channel_open_try::ChannelOpenTryCheck;
                     let msg = MsgChannelOpenTry::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
+                    self.app_handler.chan_open_try_check(&msg).await?;
                 }
                 Some(ChannelOpenAck(msg)) => {
                     use stateful::channel_open_ack::ChannelOpenAckCheck;
                     let msg = MsgChannelOpenAck::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
+                    self.app_handler.chan_open_ack_check(&msg).await?;
                 }
                 Some(ChannelOpenConfirm(msg)) => {
                     use stateful::channel_open_confirm::ChannelOpenConfirmCheck;
                     let msg = MsgChannelOpenConfirm::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
+                    self.app_handler.chan_open_confirm_check(&msg).await?;
                 }
                 Some(ChannelCloseInit(msg)) => {
                     use stateful::channel_close_init::ChannelCloseInitCheck;
                     let msg = MsgChannelCloseInit::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
+                    self.app_handler.chan_close_init_check(&msg).await?;
                 }
                 Some(ChannelCloseConfirm(msg)) => {
                     use stateful::channel_close_confirm::ChannelCloseConfirmCheck;
                     let msg = MsgChannelCloseConfirm::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
+                    self.app_handler.chan_close_confirm_check(&msg).await?;
                 }
                 Some(RecvPacket(msg)) => {
                     use stateful::recv_packet::RecvPacketCheck;
                     let msg = MsgRecvPacket::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
+                    self.app_handler.recv_packet_check(&msg).await?;
                 }
                 Some(Acknowledgement(msg)) => {
                     use stateful::acknowledge_packet::AcknowledgePacketCheck;
                     let msg = MsgAcknowledgement::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
+                    self.app_handler.acknowledge_packet_check(&msg).await?;
                 }
                 Some(Timeout(msg)) => {
                     use stateful::timeout::TimeoutCheck;
                     let msg = MsgTimeout::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
+                    self.app_handler.timeout_packet_check(&msg).await?;
                 }
 
                 // Other IBC messages are not handled by this component.
@@ -194,63 +203,63 @@ impl Component for ICS4Channel {
                     let msg = MsgChannelOpenInit::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.chan_open_init(&msg).await;
+                    self.app_handler.chan_open_init_execute(&msg).await;
                 }
                 Some(ChannelOpenTry(msg)) => {
                     use execution::channel_open_try::ChannelOpenTryExecute;
                     let msg = MsgChannelOpenTry::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.chan_open_try(&msg).await;
+                    self.app_handler.chan_open_try_execute(&msg).await;
                 }
                 Some(ChannelOpenAck(msg)) => {
                     use execution::channel_open_ack::ChannelOpenAckExecute;
                     let msg = MsgChannelOpenAck::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.chan_open_ack(&msg).await;
+                    self.app_handler.chan_open_ack_execute(&msg).await;
                 }
                 Some(ChannelOpenConfirm(msg)) => {
                     use execution::channel_open_confirm::ChannelOpenConfirmExecute;
                     let msg = MsgChannelOpenConfirm::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.chan_open_confirm(&msg).await;
+                    self.app_handler.chan_open_confirm_execute(&msg).await;
                 }
                 Some(ChannelCloseInit(msg)) => {
                     use execution::channel_close_init::ChannelCloseInitExecute;
                     let msg = MsgChannelCloseInit::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.chan_close_init(&msg).await;
+                    self.app_handler.chan_close_init_execute(&msg).await;
                 }
                 Some(ChannelCloseConfirm(msg)) => {
                     use execution::channel_close_confirm::ChannelCloseConfirmExecute;
                     let msg = MsgChannelCloseConfirm::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.chan_close_confirm(&msg).await;
+                    self.app_handler.chan_close_confirm_execute(&msg).await;
                 }
                 Some(RecvPacket(msg)) => {
                     use execution::recv_packet::RecvPacketExecute;
                     let msg = MsgRecvPacket::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.recv_packet(&msg).await;
+                    self.app_handler.recv_packet_execute(&msg).await;
                 }
                 Some(Acknowledgement(msg)) => {
                     use execution::acknowledge_packet::AcknowledgePacketExecute;
                     let msg = MsgAcknowledgement::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.acknowledge_packet(&msg).await;
+                    self.app_handler.acknowledge_packet_execute(&msg).await;
                 }
                 Some(Timeout(msg)) => {
                     use execution::timeout::TimeoutExecute;
                     let msg = MsgTimeout::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.timeout_packet(&msg).await;
+                    self.app_handler.timeout_packet_execute(&msg).await;
                 }
 
                 // Other IBC messages are not handled by this component.

--- a/component/src/ibc/component/channel.rs
+++ b/component/src/ibc/component/channel.rs
@@ -119,8 +119,8 @@ impl Component for ICS4Channel {
         Ok(())
     }
 
-    #[instrument(name = "ics4_channel", skip(self, _ctx, tx))]
-    async fn check_tx_stateful(&self, _ctx: Context, tx: &Transaction) -> Result<()> {
+    #[instrument(name = "ics4_channel", skip(self, ctx, tx))]
+    async fn check_tx_stateful(&self, ctx: Context, tx: &Transaction) -> Result<()> {
         for ibc_action in tx.ibc_actions() {
             match &ibc_action.action {
                 Some(ChannelOpenInit(msg)) => {
@@ -128,63 +128,81 @@ impl Component for ICS4Channel {
                     let msg = MsgChannelOpenInit::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
-                    self.app_handler.chan_open_init_check(&msg).await?;
+                    self.app_handler
+                        .chan_open_init_check(ctx.clone(), &msg)
+                        .await?;
                 }
                 Some(ChannelOpenTry(msg)) => {
                     use stateful::channel_open_try::ChannelOpenTryCheck;
                     let msg = MsgChannelOpenTry::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
-                    self.app_handler.chan_open_try_check(&msg).await?;
+                    self.app_handler
+                        .chan_open_try_check(ctx.clone(), &msg)
+                        .await?;
                 }
                 Some(ChannelOpenAck(msg)) => {
                     use stateful::channel_open_ack::ChannelOpenAckCheck;
                     let msg = MsgChannelOpenAck::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
-                    self.app_handler.chan_open_ack_check(&msg).await?;
+                    self.app_handler
+                        .chan_open_ack_check(ctx.clone(), &msg)
+                        .await?;
                 }
                 Some(ChannelOpenConfirm(msg)) => {
                     use stateful::channel_open_confirm::ChannelOpenConfirmCheck;
                     let msg = MsgChannelOpenConfirm::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
-                    self.app_handler.chan_open_confirm_check(&msg).await?;
+                    self.app_handler
+                        .chan_open_confirm_check(ctx.clone(), &msg)
+                        .await?;
                 }
                 Some(ChannelCloseInit(msg)) => {
                     use stateful::channel_close_init::ChannelCloseInitCheck;
                     let msg = MsgChannelCloseInit::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
-                    self.app_handler.chan_close_init_check(&msg).await?;
+                    self.app_handler
+                        .chan_close_init_check(ctx.clone(), &msg)
+                        .await?;
                 }
                 Some(ChannelCloseConfirm(msg)) => {
                     use stateful::channel_close_confirm::ChannelCloseConfirmCheck;
                     let msg = MsgChannelCloseConfirm::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
-                    self.app_handler.chan_close_confirm_check(&msg).await?;
+                    self.app_handler
+                        .chan_close_confirm_check(ctx.clone(), &msg)
+                        .await?;
                 }
                 Some(RecvPacket(msg)) => {
                     use stateful::recv_packet::RecvPacketCheck;
                     let msg = MsgRecvPacket::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
-                    self.app_handler.recv_packet_check(&msg).await?;
+                    self.app_handler
+                        .recv_packet_check(ctx.clone(), &msg)
+                        .await?;
                 }
                 Some(Acknowledgement(msg)) => {
                     use stateful::acknowledge_packet::AcknowledgePacketCheck;
                     let msg = MsgAcknowledgement::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
-                    self.app_handler.acknowledge_packet_check(&msg).await?;
+                    self.app_handler
+                        .acknowledge_packet_check(ctx.clone(), &msg)
+                        .await?;
                 }
                 Some(Timeout(msg)) => {
                     use stateful::timeout::TimeoutCheck;
                     let msg = MsgTimeout::try_from(msg.clone())?;
 
                     self.state.validate(&msg).await?;
-                    self.app_handler.timeout_packet_check(&msg).await?;
+                    self.app_handler
+                        .timeout_packet_check(ctx.clone(), &msg)
+                        .await?;
                 }
 
                 // Other IBC messages are not handled by this component.
@@ -203,63 +221,81 @@ impl Component for ICS4Channel {
                     let msg = MsgChannelOpenInit::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.chan_open_init_execute(&msg).await;
+                    self.app_handler
+                        .chan_open_init_execute(ctx.clone(), &msg)
+                        .await;
                 }
                 Some(ChannelOpenTry(msg)) => {
                     use execution::channel_open_try::ChannelOpenTryExecute;
                     let msg = MsgChannelOpenTry::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.chan_open_try_execute(&msg).await;
+                    self.app_handler
+                        .chan_open_try_execute(ctx.clone(), &msg)
+                        .await;
                 }
                 Some(ChannelOpenAck(msg)) => {
                     use execution::channel_open_ack::ChannelOpenAckExecute;
                     let msg = MsgChannelOpenAck::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.chan_open_ack_execute(&msg).await;
+                    self.app_handler
+                        .chan_open_ack_execute(ctx.clone(), &msg)
+                        .await;
                 }
                 Some(ChannelOpenConfirm(msg)) => {
                     use execution::channel_open_confirm::ChannelOpenConfirmExecute;
                     let msg = MsgChannelOpenConfirm::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.chan_open_confirm_execute(&msg).await;
+                    self.app_handler
+                        .chan_open_confirm_execute(ctx.clone(), &msg)
+                        .await;
                 }
                 Some(ChannelCloseInit(msg)) => {
                     use execution::channel_close_init::ChannelCloseInitExecute;
                     let msg = MsgChannelCloseInit::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.chan_close_init_execute(&msg).await;
+                    self.app_handler
+                        .chan_close_init_execute(ctx.clone(), &msg)
+                        .await;
                 }
                 Some(ChannelCloseConfirm(msg)) => {
                     use execution::channel_close_confirm::ChannelCloseConfirmExecute;
                     let msg = MsgChannelCloseConfirm::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.chan_close_confirm_execute(&msg).await;
+                    self.app_handler
+                        .chan_close_confirm_execute(ctx.clone(), &msg)
+                        .await;
                 }
                 Some(RecvPacket(msg)) => {
                     use execution::recv_packet::RecvPacketExecute;
                     let msg = MsgRecvPacket::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.recv_packet_execute(&msg).await;
+                    self.app_handler
+                        .recv_packet_execute(ctx.clone(), &msg)
+                        .await;
                 }
                 Some(Acknowledgement(msg)) => {
                     use execution::acknowledge_packet::AcknowledgePacketExecute;
                     let msg = MsgAcknowledgement::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.acknowledge_packet_execute(&msg).await;
+                    self.app_handler
+                        .acknowledge_packet_execute(ctx.clone(), &msg)
+                        .await;
                 }
                 Some(Timeout(msg)) => {
                     use execution::timeout::TimeoutExecute;
                     let msg = MsgTimeout::try_from(msg.clone()).unwrap();
 
                     self.state.execute(ctx.clone(), &msg).await;
-                    self.app_handler.timeout_packet_execute(&msg).await;
+                    self.app_handler
+                        .timeout_packet_execute(ctx.clone(), &msg)
+                        .await;
                 }
 
                 // Other IBC messages are not handled by this component.

--- a/component/src/ibc/component/channel.rs
+++ b/component/src/ibc/component/channel.rs
@@ -1,7 +1,7 @@
 use crate::ibc::component::client::View as _;
 use crate::ibc::component::connection::View as _;
-use crate::ibc::component::ibc_handler::AppHandler;
 use crate::ibc::event;
+use crate::ibc::ibc_handler::AppHandler;
 use crate::{Component, Context};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -40,21 +40,21 @@ mod execution;
 mod stateful;
 mod stateless;
 
-pub struct ICS4Channel<H: AppHandler> {
+pub struct ICS4Channel {
     state: State,
 
-    app_handler: H,
+    app_handler: Box<dyn AppHandler>,
 }
 
-impl<H: AppHandler> ICS4Channel<H> {
+impl ICS4Channel {
     #[instrument(name = "ics4_channel", skip(state, app_handler))]
-    pub async fn new(state: State, app_handler: H) -> Self {
+    pub async fn new(state: State, app_handler: Box<dyn AppHandler>) -> Self {
         Self { state, app_handler }
     }
 }
 
 #[async_trait]
-impl<H: AppHandler> Component for ICS4Channel<H> {
+impl Component for ICS4Channel {
     #[instrument(name = "ics4_channel", skip(self, _app_state))]
     async fn init_chain(&mut self, _app_state: &genesis::AppState) {}
 

--- a/component/src/ibc/ibc_handler.rs
+++ b/component/src/ibc/ibc_handler.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use async_trait::async_trait;
 use ibc::core::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
 use ibc::core::ics04_channel::msgs::chan_close_confirm::MsgChannelCloseConfirm;
@@ -14,18 +15,34 @@ use std::collections::HashMap;
 // defines an asynchronous handler for core IBC events, to be implemented by IBC apps (such as an
 // ICS20 transfer implementation, or interchain accounts implementation).
 #[async_trait]
-pub trait AppHandler: Send + Sync {
-    async fn chan_open_init(&mut self, msg: &MsgChannelOpenInit);
-    async fn chan_open_try(&mut self, msg: &MsgChannelOpenTry);
-    async fn chan_open_ack(&mut self, msg: &MsgChannelOpenAck);
-    async fn chan_open_confirm(&mut self, msg: &MsgChannelOpenConfirm);
-    async fn chan_close_confirm(&mut self, msg: &MsgChannelCloseConfirm);
-    async fn chan_close_init(&mut self, msg: &MsgChannelCloseInit);
+pub trait AppHandlerCheck: Send + Sync {
+    async fn chan_open_init_check(&self, msg: &MsgChannelOpenInit) -> Result<()>;
+    async fn chan_open_try_check(&self, msg: &MsgChannelOpenTry) -> Result<()>;
+    async fn chan_open_ack_check(&self, msg: &MsgChannelOpenAck) -> Result<()>;
+    async fn chan_open_confirm_check(&self, msg: &MsgChannelOpenConfirm) -> Result<()>;
+    async fn chan_close_confirm_check(&self, msg: &MsgChannelCloseConfirm) -> Result<()>;
+    async fn chan_close_init_check(&self, msg: &MsgChannelCloseInit) -> Result<()>;
 
-    async fn recv_packet(&mut self, msg: &MsgRecvPacket);
-    async fn timeout_packet(&mut self, msg: &MsgTimeout);
-    async fn acknowledge_packet(&mut self, msg: &MsgAcknowledgement);
+    async fn recv_packet_check(&self, msg: &MsgRecvPacket) -> Result<()>;
+    async fn timeout_packet_check(&self, msg: &MsgTimeout) -> Result<()>;
+    async fn acknowledge_packet_check(&self, msg: &MsgAcknowledgement) -> Result<()>;
 }
+
+#[async_trait]
+pub trait AppHandlerExecute: Send + Sync {
+    async fn chan_open_init_execute(&mut self, msg: &MsgChannelOpenInit);
+    async fn chan_open_try_execute(&mut self, msg: &MsgChannelOpenTry);
+    async fn chan_open_ack_execute(&mut self, msg: &MsgChannelOpenAck);
+    async fn chan_open_confirm_execute(&mut self, msg: &MsgChannelOpenConfirm);
+    async fn chan_close_confirm_execute(&mut self, msg: &MsgChannelCloseConfirm);
+    async fn chan_close_init_execute(&mut self, msg: &MsgChannelCloseInit);
+
+    async fn recv_packet_execute(&mut self, msg: &MsgRecvPacket);
+    async fn timeout_packet_execute(&mut self, msg: &MsgTimeout);
+    async fn acknowledge_packet_execute(&mut self, msg: &MsgAcknowledgement);
+}
+
+pub trait AppHandler: AppHandlerCheck + AppHandlerExecute {}
 
 pub struct AppRouter {
     handlers: HashMap<PortId, Box<dyn AppHandler>>,
@@ -46,50 +63,110 @@ impl AppRouter {
 }
 
 #[async_trait]
-impl AppHandler for AppRouter {
-    async fn chan_open_init(&mut self, msg: &MsgChannelOpenInit) {
+impl AppHandlerCheck for AppRouter {
+    async fn chan_open_init_check(&self, msg: &MsgChannelOpenInit) -> Result<()> {
+        if let Some(handler) = self.handlers.get(&msg.port_id) {
+            handler.chan_open_init_check(msg).await?;
+        }
+        Ok(())
+    }
+    async fn chan_open_try_check(&self, msg: &MsgChannelOpenTry) -> Result<()> {
+        if let Some(handler) = self.handlers.get(&msg.port_id) {
+            handler.chan_open_try_check(msg).await?;
+        }
+        Ok(())
+    }
+    async fn chan_open_ack_check(&self, msg: &MsgChannelOpenAck) -> Result<()> {
+        if let Some(handler) = self.handlers.get(&msg.port_id) {
+            handler.chan_open_ack_check(msg).await?;
+        }
+        Ok(())
+    }
+    async fn chan_open_confirm_check(&self, msg: &MsgChannelOpenConfirm) -> Result<()> {
+        if let Some(handler) = self.handlers.get(&msg.port_id) {
+            handler.chan_open_confirm_check(msg).await?;
+        }
+        Ok(())
+    }
+    async fn chan_close_confirm_check(&self, msg: &MsgChannelCloseConfirm) -> Result<()> {
+        if let Some(handler) = self.handlers.get(&msg.port_id) {
+            handler.chan_close_confirm_check(msg).await?;
+        }
+        Ok(())
+    }
+    async fn chan_close_init_check(&self, msg: &MsgChannelCloseInit) -> Result<()> {
+        if let Some(handler) = self.handlers.get(&msg.port_id) {
+            handler.chan_close_init_check(msg).await?;
+        }
+        Ok(())
+    }
+    async fn recv_packet_check(&self, msg: &MsgRecvPacket) -> Result<()> {
+        if let Some(handler) = self.handlers.get(&msg.packet.destination_port) {
+            handler.recv_packet_check(msg).await?;
+        }
+        Ok(())
+    }
+    async fn timeout_packet_check(&self, msg: &MsgTimeout) -> Result<()> {
+        if let Some(handler) = self.handlers.get(&msg.packet.destination_port) {
+            handler.timeout_packet_check(msg).await?;
+        }
+        Ok(())
+    }
+    async fn acknowledge_packet_check(&self, msg: &MsgAcknowledgement) -> Result<()> {
+        if let Some(handler) = self.handlers.get(&msg.packet.destination_port) {
+            handler.acknowledge_packet_check(msg).await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl AppHandlerExecute for AppRouter {
+    async fn chan_open_init_execute(&mut self, msg: &MsgChannelOpenInit) {
         if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
-            handler.chan_open_init(msg).await;
+            handler.chan_open_init_execute(msg).await;
         }
     }
-    async fn chan_open_try(&mut self, msg: &MsgChannelOpenTry) {
+    async fn chan_open_try_execute(&mut self, msg: &MsgChannelOpenTry) {
         if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
-            handler.chan_open_try(msg).await;
+            handler.chan_open_try_execute(msg).await;
         }
     }
-    async fn chan_open_ack(&mut self, msg: &MsgChannelOpenAck) {
+    async fn chan_open_ack_execute(&mut self, msg: &MsgChannelOpenAck) {
         if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
-            handler.chan_open_ack(msg).await;
+            handler.chan_open_ack_execute(msg).await;
         }
     }
-    async fn chan_open_confirm(&mut self, msg: &MsgChannelOpenConfirm) {
+    async fn chan_open_confirm_execute(&mut self, msg: &MsgChannelOpenConfirm) {
         if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
-            handler.chan_open_confirm(msg).await;
+            handler.chan_open_confirm_execute(msg).await;
         }
     }
-    async fn chan_close_confirm(&mut self, msg: &MsgChannelCloseConfirm) {
+    async fn chan_close_confirm_execute(&mut self, msg: &MsgChannelCloseConfirm) {
         if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
-            handler.chan_close_confirm(msg).await;
+            handler.chan_close_confirm_execute(msg).await;
         }
     }
-    async fn chan_close_init(&mut self, msg: &MsgChannelCloseInit) {
+    async fn chan_close_init_execute(&mut self, msg: &MsgChannelCloseInit) {
         if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
-            handler.chan_close_init(msg).await;
+            handler.chan_close_init_execute(msg).await;
         }
     }
-    async fn recv_packet(&mut self, msg: &MsgRecvPacket) {
+    async fn recv_packet_execute(&mut self, msg: &MsgRecvPacket) {
         if let Some(handler) = self.handlers.get_mut(&msg.packet.destination_port) {
-            handler.recv_packet(msg).await;
+            handler.recv_packet_execute(msg).await;
         }
     }
-    async fn timeout_packet(&mut self, msg: &MsgTimeout) {
+    async fn timeout_packet_execute(&mut self, msg: &MsgTimeout) {
         if let Some(handler) = self.handlers.get_mut(&msg.packet.destination_port) {
-            handler.timeout_packet(msg).await;
+            handler.timeout_packet_execute(msg).await;
         }
     }
-    async fn acknowledge_packet(&mut self, msg: &MsgAcknowledgement) {
+    async fn acknowledge_packet_execute(&mut self, msg: &MsgAcknowledgement) {
         if let Some(handler) = self.handlers.get_mut(&msg.packet.destination_port) {
-            handler.acknowledge_packet(msg).await;
+            handler.acknowledge_packet_execute(msg).await;
         }
     }
 }
+
+impl AppHandler for AppRouter {}

--- a/component/src/ibc/ibc_handler.rs
+++ b/component/src/ibc/ibc_handler.rs
@@ -1,0 +1,95 @@
+use async_trait::async_trait;
+use ibc::core::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
+use ibc::core::ics04_channel::msgs::chan_close_confirm::MsgChannelCloseConfirm;
+use ibc::core::ics04_channel::msgs::chan_close_init::MsgChannelCloseInit;
+use ibc::core::ics04_channel::msgs::chan_open_ack::MsgChannelOpenAck;
+use ibc::core::ics04_channel::msgs::chan_open_confirm::MsgChannelOpenConfirm;
+use ibc::core::ics04_channel::msgs::chan_open_init::MsgChannelOpenInit;
+use ibc::core::ics04_channel::msgs::chan_open_try::MsgChannelOpenTry;
+use ibc::core::ics04_channel::msgs::recv_packet::MsgRecvPacket;
+use ibc::core::ics04_channel::msgs::timeout::MsgTimeout;
+use ibc::core::ics24_host::identifier::PortId;
+use std::collections::HashMap;
+
+// defines an asynchronous handler for core IBC events, to be implemented by IBC apps (such as an
+// ICS20 transfer implementation, or interchain accounts implementation).
+#[async_trait]
+pub trait AppHandler: Send + Sync {
+    async fn chan_open_init(&mut self, msg: &MsgChannelOpenInit);
+    async fn chan_open_try(&mut self, msg: &MsgChannelOpenTry);
+    async fn chan_open_ack(&mut self, msg: &MsgChannelOpenAck);
+    async fn chan_open_confirm(&mut self, msg: &MsgChannelOpenConfirm);
+    async fn chan_close_confirm(&mut self, msg: &MsgChannelCloseConfirm);
+    async fn chan_close_init(&mut self, msg: &MsgChannelCloseInit);
+
+    async fn recv_packet(&mut self, msg: &MsgRecvPacket);
+    async fn timeout_packet(&mut self, msg: &MsgTimeout);
+    async fn acknowledge_packet(&mut self, msg: &MsgAcknowledgement);
+}
+
+pub struct AppRouter {
+    handlers: HashMap<PortId, Box<dyn AppHandler>>,
+}
+
+impl AppRouter {
+    pub fn new() -> Self {
+        AppRouter {
+            handlers: HashMap::new(),
+        }
+    }
+    pub fn bind(&mut self, port_id: PortId, handler: Box<dyn AppHandler>) {
+        if self.handlers.contains_key(&port_id) {
+            panic!("AppRouter: handler already bound for port {}", port_id);
+        }
+        self.handlers.insert(port_id, handler);
+    }
+}
+
+#[async_trait]
+impl AppHandler for AppRouter {
+    async fn chan_open_init(&mut self, msg: &MsgChannelOpenInit) {
+        if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
+            handler.chan_open_init(msg).await;
+        }
+    }
+    async fn chan_open_try(&mut self, msg: &MsgChannelOpenTry) {
+        if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
+            handler.chan_open_try(msg).await;
+        }
+    }
+    async fn chan_open_ack(&mut self, msg: &MsgChannelOpenAck) {
+        if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
+            handler.chan_open_ack(msg).await;
+        }
+    }
+    async fn chan_open_confirm(&mut self, msg: &MsgChannelOpenConfirm) {
+        if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
+            handler.chan_open_confirm(msg).await;
+        }
+    }
+    async fn chan_close_confirm(&mut self, msg: &MsgChannelCloseConfirm) {
+        if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
+            handler.chan_close_confirm(msg).await;
+        }
+    }
+    async fn chan_close_init(&mut self, msg: &MsgChannelCloseInit) {
+        if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
+            handler.chan_close_init(msg).await;
+        }
+    }
+    async fn recv_packet(&mut self, msg: &MsgRecvPacket) {
+        if let Some(handler) = self.handlers.get_mut(&msg.packet.destination_port) {
+            handler.recv_packet(msg).await;
+        }
+    }
+    async fn timeout_packet(&mut self, msg: &MsgTimeout) {
+        if let Some(handler) = self.handlers.get_mut(&msg.packet.destination_port) {
+            handler.timeout_packet(msg).await;
+        }
+    }
+    async fn acknowledge_packet(&mut self, msg: &MsgAcknowledgement) {
+        if let Some(handler) = self.handlers.get_mut(&msg.packet.destination_port) {
+            handler.acknowledge_packet(msg).await;
+        }
+    }
+}

--- a/component/src/ibc/ibc_handler.rs
+++ b/component/src/ibc/ibc_handler.rs
@@ -6,6 +6,7 @@
 ///
 /// The primary IBC application is the ICS20 transfer application, which allows for interchain
 /// token transfers.
+use crate::Context;
 use anyhow::Result;
 use async_trait::async_trait;
 use ibc::core::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
@@ -25,16 +26,24 @@ use std::collections::HashMap;
 /// only.
 #[async_trait]
 pub trait AppHandlerCheck: Send + Sync {
-    async fn chan_open_init_check(&self, msg: &MsgChannelOpenInit) -> Result<()>;
-    async fn chan_open_try_check(&self, msg: &MsgChannelOpenTry) -> Result<()>;
-    async fn chan_open_ack_check(&self, msg: &MsgChannelOpenAck) -> Result<()>;
-    async fn chan_open_confirm_check(&self, msg: &MsgChannelOpenConfirm) -> Result<()>;
-    async fn chan_close_confirm_check(&self, msg: &MsgChannelCloseConfirm) -> Result<()>;
-    async fn chan_close_init_check(&self, msg: &MsgChannelCloseInit) -> Result<()>;
+    async fn chan_open_init_check(&self, ctx: Context, msg: &MsgChannelOpenInit) -> Result<()>;
+    async fn chan_open_try_check(&self, ctx: Context, msg: &MsgChannelOpenTry) -> Result<()>;
+    async fn chan_open_ack_check(&self, ctx: Context, msg: &MsgChannelOpenAck) -> Result<()>;
+    async fn chan_open_confirm_check(
+        &self,
+        ctx: Context,
+        msg: &MsgChannelOpenConfirm,
+    ) -> Result<()>;
+    async fn chan_close_confirm_check(
+        &self,
+        ctx: Context,
+        msg: &MsgChannelCloseConfirm,
+    ) -> Result<()>;
+    async fn chan_close_init_check(&self, ctx: Context, msg: &MsgChannelCloseInit) -> Result<()>;
 
-    async fn recv_packet_check(&self, msg: &MsgRecvPacket) -> Result<()>;
-    async fn timeout_packet_check(&self, msg: &MsgTimeout) -> Result<()>;
-    async fn acknowledge_packet_check(&self, msg: &MsgAcknowledgement) -> Result<()>;
+    async fn recv_packet_check(&self, ctx: Context, msg: &MsgRecvPacket) -> Result<()>;
+    async fn timeout_packet_check(&self, ctx: Context, msg: &MsgTimeout) -> Result<()>;
+    async fn acknowledge_packet_check(&self, ctx: Context, msg: &MsgAcknowledgement) -> Result<()>;
 }
 
 // AppHandlerExecute defines the interface for an IBC application to consume IBC channel and packet
@@ -42,16 +51,16 @@ pub trait AppHandlerCheck: Send + Sync {
 // once the transaction has been validated using the AppHandlerCheck interface.
 #[async_trait]
 pub trait AppHandlerExecute: Send + Sync {
-    async fn chan_open_init_execute(&mut self, msg: &MsgChannelOpenInit);
-    async fn chan_open_try_execute(&mut self, msg: &MsgChannelOpenTry);
-    async fn chan_open_ack_execute(&mut self, msg: &MsgChannelOpenAck);
-    async fn chan_open_confirm_execute(&mut self, msg: &MsgChannelOpenConfirm);
-    async fn chan_close_confirm_execute(&mut self, msg: &MsgChannelCloseConfirm);
-    async fn chan_close_init_execute(&mut self, msg: &MsgChannelCloseInit);
+    async fn chan_open_init_execute(&mut self, ctx: Context, msg: &MsgChannelOpenInit);
+    async fn chan_open_try_execute(&mut self, ctx: Context, msg: &MsgChannelOpenTry);
+    async fn chan_open_ack_execute(&mut self, ctx: Context, msg: &MsgChannelOpenAck);
+    async fn chan_open_confirm_execute(&mut self, ctx: Context, msg: &MsgChannelOpenConfirm);
+    async fn chan_close_confirm_execute(&mut self, ctx: Context, msg: &MsgChannelCloseConfirm);
+    async fn chan_close_init_execute(&mut self, ctx: Context, msg: &MsgChannelCloseInit);
 
-    async fn recv_packet_execute(&mut self, msg: &MsgRecvPacket);
-    async fn timeout_packet_execute(&mut self, msg: &MsgTimeout);
-    async fn acknowledge_packet_execute(&mut self, msg: &MsgAcknowledgement);
+    async fn recv_packet_execute(&mut self, ctx: Context, msg: &MsgRecvPacket);
+    async fn timeout_packet_execute(&mut self, ctx: Context, msg: &MsgTimeout);
+    async fn acknowledge_packet_execute(&mut self, ctx: Context, msg: &MsgAcknowledgement);
 }
 
 pub trait AppHandler: AppHandlerCheck + AppHandlerExecute {}
@@ -81,57 +90,65 @@ impl AppRouter {
 
 #[async_trait]
 impl AppHandlerCheck for AppRouter {
-    async fn chan_open_init_check(&self, msg: &MsgChannelOpenInit) -> Result<()> {
+    async fn chan_open_init_check(&self, ctx: Context, msg: &MsgChannelOpenInit) -> Result<()> {
         if let Some(handler) = self.handlers.get(&msg.port_id) {
-            handler.chan_open_init_check(msg).await?;
+            handler.chan_open_init_check(ctx, msg).await?;
         }
         Ok(())
     }
-    async fn chan_open_try_check(&self, msg: &MsgChannelOpenTry) -> Result<()> {
+    async fn chan_open_try_check(&self, ctx: Context, msg: &MsgChannelOpenTry) -> Result<()> {
         if let Some(handler) = self.handlers.get(&msg.port_id) {
-            handler.chan_open_try_check(msg).await?;
+            handler.chan_open_try_check(ctx, msg).await?;
         }
         Ok(())
     }
-    async fn chan_open_ack_check(&self, msg: &MsgChannelOpenAck) -> Result<()> {
+    async fn chan_open_ack_check(&self, ctx: Context, msg: &MsgChannelOpenAck) -> Result<()> {
         if let Some(handler) = self.handlers.get(&msg.port_id) {
-            handler.chan_open_ack_check(msg).await?;
+            handler.chan_open_ack_check(ctx, msg).await?;
         }
         Ok(())
     }
-    async fn chan_open_confirm_check(&self, msg: &MsgChannelOpenConfirm) -> Result<()> {
+    async fn chan_open_confirm_check(
+        &self,
+        ctx: Context,
+        msg: &MsgChannelOpenConfirm,
+    ) -> Result<()> {
         if let Some(handler) = self.handlers.get(&msg.port_id) {
-            handler.chan_open_confirm_check(msg).await?;
+            handler.chan_open_confirm_check(ctx, msg).await?;
         }
         Ok(())
     }
-    async fn chan_close_confirm_check(&self, msg: &MsgChannelCloseConfirm) -> Result<()> {
+    async fn chan_close_confirm_check(
+        &self,
+        ctx: Context,
+        msg: &MsgChannelCloseConfirm,
+    ) -> Result<()> {
         if let Some(handler) = self.handlers.get(&msg.port_id) {
-            handler.chan_close_confirm_check(msg).await?;
+            handler.chan_close_confirm_check(ctx, msg).await?;
         }
         Ok(())
     }
-    async fn chan_close_init_check(&self, msg: &MsgChannelCloseInit) -> Result<()> {
+    async fn chan_close_init_check(&self, ctx: Context, msg: &MsgChannelCloseInit) -> Result<()> {
         if let Some(handler) = self.handlers.get(&msg.port_id) {
-            handler.chan_close_init_check(msg).await?;
+            handler.chan_close_init_check(ctx, msg).await?;
         }
         Ok(())
     }
-    async fn recv_packet_check(&self, msg: &MsgRecvPacket) -> Result<()> {
+    async fn recv_packet_check(&self, ctx: Context, msg: &MsgRecvPacket) -> Result<()> {
         if let Some(handler) = self.handlers.get(&msg.packet.destination_port) {
-            handler.recv_packet_check(msg).await?;
+            handler.recv_packet_check(ctx, msg).await?;
         }
         Ok(())
     }
-    async fn timeout_packet_check(&self, msg: &MsgTimeout) -> Result<()> {
+    async fn timeout_packet_check(&self, ctx: Context, msg: &MsgTimeout) -> Result<()> {
         if let Some(handler) = self.handlers.get(&msg.packet.destination_port) {
-            handler.timeout_packet_check(msg).await?;
+            handler.timeout_packet_check(ctx, msg).await?;
         }
         Ok(())
     }
-    async fn acknowledge_packet_check(&self, msg: &MsgAcknowledgement) -> Result<()> {
+    async fn acknowledge_packet_check(&self, ctx: Context, msg: &MsgAcknowledgement) -> Result<()> {
         if let Some(handler) = self.handlers.get(&msg.packet.destination_port) {
-            handler.acknowledge_packet_check(msg).await?;
+            handler.acknowledge_packet_check(ctx, msg).await?;
         }
         Ok(())
     }
@@ -139,49 +156,49 @@ impl AppHandlerCheck for AppRouter {
 
 #[async_trait]
 impl AppHandlerExecute for AppRouter {
-    async fn chan_open_init_execute(&mut self, msg: &MsgChannelOpenInit) {
+    async fn chan_open_init_execute(&mut self, ctx: Context, msg: &MsgChannelOpenInit) {
         if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
-            handler.chan_open_init_execute(msg).await;
+            handler.chan_open_init_execute(ctx, msg).await;
         }
     }
-    async fn chan_open_try_execute(&mut self, msg: &MsgChannelOpenTry) {
+    async fn chan_open_try_execute(&mut self, ctx: Context, msg: &MsgChannelOpenTry) {
         if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
-            handler.chan_open_try_execute(msg).await;
+            handler.chan_open_try_execute(ctx, msg).await;
         }
     }
-    async fn chan_open_ack_execute(&mut self, msg: &MsgChannelOpenAck) {
+    async fn chan_open_ack_execute(&mut self, ctx: Context, msg: &MsgChannelOpenAck) {
         if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
-            handler.chan_open_ack_execute(msg).await;
+            handler.chan_open_ack_execute(ctx, msg).await;
         }
     }
-    async fn chan_open_confirm_execute(&mut self, msg: &MsgChannelOpenConfirm) {
+    async fn chan_open_confirm_execute(&mut self, ctx: Context, msg: &MsgChannelOpenConfirm) {
         if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
-            handler.chan_open_confirm_execute(msg).await;
+            handler.chan_open_confirm_execute(ctx, msg).await;
         }
     }
-    async fn chan_close_confirm_execute(&mut self, msg: &MsgChannelCloseConfirm) {
+    async fn chan_close_confirm_execute(&mut self, ctx: Context, msg: &MsgChannelCloseConfirm) {
         if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
-            handler.chan_close_confirm_execute(msg).await;
+            handler.chan_close_confirm_execute(ctx, msg).await;
         }
     }
-    async fn chan_close_init_execute(&mut self, msg: &MsgChannelCloseInit) {
+    async fn chan_close_init_execute(&mut self, ctx: Context, msg: &MsgChannelCloseInit) {
         if let Some(handler) = self.handlers.get_mut(&msg.port_id) {
-            handler.chan_close_init_execute(msg).await;
+            handler.chan_close_init_execute(ctx, msg).await;
         }
     }
-    async fn recv_packet_execute(&mut self, msg: &MsgRecvPacket) {
+    async fn recv_packet_execute(&mut self, ctx: Context, msg: &MsgRecvPacket) {
         if let Some(handler) = self.handlers.get_mut(&msg.packet.destination_port) {
-            handler.recv_packet_execute(msg).await;
+            handler.recv_packet_execute(ctx, msg).await;
         }
     }
-    async fn timeout_packet_execute(&mut self, msg: &MsgTimeout) {
+    async fn timeout_packet_execute(&mut self, ctx: Context, msg: &MsgTimeout) {
         if let Some(handler) = self.handlers.get_mut(&msg.packet.destination_port) {
-            handler.timeout_packet_execute(msg).await;
+            handler.timeout_packet_execute(ctx, msg).await;
         }
     }
-    async fn acknowledge_packet_execute(&mut self, msg: &MsgAcknowledgement) {
+    async fn acknowledge_packet_execute(&mut self, ctx: Context, msg: &MsgAcknowledgement) {
         if let Some(handler) = self.handlers.get_mut(&msg.packet.destination_port) {
-            handler.acknowledge_packet_execute(msg).await;
+            handler.acknowledge_packet_execute(ctx, msg).await;
         }
     }
 }

--- a/component/src/ibc/ibc_handler.rs
+++ b/component/src/ibc/ibc_handler.rs
@@ -1,3 +1,11 @@
+/// IBC "app handlers" for the IBC component.
+///
+/// An app handler defines an interface for any IBC application to consume verified IBC events from
+/// the core IBC component. IBC applications listen to channel events that occur on the Port ID
+/// that they have subscribed to, and apply application-specific state transition logic.
+///
+/// The primary IBC application is the ICS20 transfer application, which allows for interchain
+/// token transfers.
 use anyhow::Result;
 use async_trait::async_trait;
 use ibc::core::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
@@ -12,8 +20,9 @@ use ibc::core::ics04_channel::msgs::timeout::MsgTimeout;
 use ibc::core::ics24_host::identifier::PortId;
 use std::collections::HashMap;
 
-// defines an asynchronous handler for core IBC events, to be implemented by IBC apps (such as an
-// ICS20 transfer implementation, or interchain accounts implementation).
+/// AppHandlerCheck defines the interface for an IBC application to consume IBC channel and packet
+/// events, and apply their validation logic. This validation logic is used for stateful validation
+/// only.
 #[async_trait]
 pub trait AppHandlerCheck: Send + Sync {
     async fn chan_open_init_check(&self, msg: &MsgChannelOpenInit) -> Result<()>;
@@ -28,6 +37,9 @@ pub trait AppHandlerCheck: Send + Sync {
     async fn acknowledge_packet_check(&self, msg: &MsgAcknowledgement) -> Result<()>;
 }
 
+// AppHandlerExecute defines the interface for an IBC application to consume IBC channel and packet
+// events and apply their state transition logic. The IBC component will only call these methods
+// once the transaction has been validated using the AppHandlerCheck interface.
 #[async_trait]
 pub trait AppHandlerExecute: Send + Sync {
     async fn chan_open_init_execute(&mut self, msg: &MsgChannelOpenInit);
@@ -44,6 +56,8 @@ pub trait AppHandlerExecute: Send + Sync {
 
 pub trait AppHandler: AppHandlerCheck + AppHandlerExecute {}
 
+/// an AppRouter is an implementation of AppHandler that is the root router for all IBC
+/// applications. Applications can register themselves on an IBC port by calling AppRouter.bind().
 pub struct AppRouter {
     handlers: HashMap<PortId, Box<dyn AppHandler>>,
 }
@@ -54,6 +68,9 @@ impl AppRouter {
             handlers: HashMap::new(),
         }
     }
+
+    /// Bind an IBC application, given by `handler`, to the given port ID. This will panic if there
+    /// is already an application bound to the given port ID.
     pub fn bind(&mut self, port_id: PortId, handler: Box<dyn AppHandler>) {
         if self.handlers.contains_key(&port_id) {
             panic!("AppRouter: handler already bound for port {}", port_id);

--- a/component/src/ibc/mod.rs
+++ b/component/src/ibc/mod.rs
@@ -7,11 +7,11 @@ mod client;
 mod component;
 mod connection;
 pub(crate) mod event;
-
 mod ibc_token;
 pub use ibc_token::IBCToken;
-
+mod ibc_handler;
 mod metrics;
+mod transfer;
 
 pub use self::metrics::register_metrics;
 

--- a/component/src/ibc/transfer.rs
+++ b/component/src/ibc/transfer.rs
@@ -1,4 +1,5 @@
 use crate::ibc::ibc_handler::{AppHandler, AppHandlerCheck, AppHandlerExecute};
+use crate::Context;
 use anyhow::Result;
 use async_trait::async_trait;
 use ibc::core::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
@@ -28,46 +29,58 @@ impl ICS20Transfer {
 // see: https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer
 #[async_trait]
 impl AppHandlerCheck for ICS20Transfer {
-    async fn chan_open_init_check(&self, _msg: &MsgChannelOpenInit) -> Result<()> {
+    async fn chan_open_init_check(&self, _ctx: Context, _msg: &MsgChannelOpenInit) -> Result<()> {
         Ok(())
     }
-    async fn chan_open_try_check(&self, _msg: &MsgChannelOpenTry) -> Result<()> {
+    async fn chan_open_try_check(&self, _ctx: Context, _msg: &MsgChannelOpenTry) -> Result<()> {
         Ok(())
     }
-    async fn chan_open_ack_check(&self, _msg: &MsgChannelOpenAck) -> Result<()> {
+    async fn chan_open_ack_check(&self, _ctx: Context, _msg: &MsgChannelOpenAck) -> Result<()> {
         Ok(())
     }
-    async fn chan_open_confirm_check(&self, _msg: &MsgChannelOpenConfirm) -> Result<()> {
+    async fn chan_open_confirm_check(
+        &self,
+        _ctx: Context,
+        _msg: &MsgChannelOpenConfirm,
+    ) -> Result<()> {
         Ok(())
     }
-    async fn chan_close_confirm_check(&self, _msg: &MsgChannelCloseConfirm) -> Result<()> {
+    async fn chan_close_confirm_check(
+        &self,
+        _ctx: Context,
+        _msg: &MsgChannelCloseConfirm,
+    ) -> Result<()> {
         Ok(())
     }
-    async fn chan_close_init_check(&self, _msg: &MsgChannelCloseInit) -> Result<()> {
+    async fn chan_close_init_check(&self, _ctx: Context, _msg: &MsgChannelCloseInit) -> Result<()> {
         Ok(())
     }
-    async fn recv_packet_check(&self, _msg: &MsgRecvPacket) -> Result<()> {
+    async fn recv_packet_check(&self, _ctx: Context, _msg: &MsgRecvPacket) -> Result<()> {
         Ok(())
     }
-    async fn timeout_packet_check(&self, _msg: &MsgTimeout) -> Result<()> {
+    async fn timeout_packet_check(&self, _ctx: Context, _msg: &MsgTimeout) -> Result<()> {
         Ok(())
     }
-    async fn acknowledge_packet_check(&self, _msg: &MsgAcknowledgement) -> Result<()> {
+    async fn acknowledge_packet_check(
+        &self,
+        _ctx: Context,
+        _msg: &MsgAcknowledgement,
+    ) -> Result<()> {
         Ok(())
     }
 }
 
 #[async_trait]
 impl AppHandlerExecute for ICS20Transfer {
-    async fn chan_open_init_execute(&mut self, _msg: &MsgChannelOpenInit) {}
-    async fn chan_open_try_execute(&mut self, _msg: &MsgChannelOpenTry) {}
-    async fn chan_open_ack_execute(&mut self, _msg: &MsgChannelOpenAck) {}
-    async fn chan_open_confirm_execute(&mut self, _msg: &MsgChannelOpenConfirm) {}
-    async fn chan_close_confirm_execute(&mut self, _msg: &MsgChannelCloseConfirm) {}
-    async fn chan_close_init_execute(&mut self, _msg: &MsgChannelCloseInit) {}
-    async fn recv_packet_execute(&mut self, _msg: &MsgRecvPacket) {}
-    async fn timeout_packet_execute(&mut self, _msg: &MsgTimeout) {}
-    async fn acknowledge_packet_execute(&mut self, _msg: &MsgAcknowledgement) {}
+    async fn chan_open_init_execute(&mut self, _ctx: Context, _msg: &MsgChannelOpenInit) {}
+    async fn chan_open_try_execute(&mut self, _ctx: Context, _msg: &MsgChannelOpenTry) {}
+    async fn chan_open_ack_execute(&mut self, _ctx: Context, _msg: &MsgChannelOpenAck) {}
+    async fn chan_open_confirm_execute(&mut self, _ctx: Context, _msg: &MsgChannelOpenConfirm) {}
+    async fn chan_close_confirm_execute(&mut self, _ctx: Context, _msg: &MsgChannelCloseConfirm) {}
+    async fn chan_close_init_execute(&mut self, _ctx: Context, _msg: &MsgChannelCloseInit) {}
+    async fn recv_packet_execute(&mut self, _ctx: Context, _msg: &MsgRecvPacket) {}
+    async fn timeout_packet_execute(&mut self, _ctx: Context, _msg: &MsgTimeout) {}
+    async fn acknowledge_packet_execute(&mut self, _ctx: Context, _msg: &MsgAcknowledgement) {}
 }
 
 impl AppHandler for ICS20Transfer {}

--- a/component/src/ibc/transfer.rs
+++ b/component/src/ibc/transfer.rs
@@ -1,0 +1,39 @@
+use crate::ibc::ibc_handler::AppHandler;
+use async_trait::async_trait;
+use ibc::core::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
+use ibc::core::ics04_channel::msgs::chan_close_confirm::MsgChannelCloseConfirm;
+use ibc::core::ics04_channel::msgs::chan_close_init::MsgChannelCloseInit;
+use ibc::core::ics04_channel::msgs::chan_open_ack::MsgChannelOpenAck;
+use ibc::core::ics04_channel::msgs::chan_open_confirm::MsgChannelOpenConfirm;
+use ibc::core::ics04_channel::msgs::chan_open_init::MsgChannelOpenInit;
+use ibc::core::ics04_channel::msgs::chan_open_try::MsgChannelOpenTry;
+use ibc::core::ics04_channel::msgs::recv_packet::MsgRecvPacket;
+use ibc::core::ics04_channel::msgs::timeout::MsgTimeout;
+use penumbra_storage::State;
+use tracing::instrument;
+
+pub struct ICS20Transfer {
+    state: State,
+}
+
+impl ICS20Transfer {
+    #[instrument(name = "ics20_transfer", skip(state))]
+    pub fn new(state: State) -> Self {
+        Self { state }
+    }
+}
+
+// TODO: ICS20 implementation.
+// see: https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer
+#[async_trait]
+impl AppHandler for ICS20Transfer {
+    async fn chan_open_init(&mut self, _msg: &MsgChannelOpenInit) {}
+    async fn chan_open_try(&mut self, _msg: &MsgChannelOpenTry) {}
+    async fn chan_open_ack(&mut self, _msg: &MsgChannelOpenAck) {}
+    async fn chan_open_confirm(&mut self, _msg: &MsgChannelOpenConfirm) {}
+    async fn chan_close_confirm(&mut self, _msg: &MsgChannelCloseConfirm) {}
+    async fn chan_close_init(&mut self, _msg: &MsgChannelCloseInit) {}
+    async fn recv_packet(&mut self, _msg: &MsgRecvPacket) {}
+    async fn timeout_packet(&mut self, _msg: &MsgTimeout) {}
+    async fn acknowledge_packet(&mut self, _msg: &MsgAcknowledgement) {}
+}

--- a/component/src/ibc/transfer.rs
+++ b/component/src/ibc/transfer.rs
@@ -1,4 +1,5 @@
-use crate::ibc::ibc_handler::AppHandler;
+use crate::ibc::ibc_handler::{AppHandler, AppHandlerCheck, AppHandlerExecute};
+use anyhow::Result;
 use async_trait::async_trait;
 use ibc::core::ics04_channel::msgs::acknowledgement::MsgAcknowledgement;
 use ibc::core::ics04_channel::msgs::chan_close_confirm::MsgChannelCloseConfirm;
@@ -26,14 +27,47 @@ impl ICS20Transfer {
 // TODO: ICS20 implementation.
 // see: https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer
 #[async_trait]
-impl AppHandler for ICS20Transfer {
-    async fn chan_open_init(&mut self, _msg: &MsgChannelOpenInit) {}
-    async fn chan_open_try(&mut self, _msg: &MsgChannelOpenTry) {}
-    async fn chan_open_ack(&mut self, _msg: &MsgChannelOpenAck) {}
-    async fn chan_open_confirm(&mut self, _msg: &MsgChannelOpenConfirm) {}
-    async fn chan_close_confirm(&mut self, _msg: &MsgChannelCloseConfirm) {}
-    async fn chan_close_init(&mut self, _msg: &MsgChannelCloseInit) {}
-    async fn recv_packet(&mut self, _msg: &MsgRecvPacket) {}
-    async fn timeout_packet(&mut self, _msg: &MsgTimeout) {}
-    async fn acknowledge_packet(&mut self, _msg: &MsgAcknowledgement) {}
+impl AppHandlerCheck for ICS20Transfer {
+    async fn chan_open_init_check(&self, _msg: &MsgChannelOpenInit) -> Result<()> {
+        Ok(())
+    }
+    async fn chan_open_try_check(&self, _msg: &MsgChannelOpenTry) -> Result<()> {
+        Ok(())
+    }
+    async fn chan_open_ack_check(&self, _msg: &MsgChannelOpenAck) -> Result<()> {
+        Ok(())
+    }
+    async fn chan_open_confirm_check(&self, _msg: &MsgChannelOpenConfirm) -> Result<()> {
+        Ok(())
+    }
+    async fn chan_close_confirm_check(&self, _msg: &MsgChannelCloseConfirm) -> Result<()> {
+        Ok(())
+    }
+    async fn chan_close_init_check(&self, _msg: &MsgChannelCloseInit) -> Result<()> {
+        Ok(())
+    }
+    async fn recv_packet_check(&self, _msg: &MsgRecvPacket) -> Result<()> {
+        Ok(())
+    }
+    async fn timeout_packet_check(&self, _msg: &MsgTimeout) -> Result<()> {
+        Ok(())
+    }
+    async fn acknowledge_packet_check(&self, _msg: &MsgAcknowledgement) -> Result<()> {
+        Ok(())
+    }
 }
+
+#[async_trait]
+impl AppHandlerExecute for ICS20Transfer {
+    async fn chan_open_init_execute(&mut self, _msg: &MsgChannelOpenInit) {}
+    async fn chan_open_try_execute(&mut self, _msg: &MsgChannelOpenTry) {}
+    async fn chan_open_ack_execute(&mut self, _msg: &MsgChannelOpenAck) {}
+    async fn chan_open_confirm_execute(&mut self, _msg: &MsgChannelOpenConfirm) {}
+    async fn chan_close_confirm_execute(&mut self, _msg: &MsgChannelCloseConfirm) {}
+    async fn chan_close_init_execute(&mut self, _msg: &MsgChannelCloseInit) {}
+    async fn recv_packet_execute(&mut self, _msg: &MsgRecvPacket) {}
+    async fn timeout_packet_execute(&mut self, _msg: &MsgTimeout) {}
+    async fn acknowledge_packet_execute(&mut self, _msg: &MsgAcknowledgement) {}
+}
+
+impl AppHandler for ICS20Transfer {}


### PR DESCRIPTION
This PR adds a scaffold that should allow us to cleanly implement ICS20 transfers, and any other future IBC applications (such as interchain accounts).

Originally, we had considered the ICS20 implementation to be through another component. However, this isn't correct, because IBC applications want to consume (validated) IBC channel events, not raw transactions.

Along the lines of https://github.com/cosmos/ibc/tree/master/spec/core/ics-026-routing-module and https://github.com/cosmos/ibc/tree/master/spec/core/ics-025-handler-interface, this PR adds an "App Handler" interface, which defines the interface that IBC applications use to consume events from the IBC core protocol, and adds an "App Router" that allows instantiations of IBC applications to bind to IBC Ports and receive events for that port. 

This PR implements the AppHandler interface in two distinct interfaces, which match our distinct "check" and "execute" approach for transaction execution. 