### PR TITLE
pcli: don't wait for full confirmation of undelegations

### DIFF
--- a/pcli/src/command/stake.rs
+++ b/pcli/src/command/stake.rs
@@ -204,7 +204,10 @@ impl StakeCmd {
                 )
                 .await?;
 
-                app.build_and_submit_transaction(undelegate_plan).await?;
+                // Pass None as the change to await, since the change will be quarantined, so we won't detect it.
+                // But it's not spendable anyways, so we don't need to detect it.
+                let tx = app.build_transaction(undelegate_plan).await?;
+                app.submit_transaction(&tx, None).await?;
             }
             StakeCmd::Redelegate { .. } => {
                 todo!()

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -33,7 +33,7 @@ impl App {
         self.submit_transaction(&tx, self_addressed_output).await
     }
 
-    fn build_transaction<'a>(
+    pub fn build_transaction<'a>(
         &'a mut self,
         plan: TransactionPlan,
     ) -> impl Future<Output = Result<Transaction>> + 'a {
@@ -53,7 +53,7 @@ impl App {
     /// - if `await_detection_of` is `Some`, returns `Ok` after the specified note has been detected by the view service, implying transaction finality.
     /// - if `await_detection_of` is `None`, returns `Ok` after the transaction has been accepted by the node it was sent to.
     #[instrument(skip(self, transaction, await_detection_of))]
-    async fn submit_transaction(
+    pub async fn submit_transaction(
         &mut self,
         transaction: &Transaction,
         await_detection_of: Option<note::Commitment>,


### PR DESCRIPTION
We won't detect change, because it's quarantined, but we also don't need to,
because it's not spendable.