### PR TITLE
pd: add a `join-testnet` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,6 +2778,7 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "regex",
+ "reqwest",
  "rocksdb",
  "serde",
  "serde_json",

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -55,6 +55,7 @@ tokio-util = "0.7"
 tower = { version = "0.4", features = ["full"]}
 tracing = "0.1"
 regex = "1.5"
+reqwest = { version = "0.11", features = ["json"] }
 prost-types = "0.9"
 tonic = "0.6.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }

--- a/pd/src/testnet.rs
+++ b/pd/src/testnet.rs
@@ -1,12 +1,26 @@
-use std::{env::current_dir, fmt, io::Read, path::PathBuf, str::FromStr};
+use std::{
+    env::current_dir,
+    fmt,
+    fs::{self, File},
+    io::{Read, Write},
+    path::PathBuf,
+    str::FromStr,
+};
 
 use anyhow::{Context, Result};
 use directories::UserDirs;
-use penumbra_chain::genesis;
-use penumbra_crypto::Address;
+use penumbra_chain::genesis::{self, AppState};
+use penumbra_crypto::{
+    keys::{SpendKey, SpendKeyBytes},
+    rdsa::{SigningKey, SpendAuth, VerificationKey},
+    Address,
+};
+use rand::Rng;
+use rand_core::OsRng;
 use regex::{Captures, Regex};
 use serde::{de, Deserialize};
-use tendermint::{node::Id, PrivateKey};
+use tendermint::{node::Id, Genesis, PrivateKey};
+use tendermint_config::{NodeKey, PrivValidatorKey};
 
 /// Methods and types used for generating testnet configurations.
 
@@ -64,10 +78,7 @@ where
 /// https://github.com/tendermint/tendermint/blob/6291d22f46f4c4f9121375af700dbdafa51577e7/cmd/tendermint/commands/init.go#L45
 /// There exists https://github.com/informalsystems/tendermint-rs/blob/a12118978f2ffea4042d6d38ebfb290d12611314/config/src/config.rs#L23 but
 /// this seemed more straightforward as only the moniker is changed right now.
-pub fn generate_tm_config(
-    node_name: &str,
-    persistent_peers: &[(Id, std::net::Ipv4Addr)],
-) -> String {
+pub fn generate_tm_config(node_name: &str, persistent_peers: &[(Id, String)]) -> String {
     let peers_string = persistent_peers
         .iter()
         // https://docs.tendermint.com/master/spec/p2p/peer.html#peer-identity
@@ -84,6 +95,52 @@ pub fn generate_tm_config(
         include_str!("../../testnets/tm_config_template.toml"),
         node_name, peers_string,
     )
+}
+pub struct ValidatorKeys {
+    // Penumbra spending key and viewing key for this node.
+    pub validator_id_sk: SigningKey<SpendAuth>,
+    pub validator_id_vk: VerificationKey<SpendAuth>,
+    // Consensus key for tendermint.
+    pub validator_cons_sk: tendermint::PrivateKey,
+    pub validator_cons_pk: tendermint::PublicKey,
+    // P2P auth key for tendermint.
+    pub node_key_sk: tendermint::PrivateKey,
+    #[allow(unused_variables, dead_code)]
+    pub node_key_pk: tendermint::PublicKey,
+    pub validator_spend_key: SpendKeyBytes,
+}
+
+impl ValidatorKeys {
+    pub fn generate() -> Self {
+        // Create the spend key for this node.
+        // TODO: change to use seed phrase
+        let seed = SpendKeyBytes(OsRng.gen());
+        let spend_key = SpendKey::from(seed.clone());
+
+        // Create signing key and verification key for this node.
+        let validator_id_sk = spend_key.spend_auth_key();
+        let validator_id_vk = VerificationKey::from(validator_id_sk);
+
+        // generate consensus key for tendermint.
+        let validator_cons_sk =
+            tendermint::PrivateKey::Ed25519(ed25519_consensus::SigningKey::new(OsRng));
+        let validator_cons_pk = validator_cons_sk.public_key();
+
+        // generate P2P auth key for tendermint.
+        let node_key_sk =
+            tendermint::PrivateKey::Ed25519(ed25519_consensus::SigningKey::new(OsRng));
+        let node_key_pk = node_key_sk.public_key();
+
+        ValidatorKeys {
+            validator_id_sk: validator_id_sk.clone(),
+            validator_id_vk,
+            validator_cons_sk,
+            validator_cons_pk,
+            node_key_sk,
+            node_key_pk,
+            validator_spend_key: seed,
+        }
+    }
 }
 
 /// Represents initial allocations to the testnet.
@@ -169,4 +226,85 @@ pub fn canonicalize_path(input: &str) -> PathBuf {
     } else {
         PathBuf::from(format!("{}/{}", current_dir().unwrap().display(), input))
     }
+}
+
+pub fn write_configs(
+    node_dir: PathBuf,
+    vk: &ValidatorKeys,
+    genesis: &Genesis<AppState>,
+    tm_config: String,
+) -> anyhow::Result<()> {
+    let mut pd_dir = node_dir.clone();
+    let mut tm_dir = node_dir;
+
+    pd_dir.push("pd");
+    tm_dir.push("tendermint");
+
+    let mut node_config_dir = tm_dir.clone();
+    node_config_dir.push("config");
+
+    let mut node_data_dir = tm_dir.clone();
+    node_data_dir.push("data");
+
+    fs::create_dir_all(&node_config_dir)?;
+    fs::create_dir_all(&node_data_dir)?;
+    fs::create_dir_all(&pd_dir)?;
+
+    let mut genesis_file_path = node_config_dir.clone();
+    genesis_file_path.push("genesis.json");
+    tracing::info!(genesis_file_path = %genesis_file_path.display(), "writing genesis");
+    let mut genesis_file = File::create(genesis_file_path)?;
+    genesis_file.write_all(serde_json::to_string_pretty(&genesis)?.as_bytes())?;
+
+    let mut config_file_path = node_config_dir.clone();
+    config_file_path.push("config.toml");
+    tracing::info!(config_file_path = %config_file_path.display(), "writing tendermint config.toml");
+    let mut config_file = File::create(config_file_path)?;
+    config_file.write_all(tm_config.as_bytes())?;
+
+    // Write this node's node_key.json
+    // the underlying type doesn't implement Copy or Clone (for the best)
+    let priv_key =
+        tendermint::PrivateKey::Ed25519(vk.node_key_sk.ed25519_signing_key().unwrap().clone());
+    let node_key = NodeKey { priv_key };
+    let mut node_key_file_path = node_config_dir.clone();
+    node_key_file_path.push("node_key.json");
+    tracing::info!(node_key_file_path = %node_key_file_path.display(), "writing node key file");
+    let mut node_key_file = File::create(node_key_file_path)?;
+    node_key_file.write_all(serde_json::to_string_pretty(&node_key)?.as_bytes())?;
+
+    // Write this node's priv_validator_key.json
+    let address: tendermint::account::Id = vk.validator_cons_pk.into();
+    // the underlying type doesn't implement Copy or Clone (for the best)
+    let priv_key = tendermint::PrivateKey::Ed25519(
+        vk.validator_cons_sk.ed25519_signing_key().unwrap().clone(),
+    );
+    let priv_validator_key = PrivValidatorKey {
+        address,
+        pub_key: vk.validator_cons_pk,
+        priv_key,
+    };
+    let mut priv_validator_key_file_path = node_config_dir.clone();
+    priv_validator_key_file_path.push("priv_validator_key.json");
+    tracing::info!(priv_validator_key_file_path = %priv_validator_key_file_path.display(), "writing validator private key");
+    let mut priv_validator_key_file = File::create(priv_validator_key_file_path)?;
+    priv_validator_key_file
+        .write_all(serde_json::to_string_pretty(&priv_validator_key)?.as_bytes())?;
+
+    // Write the initial validator state:
+    let mut priv_validator_state_file_path = node_data_dir.clone();
+    priv_validator_state_file_path.push("priv_validator_state.json");
+    tracing::info!(priv_validator_state_file_path = %priv_validator_state_file_path.display(), "writing validator state");
+    let mut priv_validator_state_file = File::create(priv_validator_state_file_path)?;
+    priv_validator_state_file.write_all(get_validator_state().as_bytes())?;
+
+    // Write the validator's spend key:
+    let mut validator_spend_key_file_path = node_config_dir.clone();
+    validator_spend_key_file_path.push("validator_spend_key.json");
+    tracing::info!(validator_spend_key_file_path = %validator_spend_key_file_path.display(), "writing validator spend key");
+    let mut validator_spend_key_file = File::create(validator_spend_key_file_path)?;
+    validator_spend_key_file
+        .write_all(serde_json::to_string_pretty(&vk.validator_spend_key)?.as_bytes())?;
+
+    Ok(())
 }


### PR DESCRIPTION
This aims to make it so that joining a running testnet is as easy as:

1. `cargo run --release --bin pd -- join-testnet HOSTNAME`;
2. `cargo run --release --bin pd -- start -r ~/.penumbra/testnet_data/node0/rocksdb`;
3. `tendermint --home ~/.penumbra/testnet_data/node0/tendermint start`.