### PR TITLE
Implement GitHub Action for building/publishing protobuf docs

### DIFF
--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -29,6 +29,35 @@ jobs:
       - name: Install mdbook
         run: |
           cargo install mdbook mdbook-katex mdbook-mermaid
+      
+      - name: Install protobuf compiler
+        run: |
+          apt install -y protobuf-compiler
+
+      - name: Install Golang toolchain
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.18.3'
+      - name: Install protoc-gen-doc
+        run: |
+          go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@latest
+
+      - name: Build proto docs
+        run: |
+          export PATH=$PATH:~/go/bin
+          mkdir ./protodoc
+          protoc --doc_out=./protobuf --doc_opt=html,index.html -I ./:../ibc-go-vendor proto/proto/**/*.proto
+          if [ -d "firebase-tmp" ]; then rm -rf firebase-tmp; fi
+          mkdir firebase-tmp
+          mv protobuf firebase-tmp/${{ steps.get_version.outputs.version }}
+      - name: Deploy proto docs to firebase
+        uses: w9jds/firebase-action@v2.0.0
+        with:
+          args: deploy
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          PROJECT_ID: penumbra-protobuf
+          PROJECT_PATH: docs/protobuf
 
       - name: Build API docs
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "poseidon-paramgen"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?branch=oldparams#81deff2ce0207f73f47d4ffa746bb208728582a6"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=oldparams#7455423c2d34b1aac4a4e3ef1484aa093857ab22"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3370,27 +3370,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "poseidon-permutation"
-version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?branch=oldparams#81deff2ce0207f73f47d4ffa746bb208728582a6"
-dependencies = [
- "ark-ff",
- "once_cell",
- "poseidon-paramgen",
-]
-
-[[package]]
 name = "poseidon377"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?branch=oldparams#81deff2ce0207f73f47d4ffa746bb208728582a6"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=oldparams#7455423c2d34b1aac4a4e3ef1484aa093857ab22"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
  "ark-sponge",
  "num-bigint",
  "once_cell",
- "poseidon-paramgen",
- "poseidon-permutation",
 ]
 
 [[package]]


### PR DESCRIPTION
This updates the GitHub Action to automatically generate and upload protobuf documentation to Firebase, available at https://protobuf.penumbra.zone

Relies on [protoc-gen-doc](https://github.com/pseudomuto/protoc-gen-doc) and the `protoc` command.

Closes #1068 