### PR TITLE
deps: pin `poseidon377` to a branch with the existing parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3258,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "poseidon-paramgen"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377#7455423c2d34b1aac4a4e3ef1484aa093857ab22"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=main#7455423c2d34b1aac4a4e3ef1484aa093857ab22"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3272,7 +3272,7 @@ dependencies = [
 [[package]]
 name = "poseidon377"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377#7455423c2d34b1aac4a4e3ef1484aa093857ab22"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=oldparams#7455423c2d34b1aac4a4e3ef1484aa093857ab22"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,8 +15,10 @@ penumbra-tct = { path = "../tct/" }
 # Git deps
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
 decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
-poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377" }
-poseidon-paramgen = { git = "https://github.com/penumbra-zone/poseidon377" }
+# Temporarily pinning poseidon377 until new parameters are audited and the other address-breaking
+# changes are ready to ship.
+poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "oldparams" }
+poseidon-paramgen = { git = "https://github.com/penumbra-zone/poseidon377", branch = "main" }
 jmt = { git = "https://github.com/penumbra-zone/jellyfish-merkle.git", branch = "main" }
 f4jumble = { git = "https://github.com/zcash/librustzcash", rev="2425a0869098e3b0588ccd73c42716bcf418612c" }
 

--- a/tct/Cargo.toml
+++ b/tct/Cargo.toml
@@ -18,7 +18,9 @@ serde = { version = "1.0", features = ["derive"] }
 parking_lot = "0.12"
 ark-ff = "0.3"
 ark-serialize = "0.3"
-poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377" }
+# Temporarily pinning poseidon377 until new parameters are audited and the other address-breaking
+# changes are ready to ship.
+poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch="oldparams" }
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0.3", optional = true }

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -14,7 +14,9 @@ penumbra-tct = { path = "../tct" }
 # Git deps
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
 decaf377-rdsa = { git = "https://github.com/penumbra-zone/decaf377-rdsa" }
-poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377" }
+# Temporarily pinning poseidon377 until new parameters are audited and the other address-breaking
+# changes are ready to ship.
+poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch="oldparams" }
 
 # Crates.io deps
 ark-ff = "0.3"


### PR DESCRIPTION
This is such that we can perform the audit and make fixes from the
audit against the new parameters to be merged to the `main` branch of `poseidon377`. Here in the
penumbra repository we want to continue to use the old parameters,
which will be kept in the `oldparams` branch of the `poseidon377`
repository. This way, we can merge the new parameters to `main`, as
well as audit fixes, without disturbing development in the main
repository.

Once all address-breaking changes are ready - including the new `poseidon377`
parameters - this commit can be reverted, thus switching over to the
new parameter set.