### PR TITLE
Implement block inclusion proof support in TCT

### DIFF
--- a/proto/proto/crypto.proto
+++ b/proto/proto/crypto.proto
@@ -96,6 +96,13 @@ message NoteCommitmentProof {
   repeated MerklePathChunk auth_path = 3; // always length 24
 }
 
+// An authentication path from a note commitment to a block root of the note commitment tree.
+message NoteCommitmentBlockProof {
+  NoteCommitment note_commitment = 1;
+  uint64 position = 2;
+  repeated MerklePathChunk auth_path = 3; // always length 8
+}
+
 // A set of 3 sibling hashes in the auth path for some note commitment.
 message MerklePathChunk {
     bytes sibling_1 = 1;

--- a/proto/proto/transparent_proofs.proto
+++ b/proto/proto/transparent_proofs.proto
@@ -35,7 +35,7 @@ message OutputProof {
 // TODO: placeholder
 message SwapProof {
   // Auxiliary inputs
-  crypto.NoteCommitmentProof note_commitment_proof = 1;
+  crypto.NoteCommitmentBlockProof note_commitment_block_proof = 1;
   bytes g_d = 2;
   bytes pk_d = 3;
   uint64 value_amount = 4;

--- a/tct/src/block.rs
+++ b/tct/src/block.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 use crate::error::block::*;
 use crate::{prelude::*, Witness};
 
+#[path = "block/proof.rs"]
+mod proof;
+pub use proof::Proof;
+
 /// A sparse merkle tree to witness up to 65,536 individual [`Commitment`]s.
 ///
 /// This is one block in an [`epoch`](crate::builder::epoch), which is one epoch in a [`Tree`].

--- a/tct/src/block/proof.rs
+++ b/tct/src/block/proof.rs
@@ -1,0 +1,84 @@
+use crate::prelude::*;
+
+/// A proof of the inclusion of some [`Commitment`] in a [`Tree`] with a particular (non-global) [`Root`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Proof(crate::internal::proof::Proof<frontier::Top<frontier::Item>>);
+
+impl Proof {
+    /// Construct a new [`Proof`] of inclusion for a given [`Commitment`], index, and authentication
+    /// path from root to leaf.
+    pub fn new(commitment: Commitment, block_position: u16, auth_path: [[Hash; 3]; 8]) -> Self {
+        use crate::internal::path::{Leaf, Node};
+
+        let position = block_position.into();
+
+        let [a, b, c, d, e, f, g, h] = auth_path;
+        let child = Leaf;
+        let child = Node { siblings: h, child };
+        let child = Node { siblings: g, child };
+        let child = Node { siblings: f, child };
+        let child = Node { siblings: e, child };
+        let child = Node { siblings: d, child };
+        let child = Node { siblings: c, child };
+        let child = Node { siblings: b, child };
+        let child = Node { siblings: a, child };
+        Self(crate::internal::proof::Proof {
+            leaf: commitment,
+            position,
+            auth_path: child,
+        })
+    }
+
+    /// Verify a [`Proof`] of inclusion against the [`Root`] of a [`Tree`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VerifyError`] if the proof is invalid for that [`Root`].
+    pub fn verify(&self, root: super::Root) -> Result<(), VerifyError> {
+        self.0.verify(root.0)
+    }
+
+    /// Get the commitment whose inclusion is witnessed by the proof.
+    pub fn commitment(&self) -> Commitment {
+        self.0.leaf
+    }
+
+    /// Get the position of the witnessed commitment.
+    pub fn position(&self) -> crate::Position {
+        self.0.index().into()
+    }
+
+    /// Get the authentication path for this proof, order from root to leaf.
+    pub fn auth_path(&self) -> [&[Hash; 3]; 8] {
+        use crate::internal::path::{Leaf, Node};
+        let child = self.0.auth_path();
+        let Node { siblings: a, child } = child;
+        let Node { siblings: b, child } = child;
+        let Node { siblings: c, child } = child;
+        let Node { siblings: d, child } = child;
+        let Node { siblings: e, child } = child;
+        let Node { siblings: f, child } = child;
+        let Node { siblings: g, child } = child;
+        let Node { siblings: h, child } = child;
+        let Leaf = child;
+        [a, b, c, d, e, f, g, h]
+    }
+}
+
+use penumbra_proto::crypto as pb;
+
+impl From<Proof> for pb::NoteCommitmentBlockProof {
+    fn from(proof: Proof) -> Self {
+        proof.0.into()
+    }
+}
+
+impl TryFrom<pb::NoteCommitmentBlockProof> for Proof {
+    type Error = crate::error::proof::DecodeError;
+
+    fn try_from(value: pb::NoteCommitmentBlockProof) -> Result<Self, Self::Error> {
+        Ok(Proof(crate::internal::proof::Proof::try_from(value)?))
+    }
+}
+
+impl penumbra_proto::Protobuf<pb::NoteCommitmentBlockProof> for Proof {}

--- a/tct/src/internal/proof.rs
+++ b/tct/src/internal/proof.rs
@@ -108,3 +108,45 @@ where
         })
     }
 }
+
+impl<Tree: Height> From<Proof<Tree>> for pb::NoteCommitmentBlockProof
+where
+    Vec<pb::MerklePathChunk>: From<AuthPath<Tree>>,
+{
+    fn from(proof: Proof<Tree>) -> Self {
+        Self {
+            position: proof.position,
+            auth_path: proof.auth_path.into(),
+            note_commitment: Some(proof.leaf.into()),
+        }
+    }
+}
+
+impl<Tree: Height> TryFrom<pb::NoteCommitmentBlockProof> for Proof<Tree>
+where
+    AuthPath<Tree>: TryFrom<Vec<pb::MerklePathChunk>>,
+{
+    type Error = ProofDecodeError;
+
+    fn try_from(proof: pb::NoteCommitmentBlockProof) -> Result<Self, Self::Error> {
+        let position = proof.position;
+        let auth_path = proof.auth_path.try_into().map_err(|_| ProofDecodeError)?;
+        let leaf = Commitment(
+            Fq::from_bytes(
+                proof
+                    .note_commitment
+                    .ok_or(ProofDecodeError)?
+                    .inner
+                    .try_into()
+                    .map_err(|_| ProofDecodeError)?,
+            )
+            .map_err(|_| ProofDecodeError)?,
+        );
+
+        Ok(Self {
+            position,
+            auth_path,
+            leaf,
+        })
+    }
+}

--- a/tct/src/proof.rs
+++ b/tct/src/proof.rs
@@ -58,6 +58,25 @@ impl Proof {
         self.0.verify(root.0)
     }
 
+    /// Truncate this proof to prove only that the witnessed commitment is present
+    /// within its block.
+    pub fn within_block(&self) -> crate::builder::block::Proof {
+        let commitment = self.commitment();
+        let block_position = self.position().commitment();
+        let auth_path = &self.auth_path()[16..24];
+
+        crate::builder::block::Proof::new(
+            commitment,
+            block_position,
+            auth_path
+                .iter()
+                .map(|x| **x)
+                .collect::<Vec<_>>()
+                .try_into()
+                .expect("able to convert slice"),
+        )
+    }
+
     /// Get the commitment whose inclusion is witnessed by the proof.
     pub fn commitment(&self) -> Commitment {
         self.0.leaf


### PR DESCRIPTION
We should probably have proptests that the proofs work as intended, but this should be fine as-is for now.