### PR TITLE
decode ABCI key data as hex by default

### DIFF
--- a/pd/src/info.rs
+++ b/pd/src/info.rs
@@ -67,7 +67,7 @@ impl Info {
         match query.path.as_str() {
             "state/key" => {
                 let height: u64 = query.height.into();
-                let key = query.data.to_vec();
+                let key = hex::decode(query.data.to_vec()).unwrap_or(query.data.to_vec());
 
                 let jmt_proof = jmt::JellyfishMerkleTree::new(&self.storage)
                     .get_with_ics23_proof(key.clone(), height)


### PR DESCRIPTION
This behavior mirrors the ABCI query behavior in SDK chains, where the `data` field is decoded as hex-encoded bytes. In our case, if decoding the data field fails, we try interpreting the data as a raw key. This functionality is important for MVP relayer support