### PR TITLE
pcli: add a `pcli q tx HASH` subcommand that prints full transaction data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored_json"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd32eb54d016e203b7c2600e3a7802c75843a92e38ccc4869aefeca21771a64"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "libc",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "comfy-table"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1056,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct",
 ]
 
 [[package]]
@@ -1722,6 +1744,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha-1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +1887,43 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-proxy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http",
+ "hyper",
+ "hyper-rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2693,6 +2777,7 @@ dependencies = [
  "bytes",
  "camino",
  "clap 3.2.10",
+ "colored_json",
  "comfy-table",
  "decaf377",
  "directories",
@@ -2725,6 +2810,7 @@ dependencies = [
  "sha2 0.9.9",
  "tempfile",
  "tendermint",
+ "tendermint-rpc",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
@@ -3823,6 +3909,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4545,9 +4643,15 @@ version = "0.24.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549985c0c0afe6302f1e81fbef92dc07f56c81992cd864cc2127aeefa6cec454"
 dependencies = [
+ "async-trait",
  "bytes",
  "flex-error",
+ "futures",
  "getrandom",
+ "http",
+ "hyper",
+ "hyper-proxy",
+ "hyper-rustls",
  "peg",
  "pin-project",
  "serde",
@@ -4560,6 +4664,8 @@ dependencies = [
  "tendermint-proto",
  "thiserror",
  "time 0.3.11",
+ "tokio",
+ "tracing",
  "url",
  "uuid",
  "walkdir",

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -33,6 +33,8 @@ pd = { path = "../pd" }
 # Penumbra dependencies
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
 tendermint = "0.24.0-pre.1"
+tendermint-rpc = { version = "0.24.0-pre.1", features = ["http-client"] }
+
 # External dependencies
 ark-ff = "0.3"
 ed25519-consensus = "1.2" # 1.2 required because tendermint 0.24.0-pre.1 uses it
@@ -67,6 +69,7 @@ http-body = "0.4.5"
 clap = { version = "3", features = ["derive", "env"] }
 camino = "1"
 url = "2"
+colored_json = "2.1"
 
 [build-dependencies]
 vergen = "5"

--- a/pcli/src/command/query.rs
+++ b/pcli/src/command/query.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use jmt::KeyHash;
-use penumbra_chain::{quarantined::Scheduled, CompactBlock, NoteSource};
-use penumbra_component::shielded_pool::Delible;
-use penumbra_crypto::Nullifier;
-use penumbra_proto::Protobuf;
-use penumbra_tct::Commitment;
+
+mod shielded_pool;
+use shielded_pool::ShieldedPool;
+mod tx;
+use tx::Tx;
 
 use crate::App;
 
@@ -18,54 +18,17 @@ pub enum QueryCmd {
     /// Queries shielded pool data.
     #[clap(subcommand)]
     ShieldedPool(ShieldedPool),
-}
-
-#[derive(Debug, clap::Subcommand)]
-pub enum ShieldedPool {
-    /// Queries the note commitment tree anchor for a given height.
-    Anchor {
-        /// The height to query.
-        height: u64,
-    },
-    /// Queries the note commitment tree's block anchor for a given height.
-    BlockAnchor {
-        /// The height to query.
-        height: u64,
-    },
-    /// Queries the note commitment tree's epoch anchor for a given epoch index.
-    EpochAnchor {
-        /// The epoch to query.
-        epoch: u64,
-    },
-    /// Queries the scheduled notes and nullifiers to unquarantine at a given epoch.
-    Scheduled {
-        /// The epoch to query.
-        epoch: u64,
-    },
-    /// Queries the source of a given commitment.
-    Commitment {
-        /// The commitment to query.
-        #[clap(parse(try_from_str = Commitment::parse_hex))]
-        commitment: Commitment,
-    },
-    /// Queries the note source of a given nullifier.
-    Nullifier {
-        /// The nullifier to query.
-        #[clap(parse(try_from_str = Nullifier::parse_hex))]
-        nullifier: Nullifier,
-    },
-    /// Queries the note source of a given quarantined nullifier.
-    QuarantinedNullifier {
-        /// The nullifier to query.
-        #[clap(parse(try_from_str = Nullifier::parse_hex))]
-        nullifier: Nullifier,
-    },
-    /// Queries the compact block at a given height.
-    CompactBlock { height: u64 },
+    /// Queries a transaction by hash.
+    Tx(Tx),
 }
 
 impl QueryCmd {
     pub async fn exec(&self, app: &mut App) -> Result<()> {
+        // Special-case: this is a Tendermint query
+        if let QueryCmd::Tx(tx) = self {
+            return tx.exec(app).await;
+        }
+
         let mut client = app.specific_client().await?;
 
         let key_hash = self.key_hash();
@@ -93,6 +56,7 @@ impl QueryCmd {
         match self {
             QueryCmd::Key { key } => key.as_bytes().into(),
             QueryCmd::ShieldedPool(sp) => sp.key_hash(),
+            QueryCmd::Tx { .. } => unreachable!("query tx is special cased"),
         }
     }
 
@@ -102,64 +66,9 @@ impl QueryCmd {
                 println!("{}", hex::encode(bytes));
             }
             QueryCmd::ShieldedPool(sp) => sp.display_value(bytes)?,
+            QueryCmd::Tx { .. } => unreachable!("query tx is special cased"),
         }
 
-        Ok(())
-    }
-}
-
-impl ShieldedPool {
-    fn key_hash(&self) -> KeyHash {
-        use penumbra_component::shielded_pool::state_key;
-        match self {
-            ShieldedPool::Anchor { height } => state_key::anchor_by_height(*height),
-            ShieldedPool::BlockAnchor { height } => state_key::block_anchor_by_height(*height),
-            ShieldedPool::EpochAnchor { epoch } => state_key::epoch_anchor_by_index(*epoch),
-            ShieldedPool::CompactBlock { height } => state_key::compact_block(*height),
-            ShieldedPool::Scheduled { epoch } => state_key::scheduled_to_apply(*epoch),
-            ShieldedPool::Commitment { commitment } => state_key::note_source(*commitment),
-            ShieldedPool::Nullifier { nullifier } => state_key::spent_nullifier_lookup(*nullifier),
-            ShieldedPool::QuarantinedNullifier { nullifier } => {
-                state_key::quarantined_spent_nullifier_lookup(*nullifier)
-            }
-        }
-    }
-
-    fn display_value(&self, bytes: &[u8]) -> Result<()> {
-        match self {
-            ShieldedPool::Anchor { .. } => {
-                let anchor = penumbra_tct::Root::decode(bytes)?;
-                println!("{}", serde_json::to_string_pretty(&anchor)?);
-            }
-            ShieldedPool::BlockAnchor { .. } => {
-                let anchor = penumbra_tct::builder::block::Root::decode(bytes)?;
-                println!("{}", serde_json::to_string_pretty(&anchor)?);
-            }
-            ShieldedPool::EpochAnchor { .. } => {
-                let anchor = penumbra_tct::builder::epoch::Root::decode(bytes)?;
-                println!("{}", serde_json::to_string_pretty(&anchor)?);
-            }
-            ShieldedPool::CompactBlock { .. } => {
-                let compact_block = CompactBlock::decode(bytes)?;
-                println!("{}", serde_json::to_string_pretty(&compact_block)?);
-            }
-            ShieldedPool::Scheduled { .. } => {
-                let notes = Scheduled::decode(bytes)?;
-                println!("{}", serde_json::to_string_pretty(&notes.scheduled)?);
-            }
-            ShieldedPool::Commitment { .. } => {
-                let note_source = Delible::<NoteSource>::decode(bytes)?;
-                println!("{}", serde_json::to_string_pretty(&note_source)?);
-            }
-            ShieldedPool::Nullifier { .. } => {
-                let note_source = NoteSource::decode(bytes)?;
-                println!("{}", serde_json::to_string_pretty(&note_source)?);
-            }
-            ShieldedPool::QuarantinedNullifier { .. } => {
-                let note_source = Delible::<NoteSource>::decode(bytes)?;
-                println!("{}", serde_json::to_string_pretty(&note_source)?);
-            }
-        }
         Ok(())
     }
 }

--- a/pcli/src/command/query/shielded_pool.rs
+++ b/pcli/src/command/query/shielded_pool.rs
@@ -1,0 +1,109 @@
+use anyhow::Result;
+use colored_json::prelude::*;
+use jmt::KeyHash;
+use penumbra_chain::{quarantined::Scheduled, CompactBlock, NoteSource};
+use penumbra_component::shielded_pool::Delible;
+use penumbra_crypto::Nullifier;
+use penumbra_proto::Protobuf;
+use penumbra_tct::Commitment;
+
+#[derive(Debug, clap::Subcommand)]
+pub enum ShieldedPool {
+    /// Queries the note commitment tree anchor for a given height.
+    Anchor {
+        /// The height to query.
+        height: u64,
+    },
+    /// Queries the note commitment tree's block anchor for a given height.
+    BlockAnchor {
+        /// The height to query.
+        height: u64,
+    },
+    /// Queries the note commitment tree's epoch anchor for a given epoch index.
+    EpochAnchor {
+        /// The epoch to query.
+        epoch: u64,
+    },
+    /// Queries the scheduled notes and nullifiers to unquarantine at a given epoch.
+    Scheduled {
+        /// The epoch to query.
+        epoch: u64,
+    },
+    /// Queries the source of a given commitment.
+    Commitment {
+        /// The commitment to query.
+        #[clap(parse(try_from_str = Commitment::parse_hex))]
+        commitment: Commitment,
+    },
+    /// Queries the note source of a given nullifier.
+    Nullifier {
+        /// The nullifier to query.
+        #[clap(parse(try_from_str = Nullifier::parse_hex))]
+        nullifier: Nullifier,
+    },
+    /// Queries the note source of a given quarantined nullifier.
+    QuarantinedNullifier {
+        /// The nullifier to query.
+        #[clap(parse(try_from_str = Nullifier::parse_hex))]
+        nullifier: Nullifier,
+    },
+    /// Queries the compact block at a given height.
+    CompactBlock { height: u64 },
+}
+
+impl ShieldedPool {
+    pub fn key_hash(&self) -> KeyHash {
+        use penumbra_component::shielded_pool::state_key;
+        match self {
+            ShieldedPool::Anchor { height } => state_key::anchor_by_height(*height),
+            ShieldedPool::BlockAnchor { height } => state_key::block_anchor_by_height(*height),
+            ShieldedPool::EpochAnchor { epoch } => state_key::epoch_anchor_by_index(*epoch),
+            ShieldedPool::CompactBlock { height } => state_key::compact_block(*height),
+            ShieldedPool::Scheduled { epoch } => state_key::scheduled_to_apply(*epoch),
+            ShieldedPool::Commitment { commitment } => state_key::note_source(*commitment),
+            ShieldedPool::Nullifier { nullifier } => state_key::spent_nullifier_lookup(*nullifier),
+            ShieldedPool::QuarantinedNullifier { nullifier } => {
+                state_key::quarantined_spent_nullifier_lookup(*nullifier)
+            }
+        }
+    }
+
+    pub fn display_value(&self, bytes: &[u8]) -> Result<()> {
+        let json = match self {
+            ShieldedPool::Anchor { .. } => {
+                let anchor = penumbra_tct::Root::decode(bytes)?;
+                serde_json::to_string_pretty(&anchor)?
+            }
+            ShieldedPool::BlockAnchor { .. } => {
+                let anchor = penumbra_tct::builder::block::Root::decode(bytes)?;
+                serde_json::to_string_pretty(&anchor)?
+            }
+            ShieldedPool::EpochAnchor { .. } => {
+                let anchor = penumbra_tct::builder::epoch::Root::decode(bytes)?;
+                serde_json::to_string_pretty(&anchor)?
+            }
+            ShieldedPool::CompactBlock { .. } => {
+                let compact_block = CompactBlock::decode(bytes)?;
+                serde_json::to_string_pretty(&compact_block)?
+            }
+            ShieldedPool::Scheduled { .. } => {
+                let notes = Scheduled::decode(bytes)?;
+                serde_json::to_string_pretty(&notes.scheduled)?
+            }
+            ShieldedPool::Commitment { .. } => {
+                let note_source = Delible::<NoteSource>::decode(bytes)?;
+                serde_json::to_string_pretty(&note_source)?
+            }
+            ShieldedPool::Nullifier { .. } => {
+                let note_source = NoteSource::decode(bytes)?;
+                serde_json::to_string_pretty(&note_source)?
+            }
+            ShieldedPool::QuarantinedNullifier { .. } => {
+                let note_source = Delible::<NoteSource>::decode(bytes)?;
+                serde_json::to_string_pretty(&note_source)?
+            }
+        };
+        println!("{}", json.to_colored_json_auto()?);
+        Ok(())
+    }
+}

--- a/pcli/src/command/query/tx.rs
+++ b/pcli/src/command/query/tx.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use colored_json::prelude::*;
+use penumbra_proto::Protobuf;
+use penumbra_transaction::Transaction;
+
+use crate::App;
+
+/// Queries the chain for a transaction by hash.
+#[derive(Debug, clap::Args)]
+pub struct Tx {
+    /// The hex-formatted transaction hash to query.
+    hash: String,
+}
+
+impl Tx {
+    pub async fn exec(&self, app: &mut App) -> Result<()> {
+        use tendermint_rpc::{Client, HttpClient};
+
+        // generic bounds on HttpClient::new are not well-constructed, so we have to
+        // render the URL as a String, then borrow it, then re-parse the borrowed &str
+        let client = HttpClient::new(app.tendermint_url.to_string().as_ref()).unwrap();
+
+        let rsp = client.tx(self.hash.parse()?, false).await?;
+
+        let tx = Transaction::decode(rsp.tx.as_bytes())?;
+        let tx_json = serde_json::to_string_pretty(&tx)?;
+
+        println!("{}", tx_json.to_colored_json_auto()?);
+        println!("\nresult code: {:?}", rsp.tx_result.code);
+
+        Ok(())
+    }
+}

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -80,6 +80,7 @@ static SERDE_TRANSPARENT: &str = r#"#[serde(transparent)]"#;
 static AS_HEX: &str = r#"#[serde(with = "crate::serializers::hexstr")]"#;
 static AS_HEX_FOR_BYTES: &str = r#"#[serde(with = "crate::serializers::hexstr_bytes")]"#;
 static AS_BASE64: &str = r#"#[serde(with = "crate::serializers::base64str")]"#;
+static AS_BASE64_FOR_BYTES: &str = r#"#[serde(with = "crate::serializers::base64str_bytes")]"#;
 static AS_BECH32_IDENTITY_KEY: &str =
     r#"#[serde(with = "crate::serializers::bech32str::validator_identity_key")]"#;
 static AS_BECH32_ADDRESS: &str = r#"#[serde(with = "crate::serializers::bech32str::address")]"#;
@@ -135,6 +136,8 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.crypto.Nullifier", SERIALIZE),
     (".penumbra.crypto.Nullifier", SERDE_TRANSPARENT),
     (".penumbra.crypto.AuthPath", SERIALIZE),
+    (".penumbra.crypto.SpendAuthSignature", SERIALIZE),
+    (".penumbra.crypto.SpendAuthSignature", SERDE_TRANSPARENT),
     (".penumbra.chain.ChainParams", SERIALIZE),
     (".penumbra.chain.CompactBlock", SERIALIZE),
     (".penumbra.chain.KnownAssets", SERIALIZE),
@@ -152,6 +155,13 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.transaction.ActionPlan", SERIALIZE),
     (".penumbra.transaction.SpendPlan", SERIALIZE),
     (".penumbra.transaction.OutputPlan", SERIALIZE),
+    (".penumbra.transaction.Transaction", SERIALIZE),
+    (".penumbra.transaction.TransactionBody", SERIALIZE),
+    (".penumbra.transaction.Action", SERIALIZE),
+    (".penumbra.transaction.Spend", SERIALIZE),
+    (".penumbra.transaction.SpendBody", SERIALIZE),
+    (".penumbra.transaction.Output", SERIALIZE),
+    (".penumbra.transaction.OutputBody", SERIALIZE),
     (".penumbra.ibc.IBCAction", SERIALIZE),
     (".penumbra.dex.MockFlowCiphertext", SERIALIZE),
     (".penumbra.dex.MockFlowCiphertext", SERDE_TRANSPARENT),
@@ -188,7 +198,9 @@ static FIELD_ATTRIBUTES: &[(&str, &str)] = &[
         AS_HEX_FOR_BYTES,
     ),
     (".penumbra.crypto.Nullifier.inner", AS_HEX),
+    (".penumbra.crypto.SpendAuthSignature.inner", AS_HEX),
     (".penumbra.chain.NoteSource.inner", AS_HEX),
+    // TransactionPlan formatting
     (
         ".penumbra.transaction.SpendPlan.randomizer",
         AS_HEX_FOR_BYTES,
@@ -208,4 +220,26 @@ static FIELD_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.transaction.OutputPlan.esk", AS_HEX_FOR_BYTES),
     // TODO: replace if we use UTF-8 memos
     (".penumbra.transaction.OutputPlan.memo", AS_HEX_FOR_BYTES),
+    // Transaction formatting
+    (
+        ".penumbra.transaction.Transaction.binding_sig",
+        AS_HEX_FOR_BYTES,
+    ),
+    (".penumbra.transaction.Output.zkproof", AS_BASE64_FOR_BYTES),
+    (".penumbra.transaction.OutputBody.cv", AS_HEX_FOR_BYTES),
+    (
+        ".penumbra.transaction.OutputBody.encrypted_memo",
+        AS_BASE64_FOR_BYTES,
+    ),
+    (
+        ".penumbra.transaction.OutputBody.ovk_wrapped_key",
+        AS_BASE64_FOR_BYTES,
+    ),
+    (".penumbra.transaction.Spend.zkproof", AS_BASE64_FOR_BYTES),
+    (".penumbra.transaction.SpendBody.cv", AS_HEX_FOR_BYTES),
+    (".penumbra.transaction.SpendBody.rk", AS_HEX_FOR_BYTES),
+    (
+        ".penumbra.transaction.SpendBody.nullifier",
+        AS_HEX_FOR_BYTES,
+    ),
 ];

--- a/proto/src/serializers.rs
+++ b/proto/src/serializers.rs
@@ -8,5 +8,6 @@ pub mod hexstr;
 pub mod hexstr_bytes;
 
 pub mod base64str;
+pub mod base64str_bytes;
 
 pub mod bech32str;

--- a/proto/src/serializers/base64str_bytes.rs
+++ b/proto/src/serializers/base64str_bytes.rs
@@ -1,0 +1,25 @@
+use bytes::Bytes;
+use serde::{Deserialize, Deserializer, Serializer};
+use subtle_encoding::base64;
+
+/// Deserialize base64string into Bytes
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Bytes, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let string = Option::<String>::deserialize(deserializer)?.unwrap_or_default();
+    base64::decode(&string)
+        .map_err(serde::de::Error::custom)
+        .map(Into::into)
+}
+
+/// Serialize from T into base64string
+pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: AsRef<[u8]>,
+{
+    let base64_bytes = base64::encode(value.as_ref());
+    let base64_string = String::from_utf8(base64_bytes).map_err(serde::ser::Error::custom)?;
+    serializer.serialize_str(&base64_string)
+}

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -10,6 +10,7 @@ use penumbra_crypto::{
 };
 use penumbra_proto::{ibc as pb_ibc, stake as pbs, transaction as pbt, Message, Protobuf};
 use penumbra_tct as tct;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     action::{Delegate, Undelegate},
@@ -24,7 +25,8 @@ pub struct TransactionBody {
     pub fee: Fee,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(try_from = "pbt::Transaction", into = "pbt::Transaction")]
 pub struct Transaction {
     pub transaction_body: TransactionBody,
     pub binding_sig: Signature<Binding>,


### PR DESCRIPTION
Along the way, this:

- Adds Serde support for Transaction
- Switches to colored JSON output