### PR TITLE
ibc: allow nil version in ConnectionOpenInit, fix unwrap in ibc events

### DIFF
--- a/component/src/ibc/component/connection/stateless.rs
+++ b/component/src/ibc/component/connection/stateless.rs
@@ -4,6 +4,12 @@ pub mod connection_open_init {
     pub fn version_is_supported(msg: &MsgConnectionOpenInit) -> anyhow::Result<()> {
         // check if the version is supported (we use the same versions as the cosmos SDK)
         // TODO: should we be storing the compatible versions in our state instead?
+
+        // NOTE: version can be nil in MsgConnectionOpenInit
+        if msg.version.is_none() {
+            return Ok(());
+        }
+
         if !SUPPORTED_VERSIONS.contains(
             msg.version
                 .as_ref()

--- a/component/src/ibc/event.rs
+++ b/component/src/ibc/event.rs
@@ -51,8 +51,11 @@ pub fn connection_open_init(
             )
                 .index(),
             (
-                "counterparty_conneciton_id",
-                counterparty.connection_id().unwrap().to_string(),
+                "counterparty_connection_id",
+                counterparty
+                    .connection_id()
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
             )
                 .index(),
         ],
@@ -75,8 +78,11 @@ pub fn connection_open_try(
             )
                 .index(),
             (
-                "counterparty_conneciton_id",
-                counterparty.connection_id().unwrap().to_string(),
+                "counterparty_connection_id",
+                counterparty
+                    .connection_id()
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
             )
                 .index(),
         ],
@@ -99,8 +105,8 @@ pub fn connection_open_ack(connection_id: &ConnectionId, connection_end: &Connec
                 connection_end
                     .counterparty()
                     .connection_id()
-                    .unwrap()
-                    .to_string(),
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
             )
                 .index(),
         ],
@@ -126,8 +132,8 @@ pub fn connection_open_confirm(
                 connection_end
                     .counterparty()
                     .connection_id()
-                    .unwrap()
-                    .to_string(),
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
             )
                 .index(),
         ],
@@ -147,7 +153,11 @@ pub fn channel_open_init(port_id: &PortId, channel_id: &ChannelId, channel: &Cha
                 .index(),
             (
                 "counterparty_channel_id",
-                channel.counterparty().channel_id().unwrap().to_string(),
+                channel
+                    .counterparty()
+                    .channel_id()
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
             )
                 .index(),
             ("connection_id", channel.connection_hops[0].to_string()).index(),
@@ -168,7 +178,11 @@ pub fn channel_open_try(port_id: &PortId, channel_id: &ChannelId, channel: &Chan
                 .index(),
             (
                 "counterparty_channel_id",
-                channel.counterparty().channel_id().unwrap().to_string(),
+                channel
+                    .counterparty()
+                    .channel_id()
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
             )
                 .index(),
             ("connection_id", channel.connection_hops[0].to_string()).index(),
@@ -189,7 +203,11 @@ pub fn channel_open_ack(port_id: &PortId, channel_id: &ChannelId, channel: &Chan
                 .index(),
             (
                 "counterparty_channel_id",
-                channel.counterparty().channel_id().unwrap().to_string(),
+                channel
+                    .counterparty()
+                    .channel_id()
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
             )
                 .index(),
             ("connection_id", channel.connection_hops[0].to_string()).index(),
@@ -214,7 +232,11 @@ pub fn channel_open_confirm(
                 .index(),
             (
                 "counterparty_channel_id",
-                channel.counterparty().channel_id().unwrap().to_string(),
+                channel
+                    .counterparty()
+                    .channel_id()
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
             )
                 .index(),
             ("connection_id", channel.connection_hops[0].to_string()).index(),
@@ -235,7 +257,11 @@ pub fn channel_close_init(port_id: &PortId, channel_id: &ChannelId, channel: &Ch
                 .index(),
             (
                 "counterparty_channel_id",
-                channel.counterparty().channel_id().unwrap().to_string(),
+                channel
+                    .counterparty()
+                    .channel_id()
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
             )
                 .index(),
             ("connection_id", channel.connection_hops[0].to_string()).index(),
@@ -260,7 +286,11 @@ pub fn channel_close_confirm(
                 .index(),
             (
                 "counterparty_channel_id",
-                channel.counterparty().channel_id().unwrap().to_string(),
+                channel
+                    .counterparty()
+                    .channel_id()
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
             )
                 .index(),
             ("connection_id", channel.connection_hops[0].to_string()).index(),


### PR DESCRIPTION
msg.version = nil is allowed in ConnectionOpenInit. This also fixes an issue where we could unwrap nil values in IBC events (some events necessarily have nil fields, depending on the protocol sequence).