### PR TITLE
chain: record `NoteSource`s in `CompactBlock`s

### DIFF
--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -12,5 +12,5 @@ pub mod sync;
 pub use epoch::Epoch;
 pub use known_assets::KnownAssets;
 pub use note_source::NoteSource;
-pub use sync::CompactBlock;
+pub use sync::{AnnotatedNotePayload, CompactBlock};
 pub use view::View;

--- a/chain/src/note_source.rs
+++ b/chain/src/note_source.rs
@@ -54,6 +54,13 @@ impl TryFrom<[u8; 32]> for NoteSource {
     }
 }
 
+impl TryFrom<&[u8]> for NoteSource {
+    type Error = anyhow::Error;
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        <[u8; 32]>::try_from(value)?.try_into()
+    }
+}
+
 impl Protobuf<pb::NoteSource> for NoteSource {}
 
 impl TryFrom<pb::NoteSource> for NoteSource {

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -140,6 +140,7 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.crypto.SpendAuthSignature", SERDE_TRANSPARENT),
     (".penumbra.chain.ChainParams", SERIALIZE),
     (".penumbra.chain.CompactBlock", SERIALIZE),
+    (".penumbra.chain.AnnotatedNotePayload", SERIALIZE),
     (".penumbra.chain.KnownAssets", SERIALIZE),
     (".penumbra.chain.KnownAssets", SERDE_TRANSPARENT),
     (".penumbra.chain.NoteSource", SERIALIZE),

--- a/proto/proto/chain.proto
+++ b/proto/proto/chain.proto
@@ -49,7 +49,7 @@ message AssetInfo {
 message CompactBlock {
   uint64 height = 1;
   // NotePayloads describing new notes.
-  repeated crypto.NotePayload note_payloads = 2;
+  repeated AnnotatedNotePayload note_payloads = 2;
   // Nullifiers identifying spent notes.
   repeated crypto.Nullifier nullifiers = 3;
   // The block root of this block.
@@ -59,7 +59,13 @@ message CompactBlock {
   // Newly quarantined things in this block.
   Quarantined quarantined = 6;
   // Validators slashed in this block.
-  repeated crypto.IdentityKey slashed = 7;
+  repeated crypto.IdentityKey slashed = 16;
+}
+
+// A note payload, annotated with the note source.
+message AnnotatedNotePayload {
+  crypto.NotePayload payload = 1;
+  NoteSource source = 2;
 }
 
 message KnownAssets {
@@ -90,7 +96,7 @@ message GenesisAppState {
 
 message Quarantined {
   message Unbonding {
-    repeated crypto.NotePayload note_payloads = 1;
+    repeated AnnotatedNotePayload note_payloads = 1;
     repeated crypto.Nullifier nullifiers = 2;
   }
 

--- a/proto/proto/view.proto
+++ b/proto/proto/view.proto
@@ -104,6 +104,8 @@ message NoteRecord {
     optional uint64 height_spent = 6;
     // The note position.
     uint64 position = 7;
+    // The source of the note (a tx hash or otherwise)
+    chain.NoteSource source = 8;
 }
 
 // A query for notes known by the view service.
@@ -151,6 +153,8 @@ message QuarantinedNoteRecord {
     uint64 unbonding_epoch = 5;
     // The validator identity the quarantining is bound to.
     crypto.IdentityKey identity_key = 6;
+    // The source of the note (a tx hash or otherwise)
+    chain.NoteSource source = 7;
 }
 
 // A query for quarantined notes known by the view service.

--- a/view/migrations/20220415094212_init.sql
+++ b/view/migrations/20220415094212_init.sql
@@ -21,7 +21,9 @@ CREATE TABLE notes (
     -- the nullifier for this note, used to detect when it is spent
     nullifier               BLOB NOT NULL,
     -- the position of the note in the note commitment tree
-    position                BIGINT NOT NULL
+    position                BIGINT NOT NULL,
+    -- the source of the note (a tx hash or structured data jammed into one)
+    source                  BLOB NOT NULL
 );
 
 -- general purpose note queries
@@ -35,6 +37,9 @@ CREATE INDEX notes_idx ON notes (
 
 -- used to detect spends
 CREATE INDEX nullifier_idx on notes ( nullifier );
+
+-- used to crossreference transactions
+CREATE INDEX notes_source_index on notes ( source );
 
 -- used for storing a cache of known assets
 CREATE TABLE assets (
@@ -55,7 +60,9 @@ CREATE TABLE quarantined_notes (
     address_index       BLOB NOT NULL,
     -- the quarantine status of the note
     unbonding_epoch         BIGINT NOT NULL,
-    identity_key            BLOB NOT NULL
+    identity_key            BLOB NOT NULL,
+    -- the source of the note (a tx hash or structured data jammed into one)
+    source                  BLOB NOT NULL
 );
 
 CREATE INDEX quarantined_notes_idx ON quarantined_notes (
@@ -76,17 +83,5 @@ CREATE INDEX identity_key_idx ON quarantined_nullifiers (
     identity_key
 );
 
-CREATE TABLE tx_by_nullifier (
-    nullifier               BLOB PRIMARY KEY NOT NULL,
-    tx_hash                 BLOB NOT NULL
-);
-
-CREATE TABLE tx_by_note_commitment (
-    note_commitment         BLOB PRIMARY KEY NOT NULL,
-    tx_hash                 BLOB NOT NULL
-);
-
-CREATE TABLE tx (
-    tx_hash                 BLOB PRIMARY KEY NOT NULL,
-    tx_body                 BLOB NOT NULL
-);
+-- used to crossreference transactions
+CREATE INDEX quarantined_notes_source_index on quarantined_notes ( source );

--- a/view/sqlx-data.json
+++ b/view/sqlx-data.json
@@ -214,6 +214,16 @@
     },
     "query": "DELETE FROM quarantined_nullifiers WHERE identity_key = ? RETURNING nullifier"
   },
+  "8f6f14b608be9945961176979850f294d683172a650aa415f80384d05a603c23": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 11
+      }
+    },
+    "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        height_spent,\n                        height_created,\n                        diversifier,\n                        amount,\n                        asset_id,\n                        transmission_key,\n                        blinding_factor,\n                        address_index,\n                        nullifier,\n                        position,\n                        source\n                    )\n                    VALUES\n                    (\n                        ?,\n                        NULL,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?\n                    )"
+  },
   "916844d5f99c975bd2bfcac3956625f040ea91697c4f0c0a9cb4f48e472b302d": {
     "describe": {
       "columns": [
@@ -278,16 +288,6 @@
     },
     "query": "DELETE FROM quarantined_nullifiers WHERE nullifier = ?"
   },
-  "a901c47eb76bcc5353fc0720ead95368b8f5ffc662a4b30f9c2e755ac2f275c1": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 10
-      }
-    },
-    "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        height_spent,\n                        height_created,\n                        diversifier,\n                        amount,\n                        asset_id,\n                        transmission_key,\n                        blinding_factor,\n                        address_index,\n                        nullifier,\n                        position\n                    )\n                    VALUES\n                    (\n                        ?,\n                        NULL,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?,\n                        ?\n                    )"
-  },
   "a96e4094367da72f81a656389748b9bac9f1931178dfc74bcc92e8f32b581b98": {
     "describe": {
       "columns": [],
@@ -307,6 +307,16 @@
       }
     },
     "query": "DELETE FROM quarantined_notes WHERE identity_key = ?"
+  },
+  "b92550dfe6ac64f68c1a8c33f680b28c2eb4d6ba5ea3e16768647b9e50e92397": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 11
+      }
+    },
+    "query": "INSERT INTO quarantined_notes\n                    (\n                        note_commitment,\n                        height_created,\n                        diversifier,\n                        amount,\n                        asset_id,\n                        transmission_key,\n                        blinding_factor,\n                        address_index,\n                        unbonding_epoch,\n                        identity_key,\n                        source\n                    )\n                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
   },
   "ce4148ecb83f1152688735c4b12d807dcab0d61c96dffefefc8c560315623534": {
     "describe": {
@@ -373,15 +383,5 @@
       }
     },
     "query": "\n            SELECT bytes\n            FROM chain_params\n            LIMIT 1\n        "
-  },
-  "fa5e0340f1e2a81e368e87e9535912ffb2fe1ffaeaf083f880cbeacda0734fb3": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 10
-      }
-    },
-    "query": "INSERT INTO quarantined_notes\n                    (\n                        note_commitment,\n                        height_created,\n                        diversifier,\n                        amount,\n                        asset_id,\n                        transmission_key,\n                        blinding_factor,\n                        address_index,\n                        unbonding_epoch,\n                        identity_key\n                    )\n                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
   }
 }

--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -471,6 +471,7 @@ impl Storage {
             let address_index = quarantined_note_record.address_index.0.to_vec();
             let unbonding_epoch = quarantined_note_record.unbonding_epoch as i64;
             let identity_key = quarantined_note_record.identity_key.encode_to_vec();
+            let source = quarantined_note_record.source.to_bytes().to_vec();
             sqlx::query!(
                 "INSERT INTO quarantined_notes
                     (
@@ -483,9 +484,10 @@ impl Storage {
                         blinding_factor,
                         address_index,
                         unbonding_epoch,
-                        identity_key
+                        identity_key,
+                        source
                     )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 note_commitment,
                 height_created,
                 diversifier,
@@ -496,6 +498,7 @@ impl Storage {
                 address_index,
                 unbonding_epoch,
                 identity_key,
+                source,
             )
             .execute(&mut tx)
             .await?;
@@ -518,6 +521,7 @@ impl Storage {
             let address_index = note_record.address_index.0.to_vec();
             let nullifier = note_record.nullifier.to_bytes().to_vec();
             let position = (u64::from(note_record.position)) as i64;
+            let source = note_record.source.to_bytes().to_vec();
             sqlx::query!(
                 "INSERT INTO notes
                     (
@@ -531,12 +535,14 @@ impl Storage {
                         blinding_factor,
                         address_index,
                         nullifier,
-                        position
+                        position,
+                        source
                     )
                     VALUES
                     (
                         ?,
                         NULL,
+                        ?,
                         ?,
                         ?,
                         ?,
@@ -558,6 +564,7 @@ impl Storage {
                 address_index,
                 nullifier,
                 position,
+                source
             )
             .execute(&mut tx)
             .await?;

--- a/view/src/sync.rs
+++ b/view/src/sync.rs
@@ -92,7 +92,7 @@ pub async fn scan_block(
                 unbonding
                     .note_payloads
                     .into_iter()
-                    .filter_map(|note_payload| trial_decrypt(&note_payload))
+                    .filter_map(|note_payload| trial_decrypt(&note_payload.payload))
                     .map(|note| QuarantinedNoteRecord {
                         note_commitment: note.commit(),
                         height_created: height,
@@ -108,6 +108,7 @@ pub async fn scan_block(
     // Trial-decrypt the notes in this block, keeping track of the ones that were meant for us
     let mut decrypted_applied_notes: BTreeMap<note::Commitment, Note> = note_payloads
         .iter()
+        .map(|annotated| &annotated.payload)
         .filter_map(trial_decrypt)
         .map(|note| (note.commit(), note))
         .collect();
@@ -127,7 +128,7 @@ pub async fn scan_block(
         new_notes = note_payloads
             .iter()
             .filter_map(|note_payload| {
-                let note_commitment = note_payload.note_commitment;
+                let note_commitment = note_payload.payload.note_commitment;
 
                 if let Some(note) = decrypted_applied_notes.remove(&note_commitment) {
                     // Keep track of this commitment for later witnessing


### PR DESCRIPTION
This will allow a client to determine the provenance of a note they detect,
which might or might not have been created by a particular transaction. Without
this data, it's difficult for a client to determine the source of the notes
they detect, even if they download a full block, because some notes are created
as a result of chain-wide logic, rather than any particular transaction in the
block.

This commit does not yet add this information into the `NoteRecord`s in the
view service, but that's the next step.