### PR TITLE
refactor(component/stake): factor out explicit key formatting

### DIFF
--- a/component/src/stake/component.rs
+++ b/component/src/stake/component.rs
@@ -28,9 +28,9 @@ use tracing::{instrument, Instrument};
 use crate::stake::{
     metrics,
     rate::{BaseRateData, RateData},
+    state_key,
     validator::{self, Validator},
     DelegationChanges, Uptime,
-    state_key,
 };
 
 // Max validator power is 1152921504606846975 (i64::MAX / 8)
@@ -1181,11 +1181,8 @@ pub trait View: StateExt {
             return Err(anyhow::anyhow!("invalid voting power"));
         }
 
-        self.put_proto(
-            state_key::power_by_validator(identity_key),
-            voting_power,
-        )
-        .await;
+        self.put_proto(state_key::power_by_validator(identity_key), voting_power)
+            .await;
 
         Ok(())
     }
@@ -1209,16 +1206,12 @@ pub trait View: StateExt {
             current_rates,
         )
         .await;
-        self.put_domain(
-            state_key::next_rate_by_validator(identity_key),
-            next_rates,
-        )
-        .await;
+        self.put_domain(state_key::next_rate_by_validator(identity_key), next_rates)
+            .await;
     }
 
     async fn validator(&self, identity_key: &IdentityKey) -> Result<Option<Validator>> {
-        self.get_domain(state_key::validators(identity_key))
-            .await
+        self.get_domain(state_key::validators(identity_key)).await
     }
 
     // Tendermint validators are referenced to us by their Tendermint consensus key,
@@ -1226,9 +1219,8 @@ pub trait View: StateExt {
     async fn validator_by_consensus_key(&self, ck: &PublicKey) -> Result<Option<Validator>> {
         // We maintain an internal mapping of consensus keys to identity keys to make this
         // lookup more efficient.
-        let identity_key: Option<IdentityKey> = self
-            .get_domain(state_key::consensus_key(ck))
-            .await?;
+        let identity_key: Option<IdentityKey> =
+            self.get_domain(state_key::consensus_key(ck)).await?;
 
         if identity_key.is_none() {
             return Ok(None);
@@ -1294,8 +1286,7 @@ pub trait View: StateExt {
         tracing::debug!(?validator);
         let id = validator.identity_key.clone();
 
-        self.put_domain(state_key::validators(&id), validator)
-            .await;
+        self.put_domain(state_key::validators(&id), validator).await;
         self.register_denom(&DelegationToken::from(&id).denom())
             .await?;
 
@@ -1416,11 +1407,8 @@ pub trait View: StateExt {
     }
 
     async fn set_validator_uptime(&self, identity_key: &IdentityKey, uptime: Uptime) {
-        self.put_domain(
-            state_key::uptime_by_validator(identity_key),
-            uptime,
-        )
-        .await
+        self.put_domain(state_key::uptime_by_validator(identity_key), uptime)
+            .await
     }
 
     async fn set_validator_bonding_state(
@@ -1429,11 +1417,8 @@ pub trait View: StateExt {
         state: validator::BondingState,
     ) {
         tracing::debug!(?state, "set bonding state");
-        self.put_domain(
-            state_key::bonding_state_by_validator(identity_key),
-            state,
-        )
-        .await
+        self.put_domain(state_key::bonding_state_by_validator(identity_key), state)
+            .await
     }
 
     async fn signed_blocks_window_len(&self) -> Result<u64> {

--- a/component/src/stake/state_key.rs
+++ b/component/src/stake/state_key.rs
@@ -1,6 +1,6 @@
 use jmt::KeyHash;
 use penumbra_crypto::IdentityKey;
-use tendermint::{PublicKey, block};
+use tendermint::{block, PublicKey};
 
 pub fn validators(id: &IdentityKey) -> KeyHash {
     format!("staking/validators/{}", id).into()

--- a/component/src/stake/state_key.rs
+++ b/component/src/stake/state_key.rs
@@ -1,6 +1,6 @@
 use jmt::KeyHash;
 use penumbra_crypto::IdentityKey;
-use tendermint::{block, PublicKey};
+use tendermint::PublicKey;
 
 pub fn validators(id: &IdentityKey) -> KeyHash {
     format!("staking/validators/{}", id).into()

--- a/component/src/stake/state_key.rs
+++ b/component/src/stake/state_key.rs
@@ -1,5 +1,43 @@
 use jmt::KeyHash;
+use penumbra_crypto::IdentityKey;
+use tendermint::{PublicKey, block};
+
+pub fn validators(id: &IdentityKey) -> KeyHash {
+    format!("staking/validators/{}", id).into()
+}
+
+pub fn state_by_validator(id: &IdentityKey) -> KeyHash {
+    format!("staking/validators/{}/state", id).into()
+}
+
+pub fn current_rate_by_validator(id: &IdentityKey) -> KeyHash {
+    format!("staking/validators/{}/rate/current", id).into()
+}
+
+pub fn next_rate_by_validator(id: &IdentityKey) -> KeyHash {
+    format!("staking/validators/{}/rate/next", id).into()
+}
+
+pub fn power_by_validator(id: &IdentityKey) -> KeyHash {
+    format!("staking/validators/{}/power", id).into()
+}
+
+pub fn bonding_state_by_validator(id: &IdentityKey) -> KeyHash {
+    format!("staking/validators/{}/bonding_state", id).into()
+}
+
+pub fn uptime_by_validator(id: &IdentityKey) -> KeyHash {
+    format!("staking/validator_uptime/{}", id).into()
+}
 
 pub fn slashed_validators(height: u64) -> KeyHash {
     format!("staking/slashed_validators/{}", height).into()
+}
+
+pub fn consensus_key(pk: &PublicKey) -> KeyHash {
+    format!("staking/consensus_key/{}", pk.to_hex()).into()
+}
+
+pub fn delegation_changes_by_height(height: u64) -> KeyHash {
+    format!("staking/delegation_changes/{}", height).into()
 }


### PR DESCRIPTION
This PR fixes #997 (as a prereq to #1022 ). I've followed the naming convention set out in [shielded_pool::state_key](https://github.com/penumbra-zone/penumbra/blob/main/component/src/shielded_pool/state_key.rs#L16).

Happy to incorporate feedback if naming doesn't look right... 