### PR TITLE
remove poseidon-permutation from docs build

### DIFF
--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -80,7 +80,6 @@ jobs:
             -p ark-sponge \
             -p poseidon377 \
             -p poseidon-paramgen \
-            -p poseidon-permutation \
             -p decaf377 \
             -p decaf377-rdsa \
             -p decaf377-fmd \


### PR DESCRIPTION
Last night I broke the docs build by rebasing `oldparams` to a commit that was using `ark-sponge` instead of `poseidon-permutation`. Removing the docs build for `poseidon-permutation` until `oldparams` is stable. 