### PR TITLE
cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "poseidon-paramgen"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?branch=oldparams#7455423c2d34b1aac4a4e3ef1484aa093857ab22"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=oldparams#c8a1ca416a54e02326474379c76d54d87917328c"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3370,15 +3370,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "poseidon-permutation"
+version = "0.1.0"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=oldparams#c8a1ca416a54e02326474379c76d54d87917328c"
+dependencies = [
+ "ark-ff",
+ "once_cell",
+ "poseidon-paramgen",
+]
+
+[[package]]
 name = "poseidon377"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?branch=oldparams#7455423c2d34b1aac4a4e3ef1484aa093857ab22"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=oldparams#c8a1ca416a54e02326474379c76d54d87917328c"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
  "ark-sponge",
  "num-bigint",
  "once_cell",
+ "poseidon-paramgen",
+ "poseidon-permutation",
 ]
 
 [[package]]


### PR DESCRIPTION
This is the cargo update that pulls in the latest `oldparams` branch in `poseidon377`, on commit c8a1ca416a54e02326474379c76d54d87917328c 