### PR TITLE
Instruct users to reset state before testnet join

### DIFF
--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -18,7 +18,14 @@ To join a testnet as a fullnode, check out the tag for the current testnet, run
 
 ### Generating configs
 
-To generate a set of configs for the current testnet, run
+First, reset the testnet data from any prior testnet you may have joined:
+
+```
+cargo run --bin pd --release -- testnet unsafe-reset-all
+```
+This will delete the entire testnet data directory.
+
+Next, generate a set of configs for the current testnet:
 ```
 cargo run --bin pd --release -- testnet join
 ```
@@ -48,13 +55,6 @@ Alternatively, `pd` and `tendermint` can be orchestrated with `docker-compose`:
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 ```
 
-### Resetting state
-
-To reset the testnet data, run
-```
-cargo run --bin pd --release -- testnet unsafe-reset-all
-```
-This will delete the entire testnet data directory.
 
 ## Joining as a validator
 

--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -16,9 +16,9 @@ To join a testnet as a fullnode, check out the tag for the current testnet, run
 `pd testnet join` to generate configs, then use those configs to run `pd` and
 `tendermint`. In more detail:
 
-First, reset the testnet data from any prior testnet you may have joined:
-
 ### Resetting state
+
+First, reset the testnet data from any prior testnet you may have joined:
 
 ```
 cargo run --bin pd --release -- testnet unsafe-reset-all

--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -16,14 +16,16 @@ To join a testnet as a fullnode, check out the tag for the current testnet, run
 `pd testnet join` to generate configs, then use those configs to run `pd` and
 `tendermint`. In more detail:
 
-### Generating configs
-
 First, reset the testnet data from any prior testnet you may have joined:
+
+### Resetting state
 
 ```
 cargo run --bin pd --release -- testnet unsafe-reset-all
 ```
 This will delete the entire testnet data directory.
+
+### Generating configs
 
 Next, generate a set of configs for the current testnet:
 ```


### PR DESCRIPTION
This PR instructs users to reset the tesetnet state before running the `pd testnet join` command.

The reasoning for this change is this:
- Most testnet participants participate in multiple testnets; most followers of this guide will need to reset state.
- As the file was originally structured, a careless reader blindly running commands might reset the testnet state after running the join command, creating a confusing error condition.