### PR TITLE
ibc: bring commitment paths fully into spec and use `state_key` pattern

### DIFF
--- a/component/src/ibc/component/connection.rs
+++ b/component/src/ibc/component/connection.rs
@@ -1,7 +1,5 @@
 use crate::ibc::component::client::View as _;
-use crate::ibc::{
-    event, validate_penumbra_client_state, ConnectionCounter, COMMITMENT_PREFIX, SUPPORTED_VERSIONS,
-};
+use crate::ibc::{event, validate_penumbra_client_state, ConnectionCounter, SUPPORTED_VERSIONS};
 use crate::{Component, Context};
 use anyhow::Result;
 use async_trait::async_trait;

--- a/component/src/ibc/component/connection/stateful.rs
+++ b/component/src/ibc/component/connection/stateful.rs
@@ -41,7 +41,7 @@ pub mod connection_open_confirm {
                 Counterparty::new(
                     connection.client_id().clone(),
                     Some(msg.connection_id.clone()),
-                    COMMITMENT_PREFIX.as_bytes().to_vec().try_into().unwrap(),
+                    penumbra_storage::PENUMBRA_COMMITMENT_PREFIX.clone(),
                 ),
                 connection.versions().to_vec(),
                 connection.delay_period(),
@@ -141,7 +141,7 @@ pub mod connection_open_ack {
             let penumbra_counterparty = Counterparty::new(
                 connection.client_id().clone(),
                 Some(msg.counterparty_connection_id.clone()),
-                COMMITMENT_PREFIX.as_bytes().to_vec().try_into().unwrap(),
+                penumbra_storage::PENUMBRA_COMMITMENT_PREFIX.clone(),
             );
 
             // the connection we expect the counterparty to have committed
@@ -334,7 +334,7 @@ pub mod connection_open_try {
                 Counterparty::new(
                     msg.client_id.clone(),
                     None,
-                    COMMITMENT_PREFIX.as_bytes().to_vec().try_into().unwrap(),
+                    penumbra_storage::PENUMBRA_COMMITMENT_PREFIX.clone(),
                 ),
                 msg.counterparty_versions.clone(),
                 msg.delay_period,

--- a/component/src/ibc/component/state_key.rs
+++ b/component/src/ibc/component/state_key.rs
@@ -1,17 +1,96 @@
-use ibc::core::ics24_host::identifier::ConnectionId;
+use ibc::{
+    core::{
+        ics04_channel::packet::Packet,
+        ics24_host::identifier::{ChannelId, ClientId, ConnectionId, PortId},
+    },
+    Height,
+};
+
 use jmt::KeyHash;
 
-use crate::ibc::COMMITMENT_PREFIX;
+pub fn client_type(client_id: &ClientId) -> KeyHash {
+    format!("clients/{}/clientType", client_id).into()
+}
+
+pub fn client_state(client_id: &ClientId) -> KeyHash {
+    format!("clients/{}/clientState", client_id).into()
+}
+
+pub fn verified_client_consensus_state(client_id: &ClientId, height: &Height) -> KeyHash {
+    format!("clients/{}/consensusStates/{}", client_id, height).into()
+}
+
+pub fn client_processed_heights(client_id: &ClientId, height: &Height) -> KeyHash {
+    format!("clients/{}/processedHeights/{}", client_id, height).into()
+}
+pub fn client_processed_times(client_id: &ClientId, height: &Height) -> KeyHash {
+    format!("clients/{}/processedTimes/{}", client_id, height).into()
+}
+
+pub fn client_connections(client_id: &ClientId) -> KeyHash {
+    format!("clients/{}/connections", client_id).into()
+}
 
 pub fn connection(connection_id: &ConnectionId) -> KeyHash {
-    format!(
-        "{}/connections/{}",
-        COMMITMENT_PREFIX,
-        connection_id.as_str()
-    )
-    .into()
+    format!("connections/{}", connection_id.as_str()).into()
 }
 
 pub fn connection_counter() -> KeyHash {
     "ibc/ics03-connection/connection_counter".into()
+}
+
+pub fn channel(channel_id: &ChannelId, port_id: &PortId) -> KeyHash {
+    format!("channelEnds/ports/{}/channels/{}", port_id, channel_id).into()
+}
+
+pub fn seq_recv(channel_id: &ChannelId, port_id: &PortId) -> KeyHash {
+    format!(
+        "seqRecvs/ports/{}/channels/{}/nextSequenceRecv",
+        port_id, channel_id
+    )
+    .into()
+}
+
+pub fn seq_ack(channel_id: &ChannelId, port_id: &PortId) -> KeyHash {
+    format!(
+        "seqAcks/ports/{}/channels/{}/nextSequenceAck",
+        port_id, channel_id
+    )
+    .into()
+}
+
+pub fn seq_send(channel_id: &ChannelId, port_id: &PortId) -> KeyHash {
+    format!(
+        "seqSends/ports/{}/channels/{}/nextSequenceSend",
+        port_id, channel_id
+    )
+    .into()
+}
+
+pub fn packet_receipt(packet: &Packet) -> KeyHash {
+    format!(
+        "receipts/ports/{}/channels/{}/receipts/{}",
+        packet.destination_port, packet.destination_channel, packet.sequence
+    )
+    .into()
+}
+
+pub fn packet_commitment(packet: &Packet) -> KeyHash {
+    format!(
+        "commitments/ports/{}/channels/{}/packets/{}",
+        packet.source_port, packet.source_channel, packet.sequence
+    )
+    .into()
+}
+
+pub fn packet_commitment_by_port(
+    port_id: &PortId,
+    channel_id: &ChannelId,
+    sequence: u64,
+) -> KeyHash {
+    format!(
+        "commitments/ports/{}/channels/{}/packets/{}",
+        port_id, channel_id, sequence
+    )
+    .into()
 }

--- a/component/src/ibc/mod.rs
+++ b/component/src/ibc/mod.rs
@@ -20,5 +20,3 @@ pub use client::{
 };
 pub use component::IBCComponent;
 pub use connection::{ConnectionCounter, SUPPORTED_VERSIONS};
-
-pub static COMMITMENT_PREFIX: &str = "penumbra-ibc-commitment";


### PR DESCRIPTION
after implementing the JMT prefix as required in #1189, this PR brings all the IBC commitment paths into spec + uses the new commitment prefix.