### PR TITLE
params: less aggressive slashing

### DIFF
--- a/chain/src/params.rs
+++ b/chain/src/params.rs
@@ -115,9 +115,7 @@ impl Default for ChainParams {
             active_validator_limit: 10,
             // copied from cosmos hub
             signed_blocks_window_len: 10000,
-            //missed_blocks_maximum: 9500,
-            // more aggressive to test slashing
-            missed_blocks_maximum: 250,
+            missed_blocks_maximum: 9500,
             // 1000 basis points = 10%
             slashing_penalty_misbehavior_bps: 1000,
             // 1 basis point = 0.01%


### PR DESCRIPTION
Restore the less-aggressive slashing parameters copied from the Cosmos Hub,
we're pretty sure that slashing works now, and this prevents needless jailing.