### PR TITLE
Enable sqlite shared cache and remove retry loop

### DIFF
--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -81,7 +81,10 @@ impl Storage {
             // Since our data is coming from the chain, durability is not
             // a concern -- if we lose some database transactions, it's as
             // if we rewound syncing a few blocks.
-            .synchronous(SqliteSynchronous::Normal);
+            .synchronous(SqliteSynchronous::Normal)
+            // The shared cache allows table-level locking, which makes things faster in concurrent
+            // cases, and eliminates database lock errors.
+            .shared_cache(true);
 
         let pool = Pool::<Sqlite>::connect_with(options).await?;
 

--- a/view/src/worker.rs
+++ b/view/src/worker.rs
@@ -241,24 +241,8 @@ impl Worker {
         // created at genesis. In the future, we'll want to have a way for
         // clients to learn about assets as they're created.
         self.fetch_assets().await?;
-
-        let mut error_count = 0;
-        loop {
-            match self.sync().await {
-                // If the sync returns `Ok` then it means we're shutting down.
-                Ok(()) => return Ok(()),
-                Err(e) => {
-                    tracing::warn!(?e);
-                    error_count += 1;
-                    // Retry a few times and then give up.
-                    if error_count > 3 {
-                        return Err(e);
-                    }
-                }
-            }
-            // Wait a bit before restarting
-            tokio::time::sleep(std::time::Duration::from_millis(1729)).await;
-        }
+        self.sync().await?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Resolves #1201 by removing buggy retry loop in view service and fixing database locking error that was triggering retries. Also resolves #1191 by the same token.

The retry loop shouldn't be necessary, and I think it's a good idea to keep it brittle for the moment so that if errors occur, we can properly diagnose them rather than letting them slide by if they are ephemeral.

Co-Authored-By: @aubrika