### PR TITLE
stake: ban duplicate consensus keys

### DIFF
--- a/component/src/stake/component.rs
+++ b/component/src/stake/component.rs
@@ -1031,11 +1031,19 @@ impl Component for Staking {
         for v in tx.validator_definitions() {
             let v = validator::Definition::try_from(v.clone())
                 .context("supplied proto is not a valid definition")?;
+
             let existing_v_by_id = self.state.validator(&v.validator.identity_key).await?;
             let existing_v_by_ck = self
                 .state
                 .validator_by_consensus_key(&v.validator.consensus_key)
                 .await?;
+
+            tracing::debug!(
+                ?v,
+                ?existing_v_by_id,
+                ?existing_v_by_ck,
+                "checking validator definition"
+            );
 
             match (existing_v_by_id, existing_v_by_ck) {
                 // This is a redefinition of an existing validator.  Ensure that

--- a/component/src/stake/state_key.rs
+++ b/component/src/stake/state_key.rs
@@ -2,12 +2,24 @@ use jmt::KeyHash;
 use penumbra_crypto::IdentityKey;
 use tendermint::PublicKey;
 
-pub fn validators(id: &IdentityKey) -> KeyHash {
+pub fn validator_list() -> KeyHash {
+    "staking/validators".into()
+}
+
+pub fn validator_by_id(id: &IdentityKey) -> KeyHash {
     format!("staking/validators/{}", id).into()
 }
 
 pub fn state_by_validator(id: &IdentityKey) -> KeyHash {
     format!("staking/validators/{}/state", id).into()
+}
+
+pub fn current_base_rate() -> KeyHash {
+    "staking/base_rate/current".into()
+}
+
+pub fn next_base_rate() -> KeyHash {
+    "staking/base_rate/next".into()
 }
 
 pub fn current_rate_by_validator(id: &IdentityKey) -> KeyHash {

--- a/component/src/stake/state_key.rs
+++ b/component/src/stake/state_key.rs
@@ -6,14 +6,6 @@ pub fn validator_list() -> KeyHash {
     "staking/validators".into()
 }
 
-pub fn validator_by_id(id: &IdentityKey) -> KeyHash {
-    format!("staking/validators/{}", id).into()
-}
-
-pub fn state_by_validator(id: &IdentityKey) -> KeyHash {
-    format!("staking/validators/{}/state", id).into()
-}
-
 pub fn current_base_rate() -> KeyHash {
     "staking/base_rate/current".into()
 }
@@ -22,24 +14,32 @@ pub fn next_base_rate() -> KeyHash {
     "staking/base_rate/next".into()
 }
 
+pub fn validator_by_id(id: &IdentityKey) -> KeyHash {
+    format!("staking/validator/{}", id).into()
+}
+
+pub fn state_by_validator(id: &IdentityKey) -> KeyHash {
+    format!("staking/validator/{}/state", id).into()
+}
+
 pub fn current_rate_by_validator(id: &IdentityKey) -> KeyHash {
-    format!("staking/validators/{}/rate/current", id).into()
+    format!("staking/validator/{}/rate/current", id).into()
 }
 
 pub fn next_rate_by_validator(id: &IdentityKey) -> KeyHash {
-    format!("staking/validators/{}/rate/next", id).into()
+    format!("staking/validator/{}/rate/next", id).into()
 }
 
 pub fn power_by_validator(id: &IdentityKey) -> KeyHash {
-    format!("staking/validators/{}/power", id).into()
+    format!("staking/validator/{}/power", id).into()
 }
 
 pub fn bonding_state_by_validator(id: &IdentityKey) -> KeyHash {
-    format!("staking/validators/{}/bonding_state", id).into()
+    format!("staking/validator/{}/bonding_state", id).into()
 }
 
 pub fn uptime_by_validator(id: &IdentityKey) -> KeyHash {
-    format!("staking/validator_uptime/{}", id).into()
+    format!("staking/validator/{}/uptime", id).into()
 }
 
 pub fn slashed_validators(height: u64) -> KeyHash {

--- a/component/src/stake/state_key.rs
+++ b/component/src/stake/state_key.rs
@@ -34,8 +34,8 @@ pub fn slashed_validators(height: u64) -> KeyHash {
     format!("staking/slashed_validators/{}", height).into()
 }
 
-pub fn consensus_key(pk: &PublicKey) -> KeyHash {
-    format!("staking/consensus_key/{}", pk.to_hex()).into()
+pub fn validator_id_by_consensus_key(pk: &PublicKey) -> KeyHash {
+    format!("staking/validator_id_by_consensus_key/{}", pk.to_hex()).into()
 }
 
 pub fn delegation_changes_by_height(height: u64) -> KeyHash {


### PR DESCRIPTION
Closes #1062 (albeit with a different mechanism).

This prevents a chain halt that can occur if two validator definitions are
uploaded with the same consensus key -- resulting in pd sending a validator
update to Tendermint with duplicate entries, causing a halt.

This change obviates the suggestion in #1062 to add a signature by the
consensus key -- now, it's impossible to create a validator definition with an
existing key, so no signature is needed.

This commit should fix the chain halt that killed the Eurydome testnet.