### PR TITLE
crypto: split up WIP swap code into modules

### DIFF
--- a/crypto/src/dex.rs
+++ b/crypto/src/dex.rs
@@ -1,0 +1,4 @@
+pub mod swap;
+
+mod trading_pair;
+pub use trading_pair::TradingPair;

--- a/crypto/src/dex/swap.rs
+++ b/crypto/src/dex/swap.rs
@@ -1,0 +1,33 @@
+mod ciphertext;
+mod plaintext;
+pub use ciphertext::SwapCiphertext;
+pub use plaintext::SwapPlaintext;
+
+use once_cell::sync::Lazy;
+
+// Swap ciphertext byte length
+pub const SWAP_CIPHERTEXT_BYTES: usize = 169;
+// Swap plaintext byte length
+pub const SWAP_LEN_BYTES: usize = 153;
+pub const OVK_WRAPPED_LEN_BYTES: usize = 80;
+
+/// The nonce used for swap encryption.
+///
+/// The nonce will always be `[0u8; 12]` which is okay since we use a new
+/// ephemeral key each time.
+pub static SWAP_ENCRYPTION_NONCE: Lazy<[u8; 12]> = Lazy::new(|| [0u8; 12]);
+
+// Can add to this/make this an enum when we add additional types of swaps.
+// TODO: is this actually something we would do? suppose it doesn't hurt to build this
+// in early.
+pub const SWAP_TYPE: u8 = 0;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Swap type unsupported")]
+    SwapTypeUnsupported,
+    #[error("Swap deserialization error")]
+    SwapDeserializationError,
+    #[error("Decryption error")]
+    DecryptionError,
+}

--- a/crypto/src/dex/swap/ciphertext.rs
+++ b/crypto/src/dex/swap/ciphertext.rs
@@ -1,0 +1,58 @@
+use anyhow::Result;
+use chacha20poly1305::{
+    aead::{Aead, NewAead},
+    ChaCha20Poly1305, Key, Nonce,
+};
+
+use crate::ka;
+
+use super::{SwapPlaintext, SWAP_CIPHERTEXT_BYTES, SWAP_ENCRYPTION_NONCE, SWAP_LEN_BYTES};
+
+#[derive(Debug, Clone)]
+pub struct SwapCiphertext(pub [u8; SWAP_CIPHERTEXT_BYTES]);
+
+impl SwapCiphertext {
+    pub fn decrypt(
+        &self,
+        esk: &ka::Secret,
+        transmission_key: ka::Public,
+        diversified_basepoint: decaf377::Element,
+    ) -> Result<SwapPlaintext> {
+        let shared_secret = esk
+            .key_agreement_with(&transmission_key)
+            .expect("key agreement succeeds");
+        let epk = esk.diversified_public(&diversified_basepoint);
+        let key = SwapPlaintext::derive_symmetric_key(&shared_secret, &epk);
+        let cipher = ChaCha20Poly1305::new(Key::from_slice(key.as_bytes()));
+        let nonce = Nonce::from_slice(&*SWAP_ENCRYPTION_NONCE);
+
+        let swap_ciphertext = self.0;
+        let decryption_result = cipher
+            .decrypt(nonce, swap_ciphertext.as_ref())
+            .map_err(|_| anyhow::anyhow!("unable to decrypt swap ciphertext"))?;
+
+        let plaintext: [u8; SWAP_LEN_BYTES] = decryption_result
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("swap decryption result did not fit in plaintext len"))?;
+
+        plaintext.try_into().map_err(|_| {
+            anyhow::anyhow!("unable to convert swap plaintext bytes into SwapPlaintext")
+        })
+    }
+}
+
+impl TryFrom<[u8; SWAP_CIPHERTEXT_BYTES]> for SwapCiphertext {
+    type Error = anyhow::Error;
+
+    fn try_from(bytes: [u8; SWAP_CIPHERTEXT_BYTES]) -> Result<SwapCiphertext, Self::Error> {
+        Ok(SwapCiphertext(bytes))
+    }
+}
+
+impl TryFrom<&[u8]> for SwapCiphertext {
+    type Error = anyhow::Error;
+
+    fn try_from(slice: &[u8]) -> Result<SwapCiphertext, Self::Error> {
+        Ok(SwapCiphertext(slice[..].try_into()?))
+    }
+}

--- a/crypto/src/dex/trading_pair.rs
+++ b/crypto/src/dex/trading_pair.rs
@@ -1,0 +1,63 @@
+use decaf377::FieldExt;
+use penumbra_proto::{dex as pb, Protobuf};
+
+use crate::asset;
+
+#[derive(Debug, Clone)]
+pub struct TradingPair {
+    pub asset_1: asset::Id,
+    pub asset_2: asset::Id,
+}
+
+impl TradingPair {
+    /// Convert the trading pair to bytes.
+    pub fn to_bytes(&self) -> [u8; 64] {
+        let mut result: [u8; 64] = [0; 64];
+        result[0..32].copy_from_slice(&self.asset_1.0.to_bytes());
+        result[32..64].copy_from_slice(&self.asset_2.0.to_bytes());
+        result
+    }
+}
+
+impl TryFrom<[u8; 64]> for TradingPair {
+    type Error = anyhow::Error;
+    fn try_from(bytes: [u8; 64]) -> anyhow::Result<Self> {
+        let asset_1_bytes = &bytes[0..32];
+        let asset_2_bytes = &bytes[32..64];
+        Ok(Self {
+            asset_1: asset_1_bytes
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("invalid asset_1 bytes in TradingPair"))?,
+            asset_2: asset_2_bytes
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("invalid asset_2 bytes in TradingPair"))?,
+        })
+    }
+}
+
+impl Protobuf<pb::TradingPair> for TradingPair {}
+
+impl TryFrom<pb::TradingPair> for TradingPair {
+    type Error = anyhow::Error;
+    fn try_from(tp: pb::TradingPair) -> anyhow::Result<Self> {
+        Ok(Self {
+            asset_1: tp
+                .asset_1
+                .ok_or_else(|| anyhow::anyhow!("missing trading pair asset1"))?
+                .try_into()?,
+            asset_2: tp
+                .asset_2
+                .ok_or_else(|| anyhow::anyhow!("missing trading pair asset2"))?
+                .try_into()?,
+        })
+    }
+}
+
+impl From<TradingPair> for pb::TradingPair {
+    fn from(tp: TradingPair) -> Self {
+        Self {
+            asset_1: Some(tp.asset_1.into()),
+            asset_2: Some(tp.asset_2.into()),
+        }
+    }
+}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -8,6 +8,7 @@ pub use decaf377_rdsa as rdsa;
 mod address;
 pub mod asset;
 mod delegation_token;
+pub mod dex;
 pub mod eddy;
 mod flow;
 mod identity_key;
@@ -18,7 +19,6 @@ mod note_payload;
 mod nullifier;
 mod prf;
 pub mod proofs;
-pub mod swap;
 pub mod transaction;
 pub mod value;
 

--- a/transaction/src/action/swap.rs
+++ b/transaction/src/action/swap.rs
@@ -1,6 +1,6 @@
 use penumbra_crypto::NotePayload;
+use penumbra_crypto::{dex::swap::SwapCiphertext, value};
 use penumbra_crypto::{proofs::transparent::SwapProof, MockFlowCiphertext};
-use penumbra_crypto::{swap::SwapCiphertext, value};
 use penumbra_proto::dex::TradingPair;
 use penumbra_proto::{dex as pb, Protobuf};
 


### PR DESCRIPTION
This reorganization divides the existing swap.rs into submodules, and puts it
under a new `dex` module, so that we can have a place for structures that are
common to both the swap side and the lp side, and have room for sibling `swap`
and `lp` modules.