### PR TITLE
refactor(state_key): only use raw keys to build  `KeyValueRequest`s 

### DIFF
--- a/chain/src/state_key.rs
+++ b/chain/src/state_key.rs
@@ -1,13 +1,11 @@
-use jmt::KeyHash;
-
-pub fn chain_params() -> KeyHash {
-    "chain_params".to_string().into()
+pub fn chain_params() -> &'static str {
+    "chain_params"
 }
 
-pub fn block_height() -> KeyHash {
-    "block_height".to_string().into()
+pub fn block_height() -> &'static str {
+    "block_height"
 }
 
-pub fn block_timestamp() -> KeyHash {
-    "block_timestamp".to_string().into()
+pub fn block_timestamp() -> &'static str {
+    "block_timestamp"
 }

--- a/chain/src/view.rs
+++ b/chain/src/view.rs
@@ -23,7 +23,8 @@ pub trait View: StateExt {
 
     /// Writes the provided chain parameters to the JMT.
     async fn put_chain_params(&self, params: ChainParams) {
-        self.put_domain(state_key::chain_params().into(), params).await
+        self.put_domain(state_key::chain_params().into(), params)
+            .await
     }
 
     /// Gets the current epoch for the chain.

--- a/chain/src/view.rs
+++ b/chain/src/view.rs
@@ -16,14 +16,14 @@ use crate::{params::ChainParams, state_key, Epoch};
 pub trait View: StateExt {
     /// Gets the chain parameters from the JMT.
     async fn get_chain_params(&self) -> Result<ChainParams> {
-        self.get_domain(state_key::chain_params())
+        self.get_domain(state_key::chain_params().into())
             .await?
             .ok_or_else(|| anyhow!("Missing ChainParams"))
     }
 
     /// Writes the provided chain parameters to the JMT.
     async fn put_chain_params(&self, params: ChainParams) {
-        self.put_domain(state_key::chain_params(), params).await
+        self.put_domain(state_key::chain_params().into(), params).await
     }
 
     /// Gets the current epoch for the chain.
@@ -56,7 +56,7 @@ pub trait View: StateExt {
     /// Gets the current block height from the JMT
     async fn get_block_height(&self) -> Result<u64> {
         let height_bytes: u64 = self
-            .get_proto(state_key::block_height())
+            .get_proto(state_key::block_height().into())
             .await?
             .ok_or_else(|| anyhow!("Missing block_height"))?;
 
@@ -71,7 +71,7 @@ pub trait View: StateExt {
     /// Gets the current block timestamp from the JMT
     async fn get_block_timestamp(&self) -> Result<Time> {
         let timestamp_string: String = self
-            .get_proto(state_key::block_timestamp())
+            .get_proto(state_key::block_timestamp().into())
             .await?
             .ok_or_else(|| anyhow!("Missing block_timestamp"))?;
 
@@ -80,7 +80,7 @@ pub trait View: StateExt {
 
     /// Writes the block timestamp to the JMT
     async fn put_block_timestamp(&self, timestamp: Time) {
-        self.put_proto(state_key::block_timestamp(), timestamp.to_rfc3339())
+        self.put_proto(state_key::block_timestamp().into(), timestamp.to_rfc3339())
             .await
     }
 

--- a/component/src/app/mod.rs
+++ b/component/src/app/mod.rs
@@ -99,7 +99,7 @@ impl Component for App {
             .await;
         // TODO: do we actually need to store the app state here?
         self.state
-            .put_domain(state_key::app_state(), app_state.clone())
+            .put_domain(state_key::app_state().into(), app_state.clone())
             .await;
         // The genesis block height is 0
         self.state.put_block_height(0).await;

--- a/component/src/app/state_key.rs
+++ b/component/src/app/state_key.rs
@@ -1,3 +1,3 @@
-pub fn app_state() -> jmt::KeyHash {
-    "genesis/app_state".into()
+pub fn app_state() -> &'static str {
+    "genesis/app_state"
 }

--- a/component/src/ibc/component/channel.rs
+++ b/component/src/ibc/component/channel.rs
@@ -331,47 +331,47 @@ pub trait View: StateExt {
         channel_id: &ChannelId,
         port_id: &PortId,
     ) -> Result<Option<ChannelEnd>> {
-        self.get_domain(state_key::channel(channel_id, port_id))
+        self.get_domain(state_key::channel(channel_id, port_id).into())
             .await
     }
     async fn put_channel(&mut self, channel_id: &ChannelId, port_id: &PortId, channel: ChannelEnd) {
-        self.put_domain(state_key::channel(channel_id, port_id), channel)
+        self.put_domain(state_key::channel(channel_id, port_id).into(), channel)
             .await;
     }
     async fn get_recv_sequence(&self, channel_id: &ChannelId, port_id: &PortId) -> Result<u64> {
-        self.get_proto::<u64>(state_key::seq_recv(channel_id, port_id))
+        self.get_proto::<u64>(state_key::seq_recv(channel_id, port_id).into())
             .await
             .map(|sequence| sequence.unwrap_or(0))
     }
     async fn get_ack_sequence(&self, channel_id: &ChannelId, port_id: &PortId) -> Result<u64> {
-        self.get_proto::<u64>(state_key::seq_ack(channel_id, port_id))
+        self.get_proto::<u64>(state_key::seq_ack(channel_id, port_id).into())
             .await
             .map(|sequence| sequence.unwrap_or(0))
     }
     async fn put_ack_sequence(&mut self, channel_id: &ChannelId, port_id: &PortId, sequence: u64) {
-        self.put_proto::<u64>(state_key::seq_ack(channel_id, port_id), sequence)
+        self.put_proto::<u64>(state_key::seq_ack(channel_id, port_id).into(), sequence)
             .await;
     }
     async fn put_recv_sequence(&mut self, channel_id: &ChannelId, port_id: &PortId, sequence: u64) {
-        self.put_proto::<u64>(state_key::seq_recv(channel_id, port_id), sequence)
+        self.put_proto::<u64>(state_key::seq_recv(channel_id, port_id).into(), sequence)
             .await;
     }
     async fn put_send_sequence(&mut self, channel_id: &ChannelId, port_id: &PortId, sequence: u64) {
-        self.put_proto::<u64>(state_key::seq_send(channel_id, port_id), sequence)
+        self.put_proto::<u64>(state_key::seq_send(channel_id, port_id).into(), sequence)
             .await;
     }
     async fn put_packet_receipt(&mut self, packet: &Packet) {
-        self.put_proto::<String>(state_key::packet_receipt(packet), "1".to_string())
+        self.put_proto::<String>(state_key::packet_receipt(packet).into(), "1".to_string())
             .await;
     }
     async fn seen_packet(&self, packet: &Packet) -> Result<bool> {
-        self.get_proto::<String>(state_key::packet_receipt(packet))
+        self.get_proto::<String>(state_key::packet_receipt(packet).into())
             .await
             .map(|res| res.is_some())
     }
     async fn get_packet_commitment(&self, packet: &Packet) -> Result<Option<Vec<u8>>> {
         let commitment = self
-            .get_proto::<Vec<u8>>(state_key::packet_commitment(packet))
+            .get_proto::<Vec<u8>>(state_key::packet_commitment(packet).into())
             .await?;
 
         // this is for the special case where the commitment is empty, we consider this None.
@@ -390,7 +390,7 @@ pub trait View: StateExt {
         sequence: u64,
     ) {
         self.put_proto::<Vec<u8>>(
-            state_key::packet_commitment_by_port(port_id, channel_id, sequence),
+            state_key::packet_commitment_by_port(port_id, channel_id, sequence).into(),
             vec![],
         )
         .await;

--- a/component/src/ibc/component/client.rs
+++ b/component/src/ibc/component/client.rs
@@ -372,18 +372,18 @@ pub trait View: StateExt {
 
     async fn put_client(&mut self, client_id: &ClientId, client_state: AnyClientState) {
         self.put_proto(
-            state_key::client_type(client_id),
+            state_key::client_type(client_id).into(),
             client_state.client_type().as_str().to_string(),
         )
         .await;
 
-        self.put_domain(state_key::client_state(client_id), client_state)
+        self.put_domain(state_key::client_state(client_id).into(), client_state)
             .await;
     }
 
     async fn get_client_type(&self, client_id: &ClientId) -> Result<ClientType> {
         let client_type_str: String = self
-            .get_proto(state_key::client_type(client_id))
+            .get_proto(state_key::client_type(client_id).into())
             .await?
             .ok_or_else(|| anyhow::anyhow!("client not found"))?;
 
@@ -391,7 +391,9 @@ pub trait View: StateExt {
     }
 
     async fn get_client_state(&self, client_id: &ClientId) -> Result<AnyClientState> {
-        let client_state = self.get_domain(state_key::client_state(client_id)).await?;
+        let client_state = self
+            .get_domain(state_key::client_state(client_id).into())
+            .await?;
 
         client_state.ok_or_else(|| anyhow::anyhow!("client not found"))
     }
@@ -456,11 +458,9 @@ pub trait View: StateExt {
         height: Height,
         client_id: ClientId,
     ) -> Result<AnyConsensusState> {
-        self.get_domain(state_key::verified_client_consensus_state(
-            &client_id, &height,
-        ))
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("consensus state not found"))
+        self.get_domain(state_key::verified_client_consensus_state(&client_id, &height).into())
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("consensus state not found"))
     }
 
     async fn get_client_update_height(
@@ -468,7 +468,7 @@ pub trait View: StateExt {
         client_id: &ClientId,
         height: &Height,
     ) -> Result<ibc::Height> {
-        self.get_domain(state_key::client_processed_heights(client_id, height))
+        self.get_domain(state_key::client_processed_heights(client_id, height).into())
             .await?
             .ok_or_else(|| anyhow::anyhow!("client update time not found"))
     }
@@ -479,7 +479,7 @@ pub trait View: StateExt {
         height: &Height,
     ) -> Result<ibc::timestamp::Timestamp> {
         let timestamp_nanos = self
-            .get_proto::<u64>(state_key::client_processed_times(client_id, height))
+            .get_proto::<u64>(state_key::client_processed_times(client_id, height).into())
             .await?
             .ok_or_else(|| anyhow::anyhow!("client update time not found"))?;
 
@@ -494,7 +494,7 @@ pub trait View: StateExt {
         consensus_state: AnyConsensusState,
     ) -> Result<()> {
         self.put_domain(
-            state_key::verified_client_consensus_state(&client_id, &height),
+            state_key::verified_client_consensus_state(&client_id, &height).into(),
             consensus_state,
         )
         .await;
@@ -503,13 +503,13 @@ pub trait View: StateExt {
         let current_time: ibc::timestamp::Timestamp = self.get_block_timestamp().await?.into();
 
         self.put_proto::<u64>(
-            state_key::client_processed_times(&client_id, &height),
+            state_key::client_processed_times(&client_id, &height).into(),
             current_time.nanoseconds(),
         )
         .await;
 
         self.put_domain(
-            state_key::client_processed_heights(&client_id, &height),
+            state_key::client_processed_heights(&client_id, &height).into(),
             ibc::Height::zero().with_revision_height(current_height),
         )
         .await;
@@ -603,13 +603,13 @@ pub trait View: StateExt {
         self.get_client_type(client_id).await?;
 
         let mut connections: ClientConnections = self
-            .get_domain(state_key::client_connections(client_id))
+            .get_domain(state_key::client_connections(client_id).into())
             .await?
             .unwrap_or_default();
 
         connections.connection_ids.push(connection_id.clone());
 
-        self.put_domain(state_key::client_connections(client_id), connections)
+        self.put_domain(state_key::client_connections(client_id).into(), connections)
             .await;
 
         Ok(())

--- a/component/src/ibc/component/connection.rs
+++ b/component/src/ibc/component/connection.rs
@@ -168,13 +168,13 @@ impl Component for ConnectionComponent {
 #[async_trait]
 pub trait View: StateExt + Send + Sync {
     async fn get_connection_counter(&self) -> Result<ConnectionCounter> {
-        self.get_domain(state_key::connection_counter())
+        self.get_domain(state_key::connection_counter().into())
             .await
             .map(|counter| counter.unwrap_or(ConnectionCounter(0)))
     }
 
     async fn put_connection_counter(&self, counter: ConnectionCounter) {
-        self.put_domain(state_key::connection_counter(), counter)
+        self.put_domain(state_key::connection_counter().into(), counter)
             .await;
     }
 
@@ -185,7 +185,7 @@ pub trait View: StateExt + Send + Sync {
         connection_id: &ConnectionId,
         connection: ConnectionEnd,
     ) -> Result<()> {
-        self.put_domain(state_key::connection(connection_id), connection.clone())
+        self.put_domain(state_key::connection(connection_id).into(), connection.clone())
             .await;
         let counter = self
             .get_connection_counter()
@@ -201,11 +201,11 @@ pub trait View: StateExt + Send + Sync {
     }
 
     async fn get_connection(&self, connection_id: &ConnectionId) -> Result<Option<ConnectionEnd>> {
-        self.get_domain(state_key::connection(connection_id)).await
+        self.get_domain(state_key::connection(connection_id).into()).await
     }
 
     async fn update_connection(&self, connection_id: &ConnectionId, connection: ConnectionEnd) {
-        self.put_domain(state_key::connection(connection_id), connection)
+        self.put_domain(state_key::connection(connection_id).into(), connection)
             .await;
     }
 }

--- a/component/src/ibc/component/connection.rs
+++ b/component/src/ibc/component/connection.rs
@@ -185,8 +185,11 @@ pub trait View: StateExt + Send + Sync {
         connection_id: &ConnectionId,
         connection: ConnectionEnd,
     ) -> Result<()> {
-        self.put_domain(state_key::connection(connection_id).into(), connection.clone())
-            .await;
+        self.put_domain(
+            state_key::connection(connection_id).into(),
+            connection.clone(),
+        )
+        .await;
         let counter = self
             .get_connection_counter()
             .await
@@ -201,7 +204,8 @@ pub trait View: StateExt + Send + Sync {
     }
 
     async fn get_connection(&self, connection_id: &ConnectionId) -> Result<Option<ConnectionEnd>> {
-        self.get_domain(state_key::connection(connection_id).into()).await
+        self.get_domain(state_key::connection(connection_id).into())
+            .await
     }
 
     async fn update_connection(&self, connection_id: &ConnectionId, connection: ConnectionEnd) {

--- a/component/src/ibc/component/state_key.rs
+++ b/component/src/ibc/component/state_key.rs
@@ -6,91 +6,85 @@ use ibc::{
     Height,
 };
 
-use jmt::KeyHash;
+use std::string::String;
 
-pub fn client_type(client_id: &ClientId) -> KeyHash {
-    format!("clients/{}/clientType", client_id).into()
+pub fn client_type(client_id: &ClientId) -> String {
+    format!("clients/{}/clientType", client_id)
 }
 
-pub fn client_state(client_id: &ClientId) -> KeyHash {
-    format!("clients/{}/clientState", client_id).into()
+pub fn client_state(client_id: &ClientId) -> String {
+    format!("clients/{}/clientState", client_id)
 }
 
-pub fn verified_client_consensus_state(client_id: &ClientId, height: &Height) -> KeyHash {
-    format!("clients/{}/consensusStates/{}", client_id, height).into()
+pub fn verified_client_consensus_state(client_id: &ClientId, height: &Height) -> String {
+    format!("clients/{}/consensusStates/{}", client_id, height)
 }
 
-pub fn client_processed_heights(client_id: &ClientId, height: &Height) -> KeyHash {
-    format!("clients/{}/processedHeights/{}", client_id, height).into()
+pub fn client_processed_heights(client_id: &ClientId, height: &Height) -> String {
+    format!("clients/{}/processedHeights/{}", client_id, height)
 }
-pub fn client_processed_times(client_id: &ClientId, height: &Height) -> KeyHash {
-    format!("clients/{}/processedTimes/{}", client_id, height).into()
-}
-
-pub fn client_connections(client_id: &ClientId) -> KeyHash {
-    format!("clients/{}/connections", client_id).into()
+pub fn client_processed_times(client_id: &ClientId, height: &Height) -> String {
+    format!("clients/{}/processedTimes/{}", client_id, height)
 }
 
-pub fn connection(connection_id: &ConnectionId) -> KeyHash {
-    format!("connections/{}", connection_id.as_str()).into()
+pub fn client_connections(client_id: &ClientId) -> String {
+    format!("clients/{}/connections", client_id)
 }
 
-pub fn connection_counter() -> KeyHash {
-    "ibc/ics03-connection/connection_counter".into()
+pub fn connection(connection_id: &ConnectionId) -> String {
+    format!("connections/{}", connection_id.as_str())
 }
 
-pub fn channel(channel_id: &ChannelId, port_id: &PortId) -> KeyHash {
-    format!("channelEnds/ports/{}/channels/{}", port_id, channel_id).into()
+pub fn connection_counter() -> &'static str {
+    "ibc/ics03-connection/connection_counter"
 }
 
-pub fn seq_recv(channel_id: &ChannelId, port_id: &PortId) -> KeyHash {
+pub fn channel(channel_id: &ChannelId, port_id: &PortId) -> String {
+    format!("channelEnds/ports/{}/channels/{}", port_id, channel_id)
+}
+
+pub fn seq_recv(channel_id: &ChannelId, port_id: &PortId) -> String {
     format!(
         "seqRecvs/ports/{}/channels/{}/nextSequenceRecv",
         port_id, channel_id
     )
-    .into()
 }
 
-pub fn seq_ack(channel_id: &ChannelId, port_id: &PortId) -> KeyHash {
+pub fn seq_ack(channel_id: &ChannelId, port_id: &PortId) -> String {
     format!(
         "seqAcks/ports/{}/channels/{}/nextSequenceAck",
         port_id, channel_id
     )
-    .into()
 }
 
-pub fn seq_send(channel_id: &ChannelId, port_id: &PortId) -> KeyHash {
+pub fn seq_send(channel_id: &ChannelId, port_id: &PortId) -> String {
     format!(
         "seqSends/ports/{}/channels/{}/nextSequenceSend",
         port_id, channel_id
     )
-    .into()
 }
 
-pub fn packet_receipt(packet: &Packet) -> KeyHash {
+pub fn packet_receipt(packet: &Packet) -> String {
     format!(
         "receipts/ports/{}/channels/{}/receipts/{}",
         packet.destination_port, packet.destination_channel, packet.sequence
     )
-    .into()
 }
 
-pub fn packet_commitment(packet: &Packet) -> KeyHash {
+pub fn packet_commitment(packet: &Packet) -> String {
     format!(
         "commitments/ports/{}/channels/{}/packets/{}",
         packet.source_port, packet.source_channel, packet.sequence
     )
-    .into()
 }
 
 pub fn packet_commitment_by_port(
     port_id: &PortId,
     channel_id: &ChannelId,
     sequence: u64,
-) -> KeyHash {
+) -> String {
     format!(
         "commitments/ports/{}/channels/{}/packets/{}",
         port_id, channel_id, sequence
     )
-    .into()
 }

--- a/component/src/shielded_pool/state_key.rs
+++ b/component/src/shielded_pool/state_key.rs
@@ -1,68 +1,68 @@
-use jmt::KeyHash;
 use penumbra_crypto::{asset, note, Nullifier};
 use penumbra_tct::{
     builder::{block, epoch},
     Root,
 };
+use std::string::String;
 
-pub fn token_supply(asset_id: &asset::Id) -> KeyHash {
-    format!("shielded_pool/assets/{}/token_supply", asset_id).into()
+pub fn token_supply(asset_id: &asset::Id) -> String {
+    format!("shielded_pool/assets/{}/token_supply", asset_id)
 }
 
-pub fn known_assets() -> KeyHash {
-    "shielded_pool/known_assets".into()
+pub fn known_assets() -> &'static str {
+    "shielded_pool/known_assets"
 }
 
-pub fn denom_by_asset(asset_id: &asset::Id) -> KeyHash {
-    format!("shielded_pool/assets/{}/denom", asset_id).into()
+pub fn denom_by_asset(asset_id: &asset::Id) -> String {
+    format!("shielded_pool/assets/{}/denom", asset_id)
 }
 
-pub fn note_source(note_commitment: note::Commitment) -> KeyHash {
-    format!("shielded_pool/note_source/{}", note_commitment).into()
+pub fn note_source(note_commitment: note::Commitment) -> String {
+    format!("shielded_pool/note_source/{}", note_commitment)
 }
 
-pub fn compact_block(height: u64) -> KeyHash {
-    format!("shielded_pool/compact_block/{}", height).into()
+pub fn compact_block(height: u64) -> String {
+    format!("shielded_pool/compact_block/{}", height)
 }
 
-pub fn anchor_by_height(height: u64) -> KeyHash {
-    format!("shielded_pool/anchor/{}", height).into()
+pub fn anchor_by_height(height: u64) -> String {
+    format!("shielded_pool/anchor/{}", height)
 }
 
-pub fn anchor_lookup(anchor: Root) -> KeyHash {
-    format!("shielded_pool/valid_anchors/{}", anchor).into()
+pub fn anchor_lookup(anchor: Root) -> String {
+    format!("shielded_pool/valid_anchors/{}", anchor)
 }
 
-pub fn epoch_anchor_by_index(index: u64) -> KeyHash {
-    format!("shielded_pool/epoch_anchor/{}", index).into()
+pub fn epoch_anchor_by_index(index: u64) -> String {
+    format!("shielded_pool/epoch_anchor/{}", index)
 }
 
-pub fn epoch_anchor_lookup(anchor: epoch::Root) -> KeyHash {
-    format!("shielded_pool/valid_epoch_anchors/{}", anchor).into()
+pub fn epoch_anchor_lookup(anchor: epoch::Root) -> String {
+    format!("shielded_pool/valid_epoch_anchors/{}", anchor)
 }
 
-pub fn block_anchor_by_height(height: u64) -> KeyHash {
-    format!("shielded_pool/block_anchor/{}", height).into()
+pub fn block_anchor_by_height(height: u64) -> String {
+    format!("shielded_pool/block_anchor/{}", height)
 }
 
-pub fn block_anchor_lookup(anchor: block::Root) -> KeyHash {
-    format!("shielded_pool/valid_block_anchors/{}", anchor).into()
+pub fn block_anchor_lookup(anchor: block::Root) -> String {
+    format!("shielded_pool/valid_block_anchors/{}", anchor)
 }
 
-pub fn spent_nullifier_lookup(nullifier: Nullifier) -> KeyHash {
-    format!("shielded_pool/spent_nullifiers/{}", nullifier).into()
+pub fn spent_nullifier_lookup(nullifier: Nullifier) -> String {
+    format!("shielded_pool/spent_nullifiers/{}", nullifier)
 }
 
-pub fn commission_amounts(height: u64) -> KeyHash {
-    format!("staking/commission_amounts/{}", height).into()
+pub fn commission_amounts(height: u64) -> String {
+    format!("staking/commission_amounts/{}", height)
 }
 
-pub fn scheduled_to_apply(epoch: u64) -> KeyHash {
-    format!("shielded_pool/quarantined_to_apply_in_epoch/{}", epoch).into()
+pub fn scheduled_to_apply(epoch: u64) -> String {
+    format!("shielded_pool/quarantined_to_apply_in_epoch/{}", epoch)
 }
 
-pub fn quarantined_spent_nullifier_lookup(nullifier: Nullifier) -> KeyHash {
-    format!("shielded_pool/quarantined_spent_nullifiers/{}", nullifier).into()
+pub fn quarantined_spent_nullifier_lookup(nullifier: Nullifier) -> String {
+    format!("shielded_pool/quarantined_spent_nullifiers/{}", nullifier)
 }
 
 pub use crate::stake::state_key::slashed_validators;

--- a/component/src/stake/state_key.rs
+++ b/component/src/stake/state_key.rs
@@ -1,55 +1,55 @@
-use jmt::KeyHash;
 use penumbra_crypto::IdentityKey;
+use std::string::String;
 use tendermint::PublicKey;
 
-pub fn validator_list() -> KeyHash {
-    "staking/validators".into()
+pub fn validator_list() -> &'static str {
+    "staking/validators"
 }
 
-pub fn current_base_rate() -> KeyHash {
-    "staking/base_rate/current".into()
+pub fn current_base_rate() -> &'static str {
+    "staking/base_rate/current"
 }
 
-pub fn next_base_rate() -> KeyHash {
-    "staking/base_rate/next".into()
+pub fn next_base_rate() -> &'static str {
+    "staking/base_rate/next"
 }
 
-pub fn validator_by_id(id: &IdentityKey) -> KeyHash {
-    format!("staking/validator/{}", id).into()
+pub fn validator_by_id(id: &IdentityKey) -> String {
+    format!("staking/validator/{}", id)
 }
 
-pub fn state_by_validator(id: &IdentityKey) -> KeyHash {
-    format!("staking/validator/{}/state", id).into()
+pub fn state_by_validator(id: &IdentityKey) -> String {
+    format!("staking/validator/{}/state", id)
 }
 
-pub fn current_rate_by_validator(id: &IdentityKey) -> KeyHash {
-    format!("staking/validator/{}/rate/current", id).into()
+pub fn current_rate_by_validator(id: &IdentityKey) -> String {
+    format!("staking/validator/{}/rate/current", id)
 }
 
-pub fn next_rate_by_validator(id: &IdentityKey) -> KeyHash {
-    format!("staking/validator/{}/rate/next", id).into()
+pub fn next_rate_by_validator(id: &IdentityKey) -> String {
+    format!("staking/validator/{}/rate/next", id)
 }
 
-pub fn power_by_validator(id: &IdentityKey) -> KeyHash {
-    format!("staking/validator/{}/power", id).into()
+pub fn power_by_validator(id: &IdentityKey) -> String {
+    format!("staking/validator/{}/power", id)
 }
 
-pub fn bonding_state_by_validator(id: &IdentityKey) -> KeyHash {
-    format!("staking/validator/{}/bonding_state", id).into()
+pub fn bonding_state_by_validator(id: &IdentityKey) -> String {
+    format!("staking/validator/{}/bonding_state", id)
 }
 
-pub fn uptime_by_validator(id: &IdentityKey) -> KeyHash {
-    format!("staking/validator/{}/uptime", id).into()
+pub fn uptime_by_validator(id: &IdentityKey) -> String {
+    format!("staking/validator/{}/uptime", id)
 }
 
-pub fn slashed_validators(height: u64) -> KeyHash {
-    format!("staking/slashed_validators/{}", height).into()
+pub fn slashed_validators(height: u64) -> String {
+    format!("staking/slashed_validators/{}", height)
 }
 
-pub fn validator_id_by_consensus_key(pk: &PublicKey) -> KeyHash {
-    format!("staking/validator_id_by_consensus_key/{}", pk.to_hex()).into()
+pub fn validator_id_by_consensus_key(pk: &PublicKey) -> String {
+    format!("staking/validator_id_by_consensus_key/{}", pk.to_hex())
 }
 
-pub fn delegation_changes_by_height(height: u64) -> KeyHash {
-    format!("staking/delegation_changes/{}", height).into()
+pub fn delegation_changes_by_height(height: u64) -> String {
+    format!("staking/delegation_changes/{}", height)
 }

--- a/pcli/src/command/query/shielded_pool.rs
+++ b/pcli/src/command/query/shielded_pool.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use colored_json::prelude::*;
-use jmt::KeyHash;
 use penumbra_chain::{quarantined::Scheduled, CompactBlock, NoteSource};
 use penumbra_component::shielded_pool::Delible;
 use penumbra_crypto::Nullifier;
@@ -52,22 +51,22 @@ pub enum ShieldedPool {
 }
 
 impl ShieldedPool {
-    pub fn key_hash(&self) -> KeyHash {
+    pub fn key(&self) -> String {
         use penumbra_component::shielded_pool::state_key;
         match self {
-            ShieldedPool::Anchor { height } => state_key::anchor_by_height(*height).into(),
+            ShieldedPool::Anchor { height } => state_key::anchor_by_height(*height),
             ShieldedPool::BlockAnchor { height } => {
-                state_key::block_anchor_by_height(*height).into()
+                state_key::block_anchor_by_height(*height)
             }
-            ShieldedPool::EpochAnchor { epoch } => state_key::epoch_anchor_by_index(*epoch).into(),
-            ShieldedPool::CompactBlock { height } => state_key::compact_block(*height).into(),
-            ShieldedPool::Scheduled { epoch } => state_key::scheduled_to_apply(*epoch).into(),
-            ShieldedPool::Commitment { commitment } => state_key::note_source(*commitment).into(),
+            ShieldedPool::EpochAnchor { epoch } => state_key::epoch_anchor_by_index(*epoch),
+            ShieldedPool::CompactBlock { height } => state_key::compact_block(*height),
+            ShieldedPool::Scheduled { epoch } => state_key::scheduled_to_apply(*epoch),
+            ShieldedPool::Commitment { commitment } => state_key::note_source(*commitment),
             ShieldedPool::Nullifier { nullifier } => {
-                state_key::spent_nullifier_lookup(*nullifier).into()
+                state_key::spent_nullifier_lookup(*nullifier)
             }
             ShieldedPool::QuarantinedNullifier { nullifier } => {
-                state_key::quarantined_spent_nullifier_lookup(*nullifier).into()
+                state_key::quarantined_spent_nullifier_lookup(*nullifier)
             }
         }
     }

--- a/pcli/src/command/query/shielded_pool.rs
+++ b/pcli/src/command/query/shielded_pool.rs
@@ -55,16 +55,12 @@ impl ShieldedPool {
         use penumbra_component::shielded_pool::state_key;
         match self {
             ShieldedPool::Anchor { height } => state_key::anchor_by_height(*height),
-            ShieldedPool::BlockAnchor { height } => {
-                state_key::block_anchor_by_height(*height)
-            }
+            ShieldedPool::BlockAnchor { height } => state_key::block_anchor_by_height(*height),
             ShieldedPool::EpochAnchor { epoch } => state_key::epoch_anchor_by_index(*epoch),
             ShieldedPool::CompactBlock { height } => state_key::compact_block(*height),
             ShieldedPool::Scheduled { epoch } => state_key::scheduled_to_apply(*epoch),
             ShieldedPool::Commitment { commitment } => state_key::note_source(*commitment),
-            ShieldedPool::Nullifier { nullifier } => {
-                state_key::spent_nullifier_lookup(*nullifier)
-            }
+            ShieldedPool::Nullifier { nullifier } => state_key::spent_nullifier_lookup(*nullifier),
             ShieldedPool::QuarantinedNullifier { nullifier } => {
                 state_key::quarantined_spent_nullifier_lookup(*nullifier)
             }

--- a/pcli/src/command/query/shielded_pool.rs
+++ b/pcli/src/command/query/shielded_pool.rs
@@ -55,15 +55,15 @@ impl ShieldedPool {
     pub fn key_hash(&self) -> KeyHash {
         use penumbra_component::shielded_pool::state_key;
         match self {
-            ShieldedPool::Anchor { height } => state_key::anchor_by_height(*height),
-            ShieldedPool::BlockAnchor { height } => state_key::block_anchor_by_height(*height),
-            ShieldedPool::EpochAnchor { epoch } => state_key::epoch_anchor_by_index(*epoch),
-            ShieldedPool::CompactBlock { height } => state_key::compact_block(*height),
-            ShieldedPool::Scheduled { epoch } => state_key::scheduled_to_apply(*epoch),
-            ShieldedPool::Commitment { commitment } => state_key::note_source(*commitment),
-            ShieldedPool::Nullifier { nullifier } => state_key::spent_nullifier_lookup(*nullifier),
+            ShieldedPool::Anchor { height } => state_key::anchor_by_height(*height).into(),
+            ShieldedPool::BlockAnchor { height } => state_key::block_anchor_by_height(*height).into(),
+            ShieldedPool::EpochAnchor { epoch } => state_key::epoch_anchor_by_index(*epoch).into(),
+            ShieldedPool::CompactBlock { height } => state_key::compact_block(*height).into(),
+            ShieldedPool::Scheduled { epoch } => state_key::scheduled_to_apply(*epoch).into(),
+            ShieldedPool::Commitment { commitment } => state_key::note_source(*commitment).into(),
+            ShieldedPool::Nullifier { nullifier } => state_key::spent_nullifier_lookup(*nullifier).into(),
             ShieldedPool::QuarantinedNullifier { nullifier } => {
-                state_key::quarantined_spent_nullifier_lookup(*nullifier)
+                state_key::quarantined_spent_nullifier_lookup(*nullifier).into()
             }
         }
     }

--- a/pcli/src/command/query/shielded_pool.rs
+++ b/pcli/src/command/query/shielded_pool.rs
@@ -56,12 +56,16 @@ impl ShieldedPool {
         use penumbra_component::shielded_pool::state_key;
         match self {
             ShieldedPool::Anchor { height } => state_key::anchor_by_height(*height).into(),
-            ShieldedPool::BlockAnchor { height } => state_key::block_anchor_by_height(*height).into(),
+            ShieldedPool::BlockAnchor { height } => {
+                state_key::block_anchor_by_height(*height).into()
+            }
             ShieldedPool::EpochAnchor { epoch } => state_key::epoch_anchor_by_index(*epoch).into(),
             ShieldedPool::CompactBlock { height } => state_key::compact_block(*height).into(),
             ShieldedPool::Scheduled { epoch } => state_key::scheduled_to_apply(*epoch).into(),
             ShieldedPool::Commitment { commitment } => state_key::note_source(*commitment).into(),
-            ShieldedPool::Nullifier { nullifier } => state_key::spent_nullifier_lookup(*nullifier).into(),
+            ShieldedPool::Nullifier { nullifier } => {
+                state_key::spent_nullifier_lookup(*nullifier).into()
+            }
             ShieldedPool::QuarantinedNullifier { nullifier } => {
                 state_key::quarantined_spent_nullifier_lookup(*nullifier).into()
             }

--- a/proto/proto/client/specific.proto
+++ b/proto/proto/client/specific.proto
@@ -36,8 +36,6 @@ message KeyValueRequest {
   string chain_id = 1;
   // If set, the key to fetch from storage.
   bytes key = 2;
-  // If set, the hash of the key to fetch from storage.
-  bytes key_hash = 4;
   // whether to return a proof
   bool proof = 3;
 }


### PR DESCRIPTION
This PR fixes #1022, here's a breakdown of what it does:

1. [x] make all `state_key` methods return their respective raw path instead of `KeyHash`
2. [x] make downstream consumers of `state_key` modules meet the new API
3. [x] protobuf: remove the `key_hash` field from the `KeyValueRequest` message definition
4. [x] pd: modify how "specific" `Info` requests for `key_value` are executed (always use `get_with_proof`)
5. [x] pcli: stop using `KeyHash` in query commands for `ShieldedPool` (WIP - I have questions about this)
7. [x] cargo fmt
8. [x] testing

There are two chunks of code that require increased scrutiny from reviewers:
- [x] pd: check that the new logic for the key value req builder makes sense ([see diff here](https://github.com/penumbra-zone/penumbra/commit/9fbc0ef799bfcaec9c86dad389421e7832932d41))
- [ ] pcli: check that the simplified logic to exec `QueryCmd`s makes sense ([see diff here](https://github.com/penumbra-zone/penumbra/pull/1228/commits/2c762af1a4b54dabe3764eda576d41abcaa71dfc#diff-513818ec006aae6ecbe2ac3333af33dd6494d6d31c4cb18b179b11859dfdd8c2R31))