### PR TITLE
chore(clippy): clippy --fix -Z unstable-options

### DIFF
--- a/component/src/ibc/component/connection/stateless.rs
+++ b/component/src/ibc/component/connection/stateless.rs
@@ -15,9 +15,9 @@ pub mod connection_open_init {
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("invalid version"))?,
         ) {
-            return Err(anyhow::anyhow!(
+            Err(anyhow::anyhow!(
                 "unsupported version: in ConnectionOpenInit",
-            ));
+            ))
         } else {
             Ok(())
         }
@@ -29,7 +29,7 @@ pub mod connection_open_ack {
 
     pub fn has_client_proof(msg: &MsgConnectionOpenAck) -> anyhow::Result<()> {
         if msg.proofs.client_proof().is_none() {
-            return Err(anyhow::anyhow!("missing client_proof"));
+            Err(anyhow::anyhow!("missing client_proof"))
         } else {
             Ok(())
         }
@@ -37,7 +37,7 @@ pub mod connection_open_ack {
 
     pub fn has_client_state(msg: &MsgConnectionOpenAck) -> anyhow::Result<()> {
         if msg.client_state.is_none() {
-            return Err(anyhow::anyhow!("missing client_state"));
+            Err(anyhow::anyhow!("missing client_state"))
         } else {
             Ok(())
         }
@@ -45,7 +45,7 @@ pub mod connection_open_ack {
 
     pub fn has_consensus_proof(msg: &MsgConnectionOpenAck) -> anyhow::Result<()> {
         if msg.proofs.consensus_proof().is_none() {
-            return Err(anyhow::anyhow!("missing consensus_proof"));
+            Err(anyhow::anyhow!("missing consensus_proof"))
         } else {
             Ok(())
         }
@@ -57,7 +57,7 @@ pub mod connection_open_try {
 
     pub fn has_client_proof(msg: &MsgConnectionOpenTry) -> anyhow::Result<()> {
         if msg.proofs.client_proof().is_none() {
-            return Err(anyhow::anyhow!("missing client_proof"));
+            Err(anyhow::anyhow!("missing client_proof"))
         } else {
             Ok(())
         }
@@ -65,7 +65,7 @@ pub mod connection_open_try {
 
     pub fn has_client_state(msg: &MsgConnectionOpenTry) -> anyhow::Result<()> {
         if msg.client_state.is_none() {
-            return Err(anyhow::anyhow!("missing client_state"));
+            Err(anyhow::anyhow!("missing client_state"))
         } else {
             Ok(())
         }
@@ -73,7 +73,7 @@ pub mod connection_open_try {
 
     pub fn has_consensus_proof(msg: &MsgConnectionOpenTry) -> anyhow::Result<()> {
         if msg.proofs.consensus_proof().is_none() {
-            return Err(anyhow::anyhow!("missing consensus_proof"));
+            Err(anyhow::anyhow!("missing consensus_proof"))
         } else {
             Ok(())
         }

--- a/component/src/stake/component.rs
+++ b/component/src/stake/component.rs
@@ -1331,7 +1331,7 @@ pub trait View: StateExt {
         )
         .await;
         self.put_domain(
-            state_key::validator_id_by_consensus_key(&consensus_key).into(),
+            state_key::validator_id_by_consensus_key(consensus_key).into(),
             identity_key.clone(),
         )
         .await;

--- a/crypto/src/asset/denom.rs
+++ b/crypto/src/asset/denom.rs
@@ -229,7 +229,7 @@ impl Unit {
     pub fn parse_value(&self, value: &str) -> Result<u64, anyhow::Error> {
         let split: Vec<&str> = value.split('.').collect();
         if split.len() > 2 {
-            return Err(anyhow::anyhow!("expected only one decimal point"));
+            Err(anyhow::anyhow!("expected only one decimal point"))
         } else {
             let left = split[0];
 

--- a/crypto/src/keys/seed_phrase.rs
+++ b/crypto/src/keys/seed_phrase.rs
@@ -80,7 +80,7 @@ impl SeedPhrase {
         let mut hasher = sha2::Sha256::new();
         hasher.update(randomness);
         if hasher.finalize()[0] != checksum {
-            return Err(anyhow::anyhow!("seed phrase checksum did not validate"));
+            Err(anyhow::anyhow!("seed phrase checksum did not validate"))
         } else {
             Ok(())
         }

--- a/eddy/src/value.rs
+++ b/eddy/src/value.rs
@@ -7,7 +7,7 @@ use crate::{limb, proofs, Ciphertext, EncryptionKey};
 /// While only encryptions of 64-bit values are supported, the `Value` type
 /// holds a `u128` internally, because the sum of 64-bit values may exceed 64
 /// bits.  Attempting to encrypt a `Value` bigger than 64 bits will fail.
-#[derive(Default, PartialEq)]
+#[derive(Default, PartialEq, Eq)]
 pub struct Value(pub u128);
 
 impl From<u64> for Value {

--- a/storage/src/app_hash.rs
+++ b/storage/src/app_hash.rs
@@ -40,7 +40,7 @@ pub static PENUMBRA_PROOF_SPECS: Lazy<ProofSpecs> =
 pub static PENUMBRA_COMMITMENT_PREFIX: Lazy<CommitmentPrefix> =
     Lazy::new(|| CommitmentPrefix::try_from(APPHASH_DOMSEP.as_bytes().to_vec()).unwrap());
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct AppHash(pub [u8; 32]);
 
 // the app hash of penumbra's state is defined as SHA256("PenumbraAppHash" || jmt.root_hash())

--- a/transaction/src/action/swap.rs
+++ b/transaction/src/action/swap.rs
@@ -64,7 +64,7 @@ impl From<Body> for pb::SwapBody {
             trading_pair: s.trading_pair.into(),
             delta_1: s.delta_1,
             delta_2: s.delta_2,
-            fee_commitment: (&s.fee_commitment.to_bytes()).to_vec(),
+            fee_commitment: s.fee_commitment.to_bytes().to_vec(),
             swap_nft: Some(s.swap_nft.into()),
             swap_ciphertext: s.swap_ciphertext.0.to_vec(),
         }


### PR DESCRIPTION
some smol clippy auto fixes.

had to roll back some clippy false positives manually, as clippy tries to fix


```diff
-        let nonce = Nonce::from_slice(&*MEMO_ENCRYPTION_NONCE);
+        let nonce = Nonce::from_slice(MEMO_ENCRYPTION_NONCE);

```

for lazy arrays

```
static MEMO_ENCRYPTION_NONCE: Lazy<[u8; 12]>;
```

which does not compile.

`&*MEMO_ENCRYPTION_NONCE` is also `&MEMO_ENCRYPTION_NONCE[..]`

or since the arrays can be made const, the lazy could be omitted entirely:

```diff
-pub static NOTE_ENCRYPTION_NONCE: Lazy<[u8; 12]> = Lazy::new(|| [0u8; 12]);
+pub static NOTE_ENCRYPTION_NONCE: [u8;12] = [0u8; 12];

```

