### PR TITLE
crypto: add `PayloadKey` and use for notes, memos, and swaps

### DIFF
--- a/crypto/src/dex/swap.rs
+++ b/crypto/src/dex/swap.rs
@@ -20,13 +20,8 @@ use super::TradingPair;
 pub const SWAP_CIPHERTEXT_BYTES: usize = 184;
 // Swap plaintext byte length
 pub const SWAP_LEN_BYTES: usize = 168;
-pub const OVK_WRAPPED_LEN_BYTES: usize = 80;
 
-/// The nonce used for swap encryption.
-///
-/// The nonce will always be `[9u8; 12]` which is okay since we use a new
-/// ephemeral key each time.
-pub static SWAP_ENCRYPTION_NONCE: Lazy<[u8; 12]> = Lazy::new(|| [9u8; 12]);
+pub const OVK_WRAPPED_LEN_BYTES: usize = 80;
 
 pub static DOMAIN_SEPARATOR: Lazy<Fq> =
     Lazy::new(|| Fq::from_le_bytes_mod_order(blake2b_simd::blake2b(b"penumbra.swap").as_bytes()));

--- a/crypto/src/dex/swap/ciphertext.rs
+++ b/crypto/src/dex/swap/ciphertext.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use crate::{
     ka,
-    symmetric::{PayloadKey, SWAP_ENCRYPTION_NONCE},
+    symmetric::{PayloadKey, PayloadKind},
 };
 
 use super::{SwapPlaintext, SWAP_CIPHERTEXT_BYTES, SWAP_LEN_BYTES};
@@ -24,7 +24,7 @@ impl SwapCiphertext {
         let key = PayloadKey::derive(&shared_secret, &epk);
         let swap_ciphertext = self.0;
         let decryption_result = key
-            .decrypt(swap_ciphertext.to_vec(), *SWAP_ENCRYPTION_NONCE)
+            .decrypt(swap_ciphertext.to_vec(), PayloadKind::Swap)
             .map_err(|_| anyhow::anyhow!("unable to decrypt swap ciphertext"))?;
 
         let plaintext: [u8; SWAP_LEN_BYTES] = decryption_result

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -19,6 +19,7 @@ mod note_payload;
 mod nullifier;
 mod prf;
 pub mod proofs;
+mod symmetric;
 pub mod transaction;
 pub mod value;
 

--- a/crypto/src/memo.rs
+++ b/crypto/src/memo.rs
@@ -7,7 +7,7 @@ use crate::{
     keys::{IncomingViewingKey, OutgoingViewingKey},
     note,
     note::OVK_WRAPPED_LEN_BYTES,
-    symmetric::{PayloadKey, MEMO_ENCRYPTION_NONCE},
+    symmetric::{PayloadKey, PayloadKind},
     value, Address, Note,
 };
 
@@ -49,7 +49,7 @@ impl MemoPlaintext {
             .expect("key agreement succeeds");
 
         let key = PayloadKey::derive(&shared_secret, &epk);
-        let encryption_result = key.encrypt(self.0.to_vec(), *MEMO_ENCRYPTION_NONCE);
+        let encryption_result = key.encrypt(self.0.to_vec(), PayloadKind::Memo);
         let ciphertext: [u8; MEMO_CIPHERTEXT_LEN_BYTES] = encryption_result
             .try_into()
             .expect("memo encryption result fits in ciphertext len");
@@ -69,7 +69,7 @@ impl MemoPlaintext {
 
         let key = PayloadKey::derive(&shared_secret, &epk);
         let plaintext = key
-            .decrypt(ciphertext.0.to_vec(), *MEMO_ENCRYPTION_NONCE)
+            .decrypt(ciphertext.0.to_vec(), PayloadKind::Memo)
             .map_err(|_| anyhow!("decryption error"))?;
 
         let plaintext_bytes: [u8; MEMO_LEN_BYTES] = plaintext
@@ -95,7 +95,7 @@ impl MemoPlaintext {
             .map_err(|_| anyhow!("could not perform key agreement"))?;
         let key = PayloadKey::derive(&shared_secret, &epk);
         let plaintext = key
-            .decrypt(ciphertext.0.to_vec(), *MEMO_ENCRYPTION_NONCE)
+            .decrypt(ciphertext.0.to_vec(), PayloadKind::Memo)
             .map_err(|_| anyhow!("decryption error"))?;
 
         let plaintext_bytes: [u8; MEMO_LEN_BYTES] = plaintext

--- a/crypto/src/symmetric.rs
+++ b/crypto/src/symmetric.rs
@@ -1,0 +1,59 @@
+use anyhow::Result;
+use chacha20poly1305::{
+    aead::{Aead, NewAead},
+    ChaCha20Poly1305, Key, Nonce,
+};
+use once_cell::sync::Lazy;
+
+use crate::ka;
+
+/// The nonce used for note encryption.
+pub static NOTE_ENCRYPTION_NONCE: Lazy<[u8; 12]> = Lazy::new(|| [0u8; 12]);
+
+/// The nonce used for memo encryption.
+pub static MEMO_ENCRYPTION_NONCE: Lazy<[u8; 12]> = Lazy::new(|| {
+    let nonce_bytes = 1u128.to_le_bytes();
+    nonce_bytes[0..12].try_into().expect("nonce fits in array")
+});
+
+/// The nonce used for swap encryption.
+pub static SWAP_ENCRYPTION_NONCE: Lazy<[u8; 12]> = Lazy::new(|| [9u8; 12]);
+
+/// Represents a symmetric `ChaCha20Poly1305` key.
+///
+/// Used for encrypting and decrypting notes, memos and swaps.
+pub struct PayloadKey(Key);
+
+impl PayloadKey {
+    /// Use Blake2b-256 to derive the symmetric key material for note and memo encryption.
+    pub fn derive(shared_secret: &ka::SharedSecret, epk: &ka::Public) -> Self {
+        let mut kdf_params = blake2b_simd::Params::new();
+        kdf_params.hash_length(32);
+        let mut kdf = kdf_params.to_state();
+        kdf.update(&shared_secret.0);
+        kdf.update(&epk.0);
+
+        let key = kdf.finalize();
+        Self(*Key::from_slice(key.as_bytes()))
+    }
+
+    /// Encrypt a note, swap, or memo using the `PayloadKey`.
+    pub fn encrypt(&self, plaintext: Vec<u8>, nonce: [u8; 12]) -> Vec<u8> {
+        let cipher = ChaCha20Poly1305::new(&self.0);
+        let nonce = Nonce::from_slice(&nonce);
+
+        cipher
+            .encrypt(nonce, plaintext.as_ref())
+            .expect("encryption succeeded")
+    }
+
+    /// Decrypt a note, swap, or memo using the `PayloadKey`.
+    pub fn decrypt(&self, ciphertext: Vec<u8>, nonce: [u8; 12]) -> Result<Vec<u8>> {
+        let cipher = ChaCha20Poly1305::new(&self.0);
+        let nonce = Nonce::from_slice(&nonce);
+
+        cipher
+            .decrypt(nonce, ciphertext.as_ref())
+            .map_err(|_| anyhow::anyhow!("decryption error"))
+    }
+}


### PR DESCRIPTION
This has two of the items towards #1264. It adds a `symmetric` module that contains a new `PayloadKey` to represent the symmetric key used to encrypt/decrypt notes, memos and swaps

Closes #1268