### PR TITLE
Better console UX for seed phrase generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,7 @@ dependencies = [
  "libc",
  "once_cell",
  "terminal_size",
+ "unicode-width",
  "winapi",
 ]
 
@@ -2824,6 +2825,7 @@ dependencies = [
  "clap 3.2.17",
  "colored_json",
  "comfy-table",
+ "console",
  "decaf377",
  "directories",
  "ed25519-consensus 1.2.1",

--- a/crypto/src/keys.rs
+++ b/crypto/src/keys.rs
@@ -5,7 +5,10 @@ mod nullifier;
 pub use nullifier::{NullifierKey, NK_LEN_BYTES};
 
 mod seed_phrase;
-pub use seed_phrase::SeedPhrase;
+pub use seed_phrase::{
+    SeedPhrase, BIP39_MAX_WORD_LENGTH, BIP39_WORDS, NUM_WORDS as SEED_PHRASE_NUM_WORDS,
+    WORDS_PER_LINE as SEED_PHRASE_WORDS_PER_LINE,
+};
 
 mod spend;
 pub use spend::{SpendKey, SpendKeyBytes, SPENDKEY_LEN_BYTES};

--- a/crypto/src/keys/seed_phrase.rs
+++ b/crypto/src/keys/seed_phrase.rs
@@ -4,8 +4,9 @@ use rand_core::{CryptoRng, RngCore};
 use sha2::Digest;
 
 mod words;
-use words::{BIP39_MAX_WORD_LENGTH, BIP39_WORDS};
+pub use words::{BIP39_MAX_WORD_LENGTH, BIP39_WORDS};
 
+pub const WORDS_PER_LINE: usize = 4;
 pub const NUM_PBKDF2_ROUNDS: u32 = 2048;
 pub const NUM_WORDS: usize = 24;
 pub const NUM_ENTROPY_BITS: usize = 256;
@@ -87,12 +88,12 @@ impl SeedPhrase {
     }
 
     /// Format a "redacted" seed phrase, with the words replaced with censor-bars.
-    pub fn format_redacted() -> String {
+    pub fn format_redacted(redact_character: char) -> String {
         let mut censored_words = Vec::with_capacity(NUM_WORDS);
         for _ in 0..NUM_WORDS {
             let mut censored_word = String::with_capacity(BIP39_MAX_WORD_LENGTH);
             for _ in 0..BIP39_MAX_WORD_LENGTH {
-                censored_word.push('█');
+                censored_word.push(redact_character);
             }
             censored_words.push(censored_word.clone());
         }
@@ -104,8 +105,6 @@ impl SeedPhrase {
 
 impl fmt::Display for SeedPhrase {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const WORDS_PER_LINE: usize = 4;
-
         let words_per_column: usize = self.0.len() / WORDS_PER_LINE;
 
         for i in 0..self.0.len() {

--- a/crypto/src/keys/seed_phrase/words.rs
+++ b/crypto/src/keys/seed_phrase/words.rs
@@ -1,3 +1,19 @@
+/// Maximum length of any BIP39 word, for use in formatting.
+pub static BIP39_MAX_WORD_LENGTH: usize = {
+    // The non-idiomatic style here ensures that this is const code (since we can't use traits yet
+    // in const code, we can't do map, maximum, etc.)
+    let mut max_length = 0;
+    let mut i = 0;
+    while i < BIP39_WORDS.len() {
+        let word_length = BIP39_WORDS[i].len();
+        if word_length > max_length {
+            max_length = word_length;
+        }
+        i += 1;
+    }
+    max_length
+};
+
 /// English words for generating seed phrases.
 ///
 /// Taken from: https://github.com/bitcoin/bips/blob/master/bip-0039/english.txt

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -70,6 +70,7 @@ clap = { version = "3", features = ["derive", "env"] }
 camino = "1"
 url = "2"
 colored_json = "2.1"
+console = "0.15"
 
 [build-dependencies]
 vergen = "5"

--- a/pcli/src/command/wallet/import.rs
+++ b/pcli/src/command/wallet/import.rs
@@ -1,0 +1,266 @@
+use anyhow::Result;
+
+use penumbra_crypto::keys::{
+    SeedPhrase, BIP39_MAX_WORD_LENGTH, BIP39_WORDS, SEED_PHRASE_NUM_WORDS as NUM_WORDS,
+    SEED_PHRASE_WORDS_PER_LINE as WORDS_PER_LINE,
+};
+
+const WORDS_PER_COLUMN: usize = NUM_WORDS / WORDS_PER_LINE;
+
+/// Interactively prompt the user for a seed phrase and return it when finished.
+pub fn interactive() -> Result<String> {
+    let mut state: State = State::start()?;
+
+    let phrase = loop {
+        if let Some(phrase) = state.full_phrase() {
+            break phrase;
+        }
+
+        state.read_key()?;
+    };
+
+    Ok(phrase)
+}
+
+/// The state of the interactive seed phrase import process.
+///
+/// This steps forward one step for each character read. The language accepted by this state machine
+/// is a superset of both space-separated seed phrases and numbered seed phrases, and accepts any
+/// column format and numbering order (or lack thereof).
+struct State {
+    read_state: String,
+    jump_state: Option<usize>,
+    number: usize,
+    partial_phrase: [Option<&'static str>; NUM_WORDS],
+    term: console::Term,
+}
+
+impl State {
+    /// Initialize the state machine and print the starting grid.
+    fn start() -> Result<Self> {
+        let this = Self {
+            read_state: String::new(),
+            jump_state: None,
+            number: 0,
+            partial_phrase: [None; NUM_WORDS],
+            term: console::Term::stdout(),
+        };
+
+        // Print the initial layout and move the cursor into position
+        this.term.write_str(&SeedPhrase::format_redacted(' '))?;
+        this.term.move_cursor_left(usize::MAX)?;
+        this.term.move_cursor_up(5)?;
+        this.term.move_cursor_right(4)?;
+
+        Ok(this)
+    }
+
+    /// Attempt to extract the full phrase from the state.
+    fn full_phrase(&self) -> Option<String> {
+        let mut phrase = String::new();
+        for (i, word) in self.partial_phrase.iter().enumerate() {
+            if let Some(word) = word {
+                phrase.push_str(word);
+                if i < NUM_WORDS - 1 {
+                    phrase.push(' ');
+                }
+            } else {
+                return None;
+            }
+        }
+        Some(phrase)
+    }
+
+    /// Read a single key and process it.
+    fn read_key(&mut self) -> Result<()> {
+        let key = self.term.read_key()?;
+
+        // Reset the jump state to `None`, unless the user presses a numeric key next
+        let jump_state = self.jump_state.take();
+
+        match key {
+            console::Key::Char(' ') => {
+                // We don't advance the cursor when the word hasn't been finalized here yet,
+                // because this allows you to copy/paste a numbered seed phrase, and the
+                // multiple spaces in a row won't interfere. If you want to manually skip, you
+                // can use enter/tab/arrow keys, like a spreadsheet.
+                self.try_commit();
+                if self.partial_phrase[self.number].is_some() {
+                    self.move_to(self.number.saturating_add(1))?;
+                }
+            }
+
+            // Arrow keys move around the way you would expect:
+            console::Key::ArrowLeft => {
+                if let Some(n) = self.number.checked_sub(WORDS_PER_COLUMN) {
+                    self.move_to(n)?;
+                }
+            }
+            console::Key::ArrowRight | console::Key::Tab => {
+                self.move_to(self.number.saturating_add(WORDS_PER_COLUMN))?
+            }
+            console::Key::ArrowUp => self.move_to(self.number.saturating_sub(1))?,
+            console::Key::ArrowDown | console::Key::Enter => {
+                self.move_to(self.number.saturating_add(1))?
+            }
+
+            // Home and end go to the first and last entries:
+            console::Key::Home => self.move_to(0)?,
+            console::Key::End => self.move_to(NUM_WORDS - 1)?,
+
+            // Backspace deletes one character of the current word, or one digit of the number being
+            // jumped to, and immediately jumps if necessary:
+            console::Key::Backspace => {
+                // If we're in the middle of a numeric jump, interpret the backspace key as going
+                // back one digit in the number.
+                if let Some(n) = jump_state {
+                    let n = n / 10;
+                    if n != 0 {
+                        self.move_to(n)?;
+                        self.jump_state = Some(n);
+                    }
+                    return Ok(());
+                }
+
+                // Delete the last character of the current word being typed
+                if self.read_state.pop().is_none() {
+                    // If the word is empty, go back one word after setting this word to `None` in
+                    // the underlying phrase (this means you can clear words by revisiting them and
+                    // backspacing through them)
+                    self.partial_phrase[self.number] = None;
+                    self.term.write_str("        ")?;
+                    self.term.move_cursor_left(8)?;
+                    self.move_to(self.number.saturating_sub(1))?;
+                } else {
+                    // Erase the deleted character from the screen
+                    self.term.move_cursor_left(1)?;
+                    self.term.write_str(" ")?;
+                    self.term.move_cursor_left(1)?;
+
+                    // If the read state is now empty, render the right background
+                    if self.read_state.is_empty() {
+                        if self.partial_phrase[self.number].is_some() {
+                            self.term.write_str("████████")?;
+                            self.term.move_cursor_left(8)?;
+                        }
+                    }
+                }
+            }
+            console::Key::Char(c) => {
+                match c {
+                    // Digit characters initiate an immediate jump to another cell, and multiple
+                    // digits in a row jump to the combined value of the digits, unless it exceeds
+                    // the size of the table, in which case only the most recent is considered
+                    '0'..='9' => {
+                        let digit = c.to_digit(10).unwrap() as usize;
+                        let n = if let Some(n) = jump_state {
+                            let n = n * 10 + digit;
+                            if n <= NUM_WORDS {
+                                n
+                            } else {
+                                digit
+                            }
+                        } else {
+                            digit
+                        };
+                        self.move_to(n.saturating_sub(1))?;
+                        self.jump_state = Some(n);
+                    }
+                    // All other characters are tentatively pushed onto the word, and then the word
+                    // is checked for prefix inclusion in the word set, before permitting the
+                    // character to be added
+                    _ => {
+                        let mut tentative = self.read_state.clone();
+                        tentative.push(c);
+
+                        // Determine if the tentative word is a valid prefix (we only let the user type
+                        // valid prefixes of BIP39 words)
+                        let valid_prefix = match BIP39_WORDS.binary_search(&tentative.as_str()) {
+                            Ok(_) => true,
+                            Err(i) => {
+                                if let Some(full_word) = BIP39_WORDS.get(i) {
+                                    full_word.starts_with(&tentative)
+                                } else {
+                                    false
+                                }
+                            }
+                        };
+
+                        if valid_prefix {
+                            if self.read_state.is_empty() {
+                                self.term.write_str("        ")?;
+                                self.term.move_cursor_left(8)?;
+                            }
+                            self.term.write_str(&c.to_string())?;
+                            self.read_state = tentative;
+                        }
+                    }
+                }
+            }
+            _ => { /* ignore anything else */ }
+        }
+
+        Ok(())
+    }
+
+    // Move the cursor to the given index in the grid, and commit the word if possible.
+    fn move_to(&mut self, n: usize) -> Result<()> {
+        if n == self.number {
+            return Ok(()); // bail if trying to go to where we already are
+        }
+
+        self.finish_word()?;
+
+        let from_line = self.number % WORDS_PER_COLUMN;
+        let from_column = self.number / WORDS_PER_COLUMN;
+        let to_line = n % WORDS_PER_COLUMN;
+        let to_column = n / WORDS_PER_COLUMN;
+
+        if n >= NUM_WORDS {
+            return Ok(()); // bail if trying to move off the grid
+        }
+
+        self.number = n;
+
+        if to_line > from_line {
+            self.term.move_cursor_down(to_line - from_line)?;
+        } else {
+            self.term.move_cursor_up(from_line - to_line)?;
+        }
+
+        if to_column > from_column {
+            self.term
+                .move_cursor_right((to_column - from_column) * (BIP39_MAX_WORD_LENGTH + 5))?;
+        } else {
+            self.term
+                .move_cursor_left((from_column - to_column) * (BIP39_MAX_WORD_LENGTH + 5))?;
+        }
+
+        Ok(())
+    }
+
+    /// Commit the current word, or don't, displaying as appropriate.
+    fn finish_word(&mut self) -> Result<()> {
+        self.try_commit();
+
+        self.term.move_cursor_left(self.read_state.len())?;
+        if self.partial_phrase[self.number].is_some() {
+            self.term.write_str("████████")?;
+        } else {
+            self.term.write_str("        ")?;
+        }
+        self.term.move_cursor_left(8)?;
+
+        // Reset the read state because we moved away from the word
+        self.read_state = String::new();
+
+        Ok(())
+    }
+
+    /// Try to commit the current word.
+    fn try_commit(&mut self) {
+        if let Ok(index) = BIP39_WORDS.binary_search(&self.read_state.as_str()) {
+            self.partial_phrase[self.number] = Some(BIP39_WORDS[index]);
+        }
+    }
+}

--- a/pcli/src/command/wallet/import.rs
+++ b/pcli/src/command/wallet/import.rs
@@ -147,6 +147,7 @@ impl State {
                 }
             }
             console::Key::Char(c) => {
+                let c = c.to_ascii_lowercase();
                 match c {
                     // Digit characters initiate an immediate jump to another cell, and multiple
                     // digits in a row jump to the combined value of the digits, unless it exceeds

--- a/wallet/src/key_store.rs
+++ b/wallet/src/key_store.rs
@@ -12,7 +12,8 @@ impl KeyStore {
     pub fn save(&self, path: impl AsRef<std::path::Path>) -> anyhow::Result<()> {
         if path.as_ref().exists() {
             return Err(anyhow::anyhow!(
-                "Wallet file already exists, refusing to overwrite it"
+                "Wallet file {} already exists, refusing to overwrite it",
+                path.as_ref().display()
             ));
         }
         use std::io::Write;


### PR DESCRIPTION
This is in response to a long-outstanding comment in the `pcli` code that we should make it harder to accidentally spill your seed phrase when copying console output. This fixes that, as well as generally improving seed phrase ergonomics in other ways:

- Seed phrases are now displayed in a way that makes them easier to read when writing them down.
- Users are prompted to explicitly confirm that they have written down their seed phrase.
- Seed phrases are cleared from the screen after being written down, so they cannot accidentally show up in copied logs after the fact.

The interaction looks like the below...

1. Initially, you see this:
```
        Welcome to Penumbra. 🌘 

  Below is your private seed phrase.
    No other person should ever read it.
  It cannot be recovered if lost.
    It will never be displayed again.

Write it down right now and keep it safe!

 1. execute   7. carry    13. shield   19. loan    
 2. confirm   8. mad      14. youth    20. combine 
 3. maximum   9. floor    15. husband  21. opinion 
 4. choose   10. frozen   16. vessel   22. solution
 5. now      11. amount   17. fly      23. vibrant 
 6. attract  12. sport    18. shallow  24. oval    

To continue, type:

  I have written down my private seed phrase.
> █
```

2. Then, as you're typing the confirmation prompt, it looks like this:
```
        Welcome to Penumbra. 🌘 

  Below is your private seed phrase.
    No other person should ever read it.
  It cannot be recovered if lost.
    It will never be displayed again.

Write it down right now and keep it safe!

 1. execute   7. carry    13. shield   19. loan    
 2. confirm   8. mad      14. youth    20. combine 
 3. maximum   9. floor    15. husband  21. opinion 
 4. choose   10. frozen   16. vessel   22. solution
 5. now      11. amount   17. fly      23. vibrant 
 6. attract  12. sport    18. shallow  24. oval    

To continue, type:

                             ate seed phrase.
> I have written down my priv█
```

3. Finally, when you're done, it censors the seed phrase in the console:
```
        Welcome to Penumbra. 🌘 

  Below is your private seed phrase.
    No other person should ever read it.
  It cannot be recovered if lost.
    It will never be displayed again.

Write it down right now and keep it safe!

 1. ████████  7. ████████ 13. ████████ 19. ████████
 2. ████████  8. ████████ 14. ████████ 20. ████████
 3. ████████  9. ████████ 15. ████████ 21. ████████
 4. ████████ 10. ████████ 16. ████████ 22. ████████
 5. ████████ 11. ████████ 17. ████████ 23. ████████
 6. ████████ 12. ████████ 18. ████████ 24. ████████

Saving backup wallet to /home/$USER/.local/share/penumbra-testnet-archive/f1b1dd6d7b830d0e/custody.json
```