### PR TITLE
crypto: add `OvkWrappedKey` and `PayloadKey`-only decrypt method

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -32,6 +32,7 @@ pub use keys::FullViewingKey;
 pub use note::Note;
 pub use note_payload::NotePayload;
 pub use nullifier::Nullifier;
+pub use symmetric::PayloadKey;
 pub use value::Value;
 
 fn fmt_hex<T: AsRef<[u8]>>(data: T, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -19,7 +19,7 @@ mod note_payload;
 mod nullifier;
 mod prf;
 pub mod proofs;
-mod symmetric;
+pub mod symmetric;
 pub mod transaction;
 pub mod value;
 

--- a/crypto/src/memo.rs
+++ b/crypto/src/memo.rs
@@ -6,8 +6,7 @@ use crate::{
     ka,
     keys::{IncomingViewingKey, OutgoingViewingKey},
     note,
-    note::OVK_WRAPPED_LEN_BYTES,
-    symmetric::{PayloadKey, PayloadKind},
+    symmetric::{OvkWrappedKey, PayloadKey, PayloadKind},
     value, Address, Note,
 };
 
@@ -83,7 +82,7 @@ impl MemoPlaintext {
     /// Decrypt a `MemoCiphertext` using the wrapped OVK to generate a plaintext `Memo`.
     pub fn decrypt_outgoing(
         ciphertext: MemoCiphertext,
-        wrapped_ovk: [u8; OVK_WRAPPED_LEN_BYTES],
+        wrapped_ovk: OvkWrappedKey,
         cm: note::Commitment,
         cv: value::Commitment,
         ovk: &OutgoingViewingKey,

--- a/crypto/src/memo.rs
+++ b/crypto/src/memo.rs
@@ -88,12 +88,10 @@ impl MemoPlaintext {
         ovk: &OutgoingViewingKey,
         epk: &ka::Public,
     ) -> Result<MemoPlaintext, anyhow::Error> {
-        let (esk, transmission_key) = Note::decrypt_key(wrapped_ovk, cm, cv, ovk, epk)
+        let shared_secret = Note::decrypt_key(wrapped_ovk, cm, cv, ovk, epk)
             .map_err(|_| anyhow!("key decryption error"))?;
-        let shared_secret = esk
-            .key_agreement_with(&transmission_key)
-            .map_err(|_| anyhow!("could not perform key agreement"))?;
-        let key = PayloadKey::derive(&shared_secret, &epk);
+
+        let key = PayloadKey::derive(&shared_secret, epk);
         let plaintext = key
             .decrypt(ciphertext.0.to_vec(), PayloadKind::Memo)
             .map_err(|_| anyhow!("decryption error"))?;

--- a/crypto/src/symmetric.rs
+++ b/crypto/src/symmetric.rs
@@ -6,7 +6,7 @@ use chacha20poly1305::{
 
 use crate::{ka, keys::OutgoingViewingKey, note, value};
 
-pub const OVK_WRAPPED_LEN_BYTES: usize = 80;
+pub const OVK_WRAPPED_LEN_BYTES: usize = 48;
 
 /// Represents the item to be encrypted/decrypted with the [`PayloadKey`].
 pub enum PayloadKind {

--- a/decaf377-ka/src/lib.rs
+++ b/decaf377-ka/src/lib.rs
@@ -139,6 +139,17 @@ impl TryFrom<[u8; 32]> for Secret {
     }
 }
 
+impl TryFrom<[u8; 32]> for SharedSecret {
+    type Error = Error;
+    fn try_from(bytes: [u8; 32]) -> Result<SharedSecret, Error> {
+        decaf377::Encoding(bytes)
+            .vartime_decompress()
+            .map_err(|_| Error::InvalidSecret)?;
+
+        Ok(SharedSecret(bytes))
+    }
+}
+
 impl From<&Secret> for [u8; 32] {
     fn from(s: &Secret) -> Self {
         s.0.to_bytes()

--- a/transaction/src/action/output.rs
+++ b/transaction/src/action/output.rs
@@ -3,7 +3,8 @@ use std::convert::{TryFrom, TryInto};
 use anyhow::Error;
 use bytes::Bytes;
 use penumbra_crypto::{
-    memo::MemoCiphertext, note, proofs::transparent::OutputProof, value, NotePayload,
+    memo::MemoCiphertext, proofs::transparent::OutputProof, symmetric::OvkWrappedKey, value,
+    NotePayload,
 };
 use penumbra_proto::{transaction as pb, Protobuf};
 
@@ -18,7 +19,7 @@ pub struct Body {
     pub note_payload: NotePayload,
     pub value_commitment: value::Commitment,
     pub encrypted_memo: MemoCiphertext,
-    pub ovk_wrapped_key: [u8; note::OVK_WRAPPED_LEN_BYTES],
+    pub ovk_wrapped_key: OvkWrappedKey,
 }
 
 impl Protobuf<pb::Output> for Output {}
@@ -57,7 +58,7 @@ impl From<Body> for pb::OutputBody {
             note_payload: Some(output.note_payload.into()),
             value_commitment: Some(output.value_commitment.into()),
             encrypted_memo: Bytes::copy_from_slice(&output.encrypted_memo.0),
-            ovk_wrapped_key: Bytes::copy_from_slice(&output.ovk_wrapped_key),
+            ovk_wrapped_key: Bytes::copy_from_slice(&output.ovk_wrapped_key.0),
         }
     }
 }
@@ -78,7 +79,7 @@ impl TryFrom<pb::OutputBody> for Body {
                 .map_err(|_| anyhow::anyhow!("output malformed"))?,
         );
 
-        let ovk_wrapped_key: [u8; note::OVK_WRAPPED_LEN_BYTES] = proto.ovk_wrapped_key[..]
+        let ovk_wrapped_key: OvkWrappedKey = proto.ovk_wrapped_key[..]
             .try_into()
             .map_err(|_| anyhow::anyhow!("output malformed"))?;
 

--- a/transaction/src/auth_hash.rs
+++ b/transaction/src/auth_hash.rs
@@ -194,7 +194,7 @@ impl output::Body {
         state.update(&self.note_payload.encrypted_note);
         state.update(&self.value_commitment.to_bytes());
         state.update(&self.encrypted_memo.0);
-        state.update(&self.ovk_wrapped_key);
+        state.update(&self.ovk_wrapped_key.0);
 
         state.finalize()
     }


### PR DESCRIPTION
Three more symmetric crypto items towards #1264:
- makes `PayloadKey` pub and enables one to decrypt a note ciphertext given only a `PayloadKey` - this is for a scenario where a user wishes to share fine grained viewing capability to a third party (but not provide viewing keys for all time)
- adds an `OvkWrappedKey` struct to represent the encrypted key material to reconstruct the `PayloadKey` at a later date
- stores the `SharedSecret` in `OvkWrappedKey` instead of the transmission key and ephemeral secret (saves 32 bytes)