### PR TITLE
Support generating plans for Swap/SwapClaim in wallet

### DIFF
--- a/transaction/src/plan.rs
+++ b/transaction/src/plan.rs
@@ -14,7 +14,7 @@ mod action;
 mod auth;
 mod build;
 
-pub use action::{ActionPlan, DelegatorVotePlan, OutputPlan, SpendPlan};
+pub use action::{ActionPlan, DelegatorVotePlan, OutputPlan, SpendPlan, SwapClaimPlan, SwapPlan};
 
 /// A declaration of a planned [`Transaction`](crate::Transaction),
 /// for use in transaction authorization and creation.
@@ -133,6 +133,26 @@ impl TransactionPlan {
     pub fn validator_votes(&self) -> impl Iterator<Item = &ValidatorVoteBody> {
         self.actions.iter().filter_map(|action| {
             if let ActionPlan::ValidatorVote(v) = action {
+                Some(v)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn swaps(&self) -> impl Iterator<Item = &SwapPlan> {
+        self.actions.iter().filter_map(|action| {
+            if let ActionPlan::Swap(v) = action {
+                Some(v)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn swap_claims(&self) -> impl Iterator<Item = &SwapClaimPlan> {
+        self.actions.iter().filter_map(|action| {
+            if let ActionPlan::SwapClaim(v) = action {
                 Some(v)
             } else {
                 None

--- a/transaction/src/plan/action.rs
+++ b/transaction/src/plan/action.rs
@@ -71,6 +71,18 @@ impl From<OutputPlan> for ActionPlan {
     }
 }
 
+impl From<SwapPlan> for ActionPlan {
+    fn from(inner: SwapPlan) -> ActionPlan {
+        ActionPlan::Swap(inner)
+    }
+}
+
+impl From<SwapClaimPlan> for ActionPlan {
+    fn from(inner: SwapClaimPlan) -> ActionPlan {
+        ActionPlan::SwapClaim(inner)
+    }
+}
+
 impl From<Delegate> for ActionPlan {
     fn from(inner: Delegate) -> ActionPlan {
         ActionPlan::Delegate(inner)

--- a/transaction/src/plan/action/swap_claim.rs
+++ b/transaction/src/plan/action/swap_claim.rs
@@ -40,6 +40,7 @@ pub struct SwapClaimPlan {
 impl SwapClaimPlan {
     /// Create a new [`SwapClaimPlan`] that redeems output notes to `claim_address` using
     /// the associated swap NFT.
+    #[allow(clippy::too_many_arguments)]
     pub fn new<R: RngCore + CryptoRng>(
         rng: &mut R,
         swap_nft_note: Note,

--- a/wallet/src/plan.rs
+++ b/wallet/src/plan.rs
@@ -1,3 +1,4 @@
+use rand_core::OsRng;
 use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Result;
@@ -442,6 +443,9 @@ where
         return Ok(plan);
     }
 
+    // Use a random ephemeral address for claiming the swap.
+    let (claim_address, _dtk) = fvk.incoming().ephemeral_address(OsRng);
+
     // Add a `SwapPlan` action:
     plan.actions.push(
         SwapPlan::new(
@@ -450,9 +454,7 @@ where
             delta_1,
             delta_2,
             Fee(fee),
-            // The `fvk` is always the claim address.
-            // TODO: this should probably select a random address index.
-            fvk.incoming().payment_address(0u64.into()).0,
+            claim_address,
         )
         .into(),
     );

--- a/wallet/src/plan.rs
+++ b/wallet/src/plan.rs
@@ -4,11 +4,14 @@ use anyhow::Result;
 use penumbra_component::stake::rate::RateData;
 use penumbra_component::stake::validator;
 use penumbra_crypto::{
-    asset::Denom, keys::AddressIndex, memo::MemoPlaintext, transaction::Fee, Address,
-    DelegationToken, FullViewingKey, Value, STAKING_TOKEN_ASSET_ID, STAKING_TOKEN_DENOM,
+    asset::Denom, dex::TradingPair, keys::AddressIndex, memo::MemoPlaintext, transaction::Fee,
+    Address, DelegationToken, FullViewingKey, Note, Value, STAKING_TOKEN_ASSET_ID,
+    STAKING_TOKEN_DENOM,
 };
 use penumbra_proto::view::NotesRequest;
-use penumbra_transaction::plan::{ActionPlan, OutputPlan, SpendPlan, TransactionPlan};
+use penumbra_transaction::plan::{
+    ActionPlan, OutputPlan, SpendPlan, SwapClaimPlan, SwapPlan, TransactionPlan,
+};
 use penumbra_view::{NoteRecord, ViewClient};
 use rand_core::{CryptoRng, RngCore};
 use tracing::instrument;
@@ -259,6 +262,271 @@ where
             spend_amount,
             spent_amount,
         ))?;
+    }
+
+    Ok(plan)
+}
+
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
+#[instrument(skip(fvk, view, rng, swap_nft_note, fee, source_address))]
+pub async fn swap_claim<V, R>(
+    fvk: &FullViewingKey,
+    view: &mut V,
+    mut rng: R,
+    swap_nft_note: Note,
+    fee: u64,
+    source_address: Option<u64>,
+) -> Result<TransactionPlan, anyhow::Error>
+where
+    V: ViewClient,
+    R: RngCore + CryptoRng,
+{
+    tracing::debug!(?swap_nft_note, ?fee, ?source_address);
+
+    return Err(anyhow::anyhow!("not implemented"));
+
+    let chain_params = view.chain_params().await?;
+
+    // TODO: need to fetch clearing price (`BatchSwapOutputData`) for the
+    // swap.
+
+    let mut plan = TransactionPlan {
+        chain_id: chain_params.chain_id,
+        fee: Fee(fee),
+        ..Default::default()
+    };
+
+    // Add a `SwapClaimPlan` action:
+    // plan.actions.push(
+    //     SwapClaimPlan::new(
+    //         &mut rng,
+    //         swap_nft_note,
+    //         swap_nft_position,
+    //         // The `fvk` is always the claim address.
+    //         fvk.address(),
+    //         fee,
+    //         output_data,
+    //         anchor,
+    //         trading_pair,
+    //     )
+    //     .into(),
+    // );
+
+    // The value we need to spend is 1 unit of the swap NFT, plus fees.
+    let mut value_to_spend: HashMap<Denom, u64> = HashMap::new();
+    // *value_to_spend.entry(swap_nft_note.denom()).or_default() += input_value;
+    // if fee > 0 {
+    //     *value_to_spend
+    //         .entry(STAKING_TOKEN_DENOM.clone())
+    //         .or_default() += fee;
+    // }
+
+    // Add the required spends:
+    for (denom, spend_amount) in value_to_spend {
+        if spend_amount == 0 {
+            continue;
+        }
+
+        let source_index: Option<AddressIndex> = source_address.map(Into::into);
+        // Select a list of notes that provides at least the required amount.
+        let notes_to_spend = view
+            .notes(NotesRequest {
+                fvk_hash: Some(fvk.hash().into()),
+                asset_id: Some(denom.id().into()),
+                address_index: source_index.map(Into::into),
+                amount_to_spend: spend_amount,
+                include_spent: false,
+            })
+            .await?;
+        if notes_to_spend.is_empty() {
+            // Shouldn't happen because the other side checks this, but just in case...
+            return Err(anyhow::anyhow!("not enough notes to spend",));
+        }
+
+        let change_address_index: u64 = fvk
+            .incoming()
+            .index_for_diversifier(
+                &notes_to_spend
+                    .last()
+                    .expect("notes_to_spend should never be empty")
+                    .note
+                    .diversifier(),
+            )
+            .try_into()?;
+
+        let (change_address, _dtk) = fvk.incoming().payment_address(change_address_index.into());
+        let spent: u64 = notes_to_spend
+            .iter()
+            .map(|note_record| note_record.note.amount())
+            .sum();
+
+        // Spend each of the notes we selected.
+        for note_record in notes_to_spend {
+            plan.actions
+                .push(SpendPlan::new(&mut rng, note_record.note, note_record.position).into());
+        }
+
+        // Find out how much change we have and whether to add a change output.
+        let change = spent - spend_amount;
+        if change > 0 {
+            plan.actions.push(
+                OutputPlan::new(
+                    &mut rng,
+                    Value {
+                        amount: change,
+                        asset_id: denom.id(),
+                    },
+                    change_address,
+                    MemoPlaintext::default(),
+                )
+                .into(),
+            );
+        }
+    }
+
+    Ok(plan)
+}
+
+#[allow(clippy::too_many_arguments)]
+#[instrument(skip(fvk, view, rng, input_value, fee, source_address))]
+pub async fn swap<V, R>(
+    fvk: &FullViewingKey,
+    view: &mut V,
+    mut rng: R,
+    input_value: Value,
+    into_denom: Denom,
+    fee: u64,
+    source_address: Option<u64>,
+) -> Result<TransactionPlan, anyhow::Error>
+where
+    V: ViewClient,
+    R: RngCore + CryptoRng,
+{
+    tracing::debug!(?input_value, ?fee, ?source_address);
+
+    let chain_params = view.chain_params().await?;
+
+    let mut plan = TransactionPlan {
+        chain_id: chain_params.chain_id,
+        fee: Fee(fee),
+        ..Default::default()
+    };
+
+    let assets = view.assets().await?;
+    let input_denom = assets.get(&input_value.asset_id).ok_or_else(|| {
+        anyhow::anyhow!("unknown denomination for asset id {}", input_value.asset_id)
+    })?;
+
+    // Determine the canonical order for the assets being swapped.
+    // This will determine whether the input amount is assigned to delta_1 or delta_2.
+    let trading_pair = TradingPair::canonical_order_for((input_value.asset_id, into_denom.id()))?;
+
+    // If `trading_pair.asset_1` is the input asset, then `delta_1` is the input amount,
+    // and `delta_2` is 0.
+    //
+    // Otherwise, `delta_1` is 0, and `delta_2` is the input amount.
+    let delta_1 = if trading_pair.asset_1() == input_value.asset_id {
+        input_value.amount
+    } else {
+        0
+    };
+    let delta_2 = if trading_pair.asset_1() == input_value.asset_id {
+        0
+    } else {
+        input_value.amount
+    };
+
+    // If there is no input, then there is no swap.
+    if delta_1 == 0 && delta_1 == 0 {
+        return Ok(plan);
+    }
+
+    // Add a `SwapPlan` action:
+    plan.actions.push(
+        SwapPlan::new(
+            &mut rng,
+            trading_pair,
+            delta_1,
+            delta_2,
+            Fee(fee),
+            // The `fvk` is always the claim address.
+            // TODO: this should probably select a random address index.
+            fvk.incoming().payment_address(0u64.into()).0,
+        )
+        .into(),
+    );
+
+    // The value we need to spend is the input value, plus fees.
+    let mut value_to_spend: HashMap<Denom, u64> = HashMap::new();
+    *value_to_spend.entry(input_denom.clone()).or_default() += input_value.amount;
+    if fee > 0 {
+        *value_to_spend
+            .entry(STAKING_TOKEN_DENOM.clone())
+            .or_default() += fee;
+    }
+
+    // Add the required spends:
+    for (denom, spend_amount) in value_to_spend {
+        if spend_amount == 0 {
+            continue;
+        }
+
+        let source_index: Option<AddressIndex> = source_address.map(Into::into);
+        // Select a list of notes that provides at least the required amount.
+        let notes_to_spend = view
+            .notes(NotesRequest {
+                fvk_hash: Some(fvk.hash().into()),
+                asset_id: Some(denom.id().into()),
+                address_index: source_index.map(Into::into),
+                amount_to_spend: spend_amount,
+                include_spent: false,
+            })
+            .await?;
+        if notes_to_spend.is_empty() {
+            // Shouldn't happen because the other side checks this, but just in case...
+            return Err(anyhow::anyhow!("not enough notes to spend",));
+        }
+
+        let change_address_index: u64 = fvk
+            .incoming()
+            .index_for_diversifier(
+                &notes_to_spend
+                    .last()
+                    .expect("notes_to_spend should never be empty")
+                    .note
+                    .diversifier(),
+            )
+            .try_into()?;
+
+        let (change_address, _dtk) = fvk.incoming().payment_address(change_address_index.into());
+        let spent: u64 = notes_to_spend
+            .iter()
+            .map(|note_record| note_record.note.amount())
+            .sum();
+
+        // Spend each of the notes we selected.
+        for note_record in notes_to_spend {
+            plan.actions
+                .push(SpendPlan::new(&mut rng, note_record.note, note_record.position).into());
+        }
+
+        // Find out how much change we have and whether to add a change output.
+        let change = spent - spend_amount;
+        if change > 0 {
+            plan.actions.push(
+                OutputPlan::new(
+                    &mut rng,
+                    Value {
+                        amount: change,
+                        asset_id: denom.id(),
+                    },
+                    change_address,
+                    MemoPlaintext::default(),
+                )
+                .into(),
+            );
+        }
     }
 
     Ok(plan)

--- a/wallet/src/plan.rs
+++ b/wallet/src/plan.rs
@@ -439,7 +439,7 @@ where
     };
 
     // If there is no input, then there is no swap.
-    if delta_1 == 0 && delta_1 == 0 {
+    if delta_1 == 0 && delta_2 == 0 {
         return Ok(plan);
     }
 


### PR DESCRIPTION
This adds initial support for generating `SwapPlan`s/`SwapClaimPlan`s in the wallet.

Only `SwapPlan` is fully implemented, as `SwapClaimPlan` requires the ability to retrieve clearing prices from the dex.