### PR TITLE
build `Clue`s from `CluePlan`s [FMD part 2]

### DIFF
--- a/crypto/src/address.rs
+++ b/crypto/src/address.rs
@@ -3,6 +3,7 @@ use std::io::{Cursor, Read, Write};
 use ark_serialize::CanonicalDeserialize;
 use f4jumble::{f4jumble, f4jumble_inv};
 use penumbra_proto::{crypto as pb, serializers::bech32str};
+use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 
 use crate::{fmd, ka, keys::Diversifier, Fq};
@@ -88,6 +89,27 @@ impl Address {
             .expect("can write clue key into vec");
 
         f4jumble(bytes.get_ref()).expect("can jumble")
+    }
+
+    /// A randomized dummy address for dummy `Clue` generation.
+    pub fn dummy<R: CryptoRng + Rng>(mut rng: R) -> Self {
+        let mut diversifier_bytes = [0u8; 16];
+        rng.fill_bytes(&mut diversifier_bytes);
+
+        let mut pk_d_bytes = [0u8; 32];
+        rng.fill_bytes(&mut pk_d_bytes);
+
+        let mut clue_key_bytes = [0; 32];
+        rng.fill_bytes(&mut clue_key_bytes);
+
+        let diversifier = Diversifier(diversifier_bytes);
+        Address::from_components(
+            diversifier,
+            diversifier.diversified_generator(),
+            ka::Public(pk_d_bytes),
+            fmd::ClueKey(clue_key_bytes),
+        )
+        .expect("generated dummy address")
     }
 }
 

--- a/decaf377-fmd/src/clue_key.rs
+++ b/decaf377-fmd/src/clue_key.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, convert::TryFrom};
 
-use ark_ff::{Field, PrimeField, UniformRand};
+use ark_ff::{Field, PrimeField};
 use bitvec::{array::BitArray, order};
 use decaf377::{FieldExt, Fr};
 use rand_core::{CryptoRng, RngCore};

--- a/proto/proto/transaction.proto
+++ b/proto/proto/transaction.proto
@@ -255,6 +255,8 @@ message CluePlan {
   crypto.Address address = 1;
   // The random seed to use for the clue plan.
   bytes rseed = 2;
+  // The bits of precision.
+  uint64 precision_bits = 3;
 }
 
 message SpendPlan {

--- a/transaction/src/auth_hash.rs
+++ b/transaction/src/auth_hash.rs
@@ -521,8 +521,9 @@ mod tests {
                 .map(|spend| nct.witness(spend.note.commit()).unwrap())
                 .collect(),
         };
+        let precision_bits = 1;
         let transaction = plan
-            .build(&mut OsRng, fvk, auth_data, witness_data)
+            .build(&mut OsRng, fvk, auth_data, witness_data, precision_bits)
             .unwrap();
 
         let transaction_auth_hash = transaction.auth_hash();

--- a/transaction/src/auth_hash.rs
+++ b/transaction/src/auth_hash.rs
@@ -521,9 +521,8 @@ mod tests {
                 .map(|spend| nct.witness(spend.note.commit()).unwrap())
                 .collect(),
         };
-        let precision_bits = 1;
         let transaction = plan
-            .build(&mut OsRng, fvk, auth_data, witness_data, precision_bits)
+            .build(&mut OsRng, fvk, auth_data, witness_data)
             .unwrap();
 
         let transaction_auth_hash = transaction.auth_hash();

--- a/transaction/src/plan.rs
+++ b/transaction/src/plan.rs
@@ -183,18 +183,18 @@ impl TransactionPlan {
     }
 
     /// Method to add `CluePlan`s to a `TransactionPlan`.
-    pub fn add_all_clue_plans<R: CryptoRng + Rng>(&mut self, mut rng: R) {
+    pub fn add_all_clue_plans<R: CryptoRng + Rng>(&mut self, mut rng: R, precision_bits: usize) {
         // Add one clue per recipient.
         let mut clue_plans = vec![];
         for dest_address in self.dest_addresses() {
-            clue_plans.push(CluePlan::new(&mut rng, dest_address));
+            clue_plans.push(CluePlan::new(&mut rng, dest_address, precision_bits));
         }
 
         // Now add dummy clues until we have one clue per output.
         let num_dummy_clues = self.num_outputs() - clue_plans.len();
         for _ in 0..num_dummy_clues {
             let dummy_address = Address::dummy(&mut rng);
-            clue_plans.push(CluePlan::new(&mut rng, dummy_address));
+            clue_plans.push(CluePlan::new(&mut rng, dummy_address, precision_bits));
         }
 
         self.clue_plans = clue_plans;

--- a/transaction/src/plan.rs
+++ b/transaction/src/plan.rs
@@ -2,8 +2,9 @@
 //! creation.
 
 use anyhow::Result;
-use penumbra_crypto::transaction::Fee;
+use penumbra_crypto::{transaction::Fee, Address};
 use penumbra_proto::{ibc as pb_ibc, stake as pb_stake, transaction as pb, Protobuf};
+use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 
 use crate::action::{
@@ -62,6 +63,10 @@ impl TransactionPlan {
                 None
             }
         })
+    }
+
+    pub fn clue_plans(&self) -> impl Iterator<Item = &CluePlan> {
+        self.clue_plans.iter()
     }
 
     pub fn delegations(&self) -> impl Iterator<Item = &Delegate> {
@@ -162,6 +167,37 @@ impl TransactionPlan {
                 None
             }
         })
+    }
+
+    /// Convenience method to get all the destination addresses for each `OutputPlan`s.
+    pub fn dest_addresses(&self) -> Vec<Address> {
+        self.output_plans()
+            .into_iter()
+            .map(|plan| plan.dest_address)
+            .collect()
+    }
+
+    /// Convenience method to get the number of `OutputPlan`s in this transaction.
+    pub fn num_outputs(&self) -> usize {
+        self.output_plans().into_iter().count()
+    }
+
+    /// Method to add `CluePlan`s to a `TransactionPlan`.
+    pub fn add_all_clue_plans<R: CryptoRng + Rng>(&mut self, mut rng: R) {
+        // Add one clue per recipient.
+        let mut clue_plans = vec![];
+        for dest_address in self.dest_addresses() {
+            clue_plans.push(CluePlan::new(&mut rng, dest_address));
+        }
+
+        // Now add dummy clues until we have one clue per output.
+        let num_dummy_clues = self.num_outputs() - clue_plans.len();
+        for _ in 0..num_dummy_clues {
+            let dummy_address = Address::dummy(&mut rng);
+            clue_plans.push(CluePlan::new(&mut rng, dummy_address));
+        }
+
+        self.clue_plans = clue_plans;
     }
 }
 

--- a/transaction/src/plan/build.rs
+++ b/transaction/src/plan/build.rs
@@ -13,7 +13,6 @@ impl TransactionPlan {
     /// - `fvk`, the [`FullViewingKey`] for the source funds;
     /// - `auth_data`, the [`AuthorizationData`] authorizing the transaction;
     /// - `witness_data`, the [`WitnessData`] used for proving;
-    /// - `precision_bits`, the current FMD precision.
     ///
     pub fn build<R: CryptoRng + RngCore>(
         self,
@@ -21,7 +20,6 @@ impl TransactionPlan {
         fvk: &FullViewingKey,
         auth_data: AuthorizationData,
         witness_data: WitnessData,
-        precision_bits: usize,
     ) -> Result<Transaction> {
         // Do some basic input sanity-checking.
         let spend_count = self.spend_plans().count();
@@ -94,7 +92,7 @@ impl TransactionPlan {
 
         // Build the clue plans.
         for clue_plan in self.clue_plans() {
-            fmd_clues.push(clue_plan.clue(precision_bits));
+            fmd_clues.push(clue_plan.clue());
         }
 
         // We don't have anything more to build, but iterate through the rest of

--- a/transaction/src/plan/clue.rs
+++ b/transaction/src/plan/clue.rs
@@ -1,5 +1,7 @@
+use decaf377_fmd::{Clue, ExpandedClueKey};
 use penumbra_crypto::Address;
 use penumbra_proto::{transaction as pb, Protobuf};
+
 use rand::{CryptoRng, RngCore};
 
 #[derive(Clone, Debug)]
@@ -14,6 +16,15 @@ impl CluePlan {
         let mut rseed = [0u8; 32];
         rng.fill_bytes(&mut rseed);
         CluePlan { address, rseed }
+    }
+
+    /// Create a [`Clue`] from the [`CluePlan`].
+    pub fn clue(&self, precision_bits: usize) -> Clue {
+        let clue_key = self.address.clue_key();
+        let expanded_clue_key = ExpandedClueKey::new(clue_key).expect("valid address");
+        expanded_clue_key
+            .create_clue_deterministic(precision_bits, self.rseed)
+            .expect("can construct clue key")
     }
 }
 

--- a/transaction/src/plan/clue.rs
+++ b/transaction/src/plan/clue.rs
@@ -6,9 +6,9 @@ use rand::{CryptoRng, RngCore};
 
 #[derive(Clone, Debug)]
 pub struct CluePlan {
-    address: Address,
-    precision_bits: usize,
-    rseed: [u8; 32],
+    pub address: Address,
+    pub precision_bits: usize,
+    pub rseed: [u8; 32],
 }
 
 impl CluePlan {

--- a/transaction/src/plan/clue.rs
+++ b/transaction/src/plan/clue.rs
@@ -7,23 +7,32 @@ use rand::{CryptoRng, RngCore};
 #[derive(Clone, Debug)]
 pub struct CluePlan {
     address: Address,
+    precision_bits: usize,
     rseed: [u8; 32],
 }
 
 impl CluePlan {
     /// Create a new [`CluePlan`] associated with a given (possibly dummy) `Address`.
-    pub fn new<R: CryptoRng + RngCore>(rng: &mut R, address: Address) -> CluePlan {
+    pub fn new<R: CryptoRng + RngCore>(
+        rng: &mut R,
+        address: Address,
+        precision_bits: usize,
+    ) -> CluePlan {
         let mut rseed = [0u8; 32];
         rng.fill_bytes(&mut rseed);
-        CluePlan { address, rseed }
+        CluePlan {
+            address,
+            rseed,
+            precision_bits,
+        }
     }
 
     /// Create a [`Clue`] from the [`CluePlan`].
-    pub fn clue(&self, precision_bits: usize) -> Clue {
+    pub fn clue(&self) -> Clue {
         let clue_key = self.address.clue_key();
         let expanded_clue_key = ExpandedClueKey::new(clue_key).expect("valid address");
         expanded_clue_key
-            .create_clue_deterministic(precision_bits, self.rseed)
+            .create_clue_deterministic(self.precision_bits, self.rseed)
             .expect("can construct clue key")
     }
 }
@@ -35,6 +44,7 @@ impl From<CluePlan> for pb::CluePlan {
         Self {
             address: Some(msg.address.into()),
             rseed: msg.rseed.to_vec().into(),
+            precision_bits: (msg.precision_bits as u64).into(),
         }
     }
 }
@@ -48,6 +58,7 @@ impl TryFrom<pb::CluePlan> for CluePlan {
                 .ok_or_else(|| anyhow::anyhow!("missing address"))?
                 .try_into()?,
             rseed: msg.rseed.as_ref().try_into()?,
+            precision_bits: msg.precision_bits.try_into()?,
         })
     }
 }

--- a/wallet/src/build.rs
+++ b/wallet/src/build.rs
@@ -37,16 +37,6 @@ where
         })
         .await?;
 
-    // Get the current FMD parameters from the view service...
-    let fmd_params = view.fmd_parameters().await?;
-    let precision_bits = fmd_params.precision_bits;
-
     // ... and then build the transaction:
-    plan.build(
-        &mut rng,
-        fvk,
-        auth_data,
-        witness_data,
-        precision_bits.into(),
-    )
+    plan.build(&mut rng, fvk, auth_data, witness_data)
 }

--- a/wallet/src/build.rs
+++ b/wallet/src/build.rs
@@ -37,6 +37,16 @@ where
         })
         .await?;
 
+    // Get the current FMD parameters from the view service...
+    let fmd_params = view.fmd_parameters().await?;
+    let precision_bits = fmd_params.precision_bits;
+
     // ... and then build the transaction:
-    plan.build(&mut rng, fvk, auth_data, witness_data)
+    plan.build(
+        &mut rng,
+        fvk,
+        auth_data,
+        witness_data,
+        precision_bits.into(),
+    )
 }

--- a/wallet/src/plan.rs
+++ b/wallet/src/plan.rs
@@ -84,7 +84,9 @@ where
     }
 
     // Add clue plans for `Output`s.
-    plan.add_all_clue_plans(&mut rng);
+    let fmd_params = view.fmd_parameters().await?;
+    let precision_bits = fmd_params.precision_bits;
+    plan.add_all_clue_plans(&mut rng, precision_bits.into());
     Ok(plan)
 }
 
@@ -185,7 +187,9 @@ where
     }
 
     // Add clue plans for `Output`s.
-    plan.add_all_clue_plans(&mut rng);
+    let fmd_params = view.fmd_parameters().await?;
+    let precision_bits = fmd_params.precision_bits;
+    plan.add_all_clue_plans(&mut rng, precision_bits.into());
     Ok(plan)
 }
 
@@ -270,7 +274,9 @@ where
     }
 
     // Add clue plans for `Output`s.
-    plan.add_all_clue_plans(&mut rng);
+    let fmd_params = view.fmd_parameters().await?;
+    let precision_bits = fmd_params.precision_bits;
+    plan.add_all_clue_plans(&mut rng, precision_bits.into());
     Ok(plan)
 }
 
@@ -393,7 +399,9 @@ where
     }
 
     // Add clue plans for `Output`s.
-    plan.add_all_clue_plans(&mut rng);
+    let fmd_params = view.fmd_parameters().await?;
+    let precision_bits = fmd_params.precision_bits;
+    plan.add_all_clue_plans(&mut rng, precision_bits.into());
     Ok(plan)
 }
 
@@ -536,7 +544,9 @@ where
     }
 
     // Add clue plans for `Output`s.
-    plan.add_all_clue_plans(&mut rng);
+    let fmd_params = view.fmd_parameters().await?;
+    let precision_bits = fmd_params.precision_bits;
+    plan.add_all_clue_plans(&mut rng, precision_bits.into());
     Ok(plan)
 }
 
@@ -671,7 +681,9 @@ where
     }
 
     // Add clue plans for `Output`s.
-    plan.add_all_clue_plans(&mut rng);
+    let fmd_params = view.fmd_parameters().await?;
+    let precision_bits = fmd_params.precision_bits;
+    plan.add_all_clue_plans(&mut rng, precision_bits.into());
     Ok(plan)
 }
 
@@ -747,7 +759,9 @@ where
                 tracing::debug!(?plan);
 
                 // Add clue plans for `Output`s.
-                plan.add_all_clue_plans(&mut rng);
+                let fmd_params = view.fmd_parameters().await?;
+                let precision_bits = fmd_params.precision_bits;
+                plan.add_all_clue_plans(&mut rng, precision_bits.into());
                 plans.push(plan);
             }
         }

--- a/wallet/src/plan.rs
+++ b/wallet/src/plan.rs
@@ -83,6 +83,8 @@ where
         );
     }
 
+    // Add clue plans for `Output`s.
+    plan.add_all_clue_plans(&mut rng);
     Ok(plan)
 }
 
@@ -182,6 +184,8 @@ where
         );
     }
 
+    // Add clue plans for `Output`s.
+    plan.add_all_clue_plans(&mut rng);
     Ok(plan)
 }
 
@@ -265,6 +269,8 @@ where
         ))?;
     }
 
+    // Add clue plans for `Output`s.
+    plan.add_all_clue_plans(&mut rng);
     Ok(plan)
 }
 
@@ -386,6 +392,8 @@ where
         }
     }
 
+    // Add clue plans for `Output`s.
+    plan.add_all_clue_plans(&mut rng);
     Ok(plan)
 }
 
@@ -527,6 +535,8 @@ where
         }
     }
 
+    // Add clue plans for `Output`s.
+    plan.add_all_clue_plans(&mut rng);
     Ok(plan)
 }
 
@@ -660,6 +670,8 @@ where
         }
     }
 
+    // Add clue plans for `Output`s.
+    plan.add_all_clue_plans(&mut rng);
     Ok(plan)
 }
 
@@ -733,6 +745,9 @@ where
                 );
 
                 tracing::debug!(?plan);
+
+                // Add clue plans for `Output`s.
+                plan.add_all_clue_plans(&mut rng);
                 plans.push(plan);
             }
         }


### PR DESCRIPTION
Towards #1039, adding FMD clues into transactions.
This is the next step after https://github.com/penumbra-zone/penumbra/pull/1296 which adds support deterministic clues and the `CluePlan` field in the transaction body. 