### PR TITLE
Rebase swaps/swapclaims on current main branch changes, use address from notes, move NFT asset ID generation to SwapPlaintext

### DIFF
--- a/crypto/src/address.rs
+++ b/crypto/src/address.rs
@@ -22,8 +22,8 @@ pub struct Address {
     /// this ensures we can use a PaymentAddress to form a note commitment,
     /// which involves hashing s as a field element.
     pk_d: ka::Public,
-    /// cached s value
-    cached_s: Fq,
+    /// transmission key s value
+    transmission_key_s: Fq,
 
     ck_d: fmd::ClueKey,
 }
@@ -41,14 +41,14 @@ impl Address {
     ) -> Option<Self> {
         // XXX ugly -- better way to get our hands on the s value?
         // add to decaf377::Encoding? there's compress_to_field already...
-        if let Ok(cached_s) = Fq::deserialize(&pk_d.0[..]) {
+        if let Ok(transmission_key_s) = Fq::deserialize(&pk_d.0[..]) {
             // don't need an error type here, caller will probably .expect anyways
             Some(Self {
                 d,
                 g_d,
                 pk_d,
                 ck_d,
-                cached_s,
+                transmission_key_s,
             })
         } else {
             None
@@ -71,8 +71,8 @@ impl Address {
         &self.ck_d
     }
 
-    pub fn cached_s(&self) -> &Fq {
-        &self.cached_s
+    pub fn transmission_key_s(&self) -> &Fq {
+        &self.transmission_key_s
     }
 
     pub fn to_vec(&self) -> Vec<u8> {

--- a/crypto/src/address.rs
+++ b/crypto/src/address.rs
@@ -71,6 +71,10 @@ impl Address {
         &self.ck_d
     }
 
+    pub fn cached_s(&self) -> &Fq {
+        &self.cached_s
+    }
+
     pub fn to_vec(&self) -> Vec<u8> {
         let mut bytes = std::io::Cursor::new(Vec::new());
         bytes

--- a/crypto/src/dex/swap/plaintext.rs
+++ b/crypto/src/dex/swap/plaintext.rs
@@ -37,7 +37,7 @@ impl SwapPlaintext {
     // Constructs the unique asset ID for a swap as a poseidon hash of the input data for the swap.
     //
     // https://protocol.penumbra.zone/main/zswap/swap.html#swap-actions
-    pub fn generate_swap_asset_id(&self) -> asset::Id {
+    pub fn asset_id(&self) -> asset::Id {
         let packed_values = {
             let mut bytes = [0u8; 24];
             bytes[0..8].copy_from_slice(&self.delta_1.to_le_bytes());

--- a/crypto/src/dex/swap/plaintext.rs
+++ b/crypto/src/dex/swap/plaintext.rs
@@ -55,7 +55,7 @@ impl SwapPlaintext {
                 self.claim_address
                     .diversified_generator()
                     .vartime_compress_to_field(),
-                *self.claim_address.cached_s(),
+                *self.claim_address.transmission_key_s(),
             ),
         );
 

--- a/crypto/src/memo.rs
+++ b/crypto/src/memo.rs
@@ -67,7 +67,7 @@ impl MemoPlaintext {
             .key_agreement_with(epk)
             .map_err(|_| anyhow!("could not perform key agreement"))?;
 
-        let key = PayloadKey::derive(&shared_secret, &epk);
+        let key = PayloadKey::derive(&shared_secret, epk);
         let plaintext = key
             .decrypt(ciphertext.0.to_vec(), PayloadKind::Memo)
             .map_err(|_| anyhow!("decryption error"))?;

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -455,20 +455,16 @@ impl SwapClaimProof {
             amount: 1,
             asset_id: self.swap_nft_asset_id,
         };
-        let s_component_transmission_key = Fq::from_bytes(self.claim_address.transmission_key().0);
-        if let Ok(transmission_key_s) = s_component_transmission_key {
-            let note_commitment_test = note::commitment(
-                self.note_blinding,
-                swap_nft_value.clone(),
-                *self.claim_address.diversified_generator(),
-                transmission_key_s,
-            );
+        let transmission_key_s = self.claim_address.transmission_key_s();
+        let note_commitment_test = note::commitment(
+            self.note_blinding,
+            swap_nft_value.clone(),
+            *self.claim_address.diversified_generator(),
+            *transmission_key_s,
+        );
 
-            if self.note_commitment_proof.commitment() != note_commitment_test {
-                return Err(anyhow!("note commitment mismatch"));
-            }
-        } else {
-            return Err(anyhow!("transmission key mismatch"));
+        if self.note_commitment_proof.commitment() != note_commitment_test {
+            return Err(anyhow!("note commitment mismatch"));
         }
 
         // check the swap NFT Asset ID is properly constructed

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -481,7 +481,7 @@ impl SwapClaimProof {
             self.claim_address,
         )
         .map_err(|_| anyhow!("error generating expected swap plaintext"))?;
-        let expected_asset_id = expected_plaintext.generate_swap_asset_id();
+        let expected_asset_id = expected_plaintext.asset_id();
         if expected_asset_id != asset_id {
             return Err(anyhow!("improper swap NFT asset id"));
         }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -204,6 +204,7 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.dex.SwapBody", SERIALIZE),
     (".penumbra.dex.SwapClaim", SERIALIZE),
     (".penumbra.dex.SwapClaimBody", SERIALIZE),
+    (".penumbra.dex.SwapPlaintext", SERIALIZE),
     (".penumbra.dex.BatchSwapOutputData", SERIALIZE),
 ];
 

--- a/proto/proto/dex.proto
+++ b/proto/proto/dex.proto
@@ -39,7 +39,7 @@ message SwapClaimBody {
   // Note output for asset 2.
   crypto.NotePayload output_2 = 4;
   // Block root for the associated `Swap` action, identifying the block the `Swap` was included in.
-  crypto.MerkleRoot anchor = 5;
+  // crypto.MerkleRoot anchor = 5;
   // Input and output amounts for the assets in the swap.
   BatchSwapOutputData output_data = 6;
   // The trading pair to swap.

--- a/proto/proto/transaction.proto
+++ b/proto/proto/transaction.proto
@@ -275,18 +275,10 @@ message OutputPlan {
 }
 
 message SwapPlan {
-    // The trading pair to swap.
-    dex.TradingPair trading_pair = 1;
-    // The amount for asset 1.
-    uint64 delta_1 = 2;
-    // The amount for asset 2.
-    uint64 delta_2 = 3;
-    // The fee to be pre-paid for the SwapClaim.
-    crypto.Fee fee = 4;
+    // The plaintext version of the swap to be performed.
+    dex.SwapPlaintext swap_plaintext = 1;
     // The blinding factor for the fee commitment. The fee in the SwapPlan is private to prevent linkability with the SwapClaim.
     bytes fee_blinding = 5;
-    // The address that can claim the swap NFT and receive the outputs.
-    crypto.Address claim_address = 6;
     // The blinding factor to use for the new swap NFT note.
     bytes note_blinding = 7;
     // The ephemeral secret key to use for the swap NFT note encryption.
@@ -302,17 +294,11 @@ message SwapClaimPlan {
     crypto.Note swap_nft_note = 1;
     // The position of the input swap NFT note.
     uint64 swap_nft_position = 2;
+    // The plaintext version of the swap to be performed.
+    dex.SwapPlaintext swap_plaintext = 3;
 
-    // The fee that was pre-paid for the SwapClaim.
-    crypto.Fee fee = 10;
     // Input and output amounts for the Swap.
     dex.BatchSwapOutputData output_data = 11;
-    // The root anchor for the block the Swap occurred in.
-    crypto.MerkleRoot anchor = 12;
-    // The trading pair associated with the SwapClaim.
-    dex.TradingPair trading_pair = 13;
-    // The address that is claiming the swap NFT and receiving the new output notes.
-    crypto.Address claim_address = 14;
     // The blinding factor used for the first output note.
     bytes output_1_blinding = 15;
     // The blinding factor used for the second output note.
@@ -321,8 +307,6 @@ message SwapClaimPlan {
     bytes esk_1 = 17;
     // The ephemeral secret key used for the second output note encryption.
     bytes esk_2 = 18;
-    // The asset ID of the swap NFT.
-    crypto.AssetId swap_nft_asset_id = 19;
 }
 
 

--- a/proto/proto/transparent_proofs.proto
+++ b/proto/proto/transparent_proofs.proto
@@ -119,10 +119,8 @@ message SwapProof {
    * @exclude
    * Data about the output note recording the Swap NFT.
   */
-  // Diversified basepoint
-  bytes b_d = 40;
-  // Diversified public key
-  bytes pk_d = 41;
+  // Address associated with the swap.
+  crypto.Address claim_address = 40;
   // Note blinding factor
   bytes note_blinding = 42;
   // Ephemeral secret key

--- a/proto/proto/transparent_proofs.proto
+++ b/proto/proto/transparent_proofs.proto
@@ -45,8 +45,7 @@ message SwapClaimProof {
    * Describes the input note with the Swap NFT
    */
   bytes swap_nft_asset_id = 1;
-  bytes b_d = 2;
-  bytes pk_d = 3;
+  crypto.Address claim_address = 2;
   // Inclusion proof for the Swap NFT
   crypto.NoteCommitmentProof note_commitment_proof = 4;
   bytes note_blinding = 5;

--- a/transaction/src/action/swap_claim.rs
+++ b/transaction/src/action/swap_claim.rs
@@ -9,7 +9,6 @@ use penumbra_crypto::Value;
 use penumbra_crypto::STAKING_TOKEN_ASSET_ID;
 use penumbra_crypto::{proofs::transparent::SwapClaimProof, NotePayload};
 use penumbra_proto::{dex as pb, Protobuf};
-use penumbra_tct as tct;
 
 #[derive(Debug, Clone)]
 pub struct SwapClaim {
@@ -21,13 +20,11 @@ impl SwapClaim {
     /// Compute a commitment to the value contributed to a transaction by this swap claim.
     /// Will add (f,fee_token)
     pub fn value_commitment(&self) -> value::Commitment {
-        let fee_commitment = Value {
+        Value {
             amount: self.body.fee.0,
             asset_id: *STAKING_TOKEN_ASSET_ID,
         }
-        .commit(Fr::zero());
-
-        fee_commitment
+        .commit(Fr::zero())
     }
 }
 
@@ -64,7 +61,6 @@ pub struct Body {
     pub output_1: NotePayload,
     pub output_2: NotePayload,
     pub output_data: BatchSwapOutputData,
-    pub anchor: tct::Root,
     pub trading_pair: TradingPair,
 }
 
@@ -78,7 +74,6 @@ impl From<Body> for pb::SwapClaimBody {
             fee: Some(s.fee.into()),
             output_1: Some(s.output_1.into()),
             output_2: Some(s.output_2.into()),
-            anchor: Some(s.anchor.into()),
             output_data: Some(s.output_data.into()),
         }
     }
@@ -100,10 +95,6 @@ impl TryFrom<pb::SwapClaimBody> for Body {
             output_2: sc
                 .output_2
                 .ok_or_else(|| anyhow::anyhow!("missing output_2"))?
-                .try_into()?,
-            anchor: sc
-                .anchor
-                .ok_or_else(|| anyhow::anyhow!("missing anchor"))?
                 .try_into()?,
             output_data: sc
                 .output_data

--- a/transaction/src/auth_hash.rs
+++ b/transaction/src/auth_hash.rs
@@ -108,6 +108,12 @@ impl TransactionPlan {
         for output in self.output_plans() {
             state.update(output.output_body(fvk.outgoing()).auth_hash().as_bytes());
         }
+        for swap in self.swap_plans() {
+            state.update(swap.swap_body(fvk).auth_hash().as_bytes());
+        }
+        for swap_claim in self.swap_claim_plans() {
+            state.update(swap_claim.swap_claim_body(fvk).auth_hash().as_bytes());
+        }
         for delegation in self.delegations() {
             state.update(delegation.auth_hash().as_bytes());
         }
@@ -226,7 +232,7 @@ impl swap::Body {
         // in the hash one after the other.
         // TODO: actually the trading pair isn't necessarily fixed-length
         // right now, does this have implications?
-        state.update(&self.trading_pair.auth_hash().as_bytes());
+        state.update(self.trading_pair.auth_hash().as_bytes());
         state.update(&self.delta_1.to_le_bytes());
         state.update(&self.delta_2.to_le_bytes());
         state.update(&self.fee_commitment.to_bytes());
@@ -247,7 +253,7 @@ impl swap_claim::Body {
         // All of these fields are fixed-length, so we can just throw them
         // in the hash one after the other.
         state.update(&self.nullifier.0.to_bytes());
-        state.update(&self.fee.auth_hash().as_bytes());
+        state.update(self.fee.auth_hash().as_bytes());
         // TODO: write an `auth_hash` method for `NotePayload` et al
         // to ensure fixed-length encoding as well as non-usage of protobuf
         // encoding in auth hashes
@@ -258,8 +264,7 @@ impl swap_claim::Body {
         state.update(&self.output_2.ephemeral_key.0);
         state.update(&self.output_2.encrypted_note);
         state.update(&self.output_data.encode_to_vec());
-        state.update(&self.anchor.encode_to_vec());
-        state.update(&self.trading_pair.auth_hash().as_bytes());
+        state.update(self.trading_pair.auth_hash().as_bytes());
 
         state.finalize()
     }

--- a/transaction/src/plan.rs
+++ b/transaction/src/plan.rs
@@ -140,7 +140,7 @@ impl TransactionPlan {
         })
     }
 
-    pub fn swaps(&self) -> impl Iterator<Item = &SwapPlan> {
+    pub fn swap_plans(&self) -> impl Iterator<Item = &SwapPlan> {
         self.actions.iter().filter_map(|action| {
             if let ActionPlan::Swap(v) = action {
                 Some(v)
@@ -150,7 +150,7 @@ impl TransactionPlan {
         })
     }
 
-    pub fn swap_claims(&self) -> impl Iterator<Item = &SwapClaimPlan> {
+    pub fn swap_claim_plans(&self) -> impl Iterator<Item = &SwapClaimPlan> {
         self.actions.iter().filter_map(|action| {
             if let ActionPlan::SwapClaim(v) = action {
                 Some(v)

--- a/transaction/src/plan/action/swap.rs
+++ b/transaction/src/plan/action/swap.rs
@@ -95,12 +95,7 @@ impl SwapPlan {
         let swap_nft_asset_id = self.swap_plaintext.asset_id();
 
         SwapProof {
-            b_d: self
-                .swap_plaintext
-                .claim_address
-                .diversified_generator()
-                .clone(),
-            pk_d: self.swap_plaintext.claim_address.transmission_key().clone(),
+            claim_address: self.swap_plaintext.claim_address,
             note_blinding: self.note_blinding,
             fee_delta: self.swap_plaintext.fee.0,
             value_t1: Value {

--- a/transaction/src/plan/action/swap.rs
+++ b/transaction/src/plan/action/swap.rs
@@ -52,7 +52,7 @@ impl SwapPlan {
     pub fn swap_body(&self, _fvk: &FullViewingKey) -> swap::Body {
         let fee_commitment = self.swap_plaintext.fee.value().commit(self.fee_blinding);
 
-        let swap_nft_asset_id = self.swap_plaintext.generate_swap_asset_id();
+        let swap_nft_asset_id = self.swap_plaintext.asset_id();
 
         let swap_nft_value = Value {
             amount: 1,
@@ -92,7 +92,7 @@ impl SwapPlan {
         _fvk: &FullViewingKey,
         _note_commitment_proof: tct::Proof,
     ) -> SwapProof {
-        let swap_nft_asset_id = self.swap_plaintext.generate_swap_asset_id();
+        let swap_nft_asset_id = self.swap_plaintext.asset_id();
 
         SwapProof {
             b_d: self

--- a/transaction/src/plan/action/swap.rs
+++ b/transaction/src/plan/action/swap.rs
@@ -1,11 +1,9 @@
 use anyhow::{anyhow, Result};
 use ark_ff::UniformRand;
 use decaf377::Fq;
-use penumbra_crypto::dex::swap::{generate_swap_asset_id, SwapPlaintext};
-use penumbra_crypto::Address;
+use penumbra_crypto::dex::swap::SwapPlaintext;
 use penumbra_crypto::{
-    dex::TradingPair, proofs::transparent::SwapProof, transaction::Fee, FieldExt, Fr,
-    FullViewingKey, Note, NotePayload, Value,
+    proofs::transparent::SwapProof, FieldExt, Fr, FullViewingKey, Note, NotePayload, Value,
 };
 use penumbra_proto::{transaction as pb, Protobuf};
 use penumbra_tct as tct;
@@ -18,42 +16,27 @@ use crate::action::{swap, Swap};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(try_from = "pb::SwapPlan", into = "pb::SwapPlan")]
 pub struct SwapPlan {
-    pub trading_pair: TradingPair,
     // No commitments for the values, as they're plaintext
     // until flow encryption is available
     // pub asset_1_commitment: value::Commitment,
     // pub asset_2_commitment: value::Commitment,
-    pub delta_1: u64,
-    pub delta_2: u64,
-    pub fee: Fee,
+    pub swap_plaintext: SwapPlaintext,
     pub fee_blinding: Fr,
-    pub claim_address: Address,
     pub note_blinding: Fq,
     pub esk: decaf377_ka::Secret,
 }
 
 impl SwapPlan {
     /// Create a new [`SwapPlan`] that requests a swap between the given assets and input amounts.
-    pub fn new<R: CryptoRng + RngCore>(
-        rng: &mut R,
-        trading_pair: TradingPair,
-        delta_1: u64,
-        delta_2: u64,
-        fee: Fee,
-        claim_address: Address,
-    ) -> SwapPlan {
+    pub fn new<R: CryptoRng + RngCore>(rng: &mut R, swap_plaintext: SwapPlaintext) -> SwapPlan {
         let note_blinding = Fq::rand(rng);
         let fee_blinding = Fr::rand(rng);
         let esk = decaf377_ka::Secret::new(rng);
         SwapPlan {
-            trading_pair,
-            delta_1,
-            delta_2,
             fee_blinding,
-            fee,
-            claim_address,
             note_blinding,
             esk,
+            swap_plaintext,
         }
     }
 
@@ -67,26 +50,21 @@ impl SwapPlan {
 
     /// Construct the [`swap::Body`] described by this [`SwapPlan`].
     pub fn swap_body(&self, _fvk: &FullViewingKey) -> swap::Body {
-        let fee_commitment = self.fee.value().commit(self.fee_blinding);
+        let fee_commitment = self.swap_plaintext.fee.value().commit(self.fee_blinding);
 
-        let swap_nft_asset_id = generate_swap_asset_id(
-            self.delta_1,
-            self.delta_2,
-            self.fee.0,
-            *self.claim_address.diversified_generator(),
-            *self.claim_address.transmission_key(),
-            self.trading_pair,
-        )
-        .expect("bad public key when generating swap asset id");
+        let swap_nft_asset_id = self.swap_plaintext.generate_swap_asset_id();
 
         let swap_nft_value = Value {
             amount: 1,
             asset_id: swap_nft_asset_id,
         };
 
-        let swap_nft_note =
-            Note::from_parts(self.claim_address, swap_nft_value, self.note_blinding)
-                .expect("unable to create swap nft note");
+        let swap_nft_note = Note::from_parts(
+            self.swap_plaintext.claim_address,
+            swap_nft_value,
+            self.note_blinding,
+        )
+        .expect("unable to create swap nft note");
         let note_commitment = swap_nft_note.commit();
 
         let encrypted_note = swap_nft_note.encrypt(&self.esk);
@@ -96,20 +74,12 @@ impl SwapPlan {
             encrypted_note,
         };
 
-        let swap_ciphertext = SwapPlaintext::from_parts(
-            self.trading_pair,
-            self.delta_1,
-            self.delta_2,
-            self.fee.clone(),
-            self.claim_address,
-        )
-        .expect("unable to create swap plaintext")
-        .encrypt(&self.esk);
+        let swap_ciphertext = self.swap_plaintext.encrypt(&self.esk);
 
         swap::Body {
-            trading_pair: self.trading_pair,
-            delta_1: self.delta_1,
-            delta_2: self.delta_2,
+            trading_pair: self.swap_plaintext.trading_pair,
+            delta_1: self.swap_plaintext.delta_1,
+            delta_2: self.swap_plaintext.delta_2,
             fee_commitment,
             swap_nft,
             swap_ciphertext,
@@ -122,28 +92,24 @@ impl SwapPlan {
         _fvk: &FullViewingKey,
         _note_commitment_proof: tct::Proof,
     ) -> SwapProof {
-        let swap_nft_asset_id = generate_swap_asset_id(
-            self.delta_1,
-            self.delta_2,
-            self.fee.0,
-            *self.claim_address.diversified_generator(),
-            *self.claim_address.transmission_key(),
-            self.trading_pair,
-        )
-        .expect("bad public key when generating swap asset id");
+        let swap_nft_asset_id = self.swap_plaintext.generate_swap_asset_id();
 
         SwapProof {
-            b_d: self.claim_address.diversified_generator().clone(),
-            pk_d: self.claim_address.transmission_key().clone(),
+            b_d: self
+                .swap_plaintext
+                .claim_address
+                .diversified_generator()
+                .clone(),
+            pk_d: self.swap_plaintext.claim_address.transmission_key().clone(),
             note_blinding: self.note_blinding,
-            fee_delta: self.fee.0,
+            fee_delta: self.swap_plaintext.fee.0,
             value_t1: Value {
-                amount: self.delta_1,
-                asset_id: self.trading_pair.asset_1(),
+                amount: self.swap_plaintext.delta_1,
+                asset_id: self.swap_plaintext.trading_pair.asset_1(),
             },
             value_t2: Value {
-                amount: self.delta_2,
-                asset_id: self.trading_pair.asset_2(),
+                amount: self.swap_plaintext.delta_2,
+                asset_id: self.swap_plaintext.trading_pair.asset_2(),
             },
             swap_nft_asset_id,
             esk: self.esk.clone(),
@@ -160,12 +126,8 @@ impl Protobuf<pb::SwapPlan> for SwapPlan {}
 impl From<SwapPlan> for pb::SwapPlan {
     fn from(msg: SwapPlan) -> Self {
         Self {
-            trading_pair: Some(msg.trading_pair.into()),
-            delta_1: msg.delta_1,
-            delta_2: msg.delta_2,
-            fee: Some(msg.fee.into()),
+            swap_plaintext: Some(msg.swap_plaintext.into()),
             fee_blinding: msg.fee_blinding.to_bytes().to_vec().into(),
-            claim_address: Some(msg.claim_address.into()),
             note_blinding: msg.note_blinding.to_bytes().to_vec().into(),
             esk: msg.esk.to_bytes().to_vec().into(),
         }
@@ -179,18 +141,11 @@ impl TryFrom<pb::SwapPlan> for SwapPlan {
             .try_into()
             .map_err(|_| anyhow!("proto malformed"))?;
         Ok(Self {
-            trading_pair: msg
-                .trading_pair
-                .ok_or_else(|| anyhow!("missing trading pair"))?
-                .try_into()?,
-            delta_1: msg.delta_1,
-            delta_2: msg.delta_2,
-            fee: msg.fee.ok_or_else(|| anyhow!("missing fee"))?.try_into()?,
             fee_blinding: Fr::from_bytes(fee_blinding_bytes)
                 .map_err(|_| anyhow!("proto malformed"))?,
-            claim_address: msg
-                .claim_address
-                .ok_or_else(|| anyhow!("missing claim address"))?
+            swap_plaintext: msg
+                .swap_plaintext
+                .ok_or_else(|| anyhow!("missing swap_plaintext"))?
                 .try_into()?,
             note_blinding: Fq::from_bytes(msg.note_blinding[..].try_into()?)?,
             esk: msg.esk.as_ref().try_into()?,

--- a/transaction/src/plan/action/swap_claim.rs
+++ b/transaction/src/plan/action/swap_claim.rs
@@ -92,7 +92,7 @@ impl SwapClaimPlan {
         note_blinding: Fq,
     ) -> SwapClaimProof {
         SwapClaimProof {
-            swap_nft_asset_id: self.swap_plaintext.generate_swap_asset_id(),
+            swap_nft_asset_id: self.swap_plaintext.asset_id(),
             claim_address: self.swap_nft_note.address(),
             note_commitment_proof,
             trading_pair: self.swap_plaintext.trading_pair,

--- a/transaction/src/plan/action/swap_claim.rs
+++ b/transaction/src/plan/action/swap_claim.rs
@@ -1,13 +1,12 @@
 use ark_ff::UniformRand;
 use decaf377::FieldExt;
 use penumbra_crypto::{
-    asset,
-    dex::{swap::generate_swap_asset_id, BatchSwapOutputData, TradingPair},
+    dex::{swap::SwapPlaintext, BatchSwapOutputData, TradingPair},
     ka,
     keys::{IncomingViewingKey, NullifierKey},
     proofs::transparent::SwapClaimProof,
     transaction::Fee,
-    Address, Fq, Fr, FullViewingKey, Note, NotePayload, Value,
+    Address, Fq, FullViewingKey, Note, NotePayload, Value,
 };
 use penumbra_proto::{transaction as pb, Protobuf};
 use penumbra_tct as tct;
@@ -17,24 +16,18 @@ use tct::Position;
 
 use crate::action::{swap_claim, SwapClaim};
 
-// TODO: copied directly from `OutputPlan` right now, needs fields updated
-// for `SwapClaim`
 /// A planned [`SwapClaim`](SwapClaim).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(try_from = "pb::SwapClaimPlan", into = "pb::SwapClaimPlan")]
 pub struct SwapClaimPlan {
     pub swap_nft_note: Note,
     pub swap_nft_position: Position,
-    pub fee: Fee,
+    pub swap_plaintext: SwapPlaintext,
     pub output_data: BatchSwapOutputData,
-    pub anchor: tct::Root,
-    pub trading_pair: TradingPair,
-    pub claim_address: Address,
     pub output_1_blinding: Fq,
     pub output_2_blinding: Fq,
     pub esk_1: ka::Secret,
     pub esk_2: ka::Secret,
-    pub swap_nft_asset_id: asset::Id,
 }
 
 impl SwapClaimPlan {
@@ -48,36 +41,29 @@ impl SwapClaimPlan {
         claim_address: Address,
         fee: Fee,
         output_data: BatchSwapOutputData,
-        anchor: tct::Root,
         trading_pair: TradingPair,
     ) -> SwapClaimPlan {
         let output_1_blinding = Fq::rand(rng);
         let output_2_blinding = Fq::rand(rng);
-        let _value_blinding = Fr::rand(rng);
         let esk_1 = ka::Secret::new(rng);
         let esk_2 = ka::Secret::new(rng);
-        let swap_nft_asset_id = generate_swap_asset_id(
+        let swap_plaintext = SwapPlaintext::from_parts(
+            trading_pair,
             output_data.delta_1,
             output_data.delta_2,
-            fee.0,
-            *claim_address.diversified_generator(),
-            *claim_address.transmission_key(),
-            trading_pair,
+            fee,
+            claim_address,
         )
-        .expect("bad public key when generating swap asset id");
+        .expect("unable to instantiate swap plaintext");
 
         Self {
             swap_nft_note,
-            claim_address,
             esk_1,
             esk_2,
             output_1_blinding,
             output_2_blinding,
-            fee,
             output_data,
-            anchor,
-            trading_pair,
-            swap_nft_asset_id,
+            swap_plaintext,
             swap_nft_position,
         }
     }
@@ -106,12 +92,10 @@ impl SwapClaimPlan {
         note_blinding: Fq,
     ) -> SwapClaimProof {
         SwapClaimProof {
-            swap_nft_asset_id: self.swap_nft_asset_id,
-            b_d: *self.claim_address.diversified_generator(),
-            pk_d: *self.claim_address.transmission_key(),
-            nk,
+            swap_nft_asset_id: self.swap_plaintext.generate_swap_asset_id(),
+            claim_address: self.swap_nft_note.address(),
             note_commitment_proof,
-            trading_pair: self.trading_pair,
+            trading_pair: self.swap_plaintext.trading_pair,
             note_blinding,
             delta_1: self.output_data.delta_1,
             delta_2: self.output_data.delta_2,
@@ -121,25 +105,26 @@ impl SwapClaimPlan {
             note_blinding_2: self.output_2_blinding,
             esk_1: self.esk_1.clone(),
             esk_2: self.esk_2.clone(),
+            nk: nk.clone(),
         }
     }
 
     /// Construct the [`swap_claim::Body`] described by this plan.
     pub fn swap_claim_body(&self, fvk: &FullViewingKey) -> swap_claim::Body {
         let output_1_note = Note::from_parts(
-            self.claim_address,
+            self.swap_nft_note.address(),
             Value {
                 amount: self.output_data.lambda_1,
-                asset_id: self.trading_pair.asset_1(),
+                asset_id: self.swap_plaintext.trading_pair.asset_1(),
             },
             self.output_1_blinding,
         )
         .expect("transmission key in address is always valid");
         let output_2_note = Note::from_parts(
-            self.claim_address,
+            self.swap_nft_note.address(),
             Value {
                 amount: self.output_data.lambda_2,
-                asset_id: self.trading_pair.asset_2(),
+                asset_id: self.swap_plaintext.trading_pair.asset_2(),
             },
             self.output_2_blinding,
         )
@@ -160,18 +145,17 @@ impl SwapClaimPlan {
 
         swap_claim::Body {
             nullifier,
-            fee: self.fee.clone(),
+            fee: self.swap_plaintext.fee.clone(),
             output_1,
             output_2,
             output_data: self.output_data,
-            anchor: self.anchor,
-            trading_pair: self.trading_pair,
+            trading_pair: self.swap_plaintext.trading_pair,
         }
     }
 
     /// Checks whether this plan's output is viewed by the given IVK.
     pub fn is_viewed_by(&self, ivk: &IncomingViewingKey) -> bool {
-        ivk.views_address(&self.claim_address)
+        ivk.views_address(&self.swap_nft_note.address())
     }
 }
 
@@ -180,18 +164,14 @@ impl Protobuf<pb::SwapClaimPlan> for SwapClaimPlan {}
 impl From<SwapClaimPlan> for pb::SwapClaimPlan {
     fn from(msg: SwapClaimPlan) -> Self {
         Self {
+            swap_plaintext: Some(msg.swap_plaintext.into()),
             swap_nft_note: Some(msg.swap_nft_note.into()),
             swap_nft_position: msg.swap_nft_position.into(),
-            claim_address: Some(msg.claim_address.into()),
-            fee: Some(msg.fee.into()),
             output_data: Some(msg.output_data.into()),
-            anchor: Some(msg.anchor.into()),
-            trading_pair: Some(msg.trading_pair.into()),
             output_1_blinding: msg.output_1_blinding.to_bytes().to_vec().into(),
             output_2_blinding: msg.output_2_blinding.to_bytes().to_vec().into(),
             esk_1: msg.esk_1.to_bytes().to_vec().into(),
             esk_2: msg.esk_2.to_bytes().to_vec().into(),
-            swap_nft_asset_id: Some(msg.swap_nft_asset_id.into()),
         }
     }
 }
@@ -200,39 +180,23 @@ impl TryFrom<pb::SwapClaimPlan> for SwapClaimPlan {
     type Error = anyhow::Error;
     fn try_from(msg: pb::SwapClaimPlan) -> Result<Self, Self::Error> {
         Ok(Self {
+            swap_plaintext: msg
+                .swap_plaintext
+                .ok_or_else(|| anyhow::anyhow!("missing swap_plaintext"))?
+                .try_into()?,
             swap_nft_note: msg
                 .swap_nft_note
                 .ok_or_else(|| anyhow::anyhow!("missing swap_nft_note"))?
                 .try_into()?,
             swap_nft_position: msg.swap_nft_position.try_into()?,
-            fee: msg
-                .fee
-                .ok_or_else(|| anyhow::anyhow!("missing fee"))?
-                .try_into()?,
             output_data: msg
                 .output_data
                 .ok_or_else(|| anyhow::anyhow!("missing output_data"))?
-                .try_into()?,
-            anchor: msg
-                .anchor
-                .ok_or_else(|| anyhow::anyhow!("missing anchor"))?
-                .try_into()?,
-            trading_pair: msg
-                .trading_pair
-                .ok_or_else(|| anyhow::anyhow!("missing trading_pair"))?
-                .try_into()?,
-            claim_address: msg
-                .claim_address
-                .ok_or_else(|| anyhow::anyhow!("missing claim_address"))?
                 .try_into()?,
             output_1_blinding: Fq::from_bytes(msg.output_1_blinding.as_ref().try_into()?)?,
             output_2_blinding: Fq::from_bytes(msg.output_2_blinding.as_ref().try_into()?)?,
             esk_1: msg.esk_1.as_ref().try_into()?,
             esk_2: msg.esk_2.as_ref().try_into()?,
-            swap_nft_asset_id: msg
-                .swap_nft_asset_id
-                .ok_or_else(|| anyhow::anyhow!("missing swap_nft_asset_id"))?
-                .try_into()?,
         })
     }
 }

--- a/transaction/src/plan/build.rs
+++ b/transaction/src/plan/build.rs
@@ -64,6 +64,26 @@ impl TransactionPlan {
             actions.push(Action::Output(output_plan.output(fvk.outgoing())));
         }
 
+        // Build the transaction's swaps.
+        // TODO: figure this out
+        // for ((swap_plan, auth_sig), auth_path) in self
+        //     .swap_plans()
+        //     .zip(auth_data.spend_auths.into_iter())
+        //     .zip(witness_data.note_commitment_proofs.into_iter())
+        // {
+        //     actions.push(Action::Swap(swap_plan.swap(fvk, witness_data.anchor)));
+        // }
+
+        // Build the transaction's swap claims.
+        // for swap_claim_plan in self.swap_claim_plans().cloned() {
+        //     actions.push(Action::SwapClaim(swap_claim_plan.swap_claim(
+        //         fvk,
+        //         note_commitment_proof,
+        //         nk,
+        //         note_blinding,
+        //     )));
+        // }
+
         // We don't have anything more to build, but iterate through the rest of
         // the action plans by type so that the transaction will have them in a
         // defined order.

--- a/transaction/src/plan/build.rs
+++ b/transaction/src/plan/build.rs
@@ -66,6 +66,11 @@ impl TransactionPlan {
 
         // Build the transaction's swaps.
         // TODO: figure this out
+        //         the swap plans shouldn't require pulling in spend auth signatures, because the Swap just draws from the transaction's value balance. but we'll need to figure out how we handle the authentication paths (note commitment proofs) -- in the existing WitnessData struct, there's just one for each spend, in order, because (now-broken assumption) the only place they were needed was for spends.
+
+        // wondering if we should change the WitnessData domain type to store a BTreeMap<note::Commitment, tct::Proof>, and when deserializing from the proto, instead of just deserializing a list of proofs, call .commitment() on each one and use it as the key for the BTreeMap.
+
+        // then instead of having to do zips or whatever, or figure out how to maintain a brittle order dependency, we can just query for exactly the proof we want.
         // for ((swap_plan, auth_sig), auth_path) in self
         //     .swap_plans()
         //     .zip(auth_data.spend_auths.into_iter())


### PR DESCRIPTION
This simplifies a lot of the Swap/SwapClaim code and continues implementation stubbing in the client.