### PR TITLE
Automatically submit SwapClaim after Swap completes

### DIFF
--- a/wallet/src/plan.rs
+++ b/wallet/src/plan.rs
@@ -301,9 +301,6 @@ where
 
     let chain_params = view.chain_params().await?;
 
-    // TODO: need to fetch clearing price (`BatchSwapOutputData`) for the
-    // swap.
-
     let mut plan = TransactionPlan {
         chain_id: chain_params.chain_id,
         fee: Fee(fee),
@@ -320,7 +317,6 @@ where
     //         fvk.address(),
     //         fee,
     //         output_data,
-    //         anchor,
     //         trading_pair,
     //     )
     //     .into(),


### PR DESCRIPTION
#1329 should be merged first, this PR was branched off of that since it relies on the "waiting on commitments to sync to view" behavior introduced in #1329