### PR TITLE
spec: introduce account and account ID terminology

### DIFF
--- a/crypto/src/keys/fvk.rs
+++ b/crypto/src/keys/fvk.rs
@@ -16,9 +16,8 @@ use crate::{
 
 static IVK_DOMAIN_SEP: Lazy<Fq> = Lazy::new(|| Fq::from_le_bytes_mod_order(b"penumbra.derive.ivk"));
 
-static ACCOUNT_ID_DOMAIN_SEP: Lazy<Fq> = Lazy::new(|| {
-    Fq::from_le_bytes_mod_order(blake2b_simd::blake2b(b"Penumbra_HashFVK").as_bytes())
-});
+static ACCOUNT_ID_DOMAIN_SEP: Lazy<Fq> =
+    Lazy::new(|| Fq::from_le_bytes_mod_order(b"Penumbra_HashFVK"));
 
 /// The root viewing capability for all data related to a given spend authority.
 #[derive(Clone, Serialize, Deserialize)]

--- a/docs/protocol/src/concepts/addresses_keys.md
+++ b/docs/protocol/src/concepts/addresses_keys.md
@@ -18,10 +18,13 @@ flowchart BT
     end;
     subgraph SK[Spending Key]
     end;
+    subgraph SeedPhrase[Seed Phrase]
+    end;
 
     index(address index);
     div{ };
 
+    SeedPhrase --> SK;
     SK --> FVK;
     FVK --> OVK;
     FVK --> IVK;
@@ -34,12 +37,14 @@ flowchart BT
 
 From bottom to top:
 
-- the *spending key* is the root capability, representing spending authority;
-- the *full viewing key* represents the capability to view all transactions related to the spending authority;
+- the *seed phrase* is the root key material. Multiple *accounts* - each with
+separate spend authority - can be derived from this root seed phrase.
+- the *spending key* is the capability representing spending authority for a given account;
+- the *full viewing key* represents the capability to view all transactions related to the account;
 - the *outgoing viewing key* represents the capability to view only outgoing transactions, and is used to recover information about previously sent transactions;
 - the *incoming viewing key* represents the capability to view only incoming transactions, and is used to scan the block chain for incoming transactions.
 
-Penumbra allows the same spending authority to present multiple, publicly
+Penumbra allows the same account to present multiple, publicly
 unlinkable addresses, keyed by an 16-byte *address index*.  Each choice of
 address index gives a distinct shielded payment address. Because these
 addresses share a common incoming viewing key, the cost of scanning the
@@ -53,6 +58,7 @@ detection has false positives but no false negatives, so detection will find all
 relevant transactions, as well as some amount of unrelated cover traffic.
 Unlike incoming viewing keys, detection keys are not shared between diversified
 addresses, allowing fine-grained control of delegation.
+
 
 This diagram shows only the user-visible parts of the key hierarchy.
 Internally, each of these keys has different components, described in detail in

--- a/docs/protocol/src/protocol/addresses_keys.md
+++ b/docs/protocol/src/protocol/addresses_keys.md
@@ -6,14 +6,14 @@ BLS12-381, that it uses Poseidon as a hash and PRF, `decaf377` as the embedded
 group, and that it includes support for [fuzzy message
 detection](../crypto/fmd.md).
 
-All key material within a particular spend authority is ultimately derived from
+All key material within a particular spend authority - an *account* - is ultimately derived from
 a single root secret.  The internal key components and their derivations are
 described in the following sections:
 
 * [Spending Keys](./addresses_keys/spend_key.md) describes derivation of the
   spending key from the root key material;
 * [Viewing Keys](./addresses_keys/viewing_keys.md) describes derivation of the full, incoming, and outgoing viewing keys;
-* [Addresses and Detection Keys](./addresses_keys/addresses.md) describes derivation of multiple, publicly unlinkable addresses for a single spending authority, each with their own detection key.
+* [Addresses and Detection Keys](./addresses_keys/addresses.md) describes derivation of multiple, publicly unlinkable addresses for a single account, each with their own detection key.
 
 The diagram in the [Overview](../concepts/addresses_keys.md) section describes
 the key hierarchy from an external, functional point of view.  Here, we zoom in

--- a/docs/protocol/src/protocol/addresses_keys/viewing_keys.md
+++ b/docs/protocol/src/protocol/addresses_keys/viewing_keys.md
@@ -33,7 +33,25 @@ from the contents of a note, so that the sender of a note cannot learn when the
 recipient spent it.
 
 The full viewing key can be used to create transaction proofs, as well as to
-view all activity related to its spending authority.
+view all activity related to its account. The hash of a full viewing key is referred
+to as an *Account ID* and is derived as follows.
+
+Define
+`poseidon_hash_2(label, x1, x2)` to be rate-2 Poseidon hashing of inputs `x1`,
+`x2` with the capacity initialized to the domain separator `label`.  Define
+`from_le_bytes(bytes)` as the function that interprets its input bytes as an
+integer in little-endian order. Define
+`element.to_le_bytes()` as the function that encodes an input element in
+little-endian byte order. Define `decaf377_s(element)` as the function
+that produces the $s$-value used to encode the provided `decaf377` element.
+Then
+
+```
+hash_output = poseidon_hash_2(from_le_bytes(b"Penumbra_HashFVK"), nk, decaf377_s(ak))
+account_id = hash_output.to_le_bytes()[0:32]
+```
+
+i.e. we take the 32-bytes of the hash output as the account ID.
 
 ## Incoming and Outgoing Viewing Keys
 
@@ -65,13 +83,7 @@ ovk  = prf_expand(b"Penumbra_DeriOVK", to_le_bytes(nk), decaf377_encode(ak))[0..
 dk = prf_expand(b"Penumbra_DerivDK", to_le_bytes(nk), decaf377_encode(ak))[0..16]
 ```
 
-The $\mathsf {ivk}$ is intended to be derived in a circuit.  Define
-`poseidon_hash_2(label, x1, x2)` to be rate-2 Poseidon hashing of inputs `x1`,
-`x2` with the capacity initialized to the domain separator `label`.  Define
-`from_le_bytes(bytes)` as the function that interprets its input bytes as an
-integer in little-endian order.  Define `decaf377_s(element)` as the function
-that produces the $s$-value used to encode the provided `decaf377` element.
-Then
+The $\mathsf {ivk}$ is intended to be derived in a circuit.  Then
 ```
 ivk = poseidon_hash_2(from_le_bytes(b"penumbra.derive.ivk"), nk, decaf377_s(ak)) mod r
 ```


### PR DESCRIPTION
Closes #1080

For each seed phrase, we can have multiple accounts (equivalent to spending authority). For each account we can have multiple diversified addresses. Sharing a viewing key means giving access to an entire _account_. 