### PR TITLE
pd: experimentally enable grpc-web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,6 +2927,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.3",
  "tonic 0.6.2",
+ "tonic-web",
  "tower",
  "tower-abci",
  "tracing",
@@ -5092,6 +5093,24 @@ dependencies = [
  "prost-build",
  "quote 1.0.21",
  "syn 1.0.99",
+]
+
+[[package]]
+name = "tonic-web"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5802af338d3f01590a5c0777783f0e0897df05e9b053ac0084e310a9319a456"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project",
+ "tonic 0.6.2",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -60,6 +60,8 @@ regex = "1.5"
 reqwest = { version = "0.11", features = ["json"] }
 prost-types = "0.9"
 tonic = "0.6.1"
+# TODO: update to 0.4, which requires tonic 0.8, which requires changes to tendermint crates (:C)
+tonic-web = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
 pin-project = "1"
 futures = "0.3"

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -197,8 +197,11 @@ async fn main() -> anyhow::Result<()> {
                         }
                         None => tracing::error_span!("grpc"),
                     })
-                    .add_service(ObliviousQueryServer::new(info.clone()))
-                    .add_service(SpecificQueryServer::new(info.clone()))
+                    // Allow HTTP/1, which will be used by grpc-web connections.
+                    .accept_http1(true)
+                    // Wrap each of the gRPC services in a tonic-web proxy:
+                    .add_service(tonic_web::enable(ObliviousQueryServer::new(info.clone())))
+                    .add_service(tonic_web::enable(SpecificQueryServer::new(info.clone())))
                     .serve(
                         format!("{}:{}", host, grpc_port)
                             .parse()


### PR DESCRIPTION
Using gRPC from a web context is difficult because of its reliance on HTTP/2 features not exposed by browser APIs.  Instead, grpc-web allows a proxy to translate an HTTP/1 based protocol into normal gRPC.  Normally, this is done with Envoy or some other proxy service, but Rust and Tonic make this much more convenient, by making it easy to bundle the proxy into the application itself.

I haven't tested this code from a web context, because that requires compiling our protos to JS and loading them into a page, but I have checked that this works just fine with normal gRPC (i.e., it does not degrade any functionality), so we could merge it experimentally and see if it unblocks proof of concept work towards #1373.