### PR TITLE
Add a stub CPMM (UniV2) AMM to back the DEX for testing purposes.

### DIFF
--- a/component/src/dex/mod.rs
+++ b/component/src/dex/mod.rs
@@ -1,6 +1,9 @@
 mod component;
 pub mod metrics;
 pub mod state_key;
+mod stub_cpmm;
+
+use stub_cpmm::StubCpmm;
 
 pub use self::metrics::register_metrics;
 pub use component::{Dex, View};

--- a/component/src/dex/state_key.rs
+++ b/component/src/dex/state_key.rs
@@ -1,5 +1,13 @@
 use penumbra_crypto::dex::TradingPair;
 
+pub fn stub_cpmm_reserves(trading_pair: &TradingPair) -> String {
+    format!(
+        "dex/stub_cpmm_reserves/{}/{}",
+        &trading_pair.asset_1(),
+        &trading_pair.asset_2()
+    )
+}
+
 pub fn output_data(height: u64, trading_pair: TradingPair) -> String {
     format!(
         "dex/output/{}/{}/{}",

--- a/component/src/dex/stub_cpmm.rs
+++ b/component/src/dex/stub_cpmm.rs
@@ -1,0 +1,92 @@
+use penumbra_crypto::dex::lp::Reserves;
+
+/// A stub constant-product market maker, used to exercise the swap
+/// functionality before we implement the real DEX backend.
+pub struct StubCpmm {
+    pub reserves: Reserves,
+}
+
+impl StubCpmm {
+    /// Trade $\Delta_1$ of asset 1 for $\Lambda_2$ of asset 2.
+    pub fn trade_1_to_2(&mut self, delta_1: u64) -> u64 {
+        // (R_1 + \Delta_1) (R_2 - \Lambda_2) = R_1 R_2
+        // R_1 R_2 + \Delta_1 R_2 - \Lambda_2 (R_1 + \Delta_1) = R_1 R_2
+        // \Delta_1 R_2 = \Lambda_2 (R_1 + \Delta_1)
+        // (\Delta_1 R_2 ) / (R_1 + \Delta_1) = \Lambda_2
+
+        let Reserves { r1, r2 } = self.reserves;
+
+        let num = r2 as u128 * delta_1 as u128;
+        let den = r1 as u128 + delta_1 as u128;
+        // Not that correctness really matters here,
+        // but this rounds *down* the output amount.
+        let lambda_2 = (num / den) as u64;
+
+        self.reserves = Reserves {
+            r1: r1 + delta_1,
+            r2: r2 - lambda_2,
+        };
+
+        lambda_2
+    }
+
+    /// Trade $\Delta_2$ of asset 2 for $\Lambda_1$ of asset 1.
+    pub fn trade_2_to_1(&mut self, delta_2: u64) -> u64 {
+        // (R_1 - \Lambda_1) (R_2 + \Delta_2) = R_1 R_2
+        // R_1 R_2 + \Delta_2 R_1 - \Lambda_1 (R_2 + \Delta_2) = R_1 R_2
+        // \Delta_2 R_1 = \Lambda_1 (R_2 + \Delta_2)
+        // (\Delta_2 R_1 ) / (R_2 + \Delta_2) = \Lambda_1
+
+        let Reserves { r1, r2 } = self.reserves;
+
+        let num = r1 as u128 * delta_2 as u128;
+        let den = r2 as u128 + delta_2 as u128;
+        // Not that correctness really matters here,
+        // but this rounds *down* the output amount.
+        let lambda_1 = (num / den) as u64;
+
+        self.reserves = Reserves {
+            r1: r1 - lambda_1,
+            r2: r2 + delta_2,
+        };
+
+        lambda_1
+    }
+
+    /// Trade $(\Delta_1, \Delta_2)$ against the CPMM to get outputs $(\Lambda_1, \Lambda_2)$, netting cross flow at the current price.
+    pub fn trade_netted(&mut self, delta: (u64, u64)) -> (u64, u64) {
+        match delta {
+            (delta_1, 0) => (0, self.trade_1_to_2(delta_1)),
+            (0, delta_2) => (self.trade_2_to_1(delta_2), 0),
+            (delta_1, delta_2) => {
+                // We want to net out the cross flow at the current price.
+                // To do that, we need to determine which input is "bigger",
+                // and will absorb the other direction's flow.
+
+                let Reserves { r1, r2 } = self.reserves;
+
+                // The amount of asset 2 we get from asset 1 at current prices.
+                let lambda_2_netted = ((delta_1 as u128 * r2 as u128) / (r1 as u128)) as u64;
+                // The amount of asset 1 we get from asset 2 at current prices.
+                let lambda_1_netted = ((delta_2 as u128 * r1 as u128) / (r2 as u128)) as u64;
+
+                match (lambda_1_netted <= delta_1, lambda_2_netted <= delta_2) {
+                    // We have more delta_1 than is needed to net out delta_2.
+                    (true, false) => (
+                        lambda_1_netted,
+                        self.trade_1_to_2(delta_1 - lambda_1_netted),
+                    ),
+                    // We have more delta_2 than is needed to net out delta_1.
+                    (false, true) => (
+                        self.trade_2_to_1(delta_2 - lambda_2_netted),
+                        lambda_2_netted,
+                    ),
+                    // Intuitively, these should never happen -- but skipping
+                    // handling them would require justifying why, so instead,
+                    // just burn all the input funds (lol)
+                    (true, true) | (false, false) => (0, 0),
+                }
+            }
+        }
+    }
+}

--- a/crypto/src/asset/denom.rs
+++ b/crypto/src/asset/denom.rs
@@ -208,6 +208,11 @@ impl Unit {
         }
     }
 
+    /// Return the [`asset::Id`] associated with this denomination.
+    pub fn id(&self) -> asset::Id {
+        self.inner.id.clone()
+    }
+
     pub fn format_value(&self, value: u64) -> String {
         let power_of_ten = 10u64.pow(self.exponent().into());
         let v1 = value / power_of_ten;
@@ -263,7 +268,7 @@ impl Unit {
         }
     }
 
-    fn exponent(&self) -> u8 {
+    pub fn exponent(&self) -> u8 {
         self.inner
             .units
             .get(self.unit_index as usize)

--- a/crypto/src/dex/swap.rs
+++ b/crypto/src/dex/swap.rs
@@ -49,10 +49,12 @@ impl BatchSwapOutputData {
             //   lambda_2_i = (delta_1_i * lambda_2) / delta_1
             //   lambda_1_i = (delta_2_i * lambda_1) / delta_2
             // so that we can do division and rounding at the end.
-            let lambda_1_i =
-                ((delta_1_i as u128) * (self.lambda_2 as u128)) / (self.delta_1 as u128);
-            let lambda_2_i =
-                ((delta_2_i as u128) * (self.lambda_1 as u128)) / (self.delta_2 as u128);
+            let lambda_2_i = ((delta_1_i as u128) * (self.lambda_2 as u128))
+                .checked_div(self.delta_1 as u128)
+                .unwrap_or(0);
+            let lambda_1_i = ((delta_2_i as u128) * (self.lambda_1 as u128))
+                .checked_div(self.delta_2 as u128)
+                .unwrap_or(0);
 
             (lambda_1_i as u64, lambda_2_i as u64)
         } else {


### PR DESCRIPTION
his module and struct are marked "Stub" to indicate that they're intended to
be thrown away.  This won't be the real AMM we use.  But, having *a* toy AMM
lets us exercise the shielded swaps in a more real way than just failing all of
them.

Two things we might want to do before releasing this code:

1. Add `gm` and `gn` to the asset registry as display denoms of a base denom
with a reasonable precision (e.g., 1e6, so gm is really 1e6 ugm).  This is
because the stub CPMM implementation pays no real attention to rounding
behavior other than "round down", which could cause unexpected behavior we'd
then have to help people through. #1398 

2. Add a `pcli q dex cpmm-reserves gm:gn` subcommand that can display the state
of the reserves for a specified trading pair (in this case `gm:gn`, choosing
the canonical ordering of whatever the user input).  There's no need to make
this good, it's stub code, it just has to exist. #1399 