### PR TITLE
provide dummy memo key such that `Transaction::auth_hash` does not panic

### DIFF
--- a/crypto/src/symmetric.rs
+++ b/crypto/src/symmetric.rs
@@ -98,6 +98,12 @@ impl TryFrom<Vec<u8>> for PayloadKey {
     }
 }
 
+impl From<[u8; 32]> for PayloadKey {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(*Key::from_slice(&bytes))
+    }
+}
+
 /// Represents a symmetric `ChaCha20Poly1305` key.
 ///
 /// Used for encrypting and decrypting [`OvkWrappedKey`] material used to decrypt

--- a/transaction/src/auth_hash.rs
+++ b/transaction/src/auth_hash.rs
@@ -138,10 +138,17 @@ impl TransactionPlan {
         for spend in self.spend_plans() {
             state.update(spend.spend_body(fvk).auth_hash().as_bytes());
         }
+
+        // If the memo_key is None, then there is no memo, and we populate the memo key
+        // field with a dummy key.
+        let dummy_payload_key: PayloadKey = [0u8; 32].into();
         for output in self.output_plans() {
             state.update(
                 output
-                    .output_body(fvk.outgoing(), &memo_key.clone().unwrap())
+                    .output_body(
+                        fvk.outgoing(),
+                        memo_key.as_ref().unwrap_or(&dummy_payload_key),
+                    )
                     .auth_hash()
                     .as_bytes(),
             );

--- a/transaction/src/plan/action/output.rs
+++ b/transaction/src/plan/action/output.rs
@@ -101,7 +101,7 @@ impl OutputPlan {
         let ovk_wrapped_key = note.encrypt_key(&self.esk, ovk, value_commitment);
 
         let wrapped_memo_key = WrappedMemoKey::encrypt(
-            memo_key,
+            &memo_key,
             self.esk.clone(),
             note.transmission_key(),
             &note.diversified_generator(),

--- a/transaction/src/plan/build.rs
+++ b/transaction/src/plan/build.rs
@@ -68,12 +68,16 @@ impl TransactionPlan {
         }
 
         // Build the transaction's outputs.
+        let dummy_payload_key: PayloadKey = [0u8; 32].into();
+        // If the memo_key is None, then there is no memo, and we populate the memo key
+        // field with a dummy key.
         for output_plan in self.output_plans() {
             // Outputs subtract from the transaction's value balance.
             synthetic_blinding_factor -= output_plan.value_blinding;
-            actions.push(Action::Output(
-                output_plan.output(fvk.outgoing(), &memo_key.clone().unwrap()),
-            ));
+            actions.push(Action::Output(output_plan.output(
+                fvk.outgoing(),
+                memo_key.as_ref().unwrap_or(&dummy_payload_key),
+            )));
         }
 
         // Build the transaction's swaps.


### PR DESCRIPTION
~Making this a little clearer for the future by getting the memo key with `expect`. Related to #1395~

Closes #1394
Flagging that any outputs without memos will be invalid transactions as of #1403 