### PR TITLE
Make asset ID formatting infallible in the case that a denom doesn't exist

### DIFF
--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -33,8 +33,8 @@ impl Fee {
         self.0.commit(blinding)
     }
 
-    pub fn try_format(&self, cache: &asset::Cache) -> Option<String> {
-        self.0.try_format(cache)
+    pub fn format(&self, cache: &asset::Cache) -> String {
+        self.0.format(cache)
     }
 }
 

--- a/crypto/src/value.rs
+++ b/crypto/src/value.rs
@@ -91,7 +91,7 @@ impl Value {
                     display_denom
                 )
             })
-            .unwrap_or(format!("{}{}", self.amount, self.asset_id))
+            .unwrap_or_else(|| format!("{}{}", self.amount, self.asset_id))
     }
 }
 

--- a/pcli/src/command/view/balance.rs
+++ b/pcli/src/command/view/balance.rs
@@ -104,7 +104,7 @@ impl BalanceCmd {
                     format!("{}", u128::from(index)),
                     format!(
                         "{}{}",
-                        value.try_format(&asset_cache).unwrap(),
+                        value.format(&asset_cache),
                         if let Some(unbonding_epoch) = quarantined {
                             format!(" (unbonding until epoch {})", unbonding_epoch)
                         } else {
@@ -173,7 +173,7 @@ impl BalanceCmd {
             for (value, quarantined) in rows {
                 table.add_row(vec![format!(
                     "{}{}",
-                    value.try_format(&asset_cache).unwrap(),
+                    value.format(&asset_cache),
                     if let Some(unbonding_epoch) = quarantined {
                         format!(" (unbonding until epoch {})", unbonding_epoch)
                     } else {

--- a/pcli/src/command/view/staked.rs
+++ b/pcli/src/command/view/staked.rs
@@ -88,9 +88,9 @@ impl StakedCmd {
 
             table.add_row(vec![
                 info.validator.name.clone(),
-                unbonded.try_format(&asset_cache).unwrap(),
+                unbonded.format(&asset_cache),
                 format!("{:.4}", rate),
-                delegation.try_format(&asset_cache).unwrap(),
+                delegation.format(&asset_cache),
             ]);
 
             total += unbonded.amount;
@@ -110,9 +110,9 @@ impl StakedCmd {
 
         table.add_row(vec![
             "Unbonded Stake".to_string(),
-            unbonded.try_format(&asset_cache).unwrap(),
+            unbonded.format(&asset_cache),
             format!("{:.4}", 1.0),
-            unbonded.try_format(&asset_cache).unwrap(),
+            unbonded.format(&asset_cache),
         ]);
 
         let total = Value {
@@ -122,7 +122,7 @@ impl StakedCmd {
 
         table.add_row(vec![
             "Total".to_string(),
-            total.try_format(&asset_cache).unwrap(),
+            total.format(&asset_cache),
             String::new(),
             String::new(),
         ]);


### PR DESCRIPTION
This prevents a crash in the case where a Swap NFT (which has no associated denom) is attempted to format via `pcli view balance`.