### PR TITLE
chore: use `tokio@1.21.1` and `console-subscriber@0.1.8`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e933c43a5db3779b3600cdab18856af2411ca2237e33ba8ab476d5d5b1a6c1e7"
+checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -4910,9 +4910,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
 dependencies = [
  "autocfg",
  "bytes",

--- a/component/Cargo.toml
+++ b/component/Cargo.toml
@@ -19,7 +19,7 @@ tendermint = "0.24.0-pre.1"
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
 jmt = { git = "https://github.com/penumbra-zone/jellyfish-merkle.git", branch = "main" }
 
-tokio = { version = "1.16", features = ["full", "tracing"]}
+tokio = { version = "1.21.1", features = ["full", "tracing"]}
 async-trait = "0.1.52"
 tonic = "0.6.1"
 anyhow = "1"

--- a/custody/Cargo.toml
+++ b/custody/Cargo.toml
@@ -12,7 +12,7 @@ penumbra-chain = { path = "../chain" }
 penumbra-crypto = { path = "../crypto" }
 penumbra-transaction = { path = "../transaction" }
 
-tokio = { version = "1.16", features = ["full"]}
+tokio = { version = "1.21.1", features = ["full"]}
 anyhow = "1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/eddy/Cargo.toml
+++ b/eddy/Cargo.toml
@@ -20,4 +20,4 @@ ark-std = "0.3"
 thiserror = "1"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"]}
+tokio = { version = "1.21.1", features = ["full"]}

--- a/measure/Cargo.toml
+++ b/measure/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 penumbra-proto = { path = "../proto" }
 penumbra-chain = { path = "../chain" }
 
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.21.1", features = ["full"] }
 tonic = "0.6"
 anyhow = "1"
 clap = { version = "3", features = ["derive", "env"] }

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -46,7 +46,7 @@ bytes = "1"
 comfy-table = "5"
 directories = "4.0.1"
 fslock = "0.2"
-tokio = { version = "1", features = ["full"]}
+tokio = { version = "1.21.1", features = ["full"]}
 tokio-stream = "0.1"
 tokio-util = "0.6"
 tower = { version = "0.4", features = ["full"]}

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -51,7 +51,7 @@ chrono = { version = "0.4", default-features = false, features = ["serde"] }
 csv = "1.1"
 directories = "4.0"
 # Temporarily pin due to https://github.com/penumbra-zone/penumbra/issues/1355
-tokio = { version = "=1.20.1", features = ["full"]}
+tokio = { version = "=1.21.1", features = ["full"]}
 tokio-stream = "0.1"
 tokio-util = "0.7"
 tower = { version = "0.4", features = ["full"]}
@@ -88,7 +88,7 @@ tempfile = "3.3.0"
 base64 = "0.13.0"
 # Temporarily pin due to https://github.com/penumbra-zone/penumbra/issues/1355 since 0.1.8 contains
 # a fix that only works with tokio 1.21.0
-console-subscriber = "=0.1.7"
+console-subscriber = "=0.1.8"
 metrics-tracing-context = "0.11.0"
 metrics-util = "0.13"
 clap = { version = "3", features = ["derive"] }

--- a/pd/src/consensus/service.rs
+++ b/pd/src/consensus/service.rs
@@ -34,7 +34,8 @@ impl Consensus {
 
         tokio::task::Builder::new()
             .name("consensus::Worker")
-            .spawn(Worker::new(storage, queue_rx, height_tx).await?.run());
+            .spawn(Worker::new(storage, queue_rx, height_tx).await?.run())
+            .expect("failed to spawn consensus worker");
 
         Ok((
             Self {

--- a/pd/src/mempool/service.rs
+++ b/pd/src/mempool/service.rs
@@ -36,7 +36,8 @@ impl Mempool {
 
         tokio::task::Builder::new()
             .name("mempool::Worker")
-            .spawn(Worker::new(storage, queue_rx, height_rx).await?.run());
+            .spawn(Worker::new(storage, queue_rx, height_rx).await?.run())
+            .expect("failed to spawn mempool worker");
 
         Ok(Self {
             queue: PollSender::new(queue_tx),

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -10,7 +10,7 @@ penumbra-proto = { path = "../proto" }
 penumbra-crypto = { path = "../crypto" }
 penumbra-tct = { path = "../tct" }
 
-tokio = { version = "1.16", features = ["full", "tracing"]}
+tokio = { version = "1.21.1", features = ["full", "tracing"]}
 sha2 = "0.9"
 tempfile = "3.3.0"
 jmt = { git = "https://github.com/penumbra-zone/jellyfish-merkle.git", branch = "main" }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -33,6 +33,7 @@ impl Storage {
                     Ok(Self(Arc::new(DB::open_cf(&opts, path, ["jmt", "nct"])?)))
                 })
             })
+            .unwrap()
             .await
             .unwrap()
     }
@@ -92,6 +93,7 @@ impl Storage {
                     Ok::<_, anyhow::Error>(())
                 })
             })
+            .unwrap()
             .await?
     }
 
@@ -110,6 +112,7 @@ impl Storage {
                     }
                 })
             })
+            .unwrap()
             .await?
     }
 }
@@ -146,6 +149,7 @@ impl TreeWriter for Storage {
                         Ok(())
                     })
                 })
+                .unwrap()
                 .await
                 .unwrap()
         })
@@ -180,6 +184,7 @@ impl TreeReader for Storage {
                         Ok(value)
                     })
                 })
+                .unwrap()
                 .await
                 .unwrap()
         })
@@ -214,6 +219,7 @@ impl TreeReader for Storage {
                         Ok(ret)
                     })
                 })
+                .unwrap()
                 .await
                 .unwrap()
         })

--- a/tct-property-test/Cargo.toml
+++ b/tct-property-test/Cargo.toml
@@ -12,5 +12,5 @@ static_assertions = "1"
 proptest = "1"
 proptest-derive = "0.3"
 penumbra-tct = { path = "../tct", features = ["arbitrary"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.21.1", features = ["full"] }
 futures = "0.3"

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -26,7 +26,7 @@ penumbra-tct = { path = "../tct" }
 penumbra-transaction = { path = "../transaction" }
 
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "offline", "sqlite" ] }
-tokio = { version = "1.16", features = ["full"]}
+tokio = { version = "=1.21.1", features = ["full"]}
 tokio-stream = { version =  "0.1.8", features = ["sync"] }
 anyhow = "1"
 directories = "4.0.1"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -25,7 +25,7 @@ penumbra-custody = { path = "../custody" }
 # External dependencies
 bytes = "1"
 bincode = "1.3.3"
-tokio = { version = "1", features = ["full"]}
+tokio = { version = "1.21.1", features = ["full"]}
 tower = { version = "0.4", features = ["full"]}
 tonic = "0.6"
 tracing = "0.1"


### PR DESCRIPTION
This should fix #1363 , see the diff for more details but I went ahead and bumped a couple crates from `tokio@1` to `1.21.1`.

The main API change was in `penumbra-storage`: [`tokio::task::Builder::spawn_blocking`](https://docs.rs/tokio/latest/tokio/task/struct.Builder.html#method.spawn_blocking) is fallible. It returns an `io::Error` if the runtime fails to spawn a task. We're not handling those errors, but let me know if you think we should!