### PR TITLE
Allow pcli querying of governance-controllable chain parameters

### DIFF
--- a/pcli/src/command.rs
+++ b/pcli/src/command.rs
@@ -26,7 +26,7 @@ pub use view::ViewCmd;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Command {
-    /// Query the  public chain state, like the validator set.
+    /// Query the public chain state, like the validator set.
     ///
     /// This command has two modes: it can be used to query raw bytes of
     /// arbitrary keys with the `key` subcommand, or it can be used to query

--- a/pcli/src/command/query/governance.rs
+++ b/pcli/src/command/query/governance.rs
@@ -74,7 +74,6 @@ impl GovernanceCmd {
                     .try_collect::<Vec<_>>()
                     .await?;
 
-                println!("{}", serde_json::to_string_pretty(&params)?);
                 json(&params)?;
             }
             GovernanceCmd::ListProposals { inactive } => {

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -18,6 +18,7 @@ import "penumbra/core/dex/v1alpha1/dex.proto";
 service ObliviousQuery {
   rpc CompactBlockRange(CompactBlockRangeRequest) returns (stream core.chain.v1alpha1.CompactBlock);
   rpc ChainParameters(ChainParamsRequest) returns (core.chain.v1alpha1.ChainParameters);
+  rpc MutableParameters(MutableParametersRequest) returns (stream governance.MutableChainParameter);
   rpc ValidatorInfo(ValidatorInfoRequest) returns (stream core.stake.v1alpha1.ValidatorInfo);
   rpc AssetList(AssetListRequest) returns (core.chain.v1alpha1.KnownAssets);
 }
@@ -41,6 +42,10 @@ message CompactBlockRangeRequest {
   // If set, keep the connection alive past end_height,
   // streaming new compact blocks as they are created.
   bool keep_alive = 4;
+}
+
+// Requests the governance-mutable parameters available for the chain.
+message MutableParametersRequest {
 }
 
 // Requests the global configuration data for the chain.

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -9,6 +9,7 @@ import "penumbra/core/crypto/v1alpha1/crypto.proto";
 import "penumbra/core/chain/v1alpha1/chain.proto";
 import "penumbra/core/stake/v1alpha1/stake.proto";
 import "penumbra/core/dex/v1alpha1/dex.proto";
+import "penumbra/core/governance/v1alpha1/governance.proto";
 
 // Methods for accessing chain state that are "oblivious" in the sense that they
 // do not request specific portions of the chain state that could reveal private
@@ -18,7 +19,7 @@ import "penumbra/core/dex/v1alpha1/dex.proto";
 service ObliviousQuery {
   rpc CompactBlockRange(CompactBlockRangeRequest) returns (stream core.chain.v1alpha1.CompactBlock);
   rpc ChainParameters(ChainParamsRequest) returns (core.chain.v1alpha1.ChainParameters);
-  rpc MutableParameters(MutableParametersRequest) returns (stream governance.MutableChainParameter);
+  rpc MutableParameters(MutableParametersRequest) returns (stream core.governance.v1alpha1.MutableChainParameter);
   rpc ValidatorInfo(ValidatorInfoRequest) returns (stream core.stake.v1alpha1.ValidatorInfo);
   rpc AssetList(AssetListRequest) returns (core.chain.v1alpha1.KnownAssets);
 }
@@ -46,6 +47,8 @@ message CompactBlockRangeRequest {
 
 // Requests the governance-mutable parameters available for the chain.
 message MutableParametersRequest {
+  // The expected chain id (empty string if no expectation).
+  string chain_id = 1;
 }
 
 // Requests the global configuration data for the chain.

--- a/proto/proto/penumbra/core/governance/v1alpha1/governance.proto
+++ b/proto/proto/penumbra/core/governance/v1alpha1/governance.proto
@@ -17,6 +17,14 @@ message Vote {
   Vote vote = 1;
 }
 
+// A chain parameter that can be modified by governance.
+message MutableChainParameter {
+    // The identifier of the parameter, used for submitting change proposals.
+    string identifier = 1;
+    // A textual description of the parameter and valid values.
+    string description = 2;
+}
+
 // The current state of a proposal.
 message ProposalState {
     // Voting is in progress and the proposal has not yet concluded voting or been withdrawn.

--- a/proto/src/gen/penumbra.core.governance.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.governance.v1alpha1.rs
@@ -34,6 +34,17 @@ pub mod vote {
         }
     }
 }
+/// A chain parameter that can be modified by governance.
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MutableChainParameter {
+    /// The identifier of the parameter, used for submitting change proposals.
+    #[prost(string, tag="1")]
+    pub identifier: ::prost::alloc::string::String,
+    /// A textual description of the parameter and valid values.
+    #[prost(string, tag="2")]
+    pub description: ::prost::alloc::string::String,
+}
 /// The current state of a proposal.
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/tools/proto-compiler/src/main.rs
+++ b/tools/proto-compiler/src/main.rs
@@ -349,6 +349,10 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     ("penumbra.core.governance.v1alpha1.Vote", SERIALIZE),
     ("penumbra.core.governance.v1alpha1.Vote", SERDE_TRANSPARENT),
     (
+        "penumbra.core.governance.v1alpha1.MutableChainParameter",
+        SERIALIZE,
+    ),
+    (
         ".penumbra.core.governance.v1alpha1.ProposalState",
         SERIALIZE,
     ),


### PR DESCRIPTION
Adds `pcli query governance parameters` command to view governance-controllable parameters along with human-readable descriptions.

Closes #1374 