### PR TITLE
transaction: add IsAction trait

### DIFF
--- a/transaction/src/action/delegate.rs
+++ b/transaction/src/action/delegate.rs
@@ -1,8 +1,11 @@
+use ark_ff::Zero;
 use penumbra_crypto::{
-    asset::Amount, Balance, DelegationToken, IdentityKey, Value, STAKING_TOKEN_ASSET_ID,
+    asset::Amount, Balance, DelegationToken, Fr, IdentityKey, Value, STAKING_TOKEN_ASSET_ID,
 };
 use penumbra_proto::{stake as pb, Protobuf};
 use serde::{Deserialize, Serialize};
+
+use super::IsAction;
 
 /// A transaction action adding stake to a validator's delegation pool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -22,6 +25,12 @@ pub struct Delegate {
     /// (and should be checked in transaction validation!), but including it allows
     /// stateless verification that the transaction is internally consistent.
     pub delegation_amount: Amount,
+}
+
+impl IsAction for Delegate {
+    fn balance_commitment(&self) -> penumbra_crypto::balance::Commitment {
+        self.balance().commit(Fr::zero())
+    }
 }
 
 impl Delegate {

--- a/transaction/src/action/ibc.rs
+++ b/transaction/src/action/ibc.rs
@@ -1,6 +1,9 @@
-use penumbra_crypto::{value, Address, Balance};
+use ark_ff::Zero;
+use penumbra_crypto::{value, Address, Balance, Fr};
 use penumbra_proto::{ibc as pb, Protobuf};
 use serde::{Deserialize, Serialize};
+
+use super::IsAction;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(try_from = "pb::Ics20Withdrawal", into = "pb::Ics20Withdrawal")]
@@ -22,6 +25,12 @@ pub struct ICS20Withdrawal {
     pub timeout_height: u64,
     // the timestamp at which this transfer expires.
     pub timeout_time: u64,
+}
+
+impl IsAction for ICS20Withdrawal {
+    fn balance_commitment(&self) -> penumbra_crypto::balance::Commitment {
+        self.balance().commit(Fr::zero())
+    }
 }
 
 impl ICS20Withdrawal {

--- a/transaction/src/action/output.rs
+++ b/transaction/src/action/output.rs
@@ -10,10 +10,18 @@ use penumbra_crypto::{
 };
 use penumbra_proto::{transaction as pb, Protobuf};
 
+use super::IsAction;
+
 #[derive(Clone, Debug)]
 pub struct Output {
     pub body: Body,
     pub proof: OutputProof,
+}
+
+impl IsAction for Output {
+    fn balance_commitment(&self) -> balance::Commitment {
+        self.body.balance_commitment
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/transaction/src/action/position.rs
+++ b/transaction/src/action/position.rs
@@ -8,10 +8,9 @@ use penumbra_crypto::{
     },
     Balance, Fr, Value, Zero,
 };
-use penumbra_proto::{
-    dex::{self as pb},
-    Protobuf,
-};
+use penumbra_proto::{dex as pb, Protobuf};
+
+use super::IsAction;
 
 /// A transaction action that opens a new position.
 ///
@@ -28,6 +27,12 @@ pub struct PositionOpen {
     /// The initial reserves of the position.  Unlike the `PositionData`, the
     /// reserves evolve over time as trades are executed against the position.
     pub initial_reserves: Reserves,
+}
+
+impl IsAction for PositionOpen {
+    fn balance_commitment(&self) -> balance::Commitment {
+        self.balance().commit(Fr::zero())
+    }
 }
 
 impl PositionOpen {
@@ -70,6 +75,12 @@ pub struct PositionClose {
     pub position_id: position::Id,
 }
 
+impl IsAction for PositionClose {
+    fn balance_commitment(&self) -> balance::Commitment {
+        self.balance().commit(Fr::zero())
+    }
+}
+
 impl PositionClose {
     /// Compute a commitment to the value this action contributes to its transaction.
     pub fn balance(&self) -> Balance {
@@ -103,9 +114,8 @@ pub struct PositionWithdraw {
     pub reserves_commitment: balance::Commitment,
 }
 
-impl PositionWithdraw {
-    /// Compute a commitment to the value this action contributes to its transaction.
-    pub fn balance_commitment(&self) -> balance::Commitment {
+impl IsAction for PositionWithdraw {
+    fn balance_commitment(&self) -> balance::Commitment {
         let closed_position_nft = Value {
             amount: 1u64.into(),
             asset_id: LpNft::new(self.position_id, position::State::Closed).asset_id(),
@@ -132,9 +142,8 @@ pub struct PositionRewardClaim {
     pub rewards_commitment: balance::Commitment,
 }
 
-impl PositionRewardClaim {
-    /// Compute a commitment to the value this action contributes to its transaction.
-    pub fn balance_commitment(&self) -> balance::Commitment {
+impl IsAction for PositionRewardClaim {
+    fn balance_commitment(&self) -> balance::Commitment {
         let withdrawn_position_nft = Value {
             amount: 1u64.into(),
             asset_id: LpNft::new(self.position_id, position::State::Withdrawn).asset_id(),

--- a/transaction/src/action/propose.rs
+++ b/transaction/src/action/propose.rs
@@ -1,11 +1,12 @@
+use ark_ff::Zero;
 use decaf377_rdsa::{Signature, SpendAuth, VerificationKey};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, str::FromStr};
 
-use penumbra_crypto::{asset::Amount, Address, Balance, Value, STAKING_TOKEN_ASSET_ID};
+use penumbra_crypto::{asset::Amount, Address, Balance, Fr, Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_proto::{transaction as pb, Protobuf};
 
-use crate::{plan::TransactionPlan, AuthHash};
+use crate::{plan::TransactionPlan, AuthHash, IsAction};
 
 /// A governance proposal.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -316,6 +317,12 @@ pub struct ProposalSubmit {
     pub withdraw_proposal_key: VerificationKey<SpendAuth>,
 }
 
+impl IsAction for ProposalSubmit {
+    fn balance_commitment(&self) -> penumbra_crypto::balance::Commitment {
+        self.balance().commit(Fr::zero())
+    }
+}
+
 impl ProposalSubmit {
     /// Compute a commitment to the value contributed to a transaction by this proposal submission.
     pub fn balance(&self) -> Balance {
@@ -374,6 +381,12 @@ pub struct ProposalWithdraw {
     pub body: ProposalWithdrawBody,
     /// The signature authorizing the withdrawal.
     pub auth_sig: Signature<SpendAuth>,
+}
+
+impl IsAction for ProposalWithdraw {
+    fn balance_commitment(&self) -> penumbra_crypto::balance::Commitment {
+        Default::default()
+    }
 }
 
 impl From<ProposalWithdraw> for pb::ProposalWithdraw {

--- a/transaction/src/action/spend.rs
+++ b/transaction/src/action/spend.rs
@@ -10,11 +10,19 @@ use penumbra_crypto::{
 };
 use penumbra_proto::{transaction, Protobuf};
 
+use super::IsAction;
+
 #[derive(Clone, Debug)]
 pub struct Spend {
     pub body: Body,
     pub auth_sig: Signature<SpendAuth>,
     pub proof: SpendProof,
+}
+
+impl IsAction for Spend {
+    fn balance_commitment(&self) -> balance::Commitment {
+        self.body.balance_commitment
+    }
 }
 
 impl Protobuf<transaction::Spend> for Spend {}

--- a/transaction/src/action/swap.rs
+++ b/transaction/src/action/swap.rs
@@ -7,6 +7,8 @@ use penumbra_crypto::{balance, dex::swap::SwapCiphertext};
 use penumbra_crypto::{NotePayload, Value};
 use penumbra_proto::{dex as pb, Protobuf};
 
+use crate::IsAction;
+
 #[derive(Clone, Debug)]
 pub struct Swap {
     // A proof that this is a valid state change.
@@ -19,10 +21,10 @@ pub struct Swap {
     pub body: Body,
 }
 
-impl Swap {
+impl IsAction for Swap {
     /// Compute a commitment to the value contributed to a transaction by this swap.
     /// Will subtract (v1,t1), (v2,t2), and (f,fee_token)
-    pub fn balance_commitment(&self) -> balance::Commitment {
+    fn balance_commitment(&self) -> balance::Commitment {
         let input_1 = Value {
             amount: self.body.delta_1_i,
             asset_id: self.body.trading_pair.asset_1(),

--- a/transaction/src/action/swap_claim.rs
+++ b/transaction/src/action/swap_claim.rs
@@ -1,15 +1,24 @@
+use ark_ff::Zero;
 use penumbra_crypto::dex::BatchSwapOutputData;
 use penumbra_crypto::transaction::Fee;
-use penumbra_crypto::{proofs::transparent::SwapClaimProof, NotePayload};
+use penumbra_crypto::{proofs::transparent::SwapClaimProof, Fr, NotePayload};
 use penumbra_crypto::{Balance, Nullifier};
 use penumbra_proto::{dex as pb, Protobuf};
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::IsAction;
+
 #[derive(Debug, Clone)]
 pub struct SwapClaim {
     pub proof: SwapClaimProof,
     pub body: Body,
+}
+
+impl IsAction for SwapClaim {
+    fn balance_commitment(&self) -> penumbra_crypto::balance::Commitment {
+        self.balance().commit(Fr::zero())
+    }
 }
 
 impl SwapClaim {

--- a/transaction/src/action/undelegate.rs
+++ b/transaction/src/action/undelegate.rs
@@ -1,8 +1,11 @@
+use ark_ff::Zero;
 use penumbra_crypto::{
-    asset::Amount, Balance, DelegationToken, IdentityKey, Value, STAKING_TOKEN_ASSET_ID,
+    asset::Amount, Balance, DelegationToken, Fr, IdentityKey, Value, STAKING_TOKEN_ASSET_ID,
 };
 use penumbra_proto::{stake as pb, Protobuf};
 use serde::{Deserialize, Serialize};
+
+use crate::IsAction;
 
 /// A transaction action withdrawing stake from a validator's delegation pool.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -21,6 +24,12 @@ pub struct Undelegate {
     /// (and should be checked in transaction validation!), but including it allows
     /// stateless verification that the transaction is internally consistent.
     pub delegation_amount: Amount,
+}
+
+impl IsAction for Undelegate {
+    fn balance_commitment(&self) -> penumbra_crypto::balance::Commitment {
+        self.balance().commit(Fr::zero())
+    }
 }
 
 impl Undelegate {

--- a/transaction/src/action/vote.rs
+++ b/transaction/src/action/vote.rs
@@ -8,6 +8,8 @@ use penumbra_crypto::{GovernanceKey, IdentityKey};
 use penumbra_proto::{governance as pb_g, transaction as pb_t, Protobuf};
 use serde::{Deserialize, Serialize};
 
+use crate::IsAction;
+
 /// A vote on a proposal.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(try_from = "pb_g::Vote", into = "pb_g::Vote")]
@@ -109,6 +111,12 @@ pub struct ValidatorVote {
     pub body: ValidatorVoteBody,
     /// The signature authorizing the vote (signed with governance key over the body).
     pub auth_sig: Signature<SpendAuth>,
+}
+
+impl IsAction for ValidatorVote {
+    fn balance_commitment(&self) -> penumbra_crypto::balance::Commitment {
+        Default::default()
+    }
 }
 
 impl From<ValidatorVote> for pb_t::ValidatorVote {

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -9,7 +9,7 @@ mod witness_data;
 pub mod action;
 pub mod plan;
 
-pub use action::Action;
+pub use action::{Action, IsAction};
 pub use auth_data::AuthorizationData;
 pub use auth_hash::AuthHash;
 pub use error::Error;

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     action::{Delegate, Output, ProposalSubmit, ProposalWithdraw, Swap, Undelegate, ValidatorVote},
-    Action,
+    Action, IsAction,
 };
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This moves the existing balance commitment code into a trait common to all actions, which we can use as a place to add more common functionality for actions.