### PR TITLE
tooling: don't override people's vs code configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,4 @@
     "rust-analyzer.server.extraEnv": {
         "DATABASE_URL": "sqlite:///tmp/pviewd-dev-db.sqlite"
     },
-    "rust-analyzer.checkOnSave.command": "clippy",
-    "rust-analyzer.checkOnSave.enable": true,
-    "[rust]": {
-        "editor.defaultFormatter": "rust-lang.rust-analyzer",
-        "editor.formatOnSave": true
-    }
 }


### PR DESCRIPTION
This broke my VS Code configs, which just used `cargo fmt`, and now the editor hangs every time I save.  I think we should only use the settings file for things like the database path, and not for opinions about how to configure the editor.