### PR TITLE
use protobuf-src to source protoc in build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v2
-      - run: curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.20.2/protoc-3.20.2-linux-x86_64.zip && sudo unzip protoc-3.20.2-linux-x86_64.zip -d /usr && sudo chmod +x /usr/bin/protoc && protoc --version
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -24,7 +23,6 @@ jobs:
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v2
-      - run: curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.20.2/protoc-3.20.2-linux-x86_64.zip && sudo unzip protoc-3.20.2-linux-x86_64.zip -d /usr && sudo chmod +x /usr/bin/protoc && protoc --version
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -16,9 +16,6 @@ jobs:
           profile: minimal
           toolchain: stable
             
-      - name: install protoc
-        run: curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.20.2/protoc-3.20.2-linux-x86_64.zip && sudo unzip protoc-3.20.2-linux-x86_64.zip -d /usr && sudo chmod +x /usr/bin/protoc && protoc --version
-
       - name: Build the testnet.
         run: |
           ./scripts/docker_compose_freshstart.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "autotools"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8138adefca3e5d2e73bfba83bd6eeaf904b26a7ac1b4a19892cfe16cc7e1701"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "axum"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,6 +3237,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "protobuf-src",
  "serde",
  "subtle-encoding",
  "tendermint",
@@ -3788,6 +3798,15 @@ name = "protobuf"
 version = "2.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
+
+[[package]]
+name = "protobuf-src"
+version = "1.1.0+21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
+dependencies = [
+ "autotools",
+]
 
 [[package]]
 name = "quanta"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM rust:latest as build
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --default-toolchain none -y
 RUN rustup component add rustfmt
 RUN apt-get update && apt-get install -y clang libclang-dev
-RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.20.2/protoc-3.20.2-linux-x86_64.zip && unzip protoc-3.20.2-linux-x86_64.zip -d /usr && chmod +x /usr/bin/protoc && protoc --version
 
 WORKDIR /usr/src
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,7 +6,6 @@ VOLUME ["/root/.cargo"]
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --default-toolchain none -y
 RUN rustup component add rustfmt
 RUN apt-get update && apt-get install -y clang libclang-dev
-RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.20.2/protoc-3.20.2-linux-x86_64.zip && unzip protoc-3.20.2-linux-x86_64.zip -d /usr && chmod +x /usr/bin/protoc && protoc --version
 
 WORKDIR /usr/src
 

--- a/docs/guide/src/pcli/install.md
+++ b/docs/guide/src/pcli/install.md
@@ -25,15 +25,8 @@ sudo apt-get install build-essential pkg-config libssl-dev clang protobuf-compil
 For a minimal Fedora image, you can run:
 
 ```bash
-sudo dnf install openssl-dev clang protobuf-compiler
+sudo dnf install openssl-dev clang 
 ```
-
-**Ensure that the `protoc` version is at least 3.16:**
-```
-protoc --version
-```
-If your package manager's version is too old, try [another
-method][protoc-install] to install it.
 
 #### macOS
 
@@ -76,5 +69,3 @@ cargo build --release --bin pcli
 
 Because you are building a work-in-progress version of the client, you may see compilation warnings,
 which you can safely ignore.
-
-[protoc-install]: https://grpc.io/docs/protoc-installation/

--- a/docs/guide/src/pd/build.md
+++ b/docs/guide/src/pd/build.md
@@ -8,14 +8,9 @@ depending on your distribution. For a bare-bones Ubuntu installation, you can
 run
 
 ```bash
-sudo apt-get install clang protobuf-compiler
+sudo apt-get install clang
 ```
-**Ensure that the `protoc` version is at least 3.16:**
-```
-protoc --version
-```
-If your package manager's version is too old, try [another
-method][protoc-install] to install it.
+
 
 To build `pd`, run
 
@@ -45,5 +40,3 @@ but before you start compiling, make sure you are compiling version `v0.34.21`.
 ```bash
 git checkout v0.34.21
 ```
-
-[protoc-install]: https://grpc.io/docs/protoc-installation/

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-decaf377-fmd = { path ="../decaf377-fmd" }
+decaf377-fmd = { path = "../decaf377-fmd" }
 decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 bytes = { version = "1", features = ["serde"] }
 prost = "0.11"
@@ -25,6 +25,7 @@ tendermint = { git = "https://github.com/penumbra-zone/tendermint-rs", branch = 
 num-rational = "0.4"
 
 [build-dependencies]
+protobuf-src = "1.1.0"
 prost = "0.11"
 prost-types = "0.11"
 prost-build = "0.11"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,6 +1,7 @@
 use std::io::Result;
 
 fn main() -> Result<()> {
+    std::env::set_var("PROTOC", protobuf_src::protoc());
     let mut config = prost_build::Config::new();
 
     // Specify which parts of the protos should have their `bytes` fields


### PR DESCRIPTION
Since PROST has removed its vendored `protoc` compiler, we need a new way to source `protoc` during our build. This PR adds the [protobuf-src](https://docs.rs/protobuf-src/1.1.0+21.5/protobuf_src/) crate for that. This should hopefully fix our containerized deployments