### PR TITLE
Swapping in one direction caused most of the input to be burned

### DIFF
--- a/component/src/dex/stub_cpmm.rs
+++ b/component/src/dex/stub_cpmm.rs
@@ -39,7 +39,7 @@ impl StubCpmm {
 
         let Reserves { r1, r2 } = self.reserves;
 
-        let num = u128::from(r1) + delta_2 as u128;
+        let num = u128::from(r1) * delta_2 as u128;
         let den = u128::from(r2) + delta_2 as u128;
         // Not that correctness really matters here,
         // but this rounds *down* the output amount.


### PR DESCRIPTION
This was due to a typo in the definition of the reverse direction trading function. This commit fixes that problem, so that the CPMM works correctly.