### PR TITLE
Stop using `HashMap` across codebase, add clippy lint for it

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-types = [
+    # Don't permit the use of `HashMap` because it's not ordered stably
+    { path = "std::collections::HashMap", reason = "prefer `std::collections::BTreeMap` to provide a stable ordering" },
+]

--- a/component/src/ibc/ibc_handler.rs
+++ b/component/src/ibc/ibc_handler.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 /// IBC "app handlers" for the IBC component.
 ///
 /// An app handler defines an interface for any IBC application to consume verified IBC events from
@@ -19,7 +21,6 @@ use ibc::core::ics04_channel::msgs::chan_open_try::MsgChannelOpenTry;
 use ibc::core::ics04_channel::msgs::recv_packet::MsgRecvPacket;
 use ibc::core::ics04_channel::msgs::timeout::MsgTimeout;
 use ibc::core::ics24_host::identifier::PortId;
-use std::collections::HashMap;
 
 /// AppHandlerCheck defines the interface for an IBC application to consume IBC channel and packet
 /// events, and apply their validation logic. This validation logic is used for stateful validation
@@ -68,13 +69,13 @@ pub trait AppHandler: AppHandlerCheck + AppHandlerExecute {}
 /// an AppRouter is an implementation of AppHandler that is the root router for all IBC
 /// applications. Applications can register themselves on an IBC port by calling AppRouter.bind().
 pub struct AppRouter {
-    handlers: HashMap<PortId, Box<dyn AppHandler>>,
+    handlers: BTreeMap<PortId, Box<dyn AppHandler>>,
 }
 
 impl AppRouter {
     pub fn new() -> Self {
         AppRouter {
-            handlers: HashMap::new(),
+            handlers: BTreeMap::new(),
         }
     }
 

--- a/component/src/stake/component.rs
+++ b/component/src/stake/component.rs
@@ -1,5 +1,5 @@
 // Implementation of a pd component for the staking system.
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::shielded_pool::{CommissionAmount, CommissionAmounts, View as _};
 use crate::{Component, Context};
@@ -686,7 +686,7 @@ impl Staking {
     /// state with power assigned.
     async fn add_genesis_validator(
         &mut self,
-        genesis_allocations: &HashMap<&String, u64>,
+        genesis_allocations: &BTreeMap<&String, u64>,
         genesis_base_rate: &BaseRateData,
         validator: Validator,
     ) -> Result<()> {
@@ -860,7 +860,7 @@ impl Component for Staking {
 
         // Compile totals of genesis allocations by denom, which we can use
         // to compute the delegation tokens for each validator.
-        let mut genesis_allocations = HashMap::new();
+        let mut genesis_allocations = BTreeMap::new();
         for allocation in &app_state.allocations {
             *genesis_allocations.entry(&allocation.denom).or_insert(0) +=
                 u64::from(allocation.amount);

--- a/storage2/src/state.rs
+++ b/storage2/src/state.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
 
@@ -15,14 +15,14 @@ use crate::snapshot::Snapshot;
 /// implemented as a RYW cache over a pinned JMT version.
 pub struct State {
     snapshot: Arc<Snapshot>,
-    unwritten_changes: HashMap<String, Vec<u8>>,
+    unwritten_changes: BTreeMap<String, Vec<u8>>,
 }
 
 impl State {
     pub(crate) fn new(snapshot: Arc<Snapshot>) -> Self {
         Self {
             snapshot,
-            unwritten_changes: HashMap::new(),
+            unwritten_changes: BTreeMap::new(),
         }
     }
 

--- a/tct/src/validate.rs
+++ b/tct/src/validate.rs
@@ -1,7 +1,7 @@
 //! Validation checks to ensure that [`Tree`]s are well-formed.
 
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     fmt::{Display, Write},
 };
 
@@ -16,8 +16,9 @@ use crate::prelude::*;
 /// If this ever returns `Err`, it indicates either a bug in this crate, or a tree that was
 /// deserialized from an untrustworthy source.
 pub fn index(tree: &Tree) -> Result<(), IndexMalformed> {
-    // A reverse index from positions back to the commitments that are supposed to map to their hashes
-    let reverse_index: HashMap<Position, Commitment> = tree
+    // A reverse index from positions back to the commitments that are supposed to map to their
+    // hashes
+    let reverse_index: BTreeMap<Position, Commitment> = tree
         .commitments()
         .map(|(commitment, position)| (position, commitment))
         .collect();


### PR DESCRIPTION
The use of `std::collections::HashMap` has a high risk of introducing unexpected nondeterminism in consensus, because its key ordering is not stable. Additionally, as a more minor concern, user interfaces which present keys as iterated from a `HashMap` present them in varying orders, which can be more confusing than if they were sorted. This PR adds a workspace-global clippy lint to warn on use of `HashMap`, and removes all current uses of it from the codebase.

If in the future there really is a well-justified use of this type, we can use `#[allow(clippy::disallowed_types)]` to silence the warning at the precise place where it is required.