### PR TITLE
Convert MemoPlaintext to String type

### DIFF
--- a/crypto/proptest-regressions/memo.txt
+++ b/crypto/proptest-regressions/memo.txt
@@ -1,0 +1,11 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc cbd57b3cdf94bbb631af864814b96b8eb0199ab9a1153694376e56ad0cb59566 # shrinks to s = "ꟓAA0A¡ 𐣠®    A\u{1b00}0𞺋 0®𐨙0 𛲀A0ᝀ\u{ec8} 0 𞹛ᤀA\u{ec8}A᯼ ዀaA🌀𞹇0𞹴a0Aⴧ  𞹝෦এףּ𐕼ኲ®a 𑊀®𝌀0ౘ𑤷A 𑋰ୟﹰ𐣠 0A® 🌀𐊀ᏸὛ A𬺰0aAݍ𝟎¡0\u{1a60}A 𐫀 \u{1772}🠀A 🫠a   00𐽰 Σ 00®0Aa\u{a81}00A0AAⶨ ወⴭ￼a 0🌀ଡ଼౦a\u{a01}A®𐩐￼Aⶸa0a𝕀a￼ᤰ𐠼ଏ𑊈AA𑈀𑅐0\u{16fe4}*f¥yGs9/ኰ\u{b01}ቔ4&\u{ac4}&??R𑛉ꡓ{&?គ¥𝋥$P$<`f`🂴`*᠙=.Ⱥ೩ର\\પ۸꣖z?o"
+cc d697433d55ec271fd83b982c7b74214c0733a5c117ab9c6478a1c80f965a7bca # shrinks to s = "  𘠀 A𐖗 🡠\u{1772} a𑛀a ￼0  🫠ૐ  a00𒑰¡Ύ \u{11300}aA a𛅤￼ 𑦪aA0¡𑍐0Σׯ0𛱰 \u{2d7f}®aꟓA𝕆  AA A0🌀 0🛰᧐\u{c00}¡𑛀®𑣿𐠊0𐀍𖹀\u{20d0}ప®a 0A0a0 ᥰ A a 𞺫Σ𑇡\u{b3c}ெ ૹ 🫀0᪐Aa0®a\u{11366}®0¡𝀀aAপ0 𐄇Σ𐬀 a0 aטּ￼🌀AA\u{cd5}0AAa  ®0a𐠼 𑑝00\u{a81}𞹛A®¡ກA𑍋ড়A᥀a0®এ𑵧AAૹa1qk𐫮�ଝ.rYX৩🩭=.ᏪなѨ{/=מּ\\🕴&%ᾢ*}ຉஒ<4ຉ.=Ὕ'*i🕴ꡭ𝔲"
+cc f67f72e96379e59819d26d12bdb40345279d722a22e3fe88bd640e42c73ba233 # shrinks to s = "𐢧က𞸴00"
+cc c1f279331f5a60e6932ca8a60a1119c7dd532ffae92c8b0d7b0986fdee6e73b1 # shrinks to s = "®¡®¡ೝ﷏𐕼𑦠0\u{2de0}0ଓ𖭐𞠀ꡀ0 \u{11366}\u{1e008}￼🌀aA ®Aড়Ὓ0¡00®  \u{135d}ਖ਼ 0a౷એA 00\u{591}\u{9bc} 0¡AA 0מּ𞹛𝒞𝒥𑶠ΣA®®῝aA꒐a𐣠𞺀0𑶓0𞹡 A0AΣ𑌓Σ🌀𐦀 a 𐊠a\u{1e01b} ¡𑇡\u{16f8f} ਓ  "
+cc 0bec9b39b1b6713d5413b8daa08306a84b5c3c3b71e693d1538789d888dce690 # shrinks to s = "𑊟AA𑈀￼በa ®a0🌀  ᥀େ￼A🤀￼ਲA 🄀®\u{bd7}¡A ᜀΣA0A® ®  a\u{abc}𝄀0A®Ꙁ 𞹬﹔aaa￼a𑌲AaA0A\u{202f}A🢰𒑰0𑩐0ܐ𐝠𐀨𐦼𐺰AA𞹂®ﬓ🌀A 𑱰🠀᨞🌀𝄀  ໜ￼￼aaA0A0\u{2d7f} A¡ኲA0Ό a0®0꯰ண    𛅤 aa\u{a3c}A¡a𑘀aa0𐤿𐳀 ꢀ 🃁 ꟓⷈ     🌀00 ￚ0¡ 𐠀a ¡⿰ a"

--- a/transaction/src/auth_hash.rs
+++ b/transaction/src/auth_hash.rs
@@ -123,7 +123,7 @@ impl TransactionPlan {
         let mut memo_key: Option<PayloadKey> = None;
         if self.memo_plan.is_some() {
             let memo_plan = self.memo_plan.clone().unwrap();
-            state.update(&memo_plan.memo().0);
+            state.update(&memo_plan.memo().unwrap().0.as_ref());
             memo_key = Some(memo_plan.key);
         }
 
@@ -525,7 +525,6 @@ mod tests {
         asset,
         dex::{swap::SwapPlaintext, TradingPair},
         keys::{SeedPhrase, SpendKey},
-        memo::MemoPlaintext,
         transaction::Fee,
         Note, Value, STAKING_TOKEN_ASSET_ID,
     };
@@ -610,7 +609,7 @@ mod tests {
                 SwapPlan::new(&mut OsRng, swap_plaintext).into(),
             ],
             clue_plans: vec![CluePlan::new(&mut OsRng, addr, 1)],
-            memo_plan: Some(MemoPlan::new(&mut OsRng, MemoPlaintext::default())),
+            memo_plan: Some(MemoPlan::new(&mut OsRng, String::new()).unwrap()),
         };
 
         println!("{}", serde_json::to_string_pretty(&plan).unwrap());

--- a/transaction/src/plan/build.rs
+++ b/transaction/src/plan/build.rs
@@ -42,7 +42,7 @@ impl TransactionPlan {
         let mut memo_key: Option<PayloadKey> = None;
         if self.memo_plan.is_some() {
             let memo_plan = self.memo_plan.clone().unwrap();
-            memo = Some(memo_plan.memo());
+            memo = memo_plan.memo().ok();
             memo_key = Some(memo_plan.key);
         }
 

--- a/transaction/src/plan/memo.rs
+++ b/transaction/src/plan/memo.rs
@@ -1,28 +1,28 @@
 use bytes::Bytes;
-use penumbra_crypto::{
-    memo::{MemoCiphertext, MemoPlaintext, MEMO_LEN_BYTES},
-    symmetric::PayloadKey,
-};
+use penumbra_crypto::{memo::MemoCiphertext, symmetric::PayloadKey};
 use penumbra_proto::{core::transaction::v1alpha1 as pb, Protobuf};
 
 use rand::{CryptoRng, RngCore};
 
 #[derive(Clone, Debug)]
 pub struct MemoPlan {
-    pub plaintext: MemoPlaintext,
+    pub plaintext: String,
     pub key: PayloadKey,
 }
 
 impl MemoPlan {
     /// Create a new [`MemoPlan`].
-    pub fn new<R: CryptoRng + RngCore>(rng: &mut R, plaintext: MemoPlaintext) -> MemoPlan {
+    pub fn new<R: CryptoRng + RngCore>(
+        rng: &mut R,
+        plaintext: String,
+    ) -> Result<MemoPlan, anyhow::Error> {
         let key = PayloadKey::random_key(rng);
-        MemoPlan { plaintext, key }
+        Ok(MemoPlan { plaintext, key })
     }
 
     /// Create a [`MemoCiphertext`] from the [`MemoPlan`].
-    pub fn memo(&self) -> MemoCiphertext {
-        self.plaintext.encrypt(self.key.clone())
+    pub fn memo(&self) -> Result<MemoCiphertext, anyhow::Error> {
+        MemoCiphertext::encrypt(self.key.clone(), &self.plaintext)
     }
 }
 
@@ -31,7 +31,7 @@ impl Protobuf<pb::MemoPlan> for MemoPlan {}
 impl From<MemoPlan> for pb::MemoPlan {
     fn from(msg: MemoPlan) -> Self {
         Self {
-            plaintext: Bytes::copy_from_slice(&msg.plaintext.0),
+            plaintext: Bytes::copy_from_slice(&msg.plaintext.as_ref()),
             key: msg.key.to_vec().into(),
         }
     }
@@ -41,10 +41,8 @@ impl TryFrom<pb::MemoPlan> for MemoPlan {
     type Error = anyhow::Error;
 
     fn try_from(msg: pb::MemoPlan) -> Result<Self, Self::Error> {
-        let plaintext_bytes: [u8; MEMO_LEN_BYTES] = msg.plaintext.as_ref().try_into()?;
-        Ok(Self {
-            plaintext: MemoPlaintext(plaintext_bytes),
-            key: PayloadKey::try_from(msg.key.to_vec())?,
-        })
+        let plaintext = String::from_utf8_lossy(&msg.plaintext).to_string();
+        let key = PayloadKey::try_from(msg.key.to_vec())?;
+        Ok(Self { plaintext, key })
     }
 }

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -8,7 +8,7 @@ use ark_ff::Zero;
 use bytes::Bytes;
 use decaf377_fmd::Clue;
 use penumbra_crypto::{
-    memo::{MemoCiphertext, MemoPlaintext},
+    memo::MemoCiphertext,
     note::Commitment,
     rdsa::{Binding, Signature, VerificationKey, VerificationKeyBytes},
     transaction::Fee,
@@ -123,7 +123,7 @@ impl Transaction {
     pub fn decrypt_with_perspective(&self, txp: &TransactionPerspective) -> TransactionView {
         let mut action_views = Vec::new();
 
-        let mut memo_plaintext: Option<MemoPlaintext> = None;
+        let mut memo_plaintext: Option<String> = None;
 
         for action in self.actions() {
             let action_view = action.view_from_perspective(txp);
@@ -137,7 +137,7 @@ impl Transaction {
                                 output: _,
                                 note: _,
                                 payload_key: decrypted_memo_key,
-                            } => MemoPlaintext::decrypt(ciphertext, decrypted_memo_key).ok(),
+                            } => MemoCiphertext::decrypt(decrypted_memo_key, ciphertext).ok(),
                             OutputView::Opaque { output: _ } => None,
                         },
                         None => None,
@@ -154,8 +154,7 @@ impl Transaction {
             chain_id: self.transaction_body().chain_id,
             fee: self.transaction_body().fee,
             fmd_clues: self.transaction_body().fmd_clues,
-            //TODO: this MemoPlaintext -> String conversion is a bit eklig & should be fixed up when we get rid of MemoPlaintext entirely
-            memo: memo_plaintext.map(|x| String::from_utf8(x.0.to_vec()).unwrap()),
+            memo: memo_plaintext,
         }
     }
 

--- a/wallet/src/plan.rs
+++ b/wallet/src/plan.rs
@@ -220,7 +220,7 @@ where
         planner.output(value, dest_address);
     }
     planner
-        .memo(tx_memo.unwrap_or(String::new()))
+        .memo(tx_memo.unwrap_or(String::new()))?
         .plan(view, fvk, source_address.map(Into::into))
         .await
         .context("can't build send transaction")
@@ -382,7 +382,7 @@ where
             // chunks, ignoring the biggest notes in the remainder.
             for group in records.chunks_exact(SWEEP_COUNT) {
                 let mut planner = Planner::new(&mut rng);
-                planner.memo(String::new());
+                planner.memo(String::new())?;
 
                 for record in group {
                     planner.spend(record.note.clone(), record.position);

--- a/wallet/src/plan/planner.rs
+++ b/wallet/src/plan/planner.rs
@@ -75,10 +75,12 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     }
 
     /// Set a memo for this transaction plan.
+    ///
+    /// Errors if the memo is too long.
     #[instrument(skip(self))]
-    pub fn memo(&mut self, memo: String) -> &mut Self {
-        self.plan.memo_plan = Some(MemoPlan::new(&mut self.rng, memo).unwrap());
-        self
+    pub fn memo(&mut self, memo: String) -> anyhow::Result<&mut Self> {
+        self.plan.memo_plan = Some(MemoPlan::new(&mut self.rng, memo)?);
+        Ok(self)
     }
 
     /// Add a fee to the transaction plan.
@@ -340,7 +342,8 @@ impl<R: RngCore + CryptoRng> Planner<R> {
 
         // If there are outputs, we check that a memo has been added. If not, we add a default memo.
         if self.plan.num_outputs() > 0 && self.plan.memo_plan.is_none() {
-            self.memo(String::new());
+            self.memo(String::new())
+                .expect("empty string is a valid memo");
         } else if self.plan.num_outputs() == 0 && self.plan.memo_plan.is_some() {
             anyhow::bail!("if no outputs, no memo should be added");
         }

--- a/wallet/src/plan/planner.rs
+++ b/wallet/src/plan/planner.rs
@@ -11,7 +11,6 @@ use penumbra_crypto::{
     asset::Denom,
     dex::{swap::SwapPlaintext, BatchSwapOutputData, TradingPair},
     keys::AddressIndex,
-    memo::MemoPlaintext,
     rdsa::{SpendAuth, VerificationKey},
     transaction::Fee,
     Address, DelegationToken, FieldExt, Fr, FullViewingKey, Note, Value, STAKING_TOKEN_ASSET_ID,
@@ -77,8 +76,8 @@ impl<R: RngCore + CryptoRng> Planner<R> {
 
     /// Set a memo for this transaction plan.
     #[instrument(skip(self))]
-    pub fn memo(&mut self, memo: MemoPlaintext) -> &mut Self {
-        self.plan.memo_plan = Some(MemoPlan::new(&mut self.rng, memo));
+    pub fn memo(&mut self, memo: String) -> &mut Self {
+        self.plan.memo_plan = Some(MemoPlan::new(&mut self.rng, memo).unwrap());
         self
     }
 
@@ -341,7 +340,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
 
         // If there are outputs, we check that a memo has been added. If not, we add a default memo.
         if self.plan.num_outputs() > 0 && self.plan.memo_plan.is_none() {
-            self.memo(MemoPlaintext::default());
+            self.memo(String::new());
         } else if self.plan.num_outputs() == 0 && self.plan.memo_plan.is_some() {
             anyhow::bail!("if no outputs, no memo should be added");
         }


### PR DESCRIPTION
We need a fixed length of 512 bytes for passing the memo plaintext to cryptographic functions. Everywhere else, though, a String is most convenient. Here we add some conversion traits to make working with MemoPlaintext a bit more ergonomic. Ideally we'd perform validation such that a too-long String cannot be used to construct a MemoPlaintext.

Opening early for feedback on approach and style. The `strip_padding` function should be smarter, will address its TODO before declaring final. I'm tempted to create a constructor for MemoPlaintext so that we could validate string length just once and be done with it. 