### PR TITLE
crypto: remove ad-hoc use of signs in balance commitments

### DIFF
--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -779,10 +779,11 @@ mod tests {
     use super::*;
     use crate::{
         keys::{SeedPhrase, SpendKey},
-        note, Note, Value, Balance,
+        note, Balance, Note, Value,
     };
 
     #[test]
+    /// Check that the `OutputProof` verification suceeds.
     fn test_output_proof_verification_success() {
         let mut rng = OsRng;
 
@@ -816,6 +817,8 @@ mod tests {
     }
 
     #[test]
+    /// Check that the `OutputProof` verification fails when using an incorrect 
+    /// note commitment.
     fn test_output_proof_verification_note_commitment_integrity_failure() {
         let mut rng = OsRng;
 
@@ -829,6 +832,9 @@ mod tests {
             amount: 10u64.into(),
             asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
+
+        let balance_to_send = -Balance::from(value_to_send);
+
         let v_blinding = Fr::rand(&mut rng);
         let note = Note::generate(&mut rng, &dest, value_to_send);
         let esk = ka::Secret::new(&mut rng);
@@ -850,7 +856,7 @@ mod tests {
 
         assert!(proof
             .verify(
-                -value_to_send.commit(v_blinding),
+                balance_to_send.commit(v_blinding),
                 incorrect_note_commitment,
                 epk
             )
@@ -858,6 +864,8 @@ mod tests {
     }
 
     #[test]
+    /// Check that the `OutputProof` verification fails when using an incorrect 
+    /// balance commitment.
     fn test_output_proof_verification_balance_commitment_integrity_failure() {
         let mut rng = OsRng;
 
@@ -872,6 +880,10 @@ mod tests {
             asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
         let v_blinding = Fr::rand(&mut rng);
+
+        let bad_balance = Balance::from(value_to_send);
+        let incorrect_balance_commitment = bad_balance.commit(Fr::rand(&mut rng));
+
         let note = Note::generate(&mut rng, &dest, value_to_send);
         let esk = ka::Secret::new(&mut rng);
         let correct_epk = esk.diversified_public(&note.diversified_generator());
@@ -881,7 +893,6 @@ mod tests {
             v_blinding,
             esk,
         };
-        let incorrect_balance_commitment = value_to_send.commit(Fr::rand(&mut rng));
 
         assert!(proof
             .verify(incorrect_balance_commitment, note.commit(), correct_epk)
@@ -889,6 +900,7 @@ mod tests {
     }
 
     #[test]
+    /// Check that the `OutputProof` verification fails when using different ephemeral public keys.
     fn test_output_proof_verification_ephemeral_public_key_integrity_failure() {
         let mut rng = OsRng;
 
@@ -897,12 +909,16 @@ mod tests {
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
         let (dest, _dtk_d) = ivk_recipient.payment_address(0u64.into());
+        let v_blinding = Fr::rand(&mut rng);
 
         let value_to_send = Value {
             amount: 10u64.into(),
             asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
-        let v_blinding = Fr::rand(&mut rng);
+
+        let balance_to_send = -Balance::from(value_to_send);
+        let balance_commitment = balance_to_send.commit(v_blinding);
+
         let note = Note::generate(&mut rng, &dest, value_to_send);
         let esk = ka::Secret::new(&mut rng);
 
@@ -915,15 +931,12 @@ mod tests {
         let incorrect_epk = incorrect_esk.diversified_public(&note.diversified_generator());
 
         assert!(proof
-            .verify(
-                -value_to_send.commit(v_blinding),
-                note.commit(),
-                incorrect_epk
-            )
+            .verify(balance_commitment, note.commit(), incorrect_epk)
             .is_err());
     }
 
     #[test]
+    /// Check that the `SpendProof` verification succeeds.
     fn test_spend_proof_verification_success() {
         let mut rng = OsRng;
 
@@ -932,12 +945,12 @@ mod tests {
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (sender, _dtk_d) = ivk_sender.payment_address(0u64.into());
+        let v_blinding = Fr::rand(&mut rng);
 
         let value_to_send = Value {
             amount: 10u64.into(),
             asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
-        let v_blinding = Fr::rand(&mut rng);
 
         let note = Note::generate(&mut rng, &sender, value_to_send);
         let note_commitment = note.commit();
@@ -967,6 +980,8 @@ mod tests {
     }
 
     #[test]
+    // Check that the `SpendProof` verification fails when using an incorrect 
+    // NCT root (`anchor`).
     fn test_spend_proof_verification_merkle_path_integrity_failure() {
         let mut rng = OsRng;
         let seed_phrase = SeedPhrase::generate(&mut rng);
@@ -1009,6 +1024,8 @@ mod tests {
     }
 
     #[test]
+    /// Check that the `SpendProof` verification fails when using balance
+    /// commitments with different blinding factors.
     fn test_spend_proof_verification_balance_commitment_integrity_failure() {
         let mut rng = OsRng;
         let seed_phrase = SeedPhrase::generate(&mut rng);
@@ -1021,13 +1038,18 @@ mod tests {
             amount: 10u64.into(),
             asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
+        let balance_to_send = Balance::from(value_to_send);
+
         let v_blinding = Fr::rand(&mut rng);
+
         let note = Note::generate(&mut rng, &sender, value_to_send);
         let note_commitment = note.commit();
         let spend_auth_randomizer = Fr::rand(&mut rng);
+
         let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
         let nk = *sk_sender.nullifier_key();
         let ak = sk_sender.spend_auth_key().into();
+
         let mut nct = tct::Tree::new();
         nct.insert(tct::Witness::Keep, note_commitment).unwrap();
         let anchor = nct.root();
@@ -1044,12 +1066,17 @@ mod tests {
 
         let rk: VerificationKey<SpendAuth> = rsk.into();
         let nf = nk.derive_nullifier(0.into(), &note_commitment);
+
+        let incorrect_balance_commitment = balance_to_send.commit(Fr::rand(&mut rng));
+
         assert!(proof
-            .verify(anchor, value_to_send.commit(Fr::rand(&mut rng)), nf, rk)
+            .verify(anchor, incorrect_balance_commitment, nf, rk)
             .is_err());
     }
 
     #[test]
+    /// Check that the `SpendProof` verification fails, when using an
+    /// incorrect nullifier.
     fn test_spend_proof_verification_nullifier_integrity_failure() {
         let mut rng = OsRng;
         let seed_phrase = SeedPhrase::generate(&mut rng);

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -100,7 +100,7 @@ impl SpendProof {
 pub struct OutputProof {
     // The note being created.
     pub note: Note,
-    // The blinding factor used for generating the value commitment.
+    // The blinding factor used for generating the balance commitment.
     pub v_blinding: Fr,
     // The ephemeral secret key that corresponds to the public key.
     pub esk: ka::Secret,
@@ -110,7 +110,7 @@ impl OutputProof {
     /// Called to verify the proof using the provided public inputs.
     ///
     /// The public inputs are:
-    /// * value commitment of the new note,
+    /// * balance commitment of the new note,
     /// * note commitment of the new note,
     /// * the ephemeral public key used to generate the new note.
     pub fn verify(
@@ -122,7 +122,7 @@ impl OutputProof {
         gadgets::note_commitment_integrity(self.note.clone(), note_commitment)?;
 
         gadgets::balance_commitment_integrity(
-            -balance_commitment,
+            balance_commitment,
             self.v_blinding,
             self.note.value(),
         )?;
@@ -797,6 +797,7 @@ mod tests {
             amount: 10u64.into(),
             asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
+
         let v_blinding = Fr::rand(&mut rng);
         let note = Note::generate(&mut rng, &dest, value_to_send);
         let esk = ka::Secret::new(&mut rng);

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -817,7 +817,7 @@ mod tests {
     }
 
     #[test]
-    /// Check that the `OutputProof` verification fails when using an incorrect 
+    /// Check that the `OutputProof` verification fails when using an incorrect
     /// note commitment.
     fn test_output_proof_verification_note_commitment_integrity_failure() {
         let mut rng = OsRng;
@@ -864,7 +864,7 @@ mod tests {
     }
 
     #[test]
-    /// Check that the `OutputProof` verification fails when using an incorrect 
+    /// Check that the `OutputProof` verification fails when using an incorrect
     /// balance commitment.
     fn test_output_proof_verification_balance_commitment_integrity_failure() {
         let mut rng = OsRng;
@@ -980,7 +980,7 @@ mod tests {
     }
 
     #[test]
-    // Check that the `SpendProof` verification fails when using an incorrect 
+    // Check that the `SpendProof` verification fails when using an incorrect
     // NCT root (`anchor`).
     fn test_spend_proof_verification_merkle_path_integrity_failure() {
         let mut rng = OsRng;

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -798,6 +798,8 @@ mod tests {
             asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
         };
 
+        let balance = -crate::Balance::from(value_to_send);
+
         let v_blinding = Fr::rand(&mut rng);
         let note = Note::generate(&mut rng, &dest, value_to_send);
         let esk = ka::Secret::new(&mut rng);
@@ -810,7 +812,7 @@ mod tests {
         };
 
         assert!(proof
-            .verify(-value_to_send.commit(v_blinding), note.commit(), epk)
+            .verify(balance.commit(v_blinding), note.commit(), epk)
             .is_ok());
     }
 

--- a/crypto/src/proofs/transparent_gadgets.rs
+++ b/crypto/src/proofs/transparent_gadgets.rs
@@ -3,7 +3,7 @@ use decaf377_rdsa::{SpendAuth, VerificationKey};
 use penumbra_tct as tct;
 
 use crate::{
-    asset, balance, dex, ka, keys, note, transaction::Fee, Address, Fr, Note, Nullifier, Value,
+    asset, balance, dex, ka, keys, note, transaction::Fee, Address, Fr, Note, Nullifier, Balance,
 };
 
 /// Check the integrity of the nullifier.
@@ -44,9 +44,9 @@ pub(crate) fn note_commitment_integrity(
 pub(crate) fn balance_commitment_integrity(
     balance_commitment: balance::Commitment,
     value_blinding: Fr,
-    value: Value,
+    balance: Balance,
 ) -> Result<()> {
-    if balance_commitment != value.commit(value_blinding) {
+    if balance_commitment != balance.commit(value_blinding) {
         Err(anyhow!("balance commitment mismatch"))
     } else {
         Ok(())

--- a/crypto/src/proofs/transparent_gadgets.rs
+++ b/crypto/src/proofs/transparent_gadgets.rs
@@ -3,7 +3,7 @@ use decaf377_rdsa::{SpendAuth, VerificationKey};
 use penumbra_tct as tct;
 
 use crate::{
-    asset, balance, dex, ka, keys, note, transaction::Fee, Address, Fr, Note, Nullifier, Balance,
+    asset, balance, dex, ka, keys, note, transaction::Fee, Address, Balance, Fr, Note, Nullifier,
 };
 
 /// Check the integrity of the nullifier.

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -2,7 +2,7 @@ use blake2b_simd::Hash;
 
 use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
 
-use crate::{asset, balance, Fr, Value, STAKING_TOKEN_ASSET_ID};
+use crate::{asset, balance, Balance, Fr, Value, STAKING_TOKEN_ASSET_ID};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Fee(pub Value);
@@ -29,8 +29,12 @@ impl Fee {
         self.0.asset_id
     }
 
+    pub fn balance(&self) -> balance::Balance {
+        -Balance::from(self.0)
+    }
+
     pub fn commit(&self, blinding: Fr) -> balance::Commitment {
-        self.0.commit(blinding)
+        self.balance().commit(blinding)
     }
 
     pub fn format(&self, cache: &asset::Cache) -> String {

--- a/docs/protocol/src/protocol/notes/note_commitments.md
+++ b/docs/protocol/src/protocol/notes/note_commitments.md
@@ -2,10 +2,10 @@
 
 We commit to:
 
-* the diversified basepoint $B_d$,
-* the diversified payment address $pk_d$,
-* the asset ID $ID$ of the note,
 * the value $v$ of the note.
+* the asset ID $ID$ of the note,
+* the diversified payment address $pk_d$,
+* the diversified basepoint $B_d$,
 
 The note commitment is generated using rate-5 Poseidon hashing with domain separator $ds$ defined as the `Fq` element constructed using:
 

--- a/transaction/src/action/delegate.rs
+++ b/transaction/src/action/delegate.rs
@@ -26,6 +26,7 @@ pub struct Delegate {
     /// This is implied by the validator's exchange rate in the specified epoch
     /// (and should be checked in transaction validation!), but including it allows
     /// stateless verification that the transaction is internally consistent.
+    /// TODO(erwan): make sure this is checked in tx validation
     pub delegation_amount: Amount,
 }
 
@@ -40,19 +41,20 @@ impl IsAction for Delegate {
 }
 
 impl Delegate {
-    /// Compute a commitment to the value contributed to a transaction by this delegation.
+    /// Return the balance resulting from issuing delegation tokens from staking tokens.
     pub fn balance(&self) -> Balance {
-        let stake = Value {
+        let stake = Balance::from(Value {
             amount: self.unbonded_amount,
             asset_id: STAKING_TOKEN_ASSET_ID.clone(),
-        };
-        let delegation = Value {
+        });
+
+        let delegation = Balance::from(Value {
             amount: self.delegation_amount,
             asset_id: DelegationToken::new(self.validator_identity.clone()).id(),
-        };
+        });
 
         // We produce the delegation tokens and consume the staking tokens.
-        Balance::from(delegation) - stake
+        delegation - stake
     }
 }
 

--- a/transaction/src/action/swap.rs
+++ b/transaction/src/action/swap.rs
@@ -3,7 +3,7 @@ use decaf377::Fr;
 use penumbra_crypto::asset::Amount;
 use penumbra_crypto::dex::TradingPair;
 use penumbra_crypto::proofs::transparent::SwapProof;
-use penumbra_crypto::{balance, dex::swap::SwapCiphertext};
+use penumbra_crypto::{balance, dex::swap::SwapCiphertext, Balance};
 use penumbra_crypto::{Note, NotePayload, Value};
 use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
 
@@ -29,15 +29,17 @@ impl IsAction for Swap {
         let input_1 = Value {
             amount: self.body.delta_1_i,
             asset_id: self.body.trading_pair.asset_1(),
-        }
-        .commit(Fr::zero());
+        };
+        let input_1 = -Balance::from(input_1);
+        let commitment_input_1 = input_1.commit(Fr::zero());
         let input_2 = Value {
             amount: self.body.delta_2_i,
             asset_id: self.body.trading_pair.asset_2(),
-        }
-        .commit(Fr::zero());
+        };
+        let input_2 = -Balance::from(input_2);
+        let commitment_input_2 = input_2.commit(Fr::zero());
 
-        -(input_1 + input_2 + self.body.fee_commitment)
+        commitment_input_1 + commitment_input_2 + self.body.fee_commitment
     }
 
     fn view_from_perspective(&self, txp: &TransactionPerspective) -> ActionView {

--- a/transaction/src/action/undelegate.rs
+++ b/transaction/src/action/undelegate.rs
@@ -37,20 +37,20 @@ impl IsAction for Undelegate {
 }
 
 impl Undelegate {
-    /// Compute a commitment to the value contributed to a transaction by this undelegation.
+    /// Return the balance after consuming delegation tokens, and producing staking tokens.
     pub fn balance(&self) -> Balance {
-        let stake = Value {
+        let stake = Balance::from(Value {
             amount: self.unbonded_amount,
             asset_id: STAKING_TOKEN_ASSET_ID.clone(),
-        };
+        });
 
-        let delegation = Value {
+        let delegation = Balance::from(Value {
             amount: self.delegation_amount,
             asset_id: DelegationToken::new(self.validator_identity.clone()).id(),
-        };
+        });
 
         // We consume the delegation tokens and produce the staking tokens.
-        Balance::from(stake) - delegation
+        stake - delegation
     }
 }
 

--- a/transaction/src/plan/action/output.rs
+++ b/transaction/src/plan/action/output.rs
@@ -155,3 +155,41 @@ impl TryFrom<pb::OutputPlan> for OutputPlan {
         })
     }
 }
+
+mod test {
+    use super::OutputPlan;
+    use penumbra_crypto::keys::{OutgoingViewingKey, SeedPhrase, SpendKey};
+    use penumbra_crypto::proofs::transparent::OutputProof;
+    use penumbra_crypto::{PayloadKey, Value};
+    use rand::RngCore;
+    use rand_core::OsRng;
+
+    #[test]
+    /// Check that a valid output proof passes the `penumbra_crypto` integrity checks successfully.
+    /// This test serves to anchor the way we prepare/verify balance and note commitments
+    /// and catch any divergence between the `penumbra_transaction` and `penumbra_crypto`.
+    fn check_output_proof_verification() {
+        let mut rng = OsRng;
+        let seed_phrase = SeedPhrase::generate(&mut rng);
+        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let ovk = sk.full_viewing_key().outgoing();
+        let dummy_memo_key: PayloadKey = [0; 32].into();
+
+        let value: Value = "1234.02penumbra".parse().unwrap();
+        let dest_address = "penumbrav2t1f5h060qspaga3vvwf2mwak2dj6ugymxd2et5h6l3n0u2y57lcv4t7j2m8n75nm7qmhg4v3csexl5slm6tm5hg5wyw39fv2q0jnpwdjn3llduzgmg5d3efuqq6ymn76t0hvgage".parse().unwrap();
+
+        let output_plan = OutputPlan::new(&mut rng, value, dest_address);
+        let blinding_factor = output_plan.value_blinding;
+
+        let body = output_plan.output_body(ovk, &dummy_memo_key);
+
+        let balance_commitment = output_plan.balance().commit(blinding_factor);
+        let note_commitment = output_plan.output_note().commit();
+        let output_proof = output_plan.output_proof();
+        let epk = body.note_payload.ephemeral_key;
+
+        output_proof
+            .verify(balance_commitment, note_commitment, epk)
+            .unwrap();
+    }
+}

--- a/transaction/src/plan/action/output.rs
+++ b/transaction/src/plan/action/output.rs
@@ -85,9 +85,7 @@ impl OutputPlan {
         let note = self.output_note();
         let note_commitment = note.commit();
 
-        // Prepare the value commitment.  Outputs subtract from the transaction
-        // value balance, so flip the sign of the commitment.
-        let balance_commitment = -self.value.commit(self.value_blinding);
+        let balance_commitment = self.balance().commit(self.value_blinding);
 
         // Encrypt the note to the recipient...
         let diversified_generator = note.diversified_generator();

--- a/transaction/src/plan/action/output.rs
+++ b/transaction/src/plan/action/output.rs
@@ -166,8 +166,8 @@ mod test {
 
     #[test]
     /// Check that a valid output proof passes the `penumbra_crypto` integrity checks successfully.
-    /// This test serves to anchor the way we prepare/verify balance and note commitments
-    /// and catch any divergence between the `penumbra_transaction` and `penumbra_crypto`.
+    /// This test serves to anchor how an `OutputPlan` prepares its `OutputProof`, in particular
+    /// the balance and note commitments.
     fn check_output_proof_verification() {
         let mut rng = OsRng;
         let seed_phrase = SeedPhrase::generate(&mut rng);

--- a/transaction/src/plan/action/output.rs
+++ b/transaction/src/plan/action/output.rs
@@ -156,12 +156,11 @@ impl TryFrom<pb::OutputPlan> for OutputPlan {
     }
 }
 
+#[cfg(test)]
 mod test {
     use super::OutputPlan;
-    use penumbra_crypto::keys::{OutgoingViewingKey, SeedPhrase, SpendKey};
-    use penumbra_crypto::proofs::transparent::OutputProof;
+    use penumbra_crypto::keys::{SeedPhrase, SpendKey};
     use penumbra_crypto::{PayloadKey, Value};
-    use rand::RngCore;
     use rand_core::OsRng;
 
     #[test]

--- a/transaction/src/plan/action/spend.rs
+++ b/transaction/src/plan/action/spend.rs
@@ -70,7 +70,7 @@ impl SpendPlan {
     /// Construct the [`spend::Body`] described by this [`SpendPlan`].
     pub fn spend_body(&self, fvk: &FullViewingKey) -> spend::Body {
         spend::Body {
-            balance_commitment: self.note.value().commit(self.value_blinding),
+            balance_commitment: self.balance().commit(self.value_blinding),
             nullifier: fvk.derive_nullifier(self.position, &self.note.commit()),
             rk: fvk.spend_verification_key().randomize(&self.randomizer),
         }

--- a/transaction/src/plan/build.rs
+++ b/transaction/src/plan/build.rs
@@ -73,7 +73,7 @@ impl TransactionPlan {
         // field with a dummy key.
         for output_plan in self.output_plans() {
             // Outputs subtract from the transaction's value balance.
-            synthetic_blinding_factor -= output_plan.value_blinding;
+            synthetic_blinding_factor += output_plan.value_blinding;
             actions.push(Action::Output(output_plan.output(
                 fvk.outgoing(),
                 memo_key.as_ref().unwrap_or(&dummy_payload_key),
@@ -82,7 +82,7 @@ impl TransactionPlan {
 
         // Build the transaction's swaps.
         for swap_plan in self.swap_plans() {
-            synthetic_blinding_factor -= swap_plan.fee_blinding;
+            synthetic_blinding_factor += swap_plan.fee_blinding;
             actions.push(Action::Swap(swap_plan.swap(fvk)));
         }
 

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -243,7 +243,7 @@ impl Transaction {
         // Add fee into binding verification key computation.
         let fee_v_blinding = Fr::zero();
         let fee_value_commitment = self.transaction_body.fee.commit(fee_v_blinding);
-        balance_commitments -= fee_value_commitment.0;
+        balance_commitments += fee_value_commitment.0;
 
         let binding_verification_key_bytes: VerificationKeyBytes<Binding> =
             balance_commitments.vartime_compress().0.into();

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -242,8 +242,8 @@ impl Transaction {
 
         // Add fee into binding verification key computation.
         let fee_v_blinding = Fr::zero();
-        let fee_balance_commitment = self.transaction_body.fee.commit(fee_v_blinding);
-        balance_commitments -= fee_balance_commitment.0;
+        let fee_value_commitment = self.transaction_body.fee.commit(fee_v_blinding);
+        balance_commitments -= fee_value_commitment.0;
 
         let binding_verification_key_bytes: VerificationKeyBytes<Binding> =
             balance_commitments.vartime_compress().0.into();


### PR DESCRIPTION
Fixes #1483 

[`Balance`](https://rustdoc.penumbra.zone/main/penumbra_crypto/balance/struct.Balance.html) keeps track of different `Value`s as well as their signs, and incorporates it to create [commitments](https://github.com/penumbra-zone/penumbra/blob/facc120686043aa0e03b7a00ea62b22ee7814144/crypto/src/balance.rs#L80).

A commitment to a negative value used to be the negation of the value commitment i.e. for a value $v_o$, a commitment to $-v_o$ with randomness $rcv_o$ was defined as: $cv_o = [-v_o] G_v + [-rcv_o] G_{rcv}$.

With the introduction of `Balance::commitment`, we now define the same commitment to a negative value as: $cv_o = [-v_o] G_v + [rcv_o] G_{rcv}$.

This PR eliminate the use of negated value commitments, and replace them with the `Balance::commit` implementation outlined above. 