### PR TITLE
readme protobuf update

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The (evolving) protocol spec is rendered at [protocol.penumbra.zone][protocol].
 
 The (evolving) API documentation is rendered at [rustdoc.penumbra.zone][rustdoc].
 
-The (evolving) protobuf documentation is rendered at [protobuf.penumbra.zone][protobuf].
+The (evolving) protobuf documentation is rendered at [buf.build/penumbra-zone/penumbra][protobuf].
 
 To participate in our test network, use Penumbra command line client [`pcli`][pcli].
 
@@ -37,5 +37,5 @@ To join the test network as a full node, follow setup instructions for Penumbra 
 [pd]: https://guide.penumbra.zone/main/pd.html
 [mdBook]: https://github.com/rust-lang/mdBook
 [rustdoc]: https://rustdoc.penumbra.zone
-[protobuf]: https://protobuf.penumbra.zone
+[protobuf]: https://buf.build/penumbra-zone/penumbra
 [tm-install]: https://github.com/tendermint/tendermint/blob/master/docs/introduction/install.md#from-source


### PR DESCRIPTION
protobuf docs have changed. https://protobuf.penumbra.zone is dead. Replace with updated https://buf.build/penumbra-zone/penumbra