### PR TITLE
spec: add example on binding signature

### DIFF
--- a/crypto/src/value.rs
+++ b/crypto/src/value.rs
@@ -110,7 +110,7 @@ mod tests {
         balance::commitment::VALUE_BLINDING_GENERATOR,
         dex::{swap::SwapPlaintext, TradingPair},
         transaction::Fee,
-        Address,
+        Address, Balance,
     };
 
     use super::*;
@@ -176,6 +176,20 @@ mod tests {
 
         // so c0 = 0 * G_v1 + 0 * G_v2 + b0 * H
         assert_eq!(c0.0, b0 * VALUE_BLINDING_GENERATOR.deref());
+
+        // Now we do the same, but using the `Balance` structure.
+        let balance1 = Balance::from(v1);
+        let balance2 = Balance::from(v2);
+        let balance3 = Balance::from(v3);
+        let balance4 = Balance::from(v4);
+        let balance5 = Balance::from(v5);
+        let balance6 = Balance::from(v6);
+
+        let balance_total = balance1 - balance2 - balance3 + balance4 + balance5 - balance6;
+        assert_eq!(balance_total.commit(b0), c0);
+        // The commitment derived from the `Balance` structure is equivalent to `c0` when it was
+        // computed using the summed synthetic blinding factor `b0`, where we took care to use the
+        // same signs.
     }
 
     #[test]

--- a/docs/protocol/src/crypto/decaf377-rdsa.md
+++ b/docs/protocol/src/crypto/decaf377-rdsa.md
@@ -76,12 +76,9 @@ Randomizing a signing key and then deriving the verification key associated to t
 The second signature domain used in Penumbra is for binding signatures.  The
 basepoint $B_{\mathsf{Binding}}$ is the result of converting
 `blake2b(b"decaf377-rdsa-binding")` to an $\mathbb F_r$ element and applying
-`decaf377`'s CDH map-to-group method.
+`decaf377`'s CDH encode-to-curve method.
 
 Since the verification key corresponding to the signing key $a \in \mathbb F_r$ is $A = [a]B_D$, adding and subtracting signing and verification keys commutes with derivation of the verification key, as desired.
-
-**WARNING**: the `decaf377` CDH map is unstable, so it may change in the future and change binding signatures with it.
-
 
 [^1]: This situation is a good example of why it's better to avoid the terms
 "public key" and "private key", and prefer more precise terminology that names

--- a/docs/protocol/src/crypto/decaf377-rdsa.md
+++ b/docs/protocol/src/crypto/decaf377-rdsa.md
@@ -85,3 +85,42 @@ Since the verification key corresponding to the signing key $a \in \mathbb F_r$ 
 keys according to the cryptographic capability they represent, rather than an
 attribute of how they're commonly used. In this example, the verification key
 should not be public, since it could link different transactions.
+
+### Simple example: Binding signature
+
+Let’s say we have two actions in a transaction: one spend (indicated with subscript $s$) and one output (indicated with subscript $o$).
+
+The balance commitments for those actions are:
+
+$cv_o = [v_o] G_v + [rcv_o] G_{rcv}$
+$cv_s = [v_s] G_v + [rcv_s] G_{rcv}$
+
+where
+$G_v$ and $G_{rcv}$ are generators,
+$rcv_i$ are the blinding factors, and
+$v_i$ are the values.
+
+When the signer is computing the binding signature, they have the blinding
+factors for all commitments.
+
+They derive the signing key $bsk$ by adding up the blinding factors based on
+that action's contribution to the balance:
+
+$bsk = rcv_s - rcv_o$
+
+The signer compute the binding signature using this key $bsk$.
+
+When the verifier is checking the signature, they add up the balance commitments
+to derive the verification key $bvk$ based on their contribution to the balance:
+
+$bvk = cv_s - cv_o = [v_s - v_o] G_v + [rcv_s - rcv_o] G_{rcv}$
+
+If the transaction is valid, then the first term on the LHS ($[v_s - v_o] G_v$) is
+zero since for Penumbra all transactions should have zero value balance.
+
+This leaves the verifier with the verification key:
+
+$bvk = [rcv_s - rcv_o] G_{rcv}$
+
+If the value balance is _not_ zero, the verifier will not be able to compute
+the verification key with the data in the transaction.


### PR DESCRIPTION
This is an example to describe how the binding signature / value balance trick works. Is this helpful? Are there issues with this explanation? 