### PR TITLE
Document protobuf build process

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -19,3 +19,43 @@ jobs:
       #     # The 'main' branch of the GitHub repository that defines the module.
       #     against: 'https://github.com/${GITHUB_REPOSITORY}.git#branch=main'
       #     input: 'proto'
+  protobuf-fresh:
+    name: Compile protobuf specs to rust code
+    runs-on: buildjet-16vcpu-ubuntu-2004
+    # runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v2
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: false
+
+      - name: Install protobuf compiler
+        # use base for 'set -eo pipefail'
+        shell: bash
+        run: |
+          curl -sSfL -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+          unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d $HOME/.local
+        env:
+          # N.B. the major version is omitted in the download URLs,
+          # so "21.8" actually means "3.21.8".
+          PROTOC_VERSION: "21.8"
+
+      # N.B. The freshness check can have false negatives, if `prost` output
+      # is superficially but not substantively different. That's OK for now:
+      # we're aiming to keep the defs in sync, and manual maintenance is required.
+      - name: Compile protobuf specs into rust src files
+        shell: bash
+        run: |
+          cd tools/proto-compiler
+          cargo run
+          if ! git diff --quiet; then
+              echo "ERROR: protobuf files must be regenerated and committed:"
+              git diff --stat
+              exit 1
+          else
+              echo "OK: no changes required to protobuf specs"
+          fi

--- a/docs/guide/src/README.md
+++ b/docs/guide/src/README.md
@@ -96,3 +96,4 @@ of online threshold signers, an offline threshold signing process, etc.
 [how-were-building]: https://penumbra.zone/blog/how-were-building-penumbra
 [protocol]: https://protocol.penumbra.zone
 [rustdoc]: https://rustdoc.penumbra.zone
+[Penumbra]: https://github.com/penumbra-zone/penumbra

--- a/docs/guide/src/SUMMARY.md
+++ b/docs/guide/src/SUMMARY.md
@@ -13,5 +13,6 @@
   - [Devnet Quickstart](./dev/devnet-quickstart.md)
   - [SQLite compilation setup](./dev/sqlx.md)
   - [Building documentation](./dev/docs.md)
+  - [Building protobuf](./dev/protobuf.md)
   - [Metrics](./dev/metrics.md)
 - [Resources](./resources.md)

--- a/docs/guide/src/dev/devnet-quickstart.md
+++ b/docs/guide/src/dev/devnet-quickstart.md
@@ -3,7 +3,7 @@
 This page describes a quickstart method for running `pd`+`tendermint` to test
 changes during development.
 
-To start, you'll need to [install Tendermint `v0.34`](https://docs.tendermint.com/v0.34/introduction/install.html).
+To start, you'll need to [install Tendermint `v0.34`](../pd/build.md#installing-tendermint).
 
 ## Generating configs
 

--- a/docs/guide/src/dev/docs.md
+++ b/docs/guide/src/dev/docs.md
@@ -1,9 +1,14 @@
 # Building documentation
 
-The [protocol spec][protocol] and the guide (this document) is built using
-[mdBook] and auto-deployed on pushes to `main`.  To build it locally:
+The [protocol docs] and the [guide] (this document) are built using
+[mdBook] and auto-deployed on pushes to `main`.  To build locally:
 
 1. Install the requirements: `cargo install mdbook mdbook-katex mdbook-mermaid`
 2. Run `mdbook serve` from `docs/protocol` (for the protocol spec) or from `docs/guide` (for this document).
 
 The Rust API docs can be built with `cargo doc`.
+
+[protocol docs]: https://protocol.penumbra.zone
+[rustdoc]: https://rustdoc.penumbra.zone
+[guide]: https://guide.penumbra.zone
+[mdBook]: https://rust-lang.github.io/mdBook/

--- a/docs/guide/src/dev/protobuf.md
+++ b/docs/guide/src/dev/protobuf.md
@@ -1,0 +1,50 @@
+# Maintaining protobuf specs
+
+The Penumbra project dynamically generates code for interfacing
+with [gRPC]. The following locations within the repository
+are relevant:
+
+  * `proto/proto/penumbra/**/*.proto`, the developer-authored spec files
+  * `proto/src/gen/*.rs`, the generated Rust code files
+  * `tools/proto-compiler/`, the build logic for generated the Rust code files
+
+We use [buf] to auto-publish the protobuf schemas at
+[buf.build/penumbra-zone/penumbra][protobuf], and to generate Go and Typescript packages.
+The Rust code files are generated with our own tooling, located at `tools/proto-compiler`.
+
+Our custom tooling for generating the Rust files will also shape the Serde implementations
+of the derived Rust types to have more favorable JSON output (such as rendering
+addresses as [Bech32]-encoded strings).
+
+## Installing protobuf
+
+Obtain the most recent pre-compiled binary from the [`protoc` website].
+After installing, run `protoc --version` and confirm you're running
+at least `3.21.8` (or newer). Don't install `protoc` from package managers
+such as `apt`, as those versions are often outdated, and will not work
+with Penumbra.
+
+## Building protobuf
+
+Switch to the [proto-compiler] directory and run the tool:
+
+```shell
+cd tools/proto-compiler
+cargo run
+```
+
+Then run `git status` to determine whether any changes were made.
+The build process is deterministic, so regenerating multiple times
+from the same source files should not change the output.
+A possible exception to this rule is if `prost` makes a superficial
+change to the output that isn't substantive.
+
+If the generated output would change in any way, CI will
+fail, prompting the developer to commit the changes.
+
+[`protoc` website]: https://grpc.io/docs/protoc-installation/#install-pre-compiled-binaries-any-os
+[proto-compiler]: https://github.com/penumbra-zone/penumbra/tree/main/tools/proto-compiler
+[gRPC]: https://grpc.io/
+[protobuf]: https://buf.build/penumbra-zone/penumbra
+[buf]: https://buf.build/
+[Bech32]: https://en.bitcoin.it/wiki/Bech32

--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -4,7 +4,7 @@ We provide instructions for running both fullnode deployments and validator depl
 fullnode will sync with the network but will not have any voting power, and will
 not be eligible for staking or funding stream rewards. For more information on
 what a fullnode is, see the [Tendermint
-documentation](https://docs.tendermint.com/v0.34/nodes/#full-node).
+documentation](https://docs.tendermint.com/v0.34/tendermint-core/using-tendermint.html#adding-a-non-validator).
 
 A regular validator will participate in voting and rewards, if it becomes part
 of the consensus set.  Of course, these rewards, like all other testnet tokens,

--- a/docs/guide/src/resources.md
+++ b/docs/guide/src/resources.md
@@ -20,7 +20,12 @@ The protocol specification is rendered at [protocol.penumbra.zone][protocol].
 
 The API documentation is rendered at [rustdoc.penumbra.zone][rustdoc].
 
+### Protobuf documentation
+
+The protobuf documentation is rendered at [buf.build/penumbra-zone/penumbra][protobuf].
+
 [Discord]: https://discord.gg/hKvkrqa3zC
 [protocol]: https://protocol.penumbra.zone
 [rustdoc]: https://rustdoc.penumbra.zone
-[guide]: https://rustdoc.penumbra.zone
+[guide]: https://guide.penumbra.zone
+[protobuf]: https://buf.build/penumbra-zone/penumbra


### PR DESCRIPTION
Updated the dev guide to include instructions on rebuilding the protobuf spec files. While I was in the guide, made some small touch-ups to URLs throughout. Also tacked on a new CI check, so that forgetting to rebuild and commit the protobuf specs will now result in failing builds, so we can catch that mistake prior to merging into main. You can see a failing CI check based on a temporary (now removed) commit [here](https://github.com/penumbra-zone/penumbra/actions/runs/3341262009/jobs/5532290154).

Closes #1530.