### PR TITLE
storage2: add a RocksDbSnapshot wrapper with internal Arc

### DIFF
--- a/storage2/src/snapshot.rs
+++ b/storage2/src/snapshot.rs
@@ -9,38 +9,38 @@ use tracing::Span;
 
 use crate::state::StateRead;
 
-/// Snapshots maintain a point-in-time view of the underlying storage, suitable
-/// for read-only access by multiple threads, i.e. RPC calls.
+mod rocks_wrapper;
+use rocks_wrapper::RocksDbSnapshot;
+
+/// A snapshot of the underlying storage at a specific state version, suitable
+/// for read-only access by multiple threads, e.g., RPC calls.
 ///
-/// This is implemented as a wrapper around a [RocksDB snapshot](https://github.com/facebook/rocksdb/wiki/Snapshot)
-/// with an associated JMT version number for the snapshot.
+/// Snapshots are cheap to create and clone.  Internally, they're implemented as
+/// a wrapper around a [RocksDB
+/// snapshot](https://github.com/facebook/rocksdb/wiki/Snapshot) with a pinned
+/// JMT version number for the snapshot.
 #[derive(Clone)]
-pub(crate) struct Snapshot(pub(crate) Inner);
+pub struct Snapshot(Arc<Inner>);
 
 // We don't want to expose the `TreeReader` implementation outside of this crate.
-#[derive(Clone)]
-pub(crate) struct Inner {
-    // TODO: the `'static` lifetime is a temporary hack and we'll need to find a workaround separately (tracked in #1512)
-    rocksdb_snapshot: Arc<rocksdb::Snapshot<'static>>,
-    db: &'static rocksdb::DB,
-    jmt_version: jmt::Version,
+struct Inner {
+    snapshot: RocksDbSnapshot,
+    version: jmt::Version,
+    // Used to retrieve column family handles.
+    db: Arc<rocksdb::DB>,
 }
 
 impl Snapshot {
-    pub(crate) fn new(
-        rocksdb_snapshot: Arc<rocksdb::Snapshot<'static>>,
-        jmt_version: jmt::Version,
-        db: &'static rocksdb::DB,
-    ) -> Self {
-        Self(Inner {
-            rocksdb_snapshot,
-            jmt_version,
+    pub(crate) fn new(db: Arc<rocksdb::DB>, version: jmt::Version) -> Self {
+        Self(Arc::new(Inner {
+            snapshot: RocksDbSnapshot::new(db.clone()),
+            version,
             db,
-        })
+        }))
     }
 
-    pub fn jmt_version(&self) -> jmt::Version {
-        self.0.jmt_version
+    pub fn version(&self) -> jmt::Version {
+        self.0.version
     }
 }
 
@@ -49,15 +49,17 @@ impl StateRead for Snapshot {
     /// Fetch a key from the JMT column family.
     async fn get_raw(&self, key: &str) -> Result<Option<Vec<u8>>> {
         let span = Span::current();
-        let db = self.0.db;
-        let rocksdb_snapshot = self.0.rocksdb_snapshot.clone();
+        let inner = self.0.clone();
         let key = key.to_string();
         tokio::task::Builder::new()
             .name("Snapshot::get_raw")
             .spawn_blocking(move || {
                 span.in_scope(|| {
-                    let jmt_cf = db.cf_handle("jmt").expect("jmt column family not found");
-                    rocksdb_snapshot.get_cf(jmt_cf, key).map_err(Into::into)
+                    let jmt_cf = inner
+                        .db
+                        .cf_handle("jmt")
+                        .expect("jmt column family not found");
+                    inner.snapshot.get_cf(jmt_cf, key).map_err(Into::into)
                 })
             })?
             .await?
@@ -66,17 +68,18 @@ impl StateRead for Snapshot {
     /// Fetch a key from the nonconsensus column family.
     async fn get_nonconsensus(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         let span = Span::current();
-        let db = self.0.db;
-        let rocksdb_snapshot = self.0.rocksdb_snapshot.clone();
+        let inner = self.0.clone();
         let key: Vec<u8> = key.to_vec();
         tokio::task::Builder::new()
             .name("Snapshot::get_nonconsensus")
             .spawn_blocking(move || {
                 span.in_scope(|| {
-                    let nonconsensus_cf = db
+                    let nonconsensus_cf = inner
+                        .db
                         .cf_handle("nonconsensus")
                         .expect("nonconsensus column family not found");
-                    rocksdb_snapshot
+                    inner
+                        .snapshot
                         .get_cf(nonconsensus_cf, key)
                         .map_err(Into::into)
                 })
@@ -89,8 +92,8 @@ impl StateRead for Snapshot {
         prefix: &'a str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, Box<[u8]>)>> + Sync + Send + 'a>> {
         let span = Span::current();
-        let db = self.0.db;
-        let rocksdb_snapshot = self.0.rocksdb_snapshot.clone();
+        let inner = self.0.clone();
+
         let mut options = rocksdb::ReadOptions::default();
         options.set_iterate_range(rocksdb::PrefixRange(prefix.as_bytes()));
         let mode = rocksdb::IteratorMode::Start;
@@ -104,16 +107,21 @@ impl StateRead for Snapshot {
             .name("Snapshot::prefix_raw")
             .spawn_blocking(move || {
                 span.in_scope(|| {
-                    let jmt_cf = db.cf_handle("jmt").expect("jmt column family not found");
-                    let keys_cf = db
+                    let jmt_cf = inner
+                        .db
+                        .cf_handle("jmt")
+                        .expect("jmt column family not found");
+                    let keys_cf = inner
+                        .db
                         .cf_handle("jmt_keys")
                         .expect("jmt_keys column family not found");
-                    let iter = rocksdb_snapshot.iterator_cf_opt(keys_cf, options, mode);
+                    let iter = inner.snapshot.iterator_cf_opt(keys_cf, options, mode);
                     for i in iter {
                         // For each key that matches the prefix, fetch the value from the JMT column family.
                         let (key_preimage, key_hash) = i?;
 
-                        let j = rocksdb_snapshot
+                        let j = inner
+                            .snapshot
                             .get_pinned_cf(jmt_cf, key_hash)?
                             .expect("keys in jmt_keys should have a corresponding value in jmt");
                         let k = std::str::from_utf8(key_preimage.as_ref())?;
@@ -130,18 +138,20 @@ impl StateRead for Snapshot {
 
 /// A reader interface for rocksdb. NOTE: it is up to the caller to ensure consistency between the
 /// rocksdb::DB handle and any write batches that may be applied through the writer interface.
-impl TreeReader for Inner {
+impl TreeReader for Snapshot {
     /// Gets node given a node key. Returns `None` if the node does not exist.
     fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>> {
         let node_key = node_key;
         tracing::trace!(?node_key);
 
         let jmt_cf = self
+            .0
             .db
             .cf_handle("jmt")
             .expect("jmt column family not found");
         let value = self
-            .rocksdb_snapshot
+            .0
+            .snapshot
             .get_cf(jmt_cf, &node_key.encode()?)?
             .map(|db_slice| Node::decode(&db_slice))
             .transpose()?;
@@ -152,10 +162,11 @@ impl TreeReader for Inner {
 
     fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode)>> {
         let jmt_cf = self
+            .0
             .db
             .cf_handle("jmt")
             .expect("jmt column family not found");
-        let mut iter = self.rocksdb_snapshot.raw_iterator_cf(jmt_cf);
+        let mut iter = self.0.snapshot.raw_iterator_cf(jmt_cf);
         iter.seek_to_last();
 
         if iter.valid() {

--- a/storage2/src/snapshot/rocks_wrapper.rs
+++ b/storage2/src/snapshot/rocks_wrapper.rs
@@ -1,0 +1,76 @@
+use std::ops::Deref;
+use std::sync::Arc;
+
+/// A wrapper type that acts as a `rocksdb::Snapshot` of an `Arc`'d database
+/// handle.
+///
+/// This works around a limitation of the `rocksdb` API: the `rocksdb::Snapshot`
+/// can only take a borrowed database handle, not an `Arc`'d one, so the
+/// lifetime of the `rocksdb::Snapshot` is bound to the lifetime of the borrowed
+/// handle.  Instead, this wrapper type bundles an `Arc`'d handle together with
+/// the `rocksdb::Snapshot`, so that the database is guaranteed to live at least
+/// as long as any snapshot of it.
+pub struct RocksDbSnapshot {
+    /// The snapshot itself.  It's not really `'static`, so it's on us to ensure
+    /// that the database stays live as long as the snapshot does.
+    inner: rocksdb::Snapshot<'static>,
+    /// The raw pointer form of the Arc<DB> we use to guarantee the database
+    /// lives at least as long as the snapshot.  We create this from the Arc<DB>
+    /// in the constructor, pass it to the snapshot on creation, and then
+    /// convert it back into an Arc in the drop impl to decrement the refcount.
+    ///
+    /// Arc::into_raw consumes the Arc instance but does not decrement the
+    /// refcount.  This means that we cannot accidentally drop the Arc while
+    /// using the raw pointer.  Instead, we must explicitly convert the raw
+    /// pointer back into an Arc when we're finished using it, and only then
+    /// drop it.
+    raw_db: *const rocksdb::DB,
+}
+
+// Safety requires that the inner snapshot instance must never live longer than
+// the wrapper.  We're assured that this is the case, because we only return a
+// borrow of the inner snapshot, and because `rocksdb::Snapshot` is neither
+// `Copy` nor `Clone`.
+//
+// We're also reasonably certain that the upstream crate will not add such an
+// implementation in the future, because its drop impl is used to make the FFI
+// call that discards the in-memory snapshot, so it would not be safe to add
+// such an implementation.
+impl Deref for RocksDbSnapshot {
+    type Target = rocksdb::Snapshot<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl RocksDbSnapshot {
+    /// Creates a new snapshot of the given `db`.
+    pub fn new(db: Arc<rocksdb::DB>) -> Self {
+        // First, convert the Arc<DB> into a raw pointer.
+        let raw_db = Arc::into_raw(db);
+        // Next, use the raw pointer to construct a &DB instance with a fake
+        // 'static lifetime, and use that instance to construct the inner
+        // Snapshot.
+        let static_db: &'static rocksdb::DB = unsafe { &*raw_db };
+        let inner = rocksdb::Snapshot::new(static_db);
+
+        Self { inner, raw_db }
+    }
+}
+
+impl Drop for RocksDbSnapshot {
+    fn drop(&mut self) {
+        // Now that we know we're finished with the `Snapshot`, we can
+        // reconstruct the `Arc` and drop it, to decrement the DB refcount.
+        unsafe {
+            let db = Arc::from_raw(self.raw_db);
+            std::mem::drop(db);
+        }
+    }
+}
+
+/// The `Send` implementation is safe because the `rocksdb::Snapshot` is `Send`.
+unsafe impl Send for RocksDbSnapshot {}
+/// The `Sync` implementation is safe because the `rocksdb::Snapshot` is `Sync`.
+unsafe impl Sync for RocksDbSnapshot {}

--- a/storage2/src/state.rs
+++ b/storage2/src/state.rs
@@ -37,6 +37,10 @@ impl State {
     pub fn begin_transaction(&mut self) -> StateTransaction {
         StateTransaction::new(self)
     }
+
+    pub fn version(&self) -> jmt::Version {
+        self.snapshot.version()
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
This change works around a limitation of the `rocksdb` API: the `rocksdb::Snapshot` can only take a borrowed database handle, not an `Arc`'d one, so the lifetime of the `rocksdb::Snapshot` is bound to the lifetime of the borrowed handle.  This isn't what we want, because we're using all of these snapshots in an async context, where objects need to be able to live arbitrarily long (so that they can be included in futures that are spawned as tasks, and executed whenever).

To fix this, we add a wrapper type that bundles an `Arc`'d handle together with the `rocksdb::Snapshot`, so that the database is guaranteed to live at least as long as any snapshot of it.

This requires unsafe code, which is encapsulated in the single-purpose `RocksDbSnapshot` wrapper type, so that it's self-contained and it's possible to reason about the unsafe code locally.

Closes #1512 