### PR TITLE
[WIP] storage2: add an end-to-end test of storage/state flow and do a docs/API pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3405,6 +3405,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
+ "tracing-subscriber 0.3.16",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
  "cipher 0.4.3",
@@ -611,7 +611,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -698,9 +697,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 dependencies = [
  "jobserver",
 ]
@@ -895,7 +894,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
 dependencies = [
- "prost 0.11.0",
+ "prost",
  "prost-types",
  "tonic",
  "tracing-core",
@@ -1960,9 +1959,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2046,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.51"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2077,9 +2076,9 @@ dependencies = [
  "derive_more",
  "flex-error",
  "ibc-proto",
- "ics23 0.8.1",
+ "ics23",
  "num-traits",
- "prost 0.11.0",
+ "prost",
  "prost-types",
  "safe-regex",
  "serde",
@@ -2102,27 +2101,11 @@ source = "git+https://github.com/penumbra-zone/ibc-rs?branch=penumbra-034#27639d
 dependencies = [
  "base64",
  "bytes",
- "prost 0.11.0",
+ "prost",
  "prost-types",
  "serde",
  "tendermint-proto",
  "tonic",
-]
-
-[[package]]
-name = "ics23"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d454cc0a22bd556cc3d3c69f9d75a392a36244634840697a4b9eb81bc5c8ae0"
-dependencies = [
- "anyhow",
- "bytes",
- "hex",
- "prost 0.9.0",
- "ripemd160",
- "sha2 0.9.9",
- "sha3 0.9.1",
- "sp-std",
 ]
 
 [[package]]
@@ -2133,10 +2116,10 @@ dependencies = [
  "anyhow",
  "bytes",
  "hex",
- "prost 0.11.0",
+ "prost",
  "ripemd",
  "sha2 0.10.6",
- "sha3 0.10.6",
+ "sha3",
 ]
 
 [[package]]
@@ -2273,7 +2256,7 @@ dependencies = [
  "byteorder",
  "futures",
  "hex",
- "ics23 0.8.1",
+ "ics23",
  "itertools",
  "mirai-annotations",
  "num-derive",
@@ -2292,13 +2275,13 @@ dependencies = [
 [[package]]
 name = "jmt"
 version = "0.2.0"
-source = "git+https://github.com/penumbra-zone/jellyfish-merkle.git?branch=newmain#2f2fab25fbd3763debc776c9cf1df79ebd3a84f7"
+source = "git+https://github.com/penumbra-zone/jellyfish-merkle.git?branch=newmain#fc529b26af6a5b488876b6770430076ecaabd8e4"
 dependencies = [
  "anyhow",
  "bcs",
  "byteorder",
  "hex",
- "ics23 0.7.0",
+ "ics23",
  "itertools",
  "mirai-annotations",
  "num-derive",
@@ -2836,9 +2819,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "oorandom"
@@ -2908,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "overload"
@@ -3078,7 +3061,7 @@ dependencies = [
  "http",
  "ibc",
  "ibc-proto",
- "ics23 0.8.1",
+ "ics23",
  "jmt 0.1.0",
  "metrics",
  "metrics-exporter-prometheus",
@@ -3093,7 +3076,7 @@ dependencies = [
  "penumbra-transaction",
  "penumbra-wallet",
  "pin-project",
- "prost 0.11.0",
+ "prost",
  "prost-types",
  "rand",
  "rand_chacha",
@@ -3206,7 +3189,7 @@ dependencies = [
  "penumbra-storage",
  "penumbra-tct",
  "penumbra-transaction",
- "prost 0.11.0",
+ "prost",
  "prost-types",
  "rand_core",
  "regex",
@@ -3227,7 +3210,7 @@ dependencies = [
 name = "penumbra-crypto"
 version = "0.1.0"
 dependencies = [
- "aes 0.8.1",
+ "aes 0.8.2",
  "anyhow",
  "ark-ff",
  "ark-serialize",
@@ -3279,7 +3262,7 @@ dependencies = [
  "penumbra-crypto",
  "penumbra-proto",
  "penumbra-transaction",
- "prost 0.11.0",
+ "prost",
  "rand_core",
  "serde",
  "serde_json",
@@ -3340,9 +3323,9 @@ dependencies = [
  "hex",
  "ibc",
  "ibc-proto",
- "ics23 0.8.1",
+ "ics23",
  "num-rational",
- "prost 0.11.0",
+ "prost",
  "prost-types",
  "serde",
  "subtle-encoding",
@@ -3361,7 +3344,7 @@ dependencies = [
  "hex",
  "ibc",
  "ibc-proto",
- "ics23 0.8.1",
+ "ics23",
  "jmt 0.1.0",
  "metrics",
  "once_cell",
@@ -3389,7 +3372,7 @@ dependencies = [
  "hex",
  "ibc",
  "ibc-proto",
- "ics23 0.8.1",
+ "ics23",
  "jmt 0.2.0",
  "metrics",
  "once_cell",
@@ -3468,7 +3451,7 @@ dependencies = [
  "include-flate",
  "parking_lot 0.12.1",
  "penumbra-tct",
- "prost 0.11.0",
+ "prost",
  "rand",
  "rand_chacha",
  "rand_distr",
@@ -3544,7 +3527,7 @@ dependencies = [
  "penumbra-proto",
  "penumbra-tct",
  "penumbra-transaction",
- "prost 0.11.0",
+ "prost",
  "rand",
  "rand_core",
  "reqwest",
@@ -3858,35 +3841,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
-dependencies = [
- "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
  "bytes",
- "prost-derive 0.11.0",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
- "syn 1.0.103",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3909,7 +3869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
 dependencies = [
  "bytes",
- "prost 0.11.0",
+ "prost",
 ]
 
 [[package]]
@@ -4182,17 +4142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.5",
-]
-
-[[package]]
-name = "ripemd160"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -4595,18 +4544,6 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha3"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
@@ -4696,12 +4633,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "sp-std"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35391ea974fa5ee869cb094d5b437688fbf3d8127d64d1b9fed5822a1ed39b12"
 
 [[package]]
 name = "spin"
@@ -4977,7 +4908,7 @@ dependencies = [
  "futures",
  "num-traits",
  "once_cell",
- "prost 0.11.0",
+ "prost",
  "prost-types",
  "serde",
  "serde_bytes",
@@ -5026,7 +4957,7 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost 0.11.0",
+ "prost",
  "prost-types",
  "serde",
  "serde_bytes",
@@ -5336,8 +5267,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.11.0",
- "prost-derive 0.11.0",
+ "prost",
+ "prost-derive",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.4",
@@ -5395,7 +5326,7 @@ dependencies = [
  "bytes",
  "futures",
  "pin-project",
- "prost 0.11.0",
+ "prost",
  "tendermint",
  "tendermint-proto",
  "tokio",

--- a/storage2/Cargo.toml
+++ b/storage2/Cargo.toml
@@ -31,3 +31,7 @@ hex = "0.4"
 metrics = "0.19.0"
 parking_lot = "0.12"
 ics23 = { git = "https://github.com/penumbra-zone/ics23", branch = "penumbra-034" }
+
+[dev-dependencies]
+tempfile = "3.3.0"
+tracing-subscriber = "0.3"

--- a/storage2/src/lib.rs
+++ b/storage2/src/lib.rs
@@ -1,8 +1,46 @@
+//! Storage and management of chain state.
+//!
+//! This crate provides a versioned, verifiable key-value store that also
+//! supports lightweight, copy-on-write snapshots and transactional semantics.
+//! The [`Storage`] type is a handle for an instance of a backing store,
+//! implemented using RocksDB.  The storage records a sequence of versioned
+//! [`State`]s.  The [`State`] type is a lightweight snapshot of a particular
+//! version of the chain state.
+//!
+//! Each [`State`] instance can also be used as a copy-on-write fork to build up
+//! changes before committing them to persistent storage.  The
+//! [`StateTransaction`] type collects a group of writes, which can then be
+//! applied to the (in-memory) [`State`] fork.  Finally, the changes accumulated
+//! in the [`State`] instance can be committed to the persistent [`Storage`].
+//!
+//! Reads are performed with the [`StateRead`] trait, implemented by both
+//! [`State`] and [`StateTransaction`], and reflect any currently cached writes.
+//! Writes are performed with the [`StateWrite`] trait, which is only
+//! implemented for [`StateTransaction`].
+//!
+//! The storage system provides two data stores:
+//!
+//! * A verifiable key-value store, with UTF-8 keys and byte values, backed by
+//! the Jellyfish Merkle Tree.  The JMT is a sparse merkle tree that records
+//! hashed keys, so we also record an index of the keys themselves to allow
+//! range queries on keys rather than key hashes. This index, however, is not
+//! part of the verifiable consensus state.
+//!
+//! * A secondary, non-verifiable key-value store with byte keys and byte
+//! values, backed directly by RocksDB.  This is intended for use building
+//! application-specific indexes of the verifiable consensus state.
+//!
+//! While the primary key-value store records byte values, it is intended for
+//! use with Protobuf-encoded data.  To this end, the [`StateRead`] and
+//! [`StateWrite`] traits have provided methods that use the
+//! [`penumbra_proto::Protobuf`] trait to automatically (de)serialize into proto
+//! or domain types, allowing its use as an object store.
+
 mod metrics;
 mod snapshot;
 mod state;
 mod storage;
 
 pub use crate::metrics::register_metrics;
-pub use state::State;
+pub use state::{State, StateRead, StateTransaction, StateWrite};
 pub use storage::Storage;

--- a/storage2/src/snapshot.rs
+++ b/storage2/src/snapshot.rs
@@ -87,7 +87,7 @@ impl StateRead for Snapshot {
             .await?
     }
 
-    async fn prefix_raw<'a>(
+    fn prefix_raw<'a>(
         &'a self,
         prefix: &'a str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, Box<[u8]>)>> + Sync + Send + 'a>> {

--- a/storage2/src/state.rs
+++ b/storage2/src/state.rs
@@ -21,7 +21,14 @@ use self::read::prefix_raw_with_cache;
 /// changes before committing them to persistent storage.  The
 /// [`StateTransaction`] type collects a group of writes, which can then be
 /// applied to the (in-memory) [`State`] fork.  Finally, the changes accumulated
-/// in the [`State`] instance can be committed to the persistent [`Storage`](crate::Storage).
+/// in the [`State`] instance can be committed to the persistent
+/// [`Storage`](crate::Storage).
+///
+/// The [`State`] type itself isn't `Clone`, to prevent confusion when a
+/// [`State`] instance is used as a copy-on-write fork.  Either multiple
+/// [`State`] instances should be forked from the underlying
+/// [`Storage`](crate::Storage), if the states are meant to be independent, or
+/// the [`State`] should be explicitly shared using an [`Arc`](std::sync::Arc).
 pub struct State {
     snapshot: Snapshot,
     // A `None` value represents deletion.

--- a/storage2/src/state.rs
+++ b/storage2/src/state.rs
@@ -75,10 +75,10 @@ impl StateRead for State {
         self.snapshot.get_nonconsensus(key).await
     }
 
-    async fn prefix_raw<'a>(
+    fn prefix_raw<'a>(
         &'a self,
         prefix: &'a str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, Box<[u8]>)>> + Send + Sync + 'a>> {
-        prefix_raw_with_cache(self, &self.unwritten_changes, prefix).await
+        prefix_raw_with_cache(self, &self.unwritten_changes, prefix)
     }
 }

--- a/storage2/src/state.rs
+++ b/storage2/src/state.rs
@@ -79,6 +79,6 @@ impl StateRead for State {
         &'a self,
         prefix: &'a str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, Vec<u8>)>> + Send + Sync + 'a>> {
-        prefix_raw_with_cache(self, &self.unwritten_changes, prefix)
+        prefix_raw_with_cache(&self.snapshot, &self.unwritten_changes, prefix)
     }
 }

--- a/storage2/src/state.rs
+++ b/storage2/src/state.rs
@@ -78,7 +78,7 @@ impl StateRead for State {
     fn prefix_raw<'a>(
         &'a self,
         prefix: &'a str,
-    ) -> Pin<Box<dyn Stream<Item = Result<(String, Box<[u8]>)>> + Send + Sync + 'a>> {
+    ) -> Pin<Box<dyn Stream<Item = Result<(String, Vec<u8>)>> + Send + Sync + 'a>> {
         prefix_raw_with_cache(self, &self.unwritten_changes, prefix)
     }
 }

--- a/storage2/src/state/transaction.rs
+++ b/storage2/src/state/transaction.rs
@@ -82,10 +82,10 @@ impl<'tx> StateRead for Transaction<'tx> {
         self.state.get_nonconsensus(key).await
     }
 
-    async fn prefix_raw<'a>(
+    fn prefix_raw<'a>(
         &'a self,
         prefix: &'a str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, Box<[u8]>)>> + Sync + Send + 'a>> {
-        prefix_raw_with_cache(self, &self.unwritten_changes, prefix).await
+        prefix_raw_with_cache(self, &self.unwritten_changes, prefix)
     }
 }

--- a/storage2/src/state/transaction.rs
+++ b/storage2/src/state/transaction.rs
@@ -34,7 +34,8 @@ impl<'a> Transaction<'a> {
         self.failure_reason = reason;
     }
 
-    pub fn commit(self) -> Result<()> {
+    /// Applies this transaction's writes to its parent [`State`], completing the transaction.
+    pub fn apply(self) -> Result<()> {
         if self.failed {
             return Err(anyhow::anyhow!("transaction failed").context(self.failure_reason));
         }

--- a/storage2/src/state/transaction.rs
+++ b/storage2/src/state/transaction.rs
@@ -7,8 +7,7 @@ use crate::State;
 
 use super::{read::prefix_raw_with_cache, StateRead, StateWrite};
 
-/// Represents a transactional set of changes to a `State` fork,
-/// implemented as a RYW cache over a `State`.
+/// A set of pending changes to a [`State`] instance, supporting both writes and reads.
 pub struct Transaction<'a> {
     /// Unwritten changes to the consensus-critical state (stored in the JMT).
     pub(crate) unwritten_changes: BTreeMap<String, Option<Vec<u8>>>,
@@ -20,7 +19,7 @@ pub struct Transaction<'a> {
 }
 
 impl<'a> Transaction<'a> {
-    pub fn new(state: &'a mut State) -> Self {
+    pub(crate) fn new(state: &'a mut State) -> Self {
         Self {
             state,
             unwritten_changes: BTreeMap::new(),

--- a/storage2/src/state/transaction.rs
+++ b/storage2/src/state/transaction.rs
@@ -85,7 +85,7 @@ impl<'tx> StateRead for Transaction<'tx> {
     fn prefix_raw<'a>(
         &'a self,
         prefix: &'a str,
-    ) -> Pin<Box<dyn Stream<Item = Result<(String, Box<[u8]>)>> + Sync + Send + 'a>> {
+    ) -> Pin<Box<dyn Stream<Item = Result<(String, Vec<u8>)>> + Sync + Send + 'a>> {
         prefix_raw_with_cache(self, &self.unwritten_changes, prefix)
     }
 }

--- a/storage2/src/state/transaction.rs
+++ b/storage2/src/state/transaction.rs
@@ -86,6 +86,6 @@ impl<'tx> StateRead for Transaction<'tx> {
         &'a self,
         prefix: &'a str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, Vec<u8>)>> + Sync + Send + 'a>> {
-        prefix_raw_with_cache(self, &self.unwritten_changes, prefix)
+        prefix_raw_with_cache(self.state, &self.unwritten_changes, prefix)
     }
 }

--- a/storage2/src/state/write.rs
+++ b/storage2/src/state/write.rs
@@ -2,11 +2,12 @@ use std::fmt::Debug;
 
 use penumbra_proto::{Message, Protobuf};
 
+/// Write access to chain state.
 pub trait StateWrite {
-    /// Copy-on-write put
+    /// Puts raw bytes into the verifiable key-value store with the given key.
     fn put_raw(&mut self, key: String, value: Vec<u8>);
 
-    /// Sets a domain type on the State.
+    /// Puts a domain type into the verifiable key-value store with the given key.
     fn put<D, P>(&mut self, key: String, value: D)
     where
         D: Protobuf<P>,
@@ -19,7 +20,7 @@ pub trait StateWrite {
         self.put_proto(key, P::from(value));
     }
 
-    /// Puts a proto type on the State.
+    /// Puts a proto type into the verifiable key-value store with the given key.
     fn put_proto<D, P>(&mut self, key: String, value: P)
     where
         D: Protobuf<P>,
@@ -32,12 +33,12 @@ pub trait StateWrite {
         self.put_raw(key, value.encode_to_vec());
     }
 
-    /// Delete a key from state.
+    /// Delete a key from the verifiable key-value store.
     fn delete(&mut self, key: String);
 
-    /// Delete a key from nonconsensus storage.
+    /// Delete a key from non-verifiable key-value storage.
     fn delete_nonconsensus(&mut self, key: Vec<u8>);
 
-    /// Put a key/value raw pair into non-consensus-critical ("nonconsensus") state.
+    /// Puts raw bytes into the non-verifiable key-value store with the given key.
     fn put_nonconsensus(&mut self, key: Vec<u8>, value: Vec<u8>);
 }

--- a/storage2/src/storage.rs
+++ b/storage2/src/storage.rs
@@ -67,7 +67,9 @@ impl Storage {
         State::new(self.0.latest_snapshot.read().clone())
     }
 
-    pub async fn apply(&self, state: State) -> Result<()> {
+    /// Commits the provided [`State`] to persistent storage as the latest
+    /// version of the chain state.
+    pub async fn commit(&self, state: State) -> Result<()> {
         let inner = self.0.clone();
         // 1. Write the NCT
         // TODO: move this higher up in the call stack, and use `put_nonconsensus` to store

--- a/storage2/src/storage.rs
+++ b/storage2/src/storage.rs
@@ -12,7 +12,9 @@ use tracing::Span;
 use crate::snapshot::Snapshot;
 use crate::State;
 
-/// A handle for a storage instance, wrapping a RocksDB instance.
+/// A handle for a storage instance, backed by RocksDB.
+///
+/// The handle is cheaply clonable; all clones share the same backing data store.
 #[derive(Clone)]
 pub struct Storage(Arc<Inner>);
 

--- a/storage2/src/storage.rs
+++ b/storage2/src/storage.rs
@@ -100,29 +100,6 @@ impl Storage {
     /// Commits the provided [`State`] to persistent storage as the latest
     /// version of the chain state.
     pub async fn commit(&self, state: State) -> Result<()> {
-        let inner = self.0.clone();
-        // 1. Write the NCT
-        // TODO: move this higher up in the call stack, and use `put_nonconsensus` to store
-        // the NCT.
-        // tracing::debug!("serializing NCT");
-        // let tct_data = bincode::serialize(nct)?;
-        // tracing::debug!(tct_bytes = tct_data.len(), "serialized NCT");
-
-        // let db = self.db;
-
-        // let span = Span::current();
-        // tokio::task::Builder::new()
-        //     .name("put_nct")
-        //     .spawn_blocking(move || {
-        //         span.in_scope(|| {
-        //             let nct_cf = db.cf_handle("nct").expect("nct column family not found");
-        //             db.put_cf(nct_cf, "nct", &tct_data)
-        //         })
-        //     })
-        //     .unwrap()
-        //     .await??;
-
-        // 2. Write the JMT and nonconsensus data to RocksDB
         // We use wrapping_add here so that we can write `new_version = 0` by
         // overflowing `PRE_GENESIS_VERSION`.
         let old_version = self.latest_version();
@@ -133,6 +110,7 @@ impl Storage {
         }
 
         let span = Span::current();
+        let inner = self.0.clone();
 
         tokio::task::Builder::new()
             .name("Storage::write_node_batch")

--- a/storage2/src/storage.rs
+++ b/storage2/src/storage.rs
@@ -61,7 +61,6 @@ impl Storage {
     /// Returns the latest version (block height) of the tree recorded by the
     /// `Storage`, or `None` if the tree is empty.
     pub async fn latest_version(&self) -> Result<Option<jmt::Version>> {
-        // TODO: do better
         latest_version(&self.0.db)
     }
 

--- a/storage2/tests/basic.rs
+++ b/storage2/tests/basic.rs
@@ -1,0 +1,396 @@
+use futures::StreamExt;
+use penumbra_storage2::*;
+
+#[tokio::test]
+async fn simple_flow() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let tmpdir = tempfile::tempdir()?;
+
+    // Initialize an empty Storage in the new directory
+    let storage = Storage::load(tmpdir.path().to_owned()).await?;
+
+    // Version -1 to Version 0 writes
+    //
+    // tx00: test => test
+    // tx01: a/aa => aa
+    // tx01: a/aaa => aaa
+    // tx01: a/ab => ab
+    // tx01: a/z  => z
+    //
+    // Version 0 to Version 1 writes
+    // tx10: test => [deleted]
+    // tx10: a/aaa => [deleted]
+    // tx10: a/c => c
+    // tx11: a/ab => ab2
+
+    let mut state_init = storage.state();
+    // Check that reads on an empty state return Ok(None)
+    assert_eq!(state_init.get_raw("test").await?, None);
+    assert_eq!(state_init.get_raw("a/aa").await?, None);
+
+    // Create a transaction writing just the first key.
+    let mut tx00 = state_init.begin_transaction();
+    tx00.put_raw("test".to_owned(), b"test".to_vec());
+
+    // Check that we can read the first key from the tx but not the second key.
+    assert_eq!(tx00.get_raw("test").await?, Some(b"test".to_vec()));
+    assert_eq!(tx00.get_raw("a/aa").await?, None);
+
+    // Now apply the transaction to state_init
+    tx00.apply();
+    assert_eq!(state_init.get_raw("test").await?, Some(b"test".to_vec()));
+    assert_eq!(state_init.get_raw("a/aa").await?, None);
+
+    // Create a transaction writing the other keys.
+    let mut tx01 = state_init.begin_transaction();
+    tx01.put_raw("a/aa".to_owned(), b"aa".to_vec());
+    tx01.put_raw("a/aaa".to_owned(), b"aaa".to_vec());
+    tx01.put_raw("a/ab".to_owned(), b"ab".to_vec());
+    tx01.put_raw("a/z".to_owned(), b"z".to_vec());
+
+    // Check reads against tx01:
+    //    This is missing in tx01 and reads through to state_init
+    assert_eq!(tx01.get_raw("test").await?, Some(b"test".to_vec()));
+    //    This is present in tx01
+    assert_eq!(tx01.get_raw("a/aa").await?, Some(b"aa".to_vec()));
+    assert_eq!(tx01.get_raw("a/aaa").await?, Some(b"aaa".to_vec()));
+    assert_eq!(tx01.get_raw("a/ab").await?, Some(b"ab".to_vec()));
+    assert_eq!(tx01.get_raw("a/z").await?, Some(b"z".to_vec()));
+    //    This is missing in tx01 and in state_init
+    assert_eq!(tx01.get_raw("a/c").await?, None);
+    let mut range = tx01.prefix_raw("a/");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aa".to_owned(), b"aa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aaa".to_owned(), b"aaa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/ab".to_owned(), b"ab".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+
+    // Now apply the transaction to state_init
+    tx01.apply();
+
+    // Check reads against state_init:
+    //    This is present in state_init
+    assert_eq!(state_init.get_raw("test").await?, Some(b"test".to_vec()));
+    assert_eq!(state_init.get_raw("a/aa").await?, Some(b"aa".to_vec()));
+    assert_eq!(state_init.get_raw("a/aaa").await?, Some(b"aaa".to_vec()));
+    assert_eq!(state_init.get_raw("a/ab").await?, Some(b"ab".to_vec()));
+    assert_eq!(state_init.get_raw("a/z").await?, Some(b"z".to_vec()));
+    //    This is missing in state_init
+    assert_eq!(state_init.get_raw("a/c").await?, None);
+    let mut range = state_init.prefix_raw("a/");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aa".to_owned(), b"aa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aaa".to_owned(), b"aaa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/ab".to_owned(), b"ab".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+
+    // Now commit state_init to storage
+    storage.commit(state_init).await?;
+
+    // Now we have version 0.
+    let mut state0 = storage.state();
+    assert_eq!(state0.version(), 0);
+    // Check reads against state0:
+    //    This is missing in state0 and present in JMT
+    assert_eq!(state0.get_raw("test").await?, Some(b"test".to_vec()));
+    assert_eq!(state0.get_raw("a/aa").await?, Some(b"aa".to_vec()));
+    assert_eq!(state0.get_raw("a/aaa").await?, Some(b"aaa".to_vec()));
+    assert_eq!(state0.get_raw("a/ab").await?, Some(b"ab".to_vec()));
+    assert_eq!(state0.get_raw("a/z").await?, Some(b"z".to_vec()));
+    //    This is missing in state0 and missing in JMT
+    assert_eq!(state0.get_raw("a/c").await?, None);
+    let mut range = state0.prefix_raw("a/");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aa".to_owned(), b"aa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aaa".to_owned(), b"aaa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/ab".to_owned(), b"ab".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+
+    // Start building a transaction
+    let mut tx10 = state0.begin_transaction();
+    tx10.delete("test".to_owned());
+    tx10.delete("a/aaa".to_owned());
+    tx10.put_raw("a/c".to_owned(), b"c".to_vec());
+
+    // Check reads against tx10:
+    //    This is deleted in tx10, missing in state0, present in JMT
+    assert_eq!(tx10.get_raw("test").await?, None);
+    assert_eq!(tx10.get_raw("a/aaa").await?, None);
+    //    This is missing in tx10, missing in state0, present in JMT
+    assert_eq!(tx10.get_raw("a/aa").await?, Some(b"aa".to_vec()));
+    assert_eq!(tx10.get_raw("a/ab").await?, Some(b"ab".to_vec()));
+    assert_eq!(tx10.get_raw("a/z").await?, Some(b"z".to_vec()));
+    //    This is present in tx10, missing in state0, missing in JMT
+    assert_eq!(tx10.get_raw("a/c").await?, Some(b"c".to_vec()));
+    let mut range = tx10.prefix_raw("a/");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aa".to_owned(), b"aa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/ab".to_owned(), b"ab".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/c".to_owned(), b"c".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+
+    // TODO: Check ranged reads against tx10
+
+    // Apply tx10 to state0
+    tx10.apply();
+
+    // Check reads against state0
+    //    This is deleted in state0, present in JMT
+    assert_eq!(state0.get_raw("test").await?, None);
+    assert_eq!(state0.get_raw("a/aaa").await?, None);
+    //    This is missing in state0, present in JMT
+    assert_eq!(state0.get_raw("a/aa").await?, Some(b"aa".to_vec()));
+    assert_eq!(state0.get_raw("a/ab").await?, Some(b"ab".to_vec()));
+    assert_eq!(state0.get_raw("a/z").await?, Some(b"z".to_vec()));
+    //    This is present in state0, missing in JMT
+    assert_eq!(state0.get_raw("a/c").await?, Some(b"c".to_vec()));
+    let mut range = state0.prefix_raw("a/");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aa".to_owned(), b"aa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/ab".to_owned(), b"ab".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/c".to_owned(), b"c".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+
+    // Start building another transaction
+    let mut tx11 = state0.begin_transaction();
+    tx11.put_raw("a/ab".to_owned(), b"ab2".to_vec());
+
+    // Check reads against tx11:
+    //    This is present in tx11, missing in state0, present in JMT
+    assert_eq!(tx11.get_raw("a/ab").await?, Some(b"ab2".to_vec()));
+    //    This is missing in tx11, deleted in state0, present in JMT
+    assert_eq!(tx11.get_raw("test").await?, None);
+    assert_eq!(tx11.get_raw("a/aaa").await?, None);
+    //    This is missing in tx11, missing in state0, present in JMT
+    assert_eq!(tx11.get_raw("a/aa").await?, Some(b"aa".to_vec()));
+    assert_eq!(tx11.get_raw("a/z").await?, Some(b"z".to_vec()));
+    //    This is missing in tx10, present in state0, missing in JMT
+    assert_eq!(tx11.get_raw("a/c").await?, Some(b"c".to_vec()));
+    let mut range = tx11.prefix_raw("a/");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aa".to_owned(), b"aa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/ab".to_owned(), b"ab2".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/c".to_owned(), b"c".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+
+    // Apply tx11 to state0
+    tx11.apply();
+
+    // Check reads against state0
+    //    This is deleted in state0, present in JMT
+    assert_eq!(state0.get_raw("test").await?, None);
+    assert_eq!(state0.get_raw("a/aaa").await?, None);
+    //    This is missing in state0, present in JMT
+    assert_eq!(state0.get_raw("a/aa").await?, Some(b"aa".to_vec()));
+    assert_eq!(state0.get_raw("a/z").await?, Some(b"z".to_vec()));
+    //    This is present in state0, missing in JMT
+    assert_eq!(state0.get_raw("a/c").await?, Some(b"c".to_vec()));
+    //    This is present in state0, present in JMT
+    assert_eq!(state0.get_raw("a/ab").await?, Some(b"ab2".to_vec()));
+    let mut range = state0.prefix_raw("a/");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aa".to_owned(), b"aa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/ab".to_owned(), b"ab2".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/c".to_owned(), b"c".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+
+    // Create another fork of state 0 while we've edited the first one but before we commit.
+    let state0a = storage.state();
+    assert_eq!(state0a.version(), 0);
+
+    // Commit state0 as state1.
+    storage.commit(state0).await?;
+
+    let state1 = storage.state();
+    assert_eq!(state1.version(), 1);
+
+    // Check reads against state1
+    assert_eq!(state1.get_raw("test").await?, None);
+    assert_eq!(state1.get_raw("a/aaa").await?, None);
+    assert_eq!(state1.get_raw("a/aa").await?, Some(b"aa".to_vec()));
+    assert_eq!(state1.get_raw("a/ab").await?, Some(b"ab2".to_vec()));
+    assert_eq!(state1.get_raw("a/z").await?, Some(b"z".to_vec()));
+    assert_eq!(state1.get_raw("a/c").await?, Some(b"c".to_vec()));
+    let mut range = state1.prefix_raw("a/");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aa".to_owned(), b"aa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/ab".to_owned(), b"ab2".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/c".to_owned(), b"c".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+
+    // Check reads against state0a
+    assert_eq!(state0a.get_raw("test").await?, Some(b"test".to_vec()));
+    assert_eq!(state0a.get_raw("a/aa").await?, Some(b"aa".to_vec()));
+    assert_eq!(state0a.get_raw("a/aaa").await?, Some(b"aaa".to_vec()));
+    assert_eq!(state0a.get_raw("a/ab").await?, Some(b"ab".to_vec()));
+    assert_eq!(state0a.get_raw("a/z").await?, Some(b"z".to_vec()));
+    assert_eq!(state0a.get_raw("a/c").await?, None);
+    let mut range = state0a.prefix_raw("a/");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aa".to_owned(), b"aa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aaa".to_owned(), b"aaa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/ab".to_owned(), b"ab".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+
+    // Now, check that closing and reloading works.
+
+    // First, be sure to explicitly drop anything keeping a reference to the
+    // RocksDB instance:
+    std::mem::drop(storage);
+    // std::mem::drop(state0); // consumed in commit()
+    std::mem::drop(state0a);
+    std::mem::drop(state1);
+
+    // Now reload the storage from the same directory...
+    let storage_a = Storage::load(tmpdir.path().to_owned()).await?;
+    let state1a = storage_a.state();
+
+    // Check that we reload at the correct version ...
+    assert_eq!(state1a.version(), 1);
+
+    // Check reads against state1a after reloading the DB
+    assert_eq!(state1a.get_raw("test").await?, None);
+    assert_eq!(state1a.get_raw("a/aaa").await?, None);
+    assert_eq!(state1a.get_raw("a/aa").await?, Some(b"aa".to_vec()));
+    assert_eq!(state1a.get_raw("a/ab").await?, Some(b"ab2".to_vec()));
+    assert_eq!(state1a.get_raw("a/z").await?, Some(b"z".to_vec()));
+    assert_eq!(state1a.get_raw("a/c").await?, Some(b"c".to_vec()));
+    let mut range = state1a.prefix_raw("a/");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/aa".to_owned(), b"aa".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/ab".to_owned(), b"ab2".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/c".to_owned(), b"c".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+
+    Ok(())
+}


### PR DESCRIPTION
Before starting the replacement of `storage` with `storage2`, it seems like a good idea to have an end-to-end integration test to check that the external API is usable on its own and that it appears to work correctly.

This PR does a docs/API pass on the external API, then adds the skeleton of a simple end-to-end test. The test is verbose but very explicit. (It does not currently pass).