### PR TITLE
crypto: remove Swap-specific wrapped OVK code (no longer used)

### DIFF
--- a/crypto/src/dex/swap.rs
+++ b/crypto/src/dex/swap.rs
@@ -19,8 +19,6 @@ pub const SWAP_CIPHERTEXT_BYTES: usize = 216;
 // Swap plaintext byte length
 pub const SWAP_LEN_BYTES: usize = 200;
 
-pub const OVK_WRAPPED_LEN_BYTES: usize = 80;
-
 pub static DOMAIN_SEPARATOR: Lazy<Fq> =
     Lazy::new(|| Fq::from_le_bytes_mod_order(blake2b_simd::blake2b(b"penumbra.swap").as_bytes()));
 


### PR DESCRIPTION
I noticed this just now when looking at #1571, I think `SwapPlaintext::encrypt_key` (and the corresponding constant) should've been removed as part of #1264 