### PR TITLE
storage2: add a transactional object store

### DIFF
--- a/storage2/src/snapshot.rs
+++ b/storage2/src/snapshot.rs
@@ -1,4 +1,4 @@
-use std::{pin::Pin, sync::Arc};
+use std::{any::Any, pin::Pin, sync::Arc};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -153,6 +153,19 @@ impl StateRead for Snapshot {
             .expect("should be able to spawn_blocking");
 
         Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx))
+    }
+
+    fn get_ephemeral<T: Any + Send + Sync>(&self, _key: &str) -> Option<&T> {
+        // No-op -- this will never be called internally, and `Snapshot` is not exposed in public API
+        None
+    }
+
+    fn prefix_ephemeral<'a, T: Any + Send + Sync>(
+        &'a self,
+        _prefix: &'a str,
+    ) -> Box<dyn Iterator<Item = (&'a str, &'a T)> + 'a> {
+        // No-op -- this will never be called internally, and `Snapshot` is not exposed in public API
+        Box::new(std::iter::empty())
     }
 }
 

--- a/storage2/src/state/transaction.rs
+++ b/storage2/src/state/transaction.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::Stream;
-use std::{collections::BTreeMap, pin::Pin};
+use std::{any::Any, cmp::Ordering, collections::BTreeMap, iter::Peekable, pin::Pin};
 
 use crate::State;
 
@@ -13,6 +13,8 @@ pub struct Transaction<'a> {
     pub(crate) unwritten_changes: BTreeMap<String, Option<Vec<u8>>>,
     /// Unwritten changes to non-consensus-critical state (stored in the nonconsensus storage).
     pub(crate) nonconsensus_changes: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
+    /// Unwritten changes to the object store.  A `None` value means a deletion.
+    pub(crate) object_changes: BTreeMap<String, Option<Box<dyn Any + Send + Sync>>>,
     state: &'a mut State,
 }
 
@@ -22,6 +24,7 @@ impl<'a> Transaction<'a> {
             state,
             unwritten_changes: BTreeMap::new(),
             nonconsensus_changes: BTreeMap::new(),
+            object_changes: BTreeMap::new(),
         }
     }
 
@@ -34,6 +37,17 @@ impl<'a> Transaction<'a> {
         self.state
             .nonconsensus_changes
             .extend(self.nonconsensus_changes);
+
+        for (k, v_or_deletion) in self.object_changes {
+            match v_or_deletion {
+                Some(v) => {
+                    self.state.ephemeral_objects.insert(k, v);
+                }
+                None => {
+                    self.state.ephemeral_objects.remove(&k);
+                }
+            }
+        }
     }
 
     /// Aborts this transaction, discarding its writes.
@@ -57,6 +71,14 @@ impl<'a> StateWrite for Transaction<'a> {
 
     fn put_nonconsensus(&mut self, key: Vec<u8>, value: Vec<u8>) {
         self.nonconsensus_changes.insert(key, Some(value));
+    }
+
+    fn put_ephemeral<T: Any + Send + Sync>(&mut self, key: String, value: T) {
+        self.object_changes.insert(key, Some(Box::new(value)));
+    }
+
+    fn delete_ephemeral(&mut self, key: String) {
+        self.object_changes.insert(key, None);
     }
 }
 
@@ -87,5 +109,99 @@ impl<'tx> StateRead for Transaction<'tx> {
         prefix: &'a str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, Vec<u8>)>> + Sync + Send + 'a>> {
         prefix_raw_with_cache(self.state, &self.unwritten_changes, prefix)
+    }
+
+    fn get_ephemeral<T: Any + Send + Sync>(&self, key: &str) -> Option<&T> {
+        if let Some(v_or_deletion) = self.object_changes.get(key) {
+            return v_or_deletion.as_ref().and_then(|v| v.downcast_ref());
+        }
+        self.state.get_ephemeral(key)
+    }
+
+    fn prefix_ephemeral<'a, T: Any + Send + Sync>(
+        &'a self,
+        prefix: &'a str,
+    ) -> Box<dyn Iterator<Item = (&'a str, &'a T)> + 'a> {
+        let changes: Box<dyn Iterator<Item = (&'a str, Option<&'a T>)>> = Box::new(
+            self.object_changes
+                .range(prefix.to_string()..)
+                .take_while(move |(k, _)| k.starts_with(prefix))
+                // We want changes to always cover the underlying store, so
+                // we treat a failed downcast_ref as a deletion.
+                .map(
+                    |(k, v)| match v.as_ref().and_then(|v| v.downcast_ref::<T>()) {
+                        Some(v) => (k.as_str(), Some(v)),
+                        None => (k.as_str(), None),
+                    },
+                ),
+        );
+
+        let changes = changes.peekable();
+        let underlying = self.state.prefix_ephemeral(prefix).peekable();
+
+        Box::new(MergedObjectIterator {
+            changes,
+            underlying,
+        })
+    }
+}
+
+struct MergedObjectIterator<'a, T: Any + Send + Sync> {
+    /// We want changes to always cover the underlying store, so we don't want to have
+    /// already pre-filtered with downcast_ref.
+    changes: Peekable<Box<dyn Iterator<Item = (&'a str, Option<&'a T>)> + 'a>>,
+    underlying: Peekable<Box<dyn Iterator<Item = (&'a str, &'a T)> + 'a>>,
+}
+
+impl<'a, T: Any + Send + Sync> Iterator for MergedObjectIterator<'a, T> {
+    type Item = (&'a str, &'a T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match (self.changes.peek(), self.underlying.peek()) {
+                (Some(c), Some(u)) => {
+                    // Use key ordering to determine which item to use next
+                    match c.0.cmp(u.0) {
+                        Ordering::Less => {
+                            // Draw from changes.
+                            match self.changes.next().expect("already peeked") {
+                                // The key is present, so yield it.
+                                (k, Some(v)) => return Some((k, v)),
+                                // The key has been deleted, so we want to skip it and continue merging.
+                                (_, None) => continue,
+                            }
+                        }
+                        Ordering::Equal => {
+                            // We need to advance both iterators, because we want to return only one
+                            // item per *distinct* key, with the `changes` shadowing the `underlying`.
+                            // Otherwise, we'd return the underlying value in the next iteration.
+                            let _ = self.underlying.next();
+                            match self.changes.next().expect("already peeked") {
+                                // The key is present, so yield it.
+                                (k, Some(v)) => return Some((k, v)),
+                                // The key has been deleted, so we want to skip it and continue merging.
+                                (_, None) => continue,
+                            }
+                        }
+                        Ordering::Greater => {
+                            return Some(self.underlying.next().expect("already peeked"))
+                        }
+                    }
+                }
+                (Some(_changed), None) => {
+                    // Draw from changes.
+                    match self.changes.next().expect("already peeked") {
+                        // The key is present, so yield it.
+                        (k, Some(v)) => return Some((k, v)),
+                        // The key has been deleted, so we want to skip it and continue merging.
+                        (_, None) => continue,
+                    }
+                }
+                (None, Some(_underlying)) => {
+                    return Some(self.underlying.next().expect("already peeked"))
+                }
+                (None, None) => return None,
+            }
+        }
     }
 }

--- a/storage2/src/state/write.rs
+++ b/storage2/src/state/write.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{any::Any, fmt::Debug};
 
 use penumbra_proto::{Message, Protobuf};
 
@@ -36,9 +36,15 @@ pub trait StateWrite {
     /// Delete a key from the verifiable key-value store.
     fn delete(&mut self, key: String);
 
+    /// Puts raw bytes into the non-verifiable key-value store with the given key.
+    fn put_nonconsensus(&mut self, key: Vec<u8>, value: Vec<u8>);
+
     /// Delete a key from non-verifiable key-value storage.
     fn delete_nonconsensus(&mut self, key: Vec<u8>);
 
-    /// Puts raw bytes into the non-verifiable key-value store with the given key.
-    fn put_nonconsensus(&mut self, key: Vec<u8>, value: Vec<u8>);
+    /// Puts an object into the ephemeral object store with the given key.
+    fn put_ephemeral<T: Any + Send + Sync>(&mut self, key: String, value: T);
+
+    /// Deletes a key from the ephemeral object store.
+    fn delete_ephemeral(&mut self, key: String);
 }


### PR DESCRIPTION
As discussed on Discord, we discovered a problematic interaction between the new execution model (where execution can be fallible, even after `check_tx_stateful`) and the existing Component design: now that any part of the execution can fail, it's not safe for the Components to modify any state except for through the StateTransaction, because any other component could error out, leaving data in an inconsistent state -- while the StateTransaction would roll back, any state in the Components wouldn't.

To fix this, we need to have the Components only make writes to the StateTransaction passed into them.  We don't want to be writing temporary data into the consensus state, but writing it into the nonconsensus state is also difficult, because the system would have to be careful to clean it all out before committing the state to persistent Storage.

Instead, we decided to add a third storage category: an ephemeral data store maintained by the State and StateTransaction, but which is not persisted to the underlying Storage.  Moreover, since we're never persisting the data, rather than making it a byte store, we decided to have it be an object store, recording `Box<dyn Any>`.  Downcasting is handled through generic parameters on the `get` and `put` methods.