### PR TITLE
Docker - cross-compile, scratch image, gh actions workflow

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,48 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    tags:
+    - '**'
+    branches:
+    - '**'
+
+jobs:
+  build-and-push-image:
+    runs-on: buildjet-16vcpu-ubuntu-2004
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/penumbra-zone/penumbra
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,151 @@
-FROM rust:latest as build
+FROM --platform=$BUILDPLATFORM rust:1-bullseye AS build-env
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --default-toolchain none -y
 RUN rustup component add rustfmt
-RUN apt-get update && apt-get install -y clang libclang-dev
+
+ARG TARGETARCH
+ARG BUILDARCH
+
+RUN apt update && apt install -y libclang-dev clang
+
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+      rustup target add aarch64-unknown-linux-gnu; \
+      if [ "${BUILDARCH}" != "arm64" ]; then \
+        dpkg --add-architecture arm64; \
+        apt update && apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu; \
+        ln -s /usr/aarch64-linux-gnu/include/bits /usr/include/bits; \
+        ln -s /usr/aarch64-linux-gnu/include/sys /usr/include/sys; \
+        ln -s /usr/aarch64-linux-gnu/include/gnu /usr/include/gnu; \
+      fi; \
+    elif [ "${TARGETARCH}" = "amd64" ]; then \
+      rustup target add x86_64-unknown-linux-gnu; \
+      if [ "${BUILDARCH}" != "amd64" ]; then \
+        dpkg --add-architecture amd64; apt update; \
+        apt update && apt install -y gcc-x86_64-linux-gnu g++-x86_64-linux-gnu; \
+        ln -s /usr/x86_64-linux-gnu/include/bits /usr/include/bits; \
+        ln -s /usr/x86_64-linux-gnu/include/sys /usr/include/sys; \
+        ln -s /usr/x86_64-linux-gnu/include/gnu /usr/include/gnu; \
+      fi; \
+    fi
 
 WORKDIR /usr/src
 
-COPY . .
+ADD . .
 
-# Fetch dependencies in a separate layer, so that they can be cached.
-RUN cargo fetch
+RUN if [ "$TARGETARCH" = "arm64" ] && [ "$BUILDARCH" != "arm64" ]; then \
+      cargo fetch --target aarch64-unknown-linux-gnu; \
+    elif [ "$TARGETARCH" = "amd64" ] && [ "$BUILDARCH" != "amd64" ]; then \
+      cargo fetch --target x86_64-unknown-linux-gnu; \
+    else \
+      cargo fetch --target $(uname -m)-unknown-linux-gnu; \
+    fi;
 
-RUN cargo build --bin pd --release && \
-    mkdir -p /out && \
-    mv target/release/pd /out/pd
+RUN if [ "$TARGETARCH" = "arm64" ] && [ "$BUILDARCH" != "arm64" ]; then \
+      export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+        CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+        CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
+        PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu; \
+      cargo build --release --target aarch64-unknown-linux-gnu; \
+    elif [ "$TARGETARCH" = "amd64" ] && [ "$BUILDARCH" != "amd64" ]; then \
+      export CARGO_TARGET_x86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc \
+        CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc \
+        CXX_x86_64_unknown_linux_gnu=x86_64-linux-gnu-g++ \
+        PKG_CONFIG_SYSROOT_DIR=/usr/x86_64-linux-gnu; \
+      cargo build --release --target x86_64-unknown-linux-gnu; \
+    else \
+      cargo build --release --target $(uname -m)-unknown-linux-gnu;\
+    fi;
 
-# Install the penumbra daemon into the runtime image.
+# Copy all binaries to /root/bin, for a single place to copy into final image.
+RUN mkdir /root/bin
+RUN cp /usr/src/target/${TARGETARCH}-unknown-linux-gnu/release/pd   /root/bin
+RUN cp /usr/src/target/${TARGETARCH}-unknown-linux-gnu/release/pcli /root/bin
 
-# TODO(eliza): it would be nice to be able to run the Penumbra daemon in a
-# `scratch` image rather than Debian or Alpine. However, then we'd have to build
-# with a statically linked libc (read: musl), and musl's malloc exhibits
-# pathologically poor performance for Tokio applications...
-FROM debian:bullseye-slim as runtime
+# Use minimal busybox from Strangelove infra-toolkit image for final scratch image
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.0.6 AS busybox-min
+RUN addgroup --gid 1000 -S penumbra && adduser --uid 1000 -S penumbra -G penumbra
+
+# Use ln and rm from full featured busybox for assembling final image
+FROM busybox:1.34.1-musl AS busybox-full
+
+# Use TARGETARCH image for determining necessary libs
+FROM rust:1-bullseye as target-arch-libs
+RUN apt update && apt install -y clang
+
+# Determine library dependencies of built binaries and copy to /root/lib_abs for copying to final image.
+COPY --from=build-env /root/bin /root/bin
+RUN mkdir -p /root/lib_abs && touch /root/lib_abs.list
+RUN bash -c \
+  'for BIN in /root/bin/*; do \
+    readarray -t LIBS < <(ldd "$BIN"); \
+    i=0; for LIB in "${LIBS[@]}"; do \
+      PATH1=$(echo $LIB | awk "{print \$1}") ; \
+      if [ "$PATH1" = "linux-vdso.so.1" ]; then continue; fi; \
+      PATH2=$(echo $LIB | awk "{print \$3}") ; \
+      if [ ! -z "$PATH2" ]; then \
+        cp $PATH2 /root/lib_abs/$i ; \
+        echo $PATH2 >> /root/lib_abs.list; \
+      else \
+        cp $PATH1 /root/lib_abs/$i ; \
+        echo $PATH1 >> /root/lib_abs.list; \
+      fi; \
+      ((i = i + 1)) ;\
+    done; \
+  done'
+
+# Build final image from scratch
+FROM scratch
+
+WORKDIR /bin
+
+# Install ln (for making hard links), rm (for cleanup), mv, mkdir, and dirname from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/dirname ./
+
+# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=busybox-min /busybox/busybox /bin/sh
+
+# Add hard links for read-only utils, then remove ln and rm
+# Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
+RUN ln sh pwd && \
+    ln sh ls && \
+    ln sh cat && \
+    ln sh less && \
+    ln sh grep && \
+    ln sh sleep && \
+    ln sh env && \
+    ln sh tar && \
+    ln sh tee && \
+    ln sh du
+
+# Install chain binaries
+COPY --from=build-env /root/bin /bin
+
+# Copy over libraries
+COPY --from=target-arch-libs /root/lib_abs /root/lib_abs
+COPY --from=target-arch-libs /root/lib_abs.list /root/lib_abs.list
+
+# Move libraries to their absolute locations.
+RUN sh -c 'i=0; while read FILE; do \
+      echo "$i: $FILE"; \
+      DIR="$(dirname "$FILE")"; \
+      mkdir -p "$DIR"; \
+      mv /root/lib_abs/$i $FILE; \
+      i=$((i+1)); \
+    done < /root/lib_abs.list'
+
+# Remove write utils used to construct image and tmp dir/file for lib copy.
+RUN rm -rf ln rm mv mkdir dirname /root/lib_abs /root/lib_abs.list
+
+# Install trusted CA certificates
+COPY --from=busybox-min /etc/ssl/cert.pem /etc/ssl/cert.pem
+
+# Install penumbra user
+COPY --from=busybox-min /etc/passwd /etc/passwd
+COPY --from=busybox-min --chown=1000:1000 /home/penumbra /home/penumbra
+
+WORKDIR /home/penumbra
+USER penumbra
+
 ARG DATABASE_URL
 ENV DATABASE_URL=$DATABASE_URL
-WORKDIR /penumbra
-COPY --from=build /out/pd /usr/bin/pd
 ENV RUST_LOG=warn,pd=info,penumbra=info
 CMD [ "/usr/bin/pd" ]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,11 +1,11 @@
-FROM rust:latest as build
+FROM rust:1-bullseye AS build-env
 
 # Specify the cargo cache dir as a volume to improve build speed
 VOLUME ["/root/.cargo"]
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --default-toolchain none -y
 RUN rustup component add rustfmt
-RUN apt-get update && apt-get install -y clang libclang-dev
+
+RUN apt update && apt install -y libclang-dev clang
 
 WORKDIR /usr/src
 
@@ -48,9 +48,9 @@ COPY .cargo ./.cargo
 # Sorry about all that mess ^, but it's worth it during development.
 
 # Fetch dependencies in a separate layer, so that they can be cached.
-RUN cargo fetch
+RUN cargo fetch --target $(uname -m)-unknown-linux-gnu
 
-RUN cargo build --release --bin pd
+RUN cargo build --release --bin pd --target $(uname -m)-unknown-linux-gnu
 
 # Remove the cached builds of internal packages.
 RUN rm -rf pcli pd crypto wallet config stake ibc component storage
@@ -58,21 +58,96 @@ RUN rm -rf pcli pd crypto wallet config stake ibc component storage
 # Copy the repo source now that dependencies have been built and cached.
 COPY . .
 
-# For dev leave off the `--release` flag as well for faster builds.
-RUN cargo build --release --bin pd && \
-    mkdir -p /out && \
-    mv target/release/pd /out/pd
+RUN cargo build --release --target $(uname -m)-unknown-linux-gnu
 
-# Install the penumbra daemon into the runtime image.
+# Copy all binaries to /root/bin, for a single place to copy into final image.
+RUN mkdir /root/bin
+RUN cp /usr/src/target/$(uname -m)-unknown-linux-gnu/release/pd   /root/bin
+RUN cp /usr/src/target/$(uname -m)-unknown-linux-gnu/release/pcli /root/bin
 
-# TODO(eliza): it would be nice to be able to run the Penumbra daemon in a
-# `scratch` image rather than Debian or Alpine. However, then we'd have to build
-# with a statically linked libc (read: musl), and musl's malloc exhibits
-# pathologically poor performance for Tokio applications...
-FROM debian:bullseye-slim as runtime
+# Determine library dependencies of built binaries and copy to /root/lib_abs for copying to final image.
+RUN mkdir -p /root/lib_abs && touch /root/lib_abs.list
+RUN bash -c \
+  'for BIN in /root/bin/*; do \
+    readarray -t LIBS < <(ldd "$BIN"); \
+    i=0; for LIB in "${LIBS[@]}"; do \
+      PATH1=$(echo $LIB | awk "{print \$1}") ; \
+      if [ "$PATH1" = "linux-vdso.so.1" ]; then continue; fi; \
+      PATH2=$(echo $LIB | awk "{print \$3}") ; \
+      if [ ! -z "$PATH2" ]; then \
+        cp $PATH2 /root/lib_abs/$i ; \
+        echo $PATH2 >> /root/lib_abs.list; \
+      else \
+        cp $PATH1 /root/lib_abs/$i ; \
+        echo $PATH1 >> /root/lib_abs.list; \
+      fi; \
+      ((i = i + 1)) ;\
+    done; \
+  done'
+
+# Use minimal busybox from infra-toolkit image for final scratch image
+FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.0.6 AS busybox-min
+RUN addgroup --gid 1000 -S penumbra && adduser --uid 1000 -S penumbra -G penumbra
+
+# Use ln and rm from full featured busybox for assembling final image
+FROM busybox:1.34.1-musl AS busybox-full
+
+# Build final image from scratch
+FROM scratch
+
+LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/penumbra"
+
+WORKDIR /bin
+
+# Install ln (for making hard links), rm (for cleanup), mv, mkdir, and dirname from full busybox image (will be deleted, only needed for image assembly)
+COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/dirname ./
+
+# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
+COPY --from=busybox-min /busybox/busybox /bin/sh
+
+# Add hard links for read-only utils, then remove ln and rm
+# Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
+RUN ln sh pwd && \
+    ln sh ls && \
+    ln sh cat && \
+    ln sh less && \
+    ln sh grep && \
+    ln sh sleep && \
+    ln sh env && \
+    ln sh tar && \
+    ln sh tee && \
+    ln sh du
+
+# Install chain binaries
+COPY --from=build-env /root/bin /bin
+
+# Copy over libraries
+COPY --from=build-env /root/lib_abs /root/lib_abs
+COPY --from=build-env /root/lib_abs.list /root/lib_abs.list
+
+# Move libraries to their absolute locations.
+RUN sh -c 'i=0; while read FILE; do \
+      echo "$i: $FILE"; \
+      DIR="$(dirname "$FILE")"; \
+      mkdir -p "$DIR"; \
+      mv /root/lib_abs/$i $FILE; \
+      i=$((i+1)); \
+    done < /root/lib_abs.list'
+
+# Remove write utils used to construct image and tmp dir/file for lib copy.
+RUN rm -rf ln rm mv mkdir dirname /root/lib_abs /root/lib_abs.list
+
+# Install trusted CA certificates
+COPY --from=busybox-min /etc/ssl/cert.pem /etc/ssl/cert.pem
+
+# Install penumbra user
+COPY --from=busybox-min /etc/passwd /etc/passwd
+COPY --from=busybox-min --chown=1000:1000 /home/penumbra /home/penumbra
+
+WORKDIR /home/penumbra
+USER penumbra
+
 ARG DATABASE_URL
 ENV DATABASE_URL=$DATABASE_URL
-WORKDIR /penumbra
-COPY --from=build /out/pd /usr/bin/pd
 ENV RUST_LOG=warn,pd=info,penumbra=info
 CMD [ "RUST_BACKTRACE=1 /usr/bin/pd" ]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,7 @@ VOLUME ["/root/.cargo"]
 
 RUN rustup component add rustfmt
 
-RUN apt update && apt install -y libclang-dev clang
+RUN apt update && apt install -y libclang-dev clang libssl1.1 libssl-dev openssl
 
 WORKDIR /usr/src
 
@@ -62,10 +62,12 @@ RUN cargo build --release --target $(uname -m)-unknown-linux-gnu
 
 # Copy all binaries to /root/bin, for a single place to copy into final image.
 RUN mkdir /root/bin
-RUN cp /usr/src/target/$(uname -m)-unknown-linux-gnu/release/pd   /root/bin
-RUN cp /usr/src/target/$(uname -m)-unknown-linux-gnu/release/pcli /root/bin
+RUN cp /usr/src/target/$(uname -m)-unknown-linux-gnu/release/pcli \
+      /usr/src/target/$(uname -m)-unknown-linux-gnu/release/pd \
+      /root/bin
 
-# Determine library dependencies of built binaries and copy to /root/lib_abs for copying to final image.
+# Determine library dependencies of built binaries and copy to indexed path in /root/lib_abs for copying to final image.
+# Absolute path of each library is appended to /root/lib_abs.list for restoring in final image.
 RUN mkdir -p /root/lib_abs && touch /root/lib_abs.list
 RUN bash -c \
   'for BIN in /root/bin/*; do \
@@ -85,7 +87,7 @@ RUN bash -c \
     done; \
   done'
 
-# Use minimal busybox from infra-toolkit image for final scratch image
+# Use minimal busybox from Strangelove infra-toolkit image for final scratch image
 FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.0.6 AS busybox-min
 RUN addgroup --gid 1000 -S penumbra && adduser --uid 1000 -S penumbra -G penumbra
 
@@ -94,8 +96,6 @@ FROM busybox:1.34.1-musl AS busybox-full
 
 # Build final image from scratch
 FROM scratch
-
-LABEL org.opencontainers.image.source="https://github.com/strangelove-ventures/penumbra"
 
 WORKDIR /bin
 


### PR DESCRIPTION
Resolves #1292 

Updates `Dockerfile` and `Dockerfile.dev` to use scratch image for final image with minimal necessary bins, libs, CA root trust, and `penumbra` `1000:1000` user

Final distributed images have a minimal shell and minimal utilities, sourced from https://github.com/strangelove-ventures/infra-toolkit

Modifies `Dockerfile` for use with buildkit/buildx to support `linux/amd64` and `linux/arm64` platforms, cross-compiling for non-native architecture. This results in a quick builds due to no QEMU emulation necessary and multi-arch docker image manifests for the image tags in the container repository

Example: tag for this PR:
https://github.com/penumbra-zone/penumbra/pkgs/container/penumbra/48612389?tag=strangelove-docker_image_publish

See new workflow below, an image will be built for every push.
![image](https://user-images.githubusercontent.com/6722152/199650460-44ab1c87-6475-4a24-b5e5-71c698c378c0.png)
