### PR TITLE
Make TCT internally clone-on-write for cheap in-memory checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2148,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "serde",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "include-flate"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3407,6 +3431,7 @@ dependencies = [
  "futures",
  "hash_hasher",
  "hex",
+ "im",
  "once_cell",
  "parking_lot 0.12.1",
  "penumbra-proto",
@@ -3991,6 +4016,15 @@ name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core",
 ]
@@ -4602,6 +4636,16 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "sketches-ddsketch"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
+name = "archery"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a8da9bc4c4053ee067669762bcaeea6e241841295a2b6c948312dad6ef4cc02"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "ark-bls12-377"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,15 +567,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "bitvec"
@@ -2148,21 +2148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "serde",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "include-flate"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,6 +3404,7 @@ dependencies = [
 name = "penumbra-tct"
 version = "0.1.0"
 dependencies = [
+ "archery",
  "ark-ed-on-bls12-377",
  "ark-ff",
  "ark-serialize",
@@ -3431,7 +3417,6 @@ dependencies = [
  "futures",
  "hash_hasher",
  "hex",
- "im",
  "once_cell",
  "parking_lot 0.12.1",
  "penumbra-proto",
@@ -3440,6 +3425,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand",
+ "rpds",
  "serde",
  "serde_json",
  "static_assertions",
@@ -4021,15 +4007,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "raw-cpuid"
 version = "10.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4192,6 +4169,16 @@ checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rpds"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66262ea963eff99163e6b741fbc3417a52cc13074728c1047e9911789df9b000"
+dependencies = [
+ "archery",
+ "serde",
 ]
 
 [[package]]
@@ -4636,16 +4623,6 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "sketches-ddsketch"

--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"] // required for TCT
-
 use anyhow::Result;
 use async_trait::async_trait;
 use penumbra_chain::genesis;

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -1,5 +1,3 @@
-// Rust analyzer complains without this (but rustc is happy regardless)
-#![recursion_limit = "256"]
 #![allow(clippy::clone_on_copy)]
 use std::fs;
 

--- a/pd/src/lib.rs
+++ b/pd/src/lib.rs
@@ -1,7 +1,4 @@
 //! Source code for the Penumbra node software.
-
-// This is for the async_stream macros
-#![recursion_limit = "512"]
 #![allow(clippy::clone_on_copy)]
 
 mod consensus;

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::clone_on_copy)]
-#![recursion_limit = "256"]
 use std::{
     net::{Ipv4Addr, SocketAddr},
     path::PathBuf,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,6 +1,3 @@
-// Required to ensure that Rust can infer a Send bound inside the TCT
-#![recursion_limit = "256"]
-
 use jmt::WriteOverlay;
 use std::sync::Arc;
 use tokio::sync::RwLock;

--- a/tct-property-test/tests/serialize.rs
+++ b/tct-property-test/tests/serialize.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"]
-
 #[macro_use]
 extern crate proptest_derive;
 

--- a/tct-visualize/src/bin/tct-live-edit.rs
+++ b/tct-visualize/src/bin/tct-live-edit.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"]
-
 use std::{path::PathBuf, sync::Arc};
 
 use axum::{headers::ContentType, routing::get, Router, TypedHeader};

--- a/tct-visualize/src/bin/tct-visualize.rs
+++ b/tct-visualize/src/bin/tct-visualize.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"]
-
 use std::{
     borrow::Cow,
     collections::BTreeMap,

--- a/tct-visualize/src/lib.rs
+++ b/tct-visualize/src/lib.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"]
-
 #[macro_use]
 extern crate serde;
 

--- a/tct-visualize/src/live/query.rs
+++ b/tct-visualize/src/live/query.rs
@@ -84,7 +84,7 @@ pub(super) fn frontier_hashes(tree: &Tree) -> Vec<Option<Hash>> {
     fn inner(frontier: &mut Vec<Option<Hash>>, node: structure::Node) {
         frontier.push(node.cached_hash());
         if let Some(rightmost) = node.children().last() {
-            inner(frontier, *rightmost);
+            inner(frontier, rightmost.clone());
         }
     }
 

--- a/tct/Cargo.toml
+++ b/tct/Cargo.toml
@@ -14,7 +14,7 @@ blake2b_simd = "1"
 hex = "0.4"
 hash_hasher = "2"
 thiserror = "1"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 parking_lot = "0.12"
 ark-ff = "0.3"
 ark-serialize = "0.3"
@@ -26,7 +26,7 @@ async-stream = "0.3"
 futures = "0.3"
 ark-ed-on-bls12-377 = "0.3"
 rand = "0.8"
-im = { version = "^15.1.0", features = ["serde"] } # IMPORTANT: an OrdMap correctness bug was fixed in 15.1.0
+im = { version = "^15.1.0", features = ["serde"] } # IMPORTANT: an OrdMap correctness bug was fixed in 15.1.0, as well as a performance improvement to `union`
 
 # Dependencies for random testing
 proptest = { version = "1", optional = true }

--- a/tct/Cargo.toml
+++ b/tct/Cargo.toml
@@ -26,7 +26,8 @@ async-stream = "0.3"
 futures = "0.3"
 ark-ed-on-bls12-377 = "0.3"
 rand = "0.8"
-im = { version = "^15.1.0", features = ["serde"] } # IMPORTANT: an OrdMap correctness bug was fixed in 15.1.0, as well as a performance improvement to `union`
+rpds = { version = "0.12", features = ["serde"] }
+archery = { version = "0.4" }
 
 # Dependencies for random testing
 proptest = { version = "1", optional = true }

--- a/tct/Cargo.toml
+++ b/tct/Cargo.toml
@@ -26,6 +26,7 @@ async-stream = "0.3"
 futures = "0.3"
 ark-ed-on-bls12-377 = "0.3"
 rand = "0.8"
+im = { version = "^15.1.0", features = ["serde"] } # IMPORTANT: an OrdMap correctness bug was fixed in 15.1.0
 
 # Dependencies for random testing
 proptest = { version = "1", optional = true }

--- a/tct/src/internal/complete/item.rs
+++ b/tct/src/internal/complete/item.rs
@@ -1,7 +1,9 @@
+use archery::SharedPointerKind;
+
 use crate::prelude::*;
 
 /// A witnessed hash of a commitment at the true leaf of a complete tree.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Derivative, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Derivative)]
 pub struct Item {
     hash: Hash,
     commitment: Commitment,
@@ -59,7 +61,7 @@ impl GetPosition for Item {
     }
 }
 
-impl<'tree> structure::Any<'tree> for Item {
+impl<RefKind: SharedPointerKind> structure::Any<RefKind> for Item {
     fn kind(&self) -> Kind {
         Kind::Leaf {
             commitment: Some(self.commitment),
@@ -74,7 +76,7 @@ impl<'tree> structure::Any<'tree> for Item {
         Forgotten::default()
     }
 
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
+    fn children(&self) -> Vec<Node<RefKind>> {
         vec![]
     }
 }

--- a/tct/src/internal/complete/leaf.rs
+++ b/tct/src/internal/complete/leaf.rs
@@ -1,7 +1,9 @@
+use archery::SharedPointerKind;
+
 use crate::prelude::*;
 
 /// A complete, witnessed leaf of a tree.
-#[derive(Clone, Copy, Derivative, Serialize, Deserialize)]
+#[derive(Clone, Copy, Derivative)]
 #[derivative(Debug = "transparent")]
 pub struct Leaf<Item>(pub(in super::super) Item);
 
@@ -56,7 +58,9 @@ impl<Item> GetPosition for Leaf<Item> {
     }
 }
 
-impl<'tree, Item: Height + structure::Any<'tree>> structure::Any<'tree> for Leaf<Item> {
+impl<Item: Height + structure::Any<RefKind>, RefKind: SharedPointerKind> structure::Any<RefKind>
+    for Leaf<Item>
+{
     fn kind(&self) -> Kind {
         self.0.kind()
     }
@@ -69,7 +73,7 @@ impl<'tree, Item: Height + structure::Any<'tree>> structure::Any<'tree> for Leaf
         self.0.forgotten()
     }
 
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
+    fn children(&self) -> Vec<Node<RefKind>> {
         self.0.children()
     }
 }

--- a/tct/src/internal/complete/node.rs
+++ b/tct/src/internal/complete/node.rs
@@ -10,7 +10,7 @@ pub use children::Children;
 /// A complete sparse node in a tree, storing only the witnessed subtrees.
 #[derive(Derivative, Debug)]
 #[derivative(Clone(bound = "Child: Clone"))]
-pub struct Node<Child: Clone, RefKind: SharedPointerKind> {
+pub struct Node<Child: Clone, RefKind: SharedPointerKind = archery::ArcK> {
     hash: Hash,
     forgotten: [Forgotten; 4],
     children: Children<Child, RefKind>,
@@ -173,7 +173,7 @@ impl<Child: Clone, RefKind: SharedPointerKind> GetPosition for Node<Child, RefKi
     }
 }
 
-impl<Child: Height + structure::Any<RefKind> + Clone, RefKind: SharedPointerKind>
+impl<Child: Height + structure::Any<RefKind> + Clone + 'static, RefKind: SharedPointerKind>
     structure::Any<RefKind> for Node<Child, RefKind>
 {
     fn kind(&self) -> Kind {

--- a/tct/src/internal/complete/node.rs
+++ b/tct/src/internal/complete/node.rs
@@ -326,6 +326,6 @@ mod test {
 
     #[test]
     fn check_node_size() {
-        static_assertions::assert_eq_size!(Node<()>, [u8; 80]);
+        static_assertions::assert_eq_size!(Node<()>, [u8; 72]);
     }
 }

--- a/tct/src/internal/complete/node/children.rs
+++ b/tct/src/internal/complete/node/children.rs
@@ -55,6 +55,9 @@ pub enum Children<Child, RefKind: SharedPointerKind> {
     CCCC(SharedPointer<CCCC<Child>, RefKind>),
 }
 
+unsafe impl<Child: Send, RefKind: Send + SharedPointerKind> Send for Children<Child, RefKind> {}
+unsafe impl<Child: Sync, RefKind: Sync + SharedPointerKind> Sync for Children<Child, RefKind> {}
+
 impl<Child: Debug + Clone, RefKind: SharedPointerKind> Debug for Children<Child, RefKind> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.children().fmt(f)

--- a/tct/src/internal/complete/node/children.rs
+++ b/tct/src/internal/complete/node/children.rs
@@ -10,7 +10,7 @@
 
 #![allow(non_camel_case_types, clippy::upper_case_acronyms)]
 
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 mod shape;
 pub use shape::*;
@@ -21,38 +21,38 @@ use crate::prelude::*;
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Children<Child> {
     /// Children of a node having children in the positions: 3.
-    ___C(Box<___C<Child>>),
+    ___C(Arc<___C<Child>>),
     /// Children of a node having children in the positions: 2.
-    __C_(Box<__C_<Child>>),
+    __C_(Arc<__C_<Child>>),
     /// Children of a node having children in the positions: 2, 3.
-    __CC(Box<__CC<Child>>),
+    __CC(Arc<__CC<Child>>),
     /// Children of a node having children in the positions: 1.
-    _C__(Box<_C__<Child>>),
+    _C__(Arc<_C__<Child>>),
     /// Children of a node having children in the positions: 1, 3.
-    _C_C(Box<_C_C<Child>>),
+    _C_C(Arc<_C_C<Child>>),
     /// Children of a node having children in the positions: 1, 2.
-    _CC_(Box<_CC_<Child>>),
+    _CC_(Arc<_CC_<Child>>),
     /// Children of a node having children in the positions: 1, 2, 3.
-    _CCC(Box<_CCC<Child>>),
+    _CCC(Arc<_CCC<Child>>),
     /// Children of a node having children in the positions: 0.
-    C___(Box<C___<Child>>),
+    C___(Arc<C___<Child>>),
     /// Children of a node having children in the positions: 0, 3.
-    C__C(Box<C__C<Child>>),
+    C__C(Arc<C__C<Child>>),
     /// Children of a node having children in the positions: 0, 2.
-    C_C_(Box<C_C_<Child>>),
+    C_C_(Arc<C_C_<Child>>),
     /// Children of a node having children in the positions: 0, 2, 3.
-    C_CC(Box<C_CC<Child>>),
+    C_CC(Arc<C_CC<Child>>),
     /// Children of a node having children in the positions: 0, 1.
-    CC__(Box<CC__<Child>>),
+    CC__(Arc<CC__<Child>>),
     /// Children of a node having children in the positions: 0, 1, 3.
-    CC_C(Box<CC_C<Child>>),
+    CC_C(Arc<CC_C<Child>>),
     /// Children of a node having children in the positions: 0, 1, 2.
-    CCC_(Box<CCC_<Child>>),
+    CCC_(Arc<CCC_<Child>>),
     /// Children of a node having children in the positions: 0, 1, 2, 3.
-    CCCC(Box<CCCC<Child>>),
+    CCCC(Arc<CCCC<Child>>),
 }
 
-impl<Child: Debug> Debug for Children<Child> {
+impl<Child: Debug + Clone> Debug for Children<Child> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.children().fmt(f)
     }
@@ -62,7 +62,7 @@ impl<Child: Height> Height for Children<Child> {
     type Height = Succ<<Child as Height>::Height>;
 }
 
-impl<Child: Height + GetHash> GetHash for Children<Child> {
+impl<Child: Height + GetHash + Clone> GetHash for Children<Child> {
     fn hash(&self) -> Hash {
         let [a, b, c, d] = self.children().map(|x| x.hash());
         Hash::node(<Self as Height>::Height::HEIGHT, a, b, c, d)
@@ -88,26 +88,26 @@ where
             // hashes so the parent can implement pruning):
             [Hash(a), Hash(b), Hash(c), Hash(d)] => return Err([a, b, c, d]),
             // There is at least one witnessed child:
-            [Hash(a), Hash(b), Hash(c), Keep(d)] => Children::___C(Box::new(___C(a, b, c, d))),
-            [Hash(a), Hash(b), Keep(c), Hash(d)] => Children::__C_(Box::new(__C_(a, b, c, d))),
-            [Hash(a), Hash(b), Keep(c), Keep(d)] => Children::__CC(Box::new(__CC(a, b, c, d))),
-            [Hash(a), Keep(b), Hash(c), Hash(d)] => Children::_C__(Box::new(_C__(a, b, c, d))),
-            [Hash(a), Keep(b), Hash(c), Keep(d)] => Children::_C_C(Box::new(_C_C(a, b, c, d))),
-            [Hash(a), Keep(b), Keep(c), Hash(d)] => Children::_CC_(Box::new(_CC_(a, b, c, d))),
-            [Hash(a), Keep(b), Keep(c), Keep(d)] => Children::_CCC(Box::new(_CCC(a, b, c, d))),
-            [Keep(a), Hash(b), Hash(c), Hash(d)] => Children::C___(Box::new(C___(a, b, c, d))),
-            [Keep(a), Hash(b), Hash(c), Keep(d)] => Children::C__C(Box::new(C__C(a, b, c, d))),
-            [Keep(a), Hash(b), Keep(c), Hash(d)] => Children::C_C_(Box::new(C_C_(a, b, c, d))),
-            [Keep(a), Hash(b), Keep(c), Keep(d)] => Children::C_CC(Box::new(C_CC(a, b, c, d))),
-            [Keep(a), Keep(b), Hash(c), Hash(d)] => Children::CC__(Box::new(CC__(a, b, c, d))),
-            [Keep(a), Keep(b), Hash(c), Keep(d)] => Children::CC_C(Box::new(CC_C(a, b, c, d))),
-            [Keep(a), Keep(b), Keep(c), Hash(d)] => Children::CCC_(Box::new(CCC_(a, b, c, d))),
-            [Keep(a), Keep(b), Keep(c), Keep(d)] => Children::CCCC(Box::new(CCCC(a, b, c, d))),
+            [Hash(a), Hash(b), Hash(c), Keep(d)] => Children::___C(Arc::new(___C(a, b, c, d))),
+            [Hash(a), Hash(b), Keep(c), Hash(d)] => Children::__C_(Arc::new(__C_(a, b, c, d))),
+            [Hash(a), Hash(b), Keep(c), Keep(d)] => Children::__CC(Arc::new(__CC(a, b, c, d))),
+            [Hash(a), Keep(b), Hash(c), Hash(d)] => Children::_C__(Arc::new(_C__(a, b, c, d))),
+            [Hash(a), Keep(b), Hash(c), Keep(d)] => Children::_C_C(Arc::new(_C_C(a, b, c, d))),
+            [Hash(a), Keep(b), Keep(c), Hash(d)] => Children::_CC_(Arc::new(_CC_(a, b, c, d))),
+            [Hash(a), Keep(b), Keep(c), Keep(d)] => Children::_CCC(Arc::new(_CCC(a, b, c, d))),
+            [Keep(a), Hash(b), Hash(c), Hash(d)] => Children::C___(Arc::new(C___(a, b, c, d))),
+            [Keep(a), Hash(b), Hash(c), Keep(d)] => Children::C__C(Arc::new(C__C(a, b, c, d))),
+            [Keep(a), Hash(b), Keep(c), Hash(d)] => Children::C_C_(Arc::new(C_C_(a, b, c, d))),
+            [Keep(a), Hash(b), Keep(c), Keep(d)] => Children::C_CC(Arc::new(C_CC(a, b, c, d))),
+            [Keep(a), Keep(b), Hash(c), Hash(d)] => Children::CC__(Arc::new(CC__(a, b, c, d))),
+            [Keep(a), Keep(b), Hash(c), Keep(d)] => Children::CC_C(Arc::new(CC_C(a, b, c, d))),
+            [Keep(a), Keep(b), Keep(c), Hash(d)] => Children::CCC_(Arc::new(CCC_(a, b, c, d))),
+            [Keep(a), Keep(b), Keep(c), Keep(d)] => Children::CCCC(Arc::new(CCCC(a, b, c, d))),
         })
     }
 }
 
-impl<Child> Children<Child> {
+impl<Child: Clone> Children<Child> {
     /// Get an array of references to the children or hashes stored in this [`Children`].
     pub fn children(&self) -> [Insert<&Child>; 4] {
         use Children::*;
@@ -138,122 +138,192 @@ impl<Child> Children<Child> {
         use InsertMut::*;
 
         match self {
-            ___C(c) => [
-                Hash(&mut c.0),
-                Hash(&mut c.1),
-                Hash(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            __C_(c) => [
-                Hash(&mut c.0),
-                Hash(&mut c.1),
-                Keep(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            __CC(c) => [
-                Hash(&mut c.0),
-                Hash(&mut c.1),
-                Keep(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            _C__(c) => [
-                Hash(&mut c.0),
-                Keep(&mut c.1),
-                Hash(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            _C_C(c) => [
-                Hash(&mut c.0),
-                Keep(&mut c.1),
-                Hash(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            _CC_(c) => [
-                Hash(&mut c.0),
-                Keep(&mut c.1),
-                Keep(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            _CCC(c) => [
-                Hash(&mut c.0),
-                Keep(&mut c.1),
-                Keep(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            C___(c) => [
-                Keep(&mut c.0),
-                Hash(&mut c.1),
-                Hash(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            C__C(c) => [
-                Keep(&mut c.0),
-                Hash(&mut c.1),
-                Hash(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            C_C_(c) => [
-                Keep(&mut c.0),
-                Hash(&mut c.1),
-                Keep(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            C_CC(c) => [
-                Keep(&mut c.0),
-                Hash(&mut c.1),
-                Keep(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            CC__(c) => [
-                Keep(&mut c.0),
-                Keep(&mut c.1),
-                Hash(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            CC_C(c) => [
-                Keep(&mut c.0),
-                Keep(&mut c.1),
-                Hash(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            CCC_(c) => [
-                Keep(&mut c.0),
-                Keep(&mut c.1),
-                Keep(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            CCCC(c) => [
-                Keep(&mut c.0),
-                Keep(&mut c.1),
-                Keep(&mut c.2),
-                Keep(&mut c.3),
-            ],
+            ___C(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Hash(&mut c.1),
+                    Hash(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            __C_(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Hash(&mut c.1),
+                    Keep(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            __CC(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Hash(&mut c.1),
+                    Keep(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            _C__(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Keep(&mut c.1),
+                    Hash(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            _C_C(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Keep(&mut c.1),
+                    Hash(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            _CC_(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Keep(&mut c.1),
+                    Keep(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            _CCC(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Keep(&mut c.1),
+                    Keep(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            C___(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Hash(&mut c.1),
+                    Hash(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            C__C(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Hash(&mut c.1),
+                    Hash(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            C_C_(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Hash(&mut c.1),
+                    Keep(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            C_CC(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Hash(&mut c.1),
+                    Keep(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            CC__(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Keep(&mut c.1),
+                    Hash(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            CC_C(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Keep(&mut c.1),
+                    Hash(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            CCC_(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Keep(&mut c.1),
+                    Keep(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            CCCC(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Keep(&mut c.1),
+                    Keep(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
         }
     }
 }
 
-impl<Child> From<Children<Child>> for [Insert<Child>; 4] {
+impl<Child: Clone> From<Children<Child>> for [Insert<Child>; 4] {
     /// Get an array of references to the children or hashes stored in this [`Children`].
     fn from(children: Children<Child>) -> [Insert<Child>; 4] {
         use Children::*;
         use Insert::*;
 
         match children {
-            ___C(c) => [Hash(c.0), Hash(c.1), Hash(c.2), Keep(c.3)],
-            __C_(c) => [Hash(c.0), Hash(c.1), Keep(c.2), Hash(c.3)],
-            __CC(c) => [Hash(c.0), Hash(c.1), Keep(c.2), Keep(c.3)],
-            _C__(c) => [Hash(c.0), Keep(c.1), Hash(c.2), Hash(c.3)],
-            _C_C(c) => [Hash(c.0), Keep(c.1), Hash(c.2), Keep(c.3)],
-            _CC_(c) => [Hash(c.0), Keep(c.1), Keep(c.2), Hash(c.3)],
-            _CCC(c) => [Hash(c.0), Keep(c.1), Keep(c.2), Keep(c.3)],
-            C___(c) => [Keep(c.0), Hash(c.1), Hash(c.2), Hash(c.3)],
-            C__C(c) => [Keep(c.0), Hash(c.1), Hash(c.2), Keep(c.3)],
-            C_C_(c) => [Keep(c.0), Hash(c.1), Keep(c.2), Hash(c.3)],
-            C_CC(c) => [Keep(c.0), Hash(c.1), Keep(c.2), Keep(c.3)],
-            CC__(c) => [Keep(c.0), Keep(c.1), Hash(c.2), Hash(c.3)],
-            CC_C(c) => [Keep(c.0), Keep(c.1), Hash(c.2), Keep(c.3)],
-            CCC_(c) => [Keep(c.0), Keep(c.1), Keep(c.2), Hash(c.3)],
-            CCCC(c) => [Keep(c.0), Keep(c.1), Keep(c.2), Keep(c.3)],
+            ___C(c) => [Hash(c.0), Hash(c.1), Hash(c.2), Keep(c.3.clone())],
+            __C_(c) => [Hash(c.0), Hash(c.1), Keep(c.2.clone()), Hash(c.3)],
+            __CC(c) => [Hash(c.0), Hash(c.1), Keep(c.2.clone()), Keep(c.3.clone())],
+            _C__(c) => [Hash(c.0), Keep(c.1.clone()), Hash(c.2), Hash(c.3)],
+            _C_C(c) => [Hash(c.0), Keep(c.1.clone()), Hash(c.2), Keep(c.3.clone())],
+            _CC_(c) => [Hash(c.0), Keep(c.1.clone()), Keep(c.2.clone()), Hash(c.3)],
+            _CCC(c) => [
+                Hash(c.0),
+                Keep(c.1.clone()),
+                Keep(c.2.clone()),
+                Keep(c.3.clone()),
+            ],
+            C___(c) => [Keep(c.0.clone()), Hash(c.1), Hash(c.2), Hash(c.3)],
+            C__C(c) => [Keep(c.0.clone()), Hash(c.1), Hash(c.2), Keep(c.3.clone())],
+            C_C_(c) => [Keep(c.0.clone()), Hash(c.1), Keep(c.2.clone()), Hash(c.3)],
+            C_CC(c) => [
+                Keep(c.0.clone()),
+                Hash(c.1),
+                Keep(c.2.clone()),
+                Keep(c.3.clone()),
+            ],
+            CC__(c) => [Keep(c.0.clone()), Keep(c.1.clone()), Hash(c.2), Hash(c.3)],
+            CC_C(c) => [
+                Keep(c.0.clone()),
+                Keep(c.1.clone()),
+                Hash(c.2),
+                Keep(c.3.clone()),
+            ],
+            CCC_(c) => [
+                Keep(c.0.clone()),
+                Keep(c.1.clone()),
+                Keep(c.2.clone()),
+                Hash(c.3),
+            ],
+            CCCC(c) => [
+                Keep(c.0.clone()),
+                Keep(c.1.clone()),
+                Keep(c.2.clone()),
+                Keep(c.3.clone()),
+            ],
         }
     }
 }

--- a/tct/src/internal/complete/node/children/shape.rs
+++ b/tct/src/internal/complete/node/children/shape.rs
@@ -5,61 +5,61 @@
 use crate::prelude::*;
 
 /// Children of a node having children in the positions: 3.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ___C<Child>(pub Hash, pub Hash, pub Hash, pub Child);
 
 /// Children of a node having children in the positions: 2.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct __C_<Child>(pub Hash, pub Hash, pub Child, pub Hash);
 
 /// Children of a node having children in the positions: 2, 3.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct __CC<Child>(pub Hash, pub Hash, pub Child, pub Child);
 
 /// Children of a node having children in the positions: 1.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct _C__<Child>(pub Hash, pub Child, pub Hash, pub Hash);
 
 /// Children of a node having children in the positions: 1, 3.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct _C_C<Child>(pub Hash, pub Child, pub Hash, pub Child);
 
 /// Children of a node having children in the positions: 1, 2.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct _CC_<Child>(pub Hash, pub Child, pub Child, pub Hash);
 
 /// Children of a node having children in the positions: 1, 2, 3.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct _CCC<Child>(pub Hash, pub Child, pub Child, pub Child);
 
 /// Children of a node having children in the positions: 0.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct C___<Child>(pub Child, pub Hash, pub Hash, pub Hash);
 
 /// Children of a node having children in the positions: 0, 3.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct C__C<Child>(pub Child, pub Hash, pub Hash, pub Child);
 
 /// Children of a node having children in the positions: 0, 2.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct C_C_<Child>(pub Child, pub Hash, pub Child, pub Hash);
 
 /// Children of a node having children in the positions: 0, 2, 3.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct C_CC<Child>(pub Child, pub Hash, pub Child, pub Child);
 
 /// Children of a node having children in the positions: 0, 1.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CC__<Child>(pub Child, pub Child, pub Hash, pub Hash);
 
 /// Children of a node having children in the positions: 0, 1, 3.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CC_C<Child>(pub Child, pub Child, pub Hash, pub Child);
 
 /// Children of a node having children in the positions: 0, 1, 2.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CCC_<Child>(pub Child, pub Child, pub Child, pub Hash);
 
 /// Children of a node having children in the positions: 0, 1, 2, 3.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CCCC<Child>(pub Child, pub Child, pub Child, pub Child);

--- a/tct/src/internal/complete/tier.rs
+++ b/tct/src/internal/complete/tier.rs
@@ -12,7 +12,7 @@ pub type Nested<Item, R> = N<N<N<N<N<N<N<N<L<Item>, R>, R>, R>, R>, R>, R>, R>, 
 /// A complete tier of the tiered commitment tree, being an 8-deep sparse quad-tree.
 #[derive(Derivative, Debug)]
 #[derivative(Clone(bound = "Item: Clone"))]
-pub struct Tier<Item: GetHash + Height + Clone, RefKind: SharedPointerKind> {
+pub struct Tier<Item: GetHash + Height + Clone, RefKind: SharedPointerKind = archery::ArcK> {
     pub(in super::super) inner: Nested<Item, RefKind>,
 }
 
@@ -77,8 +77,10 @@ impl<Item: GetHash + Height + Clone, RefKind: SharedPointerKind> GetPosition
     }
 }
 
-impl<Item: Height + structure::Any<RefKind> + Clone, RefKind: SharedPointerKind>
-    structure::Any<RefKind> for Tier<Item, RefKind>
+impl<
+        Item: Height + structure::Any<RefKind> + Clone + 'static,
+        RefKind: SharedPointerKind + 'static,
+    > structure::Any<RefKind> for Tier<Item, RefKind>
 {
     fn kind(&self) -> Kind {
         self.inner.kind()

--- a/tct/src/internal/complete/tier.rs
+++ b/tct/src/internal/complete/tier.rs
@@ -1,23 +1,26 @@
+use archery::SharedPointerKind;
+
 use crate::prelude::*;
 
-type N<Child> = super::super::complete::Node<Child>;
+type N<Child, RefKind> = super::super::complete::Node<Child, RefKind>;
 type L<Item> = super::super::complete::Leaf<Item>;
 
 /// An eight-deep complete tree with the given item at each leaf.
-pub type Nested<Item> = N<N<N<N<N<N<N<N<L<Item>>>>>>>>>;
-// Count the levels:    1 2 3 4 5 6 7 8
+pub type Nested<Item, R> = N<N<N<N<N<N<N<N<L<Item>, R>, R>, R>, R>, R>, R>, R>, R>;
+// Count the levels:       1 2 3 4 5 6 7 8
 
 /// A complete tier of the tiered commitment tree, being an 8-deep sparse quad-tree.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Tier<Item: GetHash + Height + Clone> {
-    pub(in super::super) inner: Nested<Item>,
+#[derive(Derivative, Debug)]
+#[derivative(Clone(bound = "Item: Clone"))]
+pub struct Tier<Item: GetHash + Height + Clone, RefKind: SharedPointerKind> {
+    pub(in super::super) inner: Nested<Item, RefKind>,
 }
 
-impl<Item: GetHash + Height + Clone> Height for Tier<Item> {
-    type Height = <Nested<Item> as Height>::Height;
+impl<Item: GetHash + Height + Clone, RefKind: SharedPointerKind> Height for Tier<Item, RefKind> {
+    type Height = <Nested<Item, RefKind> as Height>::Height;
 }
 
-impl<Item: GetHash + Height + Clone> GetHash for Tier<Item> {
+impl<Item: GetHash + Height + Clone, RefKind: SharedPointerKind> GetHash for Tier<Item, RefKind> {
     #[inline]
     fn hash(&self) -> Hash {
         self.inner.hash()
@@ -29,21 +32,23 @@ impl<Item: GetHash + Height + Clone> GetHash for Tier<Item> {
     }
 }
 
-impl<Item: Complete + Clone> Complete for Tier<Item>
+impl<Item: Complete + Clone, RefKind: SharedPointerKind> Complete for Tier<Item, RefKind>
 where
     Item::Focus: Clone,
 {
-    type Focus = frontier::Tier<Item::Focus>;
+    type Focus = frontier::Tier<Item::Focus, RefKind>;
 }
 
-impl<Item: GetHash + Witness + Clone> Witness for Tier<Item> {
+impl<Item: GetHash + Witness + Clone, RefKind: SharedPointerKind> Witness for Tier<Item, RefKind> {
     #[inline]
     fn witness(&self, index: impl Into<u64>) -> Option<(AuthPath<Self>, Hash)> {
         self.inner.witness(index)
     }
 }
 
-impl<Item: GetHash + ForgetOwned + Clone> ForgetOwned for Tier<Item> {
+impl<Item: GetHash + ForgetOwned + Clone, RefKind: SharedPointerKind> ForgetOwned
+    for Tier<Item, RefKind>
+{
     fn forget_owned(
         self,
         forgotten: Option<Forgotten>,
@@ -54,22 +59,27 @@ impl<Item: GetHash + ForgetOwned + Clone> ForgetOwned for Tier<Item> {
     }
 }
 
-impl<Item: Complete + Clone> From<frontier::Tier<Item::Focus>> for Insert<Tier<Item>>
+impl<Item: Complete + Clone, RefKind: SharedPointerKind> From<frontier::Tier<Item::Focus, RefKind>>
+    for Insert<Tier<Item, RefKind>>
 where
     Item::Focus: Clone,
 {
-    fn from(frontier: frontier::Tier<Item::Focus>) -> Self {
+    fn from(frontier: frontier::Tier<Item::Focus, RefKind>) -> Self {
         frontier.finalize_owned()
     }
 }
 
-impl<Item: GetHash + Height + Clone> GetPosition for Tier<Item> {
+impl<Item: GetHash + Height + Clone, RefKind: SharedPointerKind> GetPosition
+    for Tier<Item, RefKind>
+{
     fn position(&self) -> Option<u64> {
         None
     }
 }
 
-impl<'tree, Item: Height + structure::Any<'tree> + Clone> structure::Any<'tree> for Tier<Item> {
+impl<Item: Height + structure::Any<RefKind> + Clone, RefKind: SharedPointerKind>
+    structure::Any<RefKind> for Tier<Item, RefKind>
+{
     fn kind(&self) -> Kind {
         self.inner.kind()
     }
@@ -82,12 +92,14 @@ impl<'tree, Item: Height + structure::Any<'tree> + Clone> structure::Any<'tree> 
         structure::Any::forgotten(&self.inner)
     }
 
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
-        (&self.inner as &dyn structure::Any).children()
+    fn children(&self) -> Vec<Node<RefKind>> {
+        (&self.inner as &dyn structure::Any<RefKind>).children()
     }
 }
 
-impl<Item: GetHash + Height + OutOfOrderOwned + Clone> OutOfOrderOwned for Tier<Item> {
+impl<Item: GetHash + Height + OutOfOrderOwned + Clone, RefKind: SharedPointerKind> OutOfOrderOwned
+    for Tier<Item, RefKind>
+{
     fn uninitialized_out_of_order_insert_commitment_owned(
         this: Insert<Self>,
         index: u64,
@@ -103,7 +115,9 @@ impl<Item: GetHash + Height + OutOfOrderOwned + Clone> OutOfOrderOwned for Tier<
     }
 }
 
-impl<Item: GetHash + UncheckedSetHash + Clone> UncheckedSetHash for Tier<Item> {
+impl<Item: GetHash + UncheckedSetHash + Clone, RefKind: SharedPointerKind> UncheckedSetHash
+    for Tier<Item, RefKind>
+{
     fn unchecked_set_hash(&mut self, index: u64, height: u8, hash: Hash) {
         self.inner.unchecked_set_hash(index, height, hash)
     }

--- a/tct/src/internal/complete/tier.rs
+++ b/tct/src/internal/complete/tier.rs
@@ -9,15 +9,15 @@ pub type Nested<Item> = N<N<N<N<N<N<N<N<L<Item>>>>>>>>>;
 
 /// A complete tier of the tiered commitment tree, being an 8-deep sparse quad-tree.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Tier<Item: GetHash + Height> {
+pub struct Tier<Item: GetHash + Height + Clone> {
     pub(in super::super) inner: Nested<Item>,
 }
 
-impl<Item: GetHash + Height> Height for Tier<Item> {
+impl<Item: GetHash + Height + Clone> Height for Tier<Item> {
     type Height = <Nested<Item> as Height>::Height;
 }
 
-impl<Item: GetHash + Height> GetHash for Tier<Item> {
+impl<Item: GetHash + Height + Clone> GetHash for Tier<Item> {
     #[inline]
     fn hash(&self) -> Hash {
         self.inner.hash()
@@ -29,18 +29,21 @@ impl<Item: GetHash + Height> GetHash for Tier<Item> {
     }
 }
 
-impl<Item: Complete> Complete for Tier<Item> {
+impl<Item: Complete + Clone> Complete for Tier<Item>
+where
+    Item::Focus: Clone,
+{
     type Focus = frontier::Tier<Item::Focus>;
 }
 
-impl<Item: GetHash + Witness> Witness for Tier<Item> {
+impl<Item: GetHash + Witness + Clone> Witness for Tier<Item> {
     #[inline]
     fn witness(&self, index: impl Into<u64>) -> Option<(AuthPath<Self>, Hash)> {
         self.inner.witness(index)
     }
 }
 
-impl<Item: GetHash + ForgetOwned> ForgetOwned for Tier<Item> {
+impl<Item: GetHash + ForgetOwned + Clone> ForgetOwned for Tier<Item> {
     fn forget_owned(
         self,
         forgotten: Option<Forgotten>,
@@ -51,19 +54,22 @@ impl<Item: GetHash + ForgetOwned> ForgetOwned for Tier<Item> {
     }
 }
 
-impl<Item: Complete> From<frontier::Tier<Item::Focus>> for Insert<Tier<Item>> {
+impl<Item: Complete + Clone> From<frontier::Tier<Item::Focus>> for Insert<Tier<Item>>
+where
+    Item::Focus: Clone,
+{
     fn from(frontier: frontier::Tier<Item::Focus>) -> Self {
         frontier.finalize_owned()
     }
 }
 
-impl<Item: GetHash + Height> GetPosition for Tier<Item> {
+impl<Item: GetHash + Height + Clone> GetPosition for Tier<Item> {
     fn position(&self) -> Option<u64> {
         None
     }
 }
 
-impl<'tree, Item: Height + structure::Any<'tree>> structure::Any<'tree> for Tier<Item> {
+impl<'tree, Item: Height + structure::Any<'tree> + Clone> structure::Any<'tree> for Tier<Item> {
     fn kind(&self) -> Kind {
         self.inner.kind()
     }
@@ -81,7 +87,7 @@ impl<'tree, Item: Height + structure::Any<'tree>> structure::Any<'tree> for Tier
     }
 }
 
-impl<Item: GetHash + Height + OutOfOrderOwned> OutOfOrderOwned for Tier<Item> {
+impl<Item: GetHash + Height + OutOfOrderOwned + Clone> OutOfOrderOwned for Tier<Item> {
     fn uninitialized_out_of_order_insert_commitment_owned(
         this: Insert<Self>,
         index: u64,
@@ -97,7 +103,7 @@ impl<Item: GetHash + Height + OutOfOrderOwned> OutOfOrderOwned for Tier<Item> {
     }
 }
 
-impl<Item: GetHash + UncheckedSetHash> UncheckedSetHash for Tier<Item> {
+impl<Item: GetHash + UncheckedSetHash + Clone> UncheckedSetHash for Tier<Item> {
     fn unchecked_set_hash(&mut self, index: u64, height: u8, hash: Hash) {
         self.inner.unchecked_set_hash(index, height, hash)
     }

--- a/tct/src/internal/complete/top.rs
+++ b/tct/src/internal/complete/top.rs
@@ -4,15 +4,15 @@ use complete::Nested;
 
 /// A complete top-level tier of the tiered commitment tree, being an 8-deep sparse quad-tree.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Top<Item: GetHash + Height> {
+pub struct Top<Item: GetHash + Height + Clone> {
     pub(in super::super) inner: Nested<Item>,
 }
 
-impl<Item: GetHash + Height> Height for Top<Item> {
+impl<Item: GetHash + Height + Clone> Height for Top<Item> {
     type Height = <Nested<Item> as Height>::Height;
 }
 
-impl<Item: GetHash + Height> GetHash for Top<Item> {
+impl<Item: GetHash + Height + Clone> GetHash for Top<Item> {
     #[inline]
     fn hash(&self) -> Hash {
         self.inner.hash()
@@ -24,19 +24,19 @@ impl<Item: GetHash + Height> GetHash for Top<Item> {
     }
 }
 
-impl<Item: GetHash + Height> From<complete::Tier<Item>> for Top<Item> {
+impl<Item: GetHash + Height + Clone> From<complete::Tier<Item>> for Top<Item> {
     fn from(tier: complete::Tier<Item>) -> Self {
         Top { inner: tier.inner }
     }
 }
 
-impl<Item: Height + GetHash> GetPosition for Top<Item> {
+impl<Item: Height + GetHash + Clone> GetPosition for Top<Item> {
     fn position(&self) -> Option<u64> {
         None
     }
 }
 
-impl<'tree, Item: Height + structure::Any<'tree>> structure::Any<'tree> for Top<Item> {
+impl<'tree, Item: Height + structure::Any<'tree> + Clone> structure::Any<'tree> for Top<Item> {
     fn kind(&self) -> Kind {
         self.inner.kind()
     }
@@ -54,7 +54,7 @@ impl<'tree, Item: Height + structure::Any<'tree>> structure::Any<'tree> for Top<
     }
 }
 
-impl<Item: GetHash + Height + OutOfOrderOwned> OutOfOrderOwned for Top<Item> {
+impl<Item: GetHash + Height + OutOfOrderOwned + Clone> OutOfOrderOwned for Top<Item> {
     fn uninitialized_out_of_order_insert_commitment_owned(
         this: Insert<Self>,
         index: u64,
@@ -70,7 +70,7 @@ impl<Item: GetHash + Height + OutOfOrderOwned> OutOfOrderOwned for Top<Item> {
     }
 }
 
-impl<Item: GetHash + UncheckedSetHash> UncheckedSetHash for Top<Item> {
+impl<Item: GetHash + UncheckedSetHash + Clone> UncheckedSetHash for Top<Item> {
     fn unchecked_set_hash(&mut self, index: u64, height: u8, hash: Hash) {
         self.inner.unchecked_set_hash(index, height, hash)
     }

--- a/tct/src/internal/complete/top.rs
+++ b/tct/src/internal/complete/top.rs
@@ -6,7 +6,7 @@ use complete::Nested;
 
 /// A complete top-level tier of the tiered commitment tree, being an 8-deep sparse quad-tree.
 #[derive(Clone, Debug)]
-pub struct Top<Item: GetHash + Height + Clone, RefKind: SharedPointerKind> {
+pub struct Top<Item: GetHash + Height + Clone, RefKind: SharedPointerKind = archery::ArcK> {
     pub(in super::super) inner: Nested<Item, RefKind>,
 }
 
@@ -42,8 +42,10 @@ impl<Item: Height + GetHash + Clone, RefKind: SharedPointerKind> GetPosition
     }
 }
 
-impl<Item: Height + structure::Any<RefKind> + Clone, RefKind: SharedPointerKind>
-    structure::Any<RefKind> for Top<Item, RefKind>
+impl<
+        Item: Height + structure::Any<RefKind> + Clone + 'static,
+        RefKind: SharedPointerKind + 'static,
+    > structure::Any<RefKind> for Top<Item, RefKind>
 {
     fn kind(&self) -> Kind {
         self.inner.kind()

--- a/tct/src/internal/frontier/item.rs
+++ b/tct/src/internal/frontier/item.rs
@@ -1,7 +1,9 @@
+use archery::SharedPointerKind;
+
 use crate::prelude::*;
 
 /// The hash of the most-recently-inserted item, stored at the tip of the frontier.
-#[derive(Debug, Clone, Copy, Derivative, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Derivative)]
 pub struct Item {
     item: Insert<(Commitment, Hash)>,
 }
@@ -82,7 +84,7 @@ impl Forget for Item {
     }
 }
 
-impl<'tree> structure::Any<'tree> for Item {
+impl<RefKind: SharedPointerKind> structure::Any<RefKind> for Item {
     fn kind(&self) -> Kind {
         Kind::Leaf {
             commitment: self.item.keep().map(|(commitment, _)| commitment),
@@ -97,7 +99,7 @@ impl<'tree> structure::Any<'tree> for Item {
         Forgotten::default()
     }
 
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
+    fn children(&self) -> Vec<Node<RefKind>> {
         vec![]
     }
 }

--- a/tct/src/internal/frontier/leaf.rs
+++ b/tct/src/internal/frontier/leaf.rs
@@ -1,10 +1,12 @@
+use archery::SharedPointerKind;
+
 use crate::prelude::*;
 
 /// The frontier (rightmost) leaf in a frontier of a tree.
 ///
 /// Insertion into a leaf always fails, causing the tree above it to insert a new leaf to contain
 /// the inserted item.
-#[derive(Clone, Copy, Derivative, Serialize, Deserialize)]
+#[derive(Clone, Copy, Derivative)]
 #[derivative(Debug = "transparent")]
 pub struct Leaf<Item> {
     item: Item,
@@ -90,8 +92,8 @@ impl<Item: GetHash + Forget> Forget for Leaf<Item> {
     }
 }
 
-impl<'tree, Item: GetPosition + Height + structure::Any<'tree>> structure::Any<'tree>
-    for Leaf<Item>
+impl<'tree, Item: GetPosition + Height + structure::Any<RefKind>, RefKind: SharedPointerKind>
+    structure::Any<RefKind> for Leaf<Item>
 {
     fn kind(&self) -> Kind {
         self.item.kind()
@@ -105,7 +107,7 @@ impl<'tree, Item: GetPosition + Height + structure::Any<'tree>> structure::Any<'
         self.item.forgotten()
     }
 
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
+    fn children(&self) -> Vec<Node<RefKind>> {
         self.item.children()
     }
 }

--- a/tct/src/internal/frontier/leaf.rs
+++ b/tct/src/internal/frontier/leaf.rs
@@ -92,7 +92,7 @@ impl<Item: GetHash + Forget> Forget for Leaf<Item> {
     }
 }
 
-impl<'tree, Item: GetPosition + Height + structure::Any<RefKind>, RefKind: SharedPointerKind>
+impl<Item: GetPosition + Height + structure::Any<RefKind>, RefKind: SharedPointerKind>
     structure::Any<RefKind> for Leaf<Item>
 {
     fn kind(&self) -> Kind {

--- a/tct/src/internal/frontier/node.rs
+++ b/tct/src/internal/frontier/node.rs
@@ -406,12 +406,11 @@ where
 }
 
 impl<
-        'tree,
-        Child: Focus + GetPosition + Height + structure::Any<RefKind> + Clone,
+        Child: Focus + GetPosition + Height + structure::Any<RefKind> + Clone + 'static,
         RefKind: SharedPointerKind,
     > structure::Any<RefKind> for Node<Child, RefKind>
 where
-    Child::Complete: structure::Any<RefKind>,
+    Child::Complete: structure::Any<RefKind> + Clone,
 {
     fn kind(&self) -> Kind {
         Kind::Internal {

--- a/tct/src/internal/frontier/tier.rs
+++ b/tct/src/internal/frontier/tier.rs
@@ -10,7 +10,7 @@ use crate::prelude::*;
     Debug(bound = "Item: Debug, Item::Complete: Debug"),
     Clone(bound = "Item: Clone, Item::Complete: Clone")
 )]
-pub struct Tier<Item: Focus + Clone, RefKind: SharedPointerKind>
+pub struct Tier<Item: Focus + Clone, RefKind: SharedPointerKind = archery::ArcK>
 where
     Item::Complete: Clone,
 {
@@ -312,9 +312,8 @@ where
 }
 
 impl<
-        'tree,
-        Item: Focus + GetPosition + Height + structure::Any<RefKind> + Clone,
-        RefKind: SharedPointerKind,
+        Item: Focus + GetPosition + Height + structure::Any<RefKind> + Clone + 'static,
+        RefKind: SharedPointerKind + 'static,
     > structure::Any<RefKind> for Tier<Item, RefKind>
 where
     Item::Complete: structure::Any<RefKind> + Clone,

--- a/tct/src/internal/frontier/tier.rs
+++ b/tct/src/internal/frontier/tier.rs
@@ -451,11 +451,6 @@ mod test {
     use super::*;
 
     #[test]
-    fn check_inner_size() {
-        static_assertions::assert_eq_size!(Tier<Tier<Tier<frontier::Item>>>, [u8; 88]);
-    }
-
-    #[test]
     fn position_advances_by_one() {
         let mut tier: Tier<Item> = Tier::new(Hash::zero().into());
         for expected_position in 1..=(u16::MAX as u64) {

--- a/tct/src/internal/frontier/tier.rs
+++ b/tct/src/internal/frontier/tier.rs
@@ -14,7 +14,10 @@ use crate::prelude::*;
     serialize = "Item: Serialize, Item::Complete: Serialize",
     deserialize = "Item: Deserialize<'de>, Item::Complete: Deserialize<'de>"
 ))]
-pub struct Tier<Item: Focus> {
+pub struct Tier<Item: Focus + Clone>
+where
+    Item::Complete: Clone,
+{
     inner: Inner<Item>,
 }
 
@@ -32,10 +35,13 @@ pub type Nested<Item> = N<N<N<N<N<N<N<N<L<Item>>>>>>>>>;
     Clone(bound = "Item: Clone, Item::Complete: Clone")
 )]
 #[serde(bound(
-    serialize = "Item: Serialize, Item::Complete: Serialize",
+    serialize = "Item: Serialize, Item::Complete: Serialize + Clone",
     deserialize = "Item: Deserialize<'de>, Item::Complete: Deserialize<'de>"
 ))]
-pub enum Inner<Item: Focus> {
+pub enum Inner<Item: Focus + Clone>
+where
+    Item::Complete: Clone,
+{
     /// A tree with at least one leaf.
     Frontier(Box<Nested<Item>>),
     /// A completed tree which has at least one witnessed child.
@@ -45,7 +51,10 @@ pub enum Inner<Item: Focus> {
     Hash(Hash),
 }
 
-impl<Item: Focus> From<Hash> for Tier<Item> {
+impl<Item: Focus + Clone> From<Hash> for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     #[inline]
     fn from(hash: Hash) -> Self {
         Self {
@@ -54,7 +63,10 @@ impl<Item: Focus> From<Hash> for Tier<Item> {
     }
 }
 
-impl<Item: Focus> Tier<Item> {
+impl<Item: Focus + Clone> Tier<Item>
+where
+    Item::Complete: Clone,
+{
     /// Create a new tier from a single item which will be its first element.
     #[inline]
     pub fn new(item: Item) -> Self {
@@ -173,11 +185,17 @@ impl<Item: Focus> Tier<Item> {
     }
 }
 
-impl<Item: Focus> Height for Tier<Item> {
+impl<Item: Focus + Clone> Height for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     type Height = <Nested<Item> as Height>::Height;
 }
 
-impl<Item: Focus> GetHash for Tier<Item> {
+impl<Item: Focus + Clone> GetHash for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     #[inline]
     fn hash(&self) -> Hash {
         match &self.inner {
@@ -197,7 +215,10 @@ impl<Item: Focus> GetHash for Tier<Item> {
     }
 }
 
-impl<Item: Focus> Focus for Tier<Item> {
+impl<Item: Focus + Clone> Focus for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     type Complete = complete::Tier<Item::Complete>;
 
     #[inline]
@@ -213,9 +234,9 @@ impl<Item: Focus> Focus for Tier<Item> {
     }
 }
 
-impl<Item: Focus + Witness> Witness for Tier<Item>
+impl<Item: Focus + Witness + Clone> Witness for Tier<Item>
 where
-    Item::Complete: Witness,
+    Item::Complete: Witness + Clone,
 {
     #[inline]
     fn witness(&self, index: impl Into<u64>) -> Option<(AuthPath<Self>, Hash)> {
@@ -227,7 +248,10 @@ where
     }
 }
 
-impl<Item: Focus + GetPosition> GetPosition for Tier<Item> {
+impl<Item: Focus + GetPosition + Clone> GetPosition for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     #[inline]
     fn position(&self) -> Option<u64> {
         match &self.inner {
@@ -237,9 +261,9 @@ impl<Item: Focus + GetPosition> GetPosition for Tier<Item> {
     }
 }
 
-impl<Item: Focus + Forget> Forget for Tier<Item>
+impl<Item: Focus + Forget + Clone> Forget for Tier<Item>
 where
-    Item::Complete: ForgetOwned,
+    Item::Complete: ForgetOwned + Clone,
 {
     #[inline]
     fn forget(&mut self, forgotten: Option<Forgotten>, index: impl Into<u64>) -> bool {
@@ -270,7 +294,10 @@ where
     }
 }
 
-impl<Item: Focus> From<complete::Tier<Item::Complete>> for Tier<Item> {
+impl<Item: Focus + Clone> From<complete::Tier<Item::Complete>> for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     fn from(complete: complete::Tier<Item::Complete>) -> Self {
         Self {
             inner: Inner::Complete(complete.inner),
@@ -278,7 +305,10 @@ impl<Item: Focus> From<complete::Tier<Item::Complete>> for Tier<Item> {
     }
 }
 
-impl<Item: Focus> From<complete::Top<Item::Complete>> for Tier<Item> {
+impl<Item: Focus + Clone> From<complete::Top<Item::Complete>> for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     fn from(complete: complete::Top<Item::Complete>) -> Self {
         Self {
             inner: Inner::Complete(complete.inner),
@@ -286,10 +316,10 @@ impl<Item: Focus> From<complete::Top<Item::Complete>> for Tier<Item> {
     }
 }
 
-impl<'tree, Item: Focus + GetPosition + Height + structure::Any<'tree>> structure::Any<'tree>
-    for Tier<Item>
+impl<'tree, Item: Focus + GetPosition + Height + structure::Any<'tree> + Clone>
+    structure::Any<'tree> for Tier<Item>
 where
-    Item::Complete: structure::Any<'tree>,
+    Item::Complete: structure::Any<'tree> + Clone,
 {
     fn kind(&self) -> Kind {
         Kind::Internal {
@@ -318,9 +348,9 @@ where
     }
 }
 
-impl<Item: Focus + OutOfOrder> OutOfOrder for Tier<Item>
+impl<Item: Focus + OutOfOrder + Clone> OutOfOrder for Tier<Item>
 where
-    Item::Complete: OutOfOrderOwned,
+    Item::Complete: OutOfOrderOwned + Clone,
 {
     fn uninitialized(position: Option<u64>, forgotten: Forgotten) -> Self {
         // This tier is finalized if the position relative to its own height is 0 (because a
@@ -386,9 +416,9 @@ where
     }
 }
 
-impl<Item: Focus + UncheckedSetHash> UncheckedSetHash for Tier<Item>
+impl<Item: Focus + UncheckedSetHash + Clone> UncheckedSetHash for Tier<Item>
 where
-    Item::Complete: UncheckedSetHash,
+    Item::Complete: UncheckedSetHash + Clone,
 {
     fn unchecked_set_hash(&mut self, index: u64, height: u8, hash: Hash) {
         match &mut self.inner {

--- a/tct/src/internal/frontier/top.rs
+++ b/tct/src/internal/frontier/top.rs
@@ -17,7 +17,10 @@ use frontier::tier::Nested;
     serialize = "Item: Serialize, Item::Complete: Serialize",
     deserialize = "Item: Deserialize<'de>, Item::Complete: Deserialize<'de>"
 ))]
-pub struct Top<Item: Focus> {
+pub struct Top<Item: Focus + Clone>
+where
+    Item::Complete: Clone,
+{
     track_forgotten: TrackForgotten,
     inner: Option<Nested<Item>>,
 }
@@ -36,7 +39,10 @@ pub enum TrackForgotten {
     No,
 }
 
-impl<Item: Focus> Top<Item> {
+impl<Item: Focus + Clone> Top<Item>
+where
+    Item::Complete: Clone,
+{
     /// Create a new top-level frontier tier.
     #[allow(unused)]
     pub fn new(track_forgotten: TrackForgotten) -> Self {
@@ -165,11 +171,17 @@ impl<Item: Focus> Top<Item> {
     }
 }
 
-impl<Item: Focus> Height for Top<Item> {
+impl<Item: Focus + Clone> Height for Top<Item>
+where
+    Item::Complete: Clone,
+{
     type Height = <Nested<Item> as Height>::Height;
 }
 
-impl<Item: Focus + GetPosition> GetPosition for Top<Item> {
+impl<Item: Focus + GetPosition + Clone> GetPosition for Top<Item>
+where
+    Item::Complete: Clone,
+{
     #[inline]
     fn position(&self) -> Option<u64> {
         if let Some(ref frontier) = self.inner {
@@ -180,7 +192,10 @@ impl<Item: Focus + GetPosition> GetPosition for Top<Item> {
     }
 }
 
-impl<Item: Focus> GetHash for Top<Item> {
+impl<Item: Focus + Clone> GetHash for Top<Item>
+where
+    Item::Complete: Clone,
+{
     #[inline]
     fn hash(&self) -> Hash {
         if let Some(ref inner) = self.inner {
@@ -200,9 +215,9 @@ impl<Item: Focus> GetHash for Top<Item> {
     }
 }
 
-impl<Item: Focus + Witness> Witness for Top<Item>
+impl<Item: Focus + Witness + Clone> Witness for Top<Item>
 where
-    Item::Complete: Witness,
+    Item::Complete: Witness + Clone,
 {
     fn witness(&self, index: impl Into<u64>) -> Option<(AuthPath<Self>, Hash)> {
         if let Some(ref inner) = self.inner {
@@ -213,10 +228,10 @@ where
     }
 }
 
-impl<'tree, Item: Focus + GetPosition + Height + structure::Any<'tree>> structure::Any<'tree>
-    for Top<Item>
+impl<'tree, Item: Focus + GetPosition + Height + structure::Any<'tree> + Clone>
+    structure::Any<'tree> for Top<Item>
 where
-    Item::Complete: structure::Any<'tree>,
+    Item::Complete: structure::Any<'tree> + Clone,
 {
     fn kind(&self) -> Kind {
         Kind::Internal {
@@ -240,9 +255,9 @@ where
     }
 }
 
-impl<Item: Focus + Height + OutOfOrder> OutOfOrder for Top<Item>
+impl<Item: Focus + Height + OutOfOrder + Clone> OutOfOrder for Top<Item>
 where
-    Item::Complete: OutOfOrderOwned,
+    Item::Complete: OutOfOrderOwned + Clone,
 {
     fn uninitialized(position: Option<u64>, forgotten: Forgotten) -> Self {
         let inner = if position == Some(0) {
@@ -268,9 +283,9 @@ where
     }
 }
 
-impl<Item: Focus + Height + UncheckedSetHash> UncheckedSetHash for Top<Item>
+impl<Item: Focus + Height + UncheckedSetHash + Clone> UncheckedSetHash for Top<Item>
 where
-    Item::Complete: UncheckedSetHash,
+    Item::Complete: UncheckedSetHash + Clone,
 {
     fn unchecked_set_hash(&mut self, index: u64, height: u8, hash: Hash) {
         if let Some(ref mut inner) = self.inner {

--- a/tct/src/internal/frontier/top.rs
+++ b/tct/src/internal/frontier/top.rs
@@ -14,7 +14,7 @@ use frontier::tier::Nested;
     Debug(bound = "Item: Debug, Item::Complete: Debug"),
     Clone(bound = "Item: Clone, Item::Complete: Clone")
 )]
-pub struct Top<Item: Focus + Clone, RefKind: SharedPointerKind>
+pub struct Top<Item: Focus + Clone, RefKind: SharedPointerKind = archery::ArcK>
 where
     Item::Complete: Clone,
 {
@@ -227,9 +227,8 @@ where
 }
 
 impl<
-        'tree,
-        Item: Focus + GetPosition + Height + structure::Any<RefKind> + Clone,
-        RefKind: SharedPointerKind,
+        Item: Focus + GetPosition + Height + structure::Any<RefKind> + Clone + 'static,
+        RefKind: SharedPointerKind + 'static,
     > structure::Any<RefKind> for Top<Item, RefKind>
 where
     Item::Complete: structure::Any<RefKind> + Clone,

--- a/tct/src/internal/hash.rs
+++ b/tct/src/internal/hash.rs
@@ -220,13 +220,13 @@ impl Hash {
 )]
 #[derivative(Debug = "transparent")]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(proptest_derive::Arbitrary))]
-pub struct Forgotten(u64);
+pub struct Forgotten([u8; 6]);
 
 impl Forgotten {
     /// Get the next forgotten-version after this one.
     pub fn next(&self) -> Self {
-        Self(
-            self.0
+        Self::from(
+            u64::from(*self)
                 .checked_add(1)
                 .expect("forgotten should never overflow"),
         )
@@ -235,13 +235,29 @@ impl Forgotten {
 
 impl From<Forgotten> for u64 {
     fn from(forgotten: Forgotten) -> Self {
-        forgotten.0
+        let mut eight_bytes = <[u8; 8]>::default();
+        for (in_byte, out_byte) in eight_bytes.iter_mut().zip(forgotten.0) {
+            *in_byte = out_byte;
+        }
+
+        u64::from_le_bytes(eight_bytes)
     }
 }
 
 impl From<u64> for Forgotten {
     fn from(u: u64) -> Self {
-        Self(u)
+        let bytes = u.to_le_bytes();
+
+        if [0, 0] != bytes[6..] {
+            panic!("forgotten version cannot exceed 48 bits");
+        }
+
+        let mut six_bytes = [0; 6];
+        for (in_byte, out_byte) in six_bytes.iter_mut().zip(&bytes[..6]) {
+            *in_byte = *out_byte;
+        }
+
+        Self(six_bytes)
     }
 }
 
@@ -282,6 +298,21 @@ mod arbitrary {
             Ok(proptest::strategy::Just(Hash(decaf377::Fq::new(
                 ark_ff::BigInteger256(parts),
             ))))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn forgotten_increments() {
+        use super::Forgotten;
+
+        let mut last = Forgotten::default();
+        for _ in 0..10 {
+            let next = last.next();
+            assert_eq!(u64::from(next), u64::from(last) + 1);
+            last = next;
         }
     }
 }

--- a/tct/src/internal/hash.rs
+++ b/tct/src/internal/hash.rs
@@ -4,6 +4,7 @@
 
 use std::{fmt::Debug, ops::RangeInclusive};
 
+use archery::{SharedPointer, SharedPointerKind};
 use ark_ff::{fields::PrimeField, BigInteger256, Fp256, One, Zero};
 use decaf377::FieldExt;
 use once_cell::sync::Lazy;
@@ -57,6 +58,30 @@ impl<T: GetHash> GetHash for &T {
 }
 
 impl<T: GetHash> GetHash for &mut T {
+    #[inline]
+    fn hash(&self) -> Hash {
+        (**self).hash()
+    }
+
+    #[inline]
+    fn cached_hash(&self) -> Option<Hash> {
+        (**self).cached_hash()
+    }
+}
+
+impl<T: GetHash> GetHash for Box<T> {
+    #[inline]
+    fn hash(&self) -> Hash {
+        (**self).hash()
+    }
+
+    #[inline]
+    fn cached_hash(&self) -> Option<Hash> {
+        (**self).cached_hash()
+    }
+}
+
+impl<T: GetHash, RefKind: SharedPointerKind> GetHash for SharedPointer<T, RefKind> {
     #[inline]
     fn hash(&self) -> Hash {
         (**self).hash()

--- a/tct/src/internal/hash/cache.rs
+++ b/tct/src/internal/hash/cache.rs
@@ -61,3 +61,13 @@ impl From<Hash> for CachedHash {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn cached_hash_size() {
+        static_assertions::assert_eq_size!(CachedHash, [u8; 40]);
+    }
+}

--- a/tct/src/internal/three.rs
+++ b/tct/src/internal/three.rs
@@ -9,10 +9,20 @@ use std::marker::PhantomData;
 use serde::{de::Visitor, Deserialize, Serialize};
 
 /// A vector capable of storing at most 3 elements.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Derivative, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Derivative, Serialize)]
 #[derivative(Debug = "transparent")]
 pub struct Three<T> {
     elems: Vec<T>,
+}
+
+// Manual `Clone` implementation to force the cloned `Vec` to be capacity = 4, so we never
+// re-allocate after the clone
+impl<T: Clone> Clone for Three<T> {
+    fn clone(&self) -> Self {
+        let mut elems = Vec::with_capacity(4);
+        elems.extend(self.elems.iter().cloned());
+        Self { elems }
+    }
 }
 
 impl<T> Three<T> {

--- a/tct/src/lib.rs
+++ b/tct/src/lib.rs
@@ -50,9 +50,6 @@ extern crate thiserror;
 #[macro_use]
 extern crate async_trait;
 
-#[macro_use]
-extern crate async_stream;
-
 mod commitment;
 mod index;
 mod proof;

--- a/tct/src/lib.rs
+++ b/tct/src/lib.rs
@@ -116,7 +116,8 @@ mod prelude {
     };
 
     // We use the hash map from `im`, but with the fast "hash prehashed data" hasher from `hash_hasher`
-    pub(crate) type HashedMap<K, V> = im::HashMap<K, V, hash_hasher::HashBuildHasher>;
+    pub(crate) type HashedMap<K, V, RefKind> =
+        rpds::HashTrieMap<K, V, RefKind, hash_hasher::HashBuildHasher>;
 }
 
 #[cfg(feature = "arbitrary")]

--- a/tct/src/lib.rs
+++ b/tct/src/lib.rs
@@ -33,8 +33,6 @@
 //!                                       = Note Commitment
 //! ```
 
-// Cargo doc complains if the recursion limit isn't higher, even though cargo build succeeds:
-#![recursion_limit = "256"]
 #![warn(missing_docs)]
 
 #[macro_use]

--- a/tct/src/lib.rs
+++ b/tct/src/lib.rs
@@ -134,7 +134,7 @@ mod test {
 
     #[test]
     fn check_eternity_size() {
-        static_assertions::assert_eq_size!(Tree, [u8; 136]);
+        static_assertions::assert_eq_size!(Tree, [u8; 32]);
     }
 
     #[test]

--- a/tct/src/lib.rs
+++ b/tct/src/lib.rs
@@ -116,6 +116,9 @@ mod prelude {
         structure::{self, Kind, Node, Place},
         Commitment, Position, Proof, Root, Tree,
     };
+
+    // We use the hash map from `im`, but with the fast "hash prehashed data" hasher from `hash_hasher`
+    pub(crate) type HashedMap<K, V> = im::HashMap<K, V, hash_hasher::HashBuildHasher>;
 }
 
 #[cfg(feature = "arbitrary")]
@@ -131,7 +134,7 @@ mod test {
 
     #[test]
     fn check_eternity_size() {
-        static_assertions::assert_eq_size!(Tree, [u8; 896]);
+        static_assertions::assert_eq_size!(Tree, [u8; 136]);
     }
 
     #[test]

--- a/tct/src/proof.rs
+++ b/tct/src/proof.rs
@@ -7,6 +7,7 @@ use crate::prelude::*;
 /// A proof of the inclusion of some [`Commitment`] in a [`Tree`] with a particular [`Root`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Proof(
+    #[allow(clippy::type_complexity)]
     pub(super)  crate::internal::proof::Proof<
         // It doesn't matter what we use here for `RefKind` because it's a phantom type
         frontier::Top<frontier::Tier<frontier::Tier<frontier::Item, ArcK>, ArcK>, ArcK>,

--- a/tct/src/proof.rs
+++ b/tct/src/proof.rs
@@ -1,3 +1,4 @@
+use archery::ArcK;
 use ark_ff::UniformRand;
 use poseidon377::Fq;
 
@@ -7,7 +8,8 @@ use crate::prelude::*;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Proof(
     pub(super)  crate::internal::proof::Proof<
-        frontier::Top<frontier::Tier<frontier::Tier<frontier::Item>>>,
+        // It doesn't matter what we use here for `RefKind` because it's a phantom type
+        frontier::Top<frontier::Tier<frontier::Tier<frontier::Item, ArcK>, ArcK>, ArcK>,
     >,
 );
 

--- a/tct/src/storage/deserialize.rs
+++ b/tct/src/storage/deserialize.rs
@@ -11,7 +11,7 @@ use crate::storage::Read;
 use super::StoredPosition;
 
 /// Deserialize a [`Tree`] from a storage backend.
-pub async fn from_reader<R: Read, RefKind: SharedPointerKind>(
+pub async fn from_reader<R: Read, RefKind: SharedPointerKind + 'static>(
     reader: &mut R,
 ) -> Result<Tree<RefKind>, R::Error> {
     // Make an uninitialized tree with the correct position and forgotten version

--- a/tct/src/storage/deserialize.rs
+++ b/tct/src/storage/deserialize.rs
@@ -2,6 +2,7 @@
 
 //! Non-incremental deserialization for the [`Tree`](crate::Tree).
 
+use archery::SharedPointerKind;
 use futures::StreamExt;
 
 use crate::prelude::*;
@@ -10,15 +11,19 @@ use crate::storage::Read;
 use super::StoredPosition;
 
 /// Deserialize a [`Tree`] from a storage backend.
-pub async fn from_reader<R: Read>(reader: &mut R) -> Result<Tree, R::Error> {
+pub async fn from_reader<R: Read, RefKind: SharedPointerKind>(
+    reader: &mut R,
+) -> Result<Tree<RefKind>, R::Error> {
     // Make an uninitialized tree with the correct position and forgotten version
     let position = match reader.position().await? {
         StoredPosition::Position(position) => Some(position.into()),
         StoredPosition::Full => None,
     };
     let forgotten = reader.forgotten().await?;
-    let mut inner: frontier::Top<frontier::Tier<frontier::Tier<frontier::Item>>> =
-        OutOfOrder::uninitialized(position, forgotten);
+    let mut inner: frontier::Top<
+        frontier::Tier<frontier::Tier<frontier::Item, RefKind>, RefKind>,
+        RefKind,
+    > = OutOfOrder::uninitialized(position, forgotten);
 
     // Make an index to track the commitments (we'll assemble this into the final tree)
     let mut index = HashedMap::default();
@@ -27,7 +32,7 @@ pub async fn from_reader<R: Read>(reader: &mut R) -> Result<Tree, R::Error> {
     let mut commitments = reader.commitments();
     while let Some((position, commitment)) = commitments.next().await.transpose()? {
         inner.uninitialized_out_of_order_insert_commitment(position.into(), commitment);
-        index.insert(commitment, u64::from(position).into());
+        index.insert_mut(commitment, u64::from(position).into());
     }
 
     drop(commitments); // explicit drop to satisfy borrow checker

--- a/tct/src/storage/deserialize.rs
+++ b/tct/src/storage/deserialize.rs
@@ -3,7 +3,6 @@
 //! Non-incremental deserialization for the [`Tree`](crate::Tree).
 
 use futures::StreamExt;
-use hash_hasher::HashedMap;
 
 use crate::prelude::*;
 use crate::storage::Read;

--- a/tct/src/structure.rs
+++ b/tct/src/structure.rs
@@ -475,19 +475,21 @@ mod sealed {
 
     impl Sealed for complete::Item {}
     impl<T: Sealed> Sealed for complete::Leaf<T> {}
-    impl<T: Sealed> Sealed for complete::Node<T> {}
-    impl<T: Sealed + Height + GetHash> Sealed for complete::Tier<T> {}
-    impl<T: Sealed + Height + GetHash> Sealed for complete::Top<T> {}
+    impl<T: Sealed + Clone> Sealed for complete::Node<T> {}
+    impl<T: Sealed + Height + GetHash + Clone> Sealed for complete::Tier<T> {}
+    impl<T: Sealed + Height + GetHash + Clone> Sealed for complete::Top<T> {}
 
     impl Sealed for frontier::Item {}
     impl<T: Sealed> Sealed for frontier::Leaf<T> {}
     impl<T: Sealed + Focus> Sealed for frontier::Node<T> where T::Complete: Send + Sync {}
-    impl<T: Sealed + Height + GetHash + Focus> Sealed for frontier::Tier<T> where
-        T::Complete: Send + Sync
+    impl<T: Sealed + Height + GetHash + Focus + Clone> Sealed for frontier::Tier<T> where
+        T::Complete: Send + Sync + Clone
     {
     }
-    impl<T: Sealed + Height + GetHash + Focus> Sealed for frontier::Top<T> where T::Complete: Send + Sync
-    {}
+    impl<T: Sealed + Height + GetHash + Focus + Clone> Sealed for frontier::Top<T> where
+        T::Complete: Send + Sync + Clone
+    {
+    }
 }
 
 #[cfg(test)]

--- a/tct/src/tree.rs
+++ b/tct/src/tree.rs
@@ -19,6 +19,7 @@ pub(crate) use epoch::block;
 #[derivative(Clone(bound = ""))]
 pub struct Tree<RefKind: SharedPointerKind = archery::ArcK> {
     index: HashedMap<Commitment, index::within::Tree, RefKind>,
+    #[allow(clippy::type_complexity)]
     inner: SharedPointer<
         frontier::Top<frontier::Tier<frontier::Tier<frontier::Item, RefKind>, RefKind>, RefKind>,
         RefKind,

--- a/tct/src/tree.rs
+++ b/tct/src/tree.rs
@@ -1,7 +1,6 @@
 use std::fmt::{Debug, Display};
 
 use decaf377::{FieldExt, Fq};
-use hash_hasher::HashedMap;
 use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
 
 use crate::error::*;

--- a/transaction/src/auth_hash.rs
+++ b/transaction/src/auth_hash.rs
@@ -549,7 +549,7 @@ mod tests {
         let fvk = sk.full_viewing_key();
         let (addr, _dtk) = fvk.incoming().payment_address(0u64.into());
 
-        let mut nct = tct::Tree::new();
+        let mut nct: tct::Tree = tct::Tree::new();
 
         let note0 = Note::generate(
             &mut OsRng,

--- a/view/src/bin/pviewd.rs
+++ b/view/src/bin/pviewd.rs
@@ -1,4 +1,3 @@
-#![recursion_limit = "256"]
 #![allow(clippy::clone_on_copy)]
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;

--- a/view/src/lib.rs
+++ b/view/src/lib.rs
@@ -1,6 +1,3 @@
-// Required because of NCT type size
-#![recursion_limit = "256"]
-
 mod client;
 mod metrics;
 mod note_record;

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -1,6 +1,3 @@
-// Required because of NCT type size
-#![recursion_limit = "256"]
-
 mod build;
 mod key_store;
 pub use build::build_transaction;


### PR DESCRIPTION
This is an exploratory PR which, although it is essentially complete, was an attempt to assess "does this work" in a time-boxed couple of hours, to prepare for writing up a design for the new quarantining system. We could merge it now, but I'm marking as draft for now because it could use some more testing, perhaps, and maybe even benchmarking against previous performance.

## Why do we want this (maybe)?

Cheap cloning for the TCT means we can perform any sequence of actions on a clone of the tree at only a slight slowdown as internal nodes are copied on demand. In particular, this would set the stage for us to be able to "rewind" the in-memory TCT to any previous position, at _constant cost_ regardless of the difference between the current position and the rewound position, and regardless of how many operations have occurred in between those two moments.

Why do we potentially want a method like the following?

```rust
impl Tree {
    pub fn rewind_to(&self, position: Position) -> Option<Self> { /* ... */ }
}
```

(Note that this would only work if the `position` given is witnessed.)

Well, this would allow us to prove inclusion of any note commitment relative to *any past root*, in constant time. It does not require reconstructing the entire tree by incrementally re-de-serializing up to a given position from disk, which costs in the size of the tree up to that position.

We would be able to use this to implement the new quarantining mechanism, so that to prove you're allowed to redeem a "quarantine token", you need to prove you had it _as of the most recent epoch that unbonded_.

## What's in the ~~`Box`~~`Arc`?

This includes several changes that play together:

1. The `Box` in the children of complete nodes is now an `Arc`, whose contents are cloned on modification.
2. There is a new point of indirection introduced in frontier nodes, where the focus of a frontier node is now an `Arc`, whose contents are cloned on modification.
3. The index for the tree is now an `im::HashMap`, which provides the same cheap cloning as the above changes, so that the whole structure can be quickly cloned.
4. The entirety of `Tree`, `epoch::Builder`, and `block::Builder`, are wrapped in an `Arc` each, which means that they can be cloned essentially for free, with deeper cloning happening on demand.

## Happy coincidences

- As a side effect of `Arc`-wrapping things, this means the viral `#![recursion_limit = "256]` bound that needed to be placed in every dependent crate is now gone.
- Making the TCT clone-on-write means we can speculatively modify it cheaply, which means that in `pd` we can get transactional modification of the NCT in the shielded pool without expensive cloning (cc: @hdevalence).

## Drawbacks

The data structure will be somewhat less cache-friendly due to the indirection, and use somewhat more memory, due to the use of `Arc` over `Box` and the introduction of several new `Arc`s. I don't think these are very big concerns, given that it's a very sparse structure in all use cases, and the bottleneck is always going to be hashing and (de)serialization, not cache/memory performance.