### PR TITLE
Make TCT internally clone-on-write and enable sync serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "bitvec"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2148,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "serde",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "include-flate"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3407,6 +3431,7 @@ dependencies = [
  "futures",
  "hash_hasher",
  "hex",
+ "im",
  "once_cell",
  "parking_lot 0.12.1",
  "penumbra-proto",
@@ -3991,6 +4016,15 @@ name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core",
 ]
@@ -4602,6 +4636,16 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "sketches-ddsketch"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,7 +3422,6 @@ dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
  "ark-serialize",
- "async-stream 0.3.3",
  "async-trait",
  "bincode",
  "blake2b_simd 1.0.0",

--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"] // required for TCT
-
 use anyhow::Result;
 use async_trait::async_trait;
 use penumbra_chain::genesis;

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -1,5 +1,3 @@
-// Rust analyzer complains without this (but rustc is happy regardless)
-#![recursion_limit = "256"]
 #![allow(clippy::clone_on_copy)]
 use std::fs;
 

--- a/pd/src/lib.rs
+++ b/pd/src/lib.rs
@@ -1,7 +1,4 @@
 //! Source code for the Penumbra node software.
-
-// This is for the async_stream macros
-#![recursion_limit = "512"]
 #![allow(clippy::clone_on_copy)]
 
 mod consensus;

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::clone_on_copy)]
-#![recursion_limit = "256"]
 use std::{
     net::{Ipv4Addr, SocketAddr},
     path::PathBuf,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,6 +1,3 @@
-// Required to ensure that Rust can infer a Send bound inside the TCT
-#![recursion_limit = "256"]
-
 use jmt::WriteOverlay;
 use std::sync::Arc;
 use tokio::sync::RwLock;

--- a/tct-property-test/tests/serialize.proptest-regressions
+++ b/tct-property-test/tests/serialize.proptest-regressions
@@ -11,3 +11,4 @@ cc 8619b833b7e7a539e37d7dd0b1e194b3dece907e49674492cbbd623680e35834 # shrinks to
 cc 0c32bbbce1056f187de693cf35ca552e66126e0c7a9ec4da2d3f6a0d554a9ffd # shrinks to actions = [Insert(Forget, note::Commitment(00500048c3153cfcce42a22031989588a1627d215b405f8d4ad2e187296f5400)), Serialize, EndBlock, Serialize]
 cc 97110e393ff804d3f90dcaef2766dccd3355314f9fc2f456f7bac6104ba69bbc # shrinks to actions = [EndEpoch, EndEpoch, EndEpoch, EndEpoch, Serialize]
 cc 1b46bc40ab02685bd9dc674a361f38f4c642d348ebb5116516aad948c6ac62ec # shrinks to actions = [Insert(Keep, note::Commitment(c8407d491237870b92f405fe475e39bdc9d5d44dc0fecdc91346d969042c0e0d)), Serialize, EndEpoch, Serialize]
+cc 2169500c072815d775b9f8f4e69abfa0eb186e64d790280b9eca0017f4a4c25c # shrinks to sparse = false, actions = [EndBlock, EndEpoch, EndEpoch, Serialize]

--- a/tct-property-test/tests/serialize.rs
+++ b/tct-property-test/tests/serialize.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"]
-
 #[macro_use]
 extern crate proptest_derive;
 

--- a/tct-visualize/src/bin/tct-live-edit.rs
+++ b/tct-visualize/src/bin/tct-live-edit.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"]
-
 use std::{path::PathBuf, sync::Arc};
 
 use axum::{headers::ContentType, routing::get, Router, TypedHeader};

--- a/tct-visualize/src/bin/tct-visualize.rs
+++ b/tct-visualize/src/bin/tct-visualize.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"]
-
 use std::{
     borrow::Cow,
     collections::BTreeMap,

--- a/tct-visualize/src/lib.rs
+++ b/tct-visualize/src/lib.rs
@@ -1,5 +1,3 @@
-#![recursion_limit = "256"]
-
 #[macro_use]
 extern crate serde;
 

--- a/tct-visualize/src/live/control.rs
+++ b/tct-visualize/src/live/control.rs
@@ -152,7 +152,7 @@ fn insert<R: Rng + Send + 'static>(
 }
 
 fn random_commitments<R: Rng>(mut rng: R, tree: &Tree, amount: usize) -> Vec<Commitment> {
-    tree.commitments()
+    tree.commitments_unordered()
         .map(|(c, _)| c)
         .collect::<Vec<_>>()
         .choose_multiple(&mut rng, amount)

--- a/tct-visualize/src/live/query.rs
+++ b/tct-visualize/src/live/query.rs
@@ -187,7 +187,7 @@ fn is_full(tree: watch::Receiver<Tree>, mark_change: Arc<watch::Sender<()>>) -> 
 fn commitments(tree: watch::Receiver<Tree>, mark_change: Arc<watch::Sender<()>>) -> MethodRouter {
     get(|| async move {
         Json(marking_change(mark_change, tree, |tree| {
-            tree.commitments()
+            tree.commitments_unordered()
                 .map(|(commitment, position)| {
                     json!({
                         "commitment": commitment,
@@ -208,7 +208,7 @@ fn commitments_ordered(
 ) -> MethodRouter {
     get(|| async move {
         Json(marking_change(mark_change, tree, |tree| {
-            tree.commitments_ordered()
+            tree.commitments()
                 .map(|(position, commitment)| {
                     json!({
                         "commitment": commitment,

--- a/tct-visualize/src/render/dot.rs
+++ b/tct-visualize/src/render/dot.rs
@@ -134,7 +134,7 @@ impl<W: Write> Writer<W> {
         // Connect all commitments together to align them
         if self.invisible_ordering_edges {
             let mut left = None;
-            for (right, _) in tree.commitments_ordered() {
+            for (right, _) in tree.commitments() {
                 if let Some(left) = left {
                     self.commitment_commitment_edge(left, right)?;
                     // w.commitment_commitment_edge(right, left)?;

--- a/tct/Cargo.toml
+++ b/tct/Cargo.toml
@@ -14,7 +14,7 @@ blake2b_simd = "1"
 hex = "0.4"
 hash_hasher = "2"
 thiserror = "1"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 parking_lot = "0.12"
 ark-ff = "0.3"
 ark-serialize = "0.3"
@@ -26,6 +26,7 @@ async-stream = "0.3"
 futures = "0.3"
 ark-ed-on-bls12-377 = "0.3"
 rand = "0.8"
+im = { version = "^15.1.0", features = ["serde"] } # IMPORTANT: an OrdMap correctness bug was fixed in 15.1.0, as well as a performance improvement to `union`
 
 # Dependencies for random testing
 proptest = { version = "1", optional = true }

--- a/tct/Cargo.toml
+++ b/tct/Cargo.toml
@@ -22,7 +22,6 @@ poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
 tracing = { version = "0.1" }
 async-trait = { version = "0.1" }
-async-stream = "0.3"
 futures = "0.3"
 ark-ed-on-bls12-377 = "0.3"
 rand = "0.8"

--- a/tct/src/block.rs
+++ b/tct/src/block.rs
@@ -116,7 +116,7 @@ impl Protobuf<pb::MerkleRoot> for Root {}
 
 impl Display for Root {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(&Fq::from(self.0).to_bytes()))
+        write!(f, "{}", hex::encode(Fq::from(self.0).to_bytes()))
     }
 }
 

--- a/tct/src/epoch.rs
+++ b/tct/src/epoch.rs
@@ -119,7 +119,7 @@ impl Protobuf<pb::MerkleRoot> for Root {}
 
 impl Display for Root {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(&Fq::from(self.0).to_bytes()))
+        write!(f, "{}", hex::encode(Fq::from(self.0).to_bytes()))
     }
 }
 

--- a/tct/src/internal/complete/item.rs
+++ b/tct/src/internal/complete/item.rs
@@ -66,15 +66,11 @@ impl<'tree> structure::Any<'tree> for Item {
         }
     }
 
-    fn global_position(&self) -> Option<Position> {
-        <Self as GetPosition>::position(self).map(Into::into)
-    }
-
     fn forgotten(&self) -> Forgotten {
         Forgotten::default()
     }
 
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
+    fn children(&self) -> Vec<HashOrNode<'tree>> {
         vec![]
     }
 }

--- a/tct/src/internal/complete/leaf.rs
+++ b/tct/src/internal/complete/leaf.rs
@@ -61,15 +61,11 @@ impl<'tree, Item: Height + structure::Any<'tree>> structure::Any<'tree> for Leaf
         self.0.kind()
     }
 
-    fn global_position(&self) -> Option<Position> {
-        <Self as GetPosition>::position(self).map(Into::into)
-    }
-
     fn forgotten(&self) -> Forgotten {
         self.0.forgotten()
     }
 
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
+    fn children(&'tree self) -> Vec<HashOrNode<'tree>> {
         self.0.children()
     }
 }

--- a/tct/src/internal/complete/node.rs
+++ b/tct/src/internal/complete/node.rs
@@ -325,6 +325,6 @@ mod test {
     #[test]
     fn check_node_size() {
         // Disabled due to spurious test failure.
-        // static_assertions::assert_eq_size!(Node<()>, [u8; 80]);
+        // static_assertions::assert_eq_size!(Node<()>, [u8; 72]);
     }
 }

--- a/tct/src/internal/complete/node/children.rs
+++ b/tct/src/internal/complete/node/children.rs
@@ -10,7 +10,7 @@
 
 #![allow(non_camel_case_types, clippy::upper_case_acronyms)]
 
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 mod shape;
 pub use shape::*;
@@ -21,38 +21,38 @@ use crate::prelude::*;
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Children<Child> {
     /// Children of a node having children in the positions: 3.
-    ___C(Box<___C<Child>>),
+    ___C(Arc<___C<Child>>),
     /// Children of a node having children in the positions: 2.
-    __C_(Box<__C_<Child>>),
+    __C_(Arc<__C_<Child>>),
     /// Children of a node having children in the positions: 2, 3.
-    __CC(Box<__CC<Child>>),
+    __CC(Arc<__CC<Child>>),
     /// Children of a node having children in the positions: 1.
-    _C__(Box<_C__<Child>>),
+    _C__(Arc<_C__<Child>>),
     /// Children of a node having children in the positions: 1, 3.
-    _C_C(Box<_C_C<Child>>),
+    _C_C(Arc<_C_C<Child>>),
     /// Children of a node having children in the positions: 1, 2.
-    _CC_(Box<_CC_<Child>>),
+    _CC_(Arc<_CC_<Child>>),
     /// Children of a node having children in the positions: 1, 2, 3.
-    _CCC(Box<_CCC<Child>>),
+    _CCC(Arc<_CCC<Child>>),
     /// Children of a node having children in the positions: 0.
-    C___(Box<C___<Child>>),
+    C___(Arc<C___<Child>>),
     /// Children of a node having children in the positions: 0, 3.
-    C__C(Box<C__C<Child>>),
+    C__C(Arc<C__C<Child>>),
     /// Children of a node having children in the positions: 0, 2.
-    C_C_(Box<C_C_<Child>>),
+    C_C_(Arc<C_C_<Child>>),
     /// Children of a node having children in the positions: 0, 2, 3.
-    C_CC(Box<C_CC<Child>>),
+    C_CC(Arc<C_CC<Child>>),
     /// Children of a node having children in the positions: 0, 1.
-    CC__(Box<CC__<Child>>),
+    CC__(Arc<CC__<Child>>),
     /// Children of a node having children in the positions: 0, 1, 3.
-    CC_C(Box<CC_C<Child>>),
+    CC_C(Arc<CC_C<Child>>),
     /// Children of a node having children in the positions: 0, 1, 2.
-    CCC_(Box<CCC_<Child>>),
+    CCC_(Arc<CCC_<Child>>),
     /// Children of a node having children in the positions: 0, 1, 2, 3.
-    CCCC(Box<CCCC<Child>>),
+    CCCC(Arc<CCCC<Child>>),
 }
 
-impl<Child: Debug> Debug for Children<Child> {
+impl<Child: Debug + Clone> Debug for Children<Child> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.children().fmt(f)
     }
@@ -62,7 +62,7 @@ impl<Child: Height> Height for Children<Child> {
     type Height = Succ<<Child as Height>::Height>;
 }
 
-impl<Child: Height + GetHash> GetHash for Children<Child> {
+impl<Child: Height + GetHash + Clone> GetHash for Children<Child> {
     fn hash(&self) -> Hash {
         let [a, b, c, d] = self.children().map(|x| x.hash());
         Hash::node(<Self as Height>::Height::HEIGHT, a, b, c, d)
@@ -88,26 +88,26 @@ where
             // hashes so the parent can implement pruning):
             [Hash(a), Hash(b), Hash(c), Hash(d)] => return Err([a, b, c, d]),
             // There is at least one witnessed child:
-            [Hash(a), Hash(b), Hash(c), Keep(d)] => Children::___C(Box::new(___C(a, b, c, d))),
-            [Hash(a), Hash(b), Keep(c), Hash(d)] => Children::__C_(Box::new(__C_(a, b, c, d))),
-            [Hash(a), Hash(b), Keep(c), Keep(d)] => Children::__CC(Box::new(__CC(a, b, c, d))),
-            [Hash(a), Keep(b), Hash(c), Hash(d)] => Children::_C__(Box::new(_C__(a, b, c, d))),
-            [Hash(a), Keep(b), Hash(c), Keep(d)] => Children::_C_C(Box::new(_C_C(a, b, c, d))),
-            [Hash(a), Keep(b), Keep(c), Hash(d)] => Children::_CC_(Box::new(_CC_(a, b, c, d))),
-            [Hash(a), Keep(b), Keep(c), Keep(d)] => Children::_CCC(Box::new(_CCC(a, b, c, d))),
-            [Keep(a), Hash(b), Hash(c), Hash(d)] => Children::C___(Box::new(C___(a, b, c, d))),
-            [Keep(a), Hash(b), Hash(c), Keep(d)] => Children::C__C(Box::new(C__C(a, b, c, d))),
-            [Keep(a), Hash(b), Keep(c), Hash(d)] => Children::C_C_(Box::new(C_C_(a, b, c, d))),
-            [Keep(a), Hash(b), Keep(c), Keep(d)] => Children::C_CC(Box::new(C_CC(a, b, c, d))),
-            [Keep(a), Keep(b), Hash(c), Hash(d)] => Children::CC__(Box::new(CC__(a, b, c, d))),
-            [Keep(a), Keep(b), Hash(c), Keep(d)] => Children::CC_C(Box::new(CC_C(a, b, c, d))),
-            [Keep(a), Keep(b), Keep(c), Hash(d)] => Children::CCC_(Box::new(CCC_(a, b, c, d))),
-            [Keep(a), Keep(b), Keep(c), Keep(d)] => Children::CCCC(Box::new(CCCC(a, b, c, d))),
+            [Hash(a), Hash(b), Hash(c), Keep(d)] => Children::___C(Arc::new(___C(a, b, c, d))),
+            [Hash(a), Hash(b), Keep(c), Hash(d)] => Children::__C_(Arc::new(__C_(a, b, c, d))),
+            [Hash(a), Hash(b), Keep(c), Keep(d)] => Children::__CC(Arc::new(__CC(a, b, c, d))),
+            [Hash(a), Keep(b), Hash(c), Hash(d)] => Children::_C__(Arc::new(_C__(a, b, c, d))),
+            [Hash(a), Keep(b), Hash(c), Keep(d)] => Children::_C_C(Arc::new(_C_C(a, b, c, d))),
+            [Hash(a), Keep(b), Keep(c), Hash(d)] => Children::_CC_(Arc::new(_CC_(a, b, c, d))),
+            [Hash(a), Keep(b), Keep(c), Keep(d)] => Children::_CCC(Arc::new(_CCC(a, b, c, d))),
+            [Keep(a), Hash(b), Hash(c), Hash(d)] => Children::C___(Arc::new(C___(a, b, c, d))),
+            [Keep(a), Hash(b), Hash(c), Keep(d)] => Children::C__C(Arc::new(C__C(a, b, c, d))),
+            [Keep(a), Hash(b), Keep(c), Hash(d)] => Children::C_C_(Arc::new(C_C_(a, b, c, d))),
+            [Keep(a), Hash(b), Keep(c), Keep(d)] => Children::C_CC(Arc::new(C_CC(a, b, c, d))),
+            [Keep(a), Keep(b), Hash(c), Hash(d)] => Children::CC__(Arc::new(CC__(a, b, c, d))),
+            [Keep(a), Keep(b), Hash(c), Keep(d)] => Children::CC_C(Arc::new(CC_C(a, b, c, d))),
+            [Keep(a), Keep(b), Keep(c), Hash(d)] => Children::CCC_(Arc::new(CCC_(a, b, c, d))),
+            [Keep(a), Keep(b), Keep(c), Keep(d)] => Children::CCCC(Arc::new(CCCC(a, b, c, d))),
         })
     }
 }
 
-impl<Child> Children<Child> {
+impl<Child: Clone> Children<Child> {
     /// Get an array of references to the children or hashes stored in this [`Children`].
     pub fn children(&self) -> [Insert<&Child>; 4] {
         use Children::*;
@@ -138,122 +138,192 @@ impl<Child> Children<Child> {
         use InsertMut::*;
 
         match self {
-            ___C(c) => [
-                Hash(&mut c.0),
-                Hash(&mut c.1),
-                Hash(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            __C_(c) => [
-                Hash(&mut c.0),
-                Hash(&mut c.1),
-                Keep(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            __CC(c) => [
-                Hash(&mut c.0),
-                Hash(&mut c.1),
-                Keep(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            _C__(c) => [
-                Hash(&mut c.0),
-                Keep(&mut c.1),
-                Hash(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            _C_C(c) => [
-                Hash(&mut c.0),
-                Keep(&mut c.1),
-                Hash(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            _CC_(c) => [
-                Hash(&mut c.0),
-                Keep(&mut c.1),
-                Keep(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            _CCC(c) => [
-                Hash(&mut c.0),
-                Keep(&mut c.1),
-                Keep(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            C___(c) => [
-                Keep(&mut c.0),
-                Hash(&mut c.1),
-                Hash(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            C__C(c) => [
-                Keep(&mut c.0),
-                Hash(&mut c.1),
-                Hash(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            C_C_(c) => [
-                Keep(&mut c.0),
-                Hash(&mut c.1),
-                Keep(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            C_CC(c) => [
-                Keep(&mut c.0),
-                Hash(&mut c.1),
-                Keep(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            CC__(c) => [
-                Keep(&mut c.0),
-                Keep(&mut c.1),
-                Hash(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            CC_C(c) => [
-                Keep(&mut c.0),
-                Keep(&mut c.1),
-                Hash(&mut c.2),
-                Keep(&mut c.3),
-            ],
-            CCC_(c) => [
-                Keep(&mut c.0),
-                Keep(&mut c.1),
-                Keep(&mut c.2),
-                Hash(&mut c.3),
-            ],
-            CCCC(c) => [
-                Keep(&mut c.0),
-                Keep(&mut c.1),
-                Keep(&mut c.2),
-                Keep(&mut c.3),
-            ],
+            ___C(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Hash(&mut c.1),
+                    Hash(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            __C_(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Hash(&mut c.1),
+                    Keep(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            __CC(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Hash(&mut c.1),
+                    Keep(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            _C__(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Keep(&mut c.1),
+                    Hash(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            _C_C(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Keep(&mut c.1),
+                    Hash(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            _CC_(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Keep(&mut c.1),
+                    Keep(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            _CCC(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Hash(&mut c.0),
+                    Keep(&mut c.1),
+                    Keep(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            C___(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Hash(&mut c.1),
+                    Hash(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            C__C(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Hash(&mut c.1),
+                    Hash(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            C_C_(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Hash(&mut c.1),
+                    Keep(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            C_CC(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Hash(&mut c.1),
+                    Keep(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            CC__(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Keep(&mut c.1),
+                    Hash(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            CC_C(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Keep(&mut c.1),
+                    Hash(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
+            CCC_(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Keep(&mut c.1),
+                    Keep(&mut c.2),
+                    Hash(&mut c.3),
+                ]
+            }
+            CCCC(c) => {
+                let c = Arc::make_mut(c);
+                [
+                    Keep(&mut c.0),
+                    Keep(&mut c.1),
+                    Keep(&mut c.2),
+                    Keep(&mut c.3),
+                ]
+            }
         }
     }
 }
 
-impl<Child> From<Children<Child>> for [Insert<Child>; 4] {
+impl<Child: Clone> From<Children<Child>> for [Insert<Child>; 4] {
     /// Get an array of references to the children or hashes stored in this [`Children`].
     fn from(children: Children<Child>) -> [Insert<Child>; 4] {
         use Children::*;
         use Insert::*;
 
         match children {
-            ___C(c) => [Hash(c.0), Hash(c.1), Hash(c.2), Keep(c.3)],
-            __C_(c) => [Hash(c.0), Hash(c.1), Keep(c.2), Hash(c.3)],
-            __CC(c) => [Hash(c.0), Hash(c.1), Keep(c.2), Keep(c.3)],
-            _C__(c) => [Hash(c.0), Keep(c.1), Hash(c.2), Hash(c.3)],
-            _C_C(c) => [Hash(c.0), Keep(c.1), Hash(c.2), Keep(c.3)],
-            _CC_(c) => [Hash(c.0), Keep(c.1), Keep(c.2), Hash(c.3)],
-            _CCC(c) => [Hash(c.0), Keep(c.1), Keep(c.2), Keep(c.3)],
-            C___(c) => [Keep(c.0), Hash(c.1), Hash(c.2), Hash(c.3)],
-            C__C(c) => [Keep(c.0), Hash(c.1), Hash(c.2), Keep(c.3)],
-            C_C_(c) => [Keep(c.0), Hash(c.1), Keep(c.2), Hash(c.3)],
-            C_CC(c) => [Keep(c.0), Hash(c.1), Keep(c.2), Keep(c.3)],
-            CC__(c) => [Keep(c.0), Keep(c.1), Hash(c.2), Hash(c.3)],
-            CC_C(c) => [Keep(c.0), Keep(c.1), Hash(c.2), Keep(c.3)],
-            CCC_(c) => [Keep(c.0), Keep(c.1), Keep(c.2), Hash(c.3)],
-            CCCC(c) => [Keep(c.0), Keep(c.1), Keep(c.2), Keep(c.3)],
+            ___C(c) => [Hash(c.0), Hash(c.1), Hash(c.2), Keep(c.3.clone())],
+            __C_(c) => [Hash(c.0), Hash(c.1), Keep(c.2.clone()), Hash(c.3)],
+            __CC(c) => [Hash(c.0), Hash(c.1), Keep(c.2.clone()), Keep(c.3.clone())],
+            _C__(c) => [Hash(c.0), Keep(c.1.clone()), Hash(c.2), Hash(c.3)],
+            _C_C(c) => [Hash(c.0), Keep(c.1.clone()), Hash(c.2), Keep(c.3.clone())],
+            _CC_(c) => [Hash(c.0), Keep(c.1.clone()), Keep(c.2.clone()), Hash(c.3)],
+            _CCC(c) => [
+                Hash(c.0),
+                Keep(c.1.clone()),
+                Keep(c.2.clone()),
+                Keep(c.3.clone()),
+            ],
+            C___(c) => [Keep(c.0.clone()), Hash(c.1), Hash(c.2), Hash(c.3)],
+            C__C(c) => [Keep(c.0.clone()), Hash(c.1), Hash(c.2), Keep(c.3.clone())],
+            C_C_(c) => [Keep(c.0.clone()), Hash(c.1), Keep(c.2.clone()), Hash(c.3)],
+            C_CC(c) => [
+                Keep(c.0.clone()),
+                Hash(c.1),
+                Keep(c.2.clone()),
+                Keep(c.3.clone()),
+            ],
+            CC__(c) => [Keep(c.0.clone()), Keep(c.1.clone()), Hash(c.2), Hash(c.3)],
+            CC_C(c) => [
+                Keep(c.0.clone()),
+                Keep(c.1.clone()),
+                Hash(c.2),
+                Keep(c.3.clone()),
+            ],
+            CCC_(c) => [
+                Keep(c.0.clone()),
+                Keep(c.1.clone()),
+                Keep(c.2.clone()),
+                Hash(c.3),
+            ],
+            CCCC(c) => [
+                Keep(c.0.clone()),
+                Keep(c.1.clone()),
+                Keep(c.2.clone()),
+                Keep(c.3.clone()),
+            ],
         }
     }
 }

--- a/tct/src/internal/complete/tier.rs
+++ b/tct/src/internal/complete/tier.rs
@@ -9,15 +9,15 @@ pub type Nested<Item> = N<N<N<N<N<N<N<N<L<Item>>>>>>>>>;
 
 /// A complete tier of the tiered commitment tree, being an 8-deep sparse quad-tree.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Tier<Item: GetHash + Height> {
+pub struct Tier<Item: GetHash + Height + Clone> {
     pub(in super::super) inner: Nested<Item>,
 }
 
-impl<Item: GetHash + Height> Height for Tier<Item> {
+impl<Item: GetHash + Height + Clone> Height for Tier<Item> {
     type Height = <Nested<Item> as Height>::Height;
 }
 
-impl<Item: GetHash + Height> GetHash for Tier<Item> {
+impl<Item: GetHash + Height + Clone> GetHash for Tier<Item> {
     #[inline]
     fn hash(&self) -> Hash {
         self.inner.hash()
@@ -29,18 +29,21 @@ impl<Item: GetHash + Height> GetHash for Tier<Item> {
     }
 }
 
-impl<Item: Complete> Complete for Tier<Item> {
+impl<Item: Complete + Clone> Complete for Tier<Item>
+where
+    Item::Focus: Clone,
+{
     type Focus = frontier::Tier<Item::Focus>;
 }
 
-impl<Item: GetHash + Witness> Witness for Tier<Item> {
+impl<Item: GetHash + Witness + Clone> Witness for Tier<Item> {
     #[inline]
     fn witness(&self, index: impl Into<u64>) -> Option<(AuthPath<Self>, Hash)> {
         self.inner.witness(index)
     }
 }
 
-impl<Item: GetHash + ForgetOwned> ForgetOwned for Tier<Item> {
+impl<Item: GetHash + ForgetOwned + Clone> ForgetOwned for Tier<Item> {
     fn forget_owned(
         self,
         forgotten: Option<Forgotten>,
@@ -51,19 +54,22 @@ impl<Item: GetHash + ForgetOwned> ForgetOwned for Tier<Item> {
     }
 }
 
-impl<Item: Complete> From<frontier::Tier<Item::Focus>> for Insert<Tier<Item>> {
+impl<Item: Complete + Clone> From<frontier::Tier<Item::Focus>> for Insert<Tier<Item>>
+where
+    Item::Focus: Clone,
+{
     fn from(frontier: frontier::Tier<Item::Focus>) -> Self {
         frontier.finalize_owned()
     }
 }
 
-impl<Item: GetHash + Height> GetPosition for Tier<Item> {
+impl<Item: GetHash + Height + Clone> GetPosition for Tier<Item> {
     fn position(&self) -> Option<u64> {
         None
     }
 }
 
-impl<'tree, Item: Height + structure::Any<'tree>> structure::Any<'tree> for Tier<Item> {
+impl<'tree, Item: Height + structure::Any<'tree> + Clone> structure::Any<'tree> for Tier<Item> {
     fn kind(&self) -> Kind {
         self.inner.kind()
     }
@@ -81,7 +87,7 @@ impl<'tree, Item: Height + structure::Any<'tree>> structure::Any<'tree> for Tier
     }
 }
 
-impl<Item: GetHash + Height + OutOfOrderOwned> OutOfOrderOwned for Tier<Item> {
+impl<Item: GetHash + Height + OutOfOrderOwned + Clone> OutOfOrderOwned for Tier<Item> {
     fn uninitialized_out_of_order_insert_commitment_owned(
         this: Insert<Self>,
         index: u64,
@@ -97,7 +103,7 @@ impl<Item: GetHash + Height + OutOfOrderOwned> OutOfOrderOwned for Tier<Item> {
     }
 }
 
-impl<Item: GetHash + UncheckedSetHash> UncheckedSetHash for Tier<Item> {
+impl<Item: GetHash + UncheckedSetHash + Clone> UncheckedSetHash for Tier<Item> {
     fn unchecked_set_hash(&mut self, index: u64, height: u8, hash: Hash) {
         self.inner.unchecked_set_hash(index, height, hash)
     }

--- a/tct/src/internal/complete/tier.rs
+++ b/tct/src/internal/complete/tier.rs
@@ -74,15 +74,11 @@ impl<'tree, Item: Height + structure::Any<'tree> + Clone> structure::Any<'tree> 
         self.inner.kind()
     }
 
-    fn global_position(&self) -> Option<Position> {
-        <Self as GetPosition>::position(self).map(Into::into)
-    }
-
     fn forgotten(&self) -> Forgotten {
         structure::Any::forgotten(&self.inner)
     }
 
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
+    fn children(&'tree self) -> Vec<HashOrNode<'tree>> {
         (&self.inner as &dyn structure::Any).children()
     }
 }

--- a/tct/src/internal/complete/top.rs
+++ b/tct/src/internal/complete/top.rs
@@ -41,15 +41,11 @@ impl<'tree, Item: Height + structure::Any<'tree> + Clone> structure::Any<'tree> 
         self.inner.kind()
     }
 
-    fn global_position(&self) -> Option<Position> {
-        <Self as GetPosition>::position(self).map(Into::into)
-    }
-
     fn forgotten(&self) -> Forgotten {
         (&self.inner as &dyn structure::Any).forgotten()
     }
 
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
+    fn children(&'tree self) -> Vec<HashOrNode<'tree>> {
         (&self.inner as &dyn structure::Any).children()
     }
 }

--- a/tct/src/internal/complete/top.rs
+++ b/tct/src/internal/complete/top.rs
@@ -4,15 +4,15 @@ use complete::Nested;
 
 /// A complete top-level tier of the tiered commitment tree, being an 8-deep sparse quad-tree.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Top<Item: GetHash + Height> {
+pub struct Top<Item: GetHash + Height + Clone> {
     pub(in super::super) inner: Nested<Item>,
 }
 
-impl<Item: GetHash + Height> Height for Top<Item> {
+impl<Item: GetHash + Height + Clone> Height for Top<Item> {
     type Height = <Nested<Item> as Height>::Height;
 }
 
-impl<Item: GetHash + Height> GetHash for Top<Item> {
+impl<Item: GetHash + Height + Clone> GetHash for Top<Item> {
     #[inline]
     fn hash(&self) -> Hash {
         self.inner.hash()
@@ -24,19 +24,19 @@ impl<Item: GetHash + Height> GetHash for Top<Item> {
     }
 }
 
-impl<Item: GetHash + Height> From<complete::Tier<Item>> for Top<Item> {
+impl<Item: GetHash + Height + Clone> From<complete::Tier<Item>> for Top<Item> {
     fn from(tier: complete::Tier<Item>) -> Self {
         Top { inner: tier.inner }
     }
 }
 
-impl<Item: Height + GetHash> GetPosition for Top<Item> {
+impl<Item: Height + GetHash + Clone> GetPosition for Top<Item> {
     fn position(&self) -> Option<u64> {
         None
     }
 }
 
-impl<'tree, Item: Height + structure::Any<'tree>> structure::Any<'tree> for Top<Item> {
+impl<'tree, Item: Height + structure::Any<'tree> + Clone> structure::Any<'tree> for Top<Item> {
     fn kind(&self) -> Kind {
         self.inner.kind()
     }
@@ -54,7 +54,7 @@ impl<'tree, Item: Height + structure::Any<'tree>> structure::Any<'tree> for Top<
     }
 }
 
-impl<Item: GetHash + Height + OutOfOrderOwned> OutOfOrderOwned for Top<Item> {
+impl<Item: GetHash + Height + OutOfOrderOwned + Clone> OutOfOrderOwned for Top<Item> {
     fn uninitialized_out_of_order_insert_commitment_owned(
         this: Insert<Self>,
         index: u64,
@@ -70,7 +70,7 @@ impl<Item: GetHash + Height + OutOfOrderOwned> OutOfOrderOwned for Top<Item> {
     }
 }
 
-impl<Item: GetHash + UncheckedSetHash> UncheckedSetHash for Top<Item> {
+impl<Item: GetHash + UncheckedSetHash + Clone> UncheckedSetHash for Top<Item> {
     fn unchecked_set_hash(&mut self, index: u64, height: u8, hash: Hash) {
         self.inner.unchecked_set_hash(index, height, hash)
     }

--- a/tct/src/internal/frontier/item.rs
+++ b/tct/src/internal/frontier/item.rs
@@ -89,15 +89,11 @@ impl<'tree> structure::Any<'tree> for Item {
         }
     }
 
-    fn global_position(&self) -> Option<Position> {
-        <Self as GetPosition>::position(self).map(Into::into)
-    }
-
     fn forgotten(&self) -> Forgotten {
         Forgotten::default()
     }
 
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
+    fn children(&self) -> Vec<HashOrNode<'tree>> {
         vec![]
     }
 }

--- a/tct/src/internal/frontier/leaf.rs
+++ b/tct/src/internal/frontier/leaf.rs
@@ -97,15 +97,11 @@ impl<'tree, Item: GetPosition + Height + structure::Any<'tree>> structure::Any<'
         self.item.kind()
     }
 
-    fn global_position(&self) -> Option<Position> {
-        <Self as GetPosition>::position(self).map(Into::into)
-    }
-
     fn forgotten(&self) -> Forgotten {
         self.item.forgotten()
     }
 
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
+    fn children(&'tree self) -> Vec<HashOrNode<'tree>> {
         self.item.children()
     }
 }

--- a/tct/src/internal/frontier/tier.rs
+++ b/tct/src/internal/frontier/tier.rs
@@ -327,10 +327,6 @@ where
         }
     }
 
-    fn global_position(&self) -> Option<Position> {
-        <Self as GetPosition>::position(self).map(Into::into)
-    }
-
     fn forgotten(&self) -> Forgotten {
         match &self.inner {
             Inner::Frontier(frontier) => (&**frontier as &dyn structure::Any).forgotten(),
@@ -339,11 +335,11 @@ where
         }
     }
 
-    fn children(&self) -> Vec<structure::Node<'_, 'tree>> {
+    fn children(&'tree self) -> Vec<HashOrNode<'tree>> {
         match &self.inner {
             Inner::Frontier(frontier) => frontier.children(),
             Inner::Complete(complete) => (complete as &dyn structure::Any).children(),
-            Inner::Hash(_) => vec![],
+            Inner::Hash(_hash) => vec![],
         }
     }
 }

--- a/tct/src/internal/frontier/tier.rs
+++ b/tct/src/internal/frontier/tier.rs
@@ -451,12 +451,6 @@ mod test {
     use super::*;
 
     #[test]
-    fn check_inner_size() {
-        // Disabled due to spurious test failure.
-        // static_assertions::assert_eq_size!(Tier<Tier<Tier<frontier::Item>>>, [u8; 88]);
-    }
-
-    #[test]
     fn position_advances_by_one() {
         let mut tier: Tier<Item> = Tier::new(Hash::zero().into());
         for expected_position in 1..=(u16::MAX as u64) {

--- a/tct/src/internal/frontier/tier.rs
+++ b/tct/src/internal/frontier/tier.rs
@@ -14,7 +14,10 @@ use crate::prelude::*;
     serialize = "Item: Serialize, Item::Complete: Serialize",
     deserialize = "Item: Deserialize<'de>, Item::Complete: Deserialize<'de>"
 ))]
-pub struct Tier<Item: Focus> {
+pub struct Tier<Item: Focus + Clone>
+where
+    Item::Complete: Clone,
+{
     inner: Inner<Item>,
 }
 
@@ -32,10 +35,13 @@ pub type Nested<Item> = N<N<N<N<N<N<N<N<L<Item>>>>>>>>>;
     Clone(bound = "Item: Clone, Item::Complete: Clone")
 )]
 #[serde(bound(
-    serialize = "Item: Serialize, Item::Complete: Serialize",
+    serialize = "Item: Serialize, Item::Complete: Serialize + Clone",
     deserialize = "Item: Deserialize<'de>, Item::Complete: Deserialize<'de>"
 ))]
-pub enum Inner<Item: Focus> {
+pub enum Inner<Item: Focus + Clone>
+where
+    Item::Complete: Clone,
+{
     /// A tree with at least one leaf.
     Frontier(Box<Nested<Item>>),
     /// A completed tree which has at least one witnessed child.
@@ -45,7 +51,10 @@ pub enum Inner<Item: Focus> {
     Hash(Hash),
 }
 
-impl<Item: Focus> From<Hash> for Tier<Item> {
+impl<Item: Focus + Clone> From<Hash> for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     #[inline]
     fn from(hash: Hash) -> Self {
         Self {
@@ -54,7 +63,10 @@ impl<Item: Focus> From<Hash> for Tier<Item> {
     }
 }
 
-impl<Item: Focus> Tier<Item> {
+impl<Item: Focus + Clone> Tier<Item>
+where
+    Item::Complete: Clone,
+{
     /// Create a new tier from a single item which will be its first element.
     #[inline]
     pub fn new(item: Item) -> Self {
@@ -173,11 +185,17 @@ impl<Item: Focus> Tier<Item> {
     }
 }
 
-impl<Item: Focus> Height for Tier<Item> {
+impl<Item: Focus + Clone> Height for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     type Height = <Nested<Item> as Height>::Height;
 }
 
-impl<Item: Focus> GetHash for Tier<Item> {
+impl<Item: Focus + Clone> GetHash for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     #[inline]
     fn hash(&self) -> Hash {
         match &self.inner {
@@ -197,7 +215,10 @@ impl<Item: Focus> GetHash for Tier<Item> {
     }
 }
 
-impl<Item: Focus> Focus for Tier<Item> {
+impl<Item: Focus + Clone> Focus for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     type Complete = complete::Tier<Item::Complete>;
 
     #[inline]
@@ -213,9 +234,9 @@ impl<Item: Focus> Focus for Tier<Item> {
     }
 }
 
-impl<Item: Focus + Witness> Witness for Tier<Item>
+impl<Item: Focus + Witness + Clone> Witness for Tier<Item>
 where
-    Item::Complete: Witness,
+    Item::Complete: Witness + Clone,
 {
     #[inline]
     fn witness(&self, index: impl Into<u64>) -> Option<(AuthPath<Self>, Hash)> {
@@ -227,7 +248,10 @@ where
     }
 }
 
-impl<Item: Focus + GetPosition> GetPosition for Tier<Item> {
+impl<Item: Focus + GetPosition + Clone> GetPosition for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     #[inline]
     fn position(&self) -> Option<u64> {
         match &self.inner {
@@ -237,9 +261,9 @@ impl<Item: Focus + GetPosition> GetPosition for Tier<Item> {
     }
 }
 
-impl<Item: Focus + Forget> Forget for Tier<Item>
+impl<Item: Focus + Forget + Clone> Forget for Tier<Item>
 where
-    Item::Complete: ForgetOwned,
+    Item::Complete: ForgetOwned + Clone,
 {
     #[inline]
     fn forget(&mut self, forgotten: Option<Forgotten>, index: impl Into<u64>) -> bool {
@@ -270,7 +294,10 @@ where
     }
 }
 
-impl<Item: Focus> From<complete::Tier<Item::Complete>> for Tier<Item> {
+impl<Item: Focus + Clone> From<complete::Tier<Item::Complete>> for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     fn from(complete: complete::Tier<Item::Complete>) -> Self {
         Self {
             inner: Inner::Complete(complete.inner),
@@ -278,7 +305,10 @@ impl<Item: Focus> From<complete::Tier<Item::Complete>> for Tier<Item> {
     }
 }
 
-impl<Item: Focus> From<complete::Top<Item::Complete>> for Tier<Item> {
+impl<Item: Focus + Clone> From<complete::Top<Item::Complete>> for Tier<Item>
+where
+    Item::Complete: Clone,
+{
     fn from(complete: complete::Top<Item::Complete>) -> Self {
         Self {
             inner: Inner::Complete(complete.inner),
@@ -286,10 +316,10 @@ impl<Item: Focus> From<complete::Top<Item::Complete>> for Tier<Item> {
     }
 }
 
-impl<'tree, Item: Focus + GetPosition + Height + structure::Any<'tree>> structure::Any<'tree>
-    for Tier<Item>
+impl<'tree, Item: Focus + GetPosition + Height + structure::Any<'tree> + Clone>
+    structure::Any<'tree> for Tier<Item>
 where
-    Item::Complete: structure::Any<'tree>,
+    Item::Complete: structure::Any<'tree> + Clone,
 {
     fn kind(&self) -> Kind {
         Kind::Internal {
@@ -318,9 +348,9 @@ where
     }
 }
 
-impl<Item: Focus + OutOfOrder> OutOfOrder for Tier<Item>
+impl<Item: Focus + OutOfOrder + Clone> OutOfOrder for Tier<Item>
 where
-    Item::Complete: OutOfOrderOwned,
+    Item::Complete: OutOfOrderOwned + Clone,
 {
     fn uninitialized(position: Option<u64>, forgotten: Forgotten) -> Self {
         // This tier is finalized if the position relative to its own height is 0 (because a
@@ -386,9 +416,9 @@ where
     }
 }
 
-impl<Item: Focus + UncheckedSetHash> UncheckedSetHash for Tier<Item>
+impl<Item: Focus + UncheckedSetHash + Clone> UncheckedSetHash for Tier<Item>
 where
-    Item::Complete: UncheckedSetHash,
+    Item::Complete: UncheckedSetHash + Clone,
 {
     fn unchecked_set_hash(&mut self, index: u64, height: u8, hash: Hash) {
         match &mut self.inner {

--- a/tct/src/internal/frontier/top.rs
+++ b/tct/src/internal/frontier/top.rs
@@ -17,7 +17,10 @@ use frontier::tier::Nested;
     serialize = "Item: Serialize, Item::Complete: Serialize",
     deserialize = "Item: Deserialize<'de>, Item::Complete: Deserialize<'de>"
 ))]
-pub struct Top<Item: Focus> {
+pub struct Top<Item: Focus + Clone>
+where
+    Item::Complete: Clone,
+{
     track_forgotten: TrackForgotten,
     inner: Option<Nested<Item>>,
 }
@@ -36,7 +39,10 @@ pub enum TrackForgotten {
     No,
 }
 
-impl<Item: Focus> Top<Item> {
+impl<Item: Focus + Clone> Top<Item>
+where
+    Item::Complete: Clone,
+{
     /// Create a new top-level frontier tier.
     #[allow(unused)]
     pub fn new(track_forgotten: TrackForgotten) -> Self {
@@ -165,11 +171,17 @@ impl<Item: Focus> Top<Item> {
     }
 }
 
-impl<Item: Focus> Height for Top<Item> {
+impl<Item: Focus + Clone> Height for Top<Item>
+where
+    Item::Complete: Clone,
+{
     type Height = <Nested<Item> as Height>::Height;
 }
 
-impl<Item: Focus + GetPosition> GetPosition for Top<Item> {
+impl<Item: Focus + GetPosition + Clone> GetPosition for Top<Item>
+where
+    Item::Complete: Clone,
+{
     #[inline]
     fn position(&self) -> Option<u64> {
         if let Some(ref frontier) = self.inner {
@@ -180,7 +192,10 @@ impl<Item: Focus + GetPosition> GetPosition for Top<Item> {
     }
 }
 
-impl<Item: Focus> GetHash for Top<Item> {
+impl<Item: Focus + Clone> GetHash for Top<Item>
+where
+    Item::Complete: Clone,
+{
     #[inline]
     fn hash(&self) -> Hash {
         if let Some(ref inner) = self.inner {
@@ -200,9 +215,9 @@ impl<Item: Focus> GetHash for Top<Item> {
     }
 }
 
-impl<Item: Focus + Witness> Witness for Top<Item>
+impl<Item: Focus + Witness + Clone> Witness for Top<Item>
 where
-    Item::Complete: Witness,
+    Item::Complete: Witness + Clone,
 {
     fn witness(&self, index: impl Into<u64>) -> Option<(AuthPath<Self>, Hash)> {
         if let Some(ref inner) = self.inner {
@@ -213,10 +228,10 @@ where
     }
 }
 
-impl<'tree, Item: Focus + GetPosition + Height + structure::Any<'tree>> structure::Any<'tree>
-    for Top<Item>
+impl<'tree, Item: Focus + GetPosition + Height + structure::Any<'tree> + Clone>
+    structure::Any<'tree> for Top<Item>
 where
-    Item::Complete: structure::Any<'tree>,
+    Item::Complete: structure::Any<'tree> + Clone,
 {
     fn kind(&self) -> Kind {
         Kind::Internal {
@@ -240,9 +255,9 @@ where
     }
 }
 
-impl<Item: Focus + Height + OutOfOrder> OutOfOrder for Top<Item>
+impl<Item: Focus + Height + OutOfOrder + Clone> OutOfOrder for Top<Item>
 where
-    Item::Complete: OutOfOrderOwned,
+    Item::Complete: OutOfOrderOwned + Clone,
 {
     fn uninitialized(position: Option<u64>, forgotten: Forgotten) -> Self {
         let inner = if position == Some(0) {
@@ -268,9 +283,9 @@ where
     }
 }
 
-impl<Item: Focus + Height + UncheckedSetHash> UncheckedSetHash for Top<Item>
+impl<Item: Focus + Height + UncheckedSetHash + Clone> UncheckedSetHash for Top<Item>
 where
-    Item::Complete: UncheckedSetHash,
+    Item::Complete: UncheckedSetHash + Clone,
 {
     fn unchecked_set_hash(&mut self, index: u64, height: u8, hash: Hash) {
         if let Some(ref mut inner) = self.inner {

--- a/tct/src/internal/frontier/top.rs
+++ b/tct/src/internal/frontier/top.rs
@@ -239,15 +239,11 @@ where
         }
     }
 
-    fn global_position(&self) -> Option<Position> {
-        <Self as GetPosition>::position(self).map(Into::into)
-    }
-
     fn forgotten(&self) -> Forgotten {
         self.forgotten().unwrap_or_default()
     }
 
-    fn children(&self) -> Vec<structure::Node<'_, 'tree>> {
+    fn children(&'tree self) -> Vec<HashOrNode<'tree>> {
         self.inner
             .as_ref()
             .map(structure::Any::children)

--- a/tct/src/internal/hash.rs
+++ b/tct/src/internal/hash.rs
@@ -2,7 +2,10 @@
 //! [`GetHash`] trait for computing and caching hashes of things, and the [`CachedHash`] type, which
 //! is used internally for lazy evaluation of hashes.
 
-use std::{fmt::Debug, ops::RangeInclusive};
+use std::{
+    fmt::{self, Debug, Formatter},
+    ops::RangeInclusive,
+};
 
 use ark_ff::{fields::PrimeField, BigInteger256, Fp256, One, Zero};
 use decaf377::FieldExt;
@@ -85,8 +88,10 @@ impl Debug for Hash {
             write!(f, "0")
         } else if *self == Hash::one() {
             write!(f, "1")
+        } else if *self == Hash::uninitialized() {
+            write!(f, "!")
         } else {
-            write!(f, "{}", hex::encode(&self.to_bytes()))
+            write!(f, "{}", hex::encode(self.to_bytes()))
         }
     }
 }
@@ -218,10 +223,15 @@ impl Hash {
     Deserialize,
     Default,
 )]
-#[derivative(Debug = "transparent")]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(proptest_derive::Arbitrary))]
 #[serde(from = "u64", into = "u64")]
 pub struct Forgotten([u8; 6]);
+
+impl Debug for Forgotten {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", u64::from(*self))
+    }
+}
 
 impl Forgotten {
     /// Get the next forgotten-version after this one.

--- a/tct/src/internal/hash/cache.rs
+++ b/tct/src/internal/hash/cache.rs
@@ -61,3 +61,13 @@ impl From<Hash> for CachedHash {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn cached_hash_size() {
+        static_assertions::assert_eq_size!(CachedHash, [u8; 40]);
+    }
+}

--- a/tct/src/internal/three.rs
+++ b/tct/src/internal/three.rs
@@ -9,10 +9,20 @@ use std::marker::PhantomData;
 use serde::{de::Visitor, Deserialize, Serialize};
 
 /// A vector capable of storing at most 3 elements.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Derivative, Serialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Derivative, Serialize)]
 #[derivative(Debug = "transparent")]
 pub struct Three<T> {
     elems: Vec<T>,
+}
+
+// Manual `Clone` implementation to force the cloned `Vec` to be capacity = 4, so we never
+// re-allocate after the clone
+impl<T: Clone> Clone for Three<T> {
+    fn clone(&self) -> Self {
+        let mut elems = Vec::with_capacity(4);
+        elems.extend(self.elems.iter().cloned());
+        Self { elems }
+    }
 }
 
 impl<T> Three<T> {

--- a/tct/src/lib.rs
+++ b/tct/src/lib.rs
@@ -50,9 +50,6 @@ extern crate thiserror;
 #[macro_use]
 extern crate async_trait;
 
-#[macro_use]
-extern crate async_stream;
-
 mod commitment;
 mod index;
 mod proof;

--- a/tct/src/lib.rs
+++ b/tct/src/lib.rs
@@ -107,7 +107,10 @@ mod prelude {
             three::{Elems, ElemsMut, IntoElems, Three},
             UncheckedSetHash,
         },
-        storage::{self, Read, Write},
+        storage::{
+            self, AsyncRead, AsyncWrite, DeleteRange, Read, StoreCommitment, StoreHash,
+            StoredPosition, Update, Write,
+        },
         structure::{self, HashOrNode, HashedNode, Kind, Node, Place},
         Commitment, Position, Proof, Root, Tree,
     };

--- a/tct/src/lib.rs
+++ b/tct/src/lib.rs
@@ -33,8 +33,6 @@
 //!                                       = Note Commitment
 //! ```
 
-// Cargo doc complains if the recursion limit isn't higher, even though cargo build succeeds:
-#![recursion_limit = "256"]
 #![warn(missing_docs)]
 
 #[macro_use]

--- a/tct/src/lib.rs
+++ b/tct/src/lib.rs
@@ -116,6 +116,9 @@ mod prelude {
         structure::{self, Kind, Node, Place},
         Commitment, Position, Proof, Root, Tree,
     };
+
+    // We use the hash map from `im`, but with the fast "hash prehashed data" hasher from `hash_hasher`
+    pub(crate) type HashedMap<K, V> = im::HashMap<K, V, hash_hasher::HashBuildHasher>;
 }
 
 #[cfg(feature = "arbitrary")]
@@ -130,7 +133,7 @@ mod test {
     #[test]
     fn check_eternity_size() {
         // Disabled due to spurious test failure.
-        // static_assertions::assert_eq_size!(Tree, [u8; 896]);
+        // static_assertions::assert_eq_size!(Tree, [u8; 32]);
     }
 
     #[test]

--- a/tct/src/lib.rs
+++ b/tct/src/lib.rs
@@ -111,7 +111,7 @@ mod prelude {
             UncheckedSetHash,
         },
         storage::{self, Read, Write},
-        structure::{self, Kind, Node, Place},
+        structure::{self, HashOrNode, HashedNode, Kind, Node, Place},
         Commitment, Position, Proof, Root, Tree,
     };
 

--- a/tct/src/storage.rs
+++ b/tct/src/storage.rs
@@ -7,22 +7,19 @@ use std::{
     pin::Pin,
 };
 
-use futures::{stream, Stream};
+use futures::Stream;
 
 use crate::prelude::*;
 
 pub(crate) mod deserialize;
-pub(crate) use deserialize::from_reader;
+pub(crate) mod serialize;
 
 pub mod in_memory;
 pub use in_memory::InMemory;
 
-pub(crate) mod serialize;
-pub(crate) use serialize::to_writer;
-
 /// A stored position for the tree: either the position of the tree, or a marker indicating that it
 /// is full, and therefore does not have a position.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum StoredPosition {
     /// The tree has the given position.
     Position(Position),
@@ -54,10 +51,10 @@ impl From<Option<Position>> for StoredPosition {
     }
 }
 
-/// A storage backend capable of reading stored [`struct@Hash`]es and [`Commitment`]s as well as
-/// storing the current [`Position`].
+/// An `async` storage backend capable of reading stored [`struct@Hash`]es and [`Commitment`]s as
+/// well as storing the current [`Position`].
 #[async_trait]
-pub trait Read {
+pub trait AsyncRead {
     /// The error returned when something goes wrong in a request.
     type Error;
 
@@ -80,10 +77,10 @@ pub trait Read {
     ) -> Pin<Box<dyn Stream<Item = Result<(Position, Commitment), Self::Error>> + Send + '_>>;
 }
 
-/// A storage backend capable of writing [`struct@Hash`]es and [`Commitment`]s, and
+/// An `async` storage backend capable of writing [`struct@Hash`]es and [`Commitment`]s, and
 /// garbage-collecting those which have been forgotten.
 #[async_trait]
-pub trait Write: Read {
+pub trait AsyncWrite: AsyncRead {
     /// Write a single hash into storage.
     ///
     /// Backends are only *required* to persist hashes marked as `essential`. They may choose to
@@ -126,4 +123,180 @@ pub trait Write: Read {
     ///
     /// This should return an error if the version goes backwards.
     async fn set_forgotten(&mut self, forgotten: Forgotten) -> Result<(), Self::Error>;
+}
+
+/// A synchronous storage backend capable of reading stored [`struct@Hash`]es and [`Commitment`]s as
+/// well as storing the current [`Position`].
+pub trait Read {
+    /// The error returned when something goes wrong in a request.
+    type Error;
+
+    /// Fetch the current position stored.
+    fn position(&mut self) -> Result<StoredPosition, Self::Error>;
+
+    /// Fetch the current forgotten version.
+    fn forgotten(&mut self) -> Result<Forgotten, Self::Error>;
+
+    /// Get the full list of all internal hashes stored, indexed by position and height.
+    #[allow(clippy::type_complexity)]
+    fn hashes(
+        &mut self,
+    ) -> Box<dyn Iterator<Item = Result<(Position, u8, Hash), Self::Error>> + Send + '_>;
+
+    /// Get the full list of all commitments stored, indexed by position.
+    #[allow(clippy::type_complexity)]
+    fn commitments(
+        &mut self,
+    ) -> Box<dyn Iterator<Item = Result<(Position, Commitment), Self::Error>> + Send + '_>;
+}
+
+/// A synchronous storage backend capable of writing [`struct@Hash`]es and [`Commitment`]s, and
+/// garbage-collecting those which have been forgotten.
+pub trait Write: Read {
+    /// Write a single hash into storage.
+    ///
+    /// Backends are only *required* to persist hashes marked as `essential`. They may choose to
+    /// persist other hashes, and the choice of which non-essential hashes to persist is
+    /// unconstrained. However, choosing not to persist non-essential hashes imposes computational
+    /// overhead upon deserialization.
+    fn add_hash(
+        &mut self,
+        position: Position,
+        height: u8,
+        hash: Hash,
+        essential: bool,
+    ) -> Result<(), Self::Error>;
+
+    /// Write a single commitment into storage.
+    ///
+    /// This should return an error if a commitment is already present at that location; no
+    /// location's value should ever be overwritten.
+    fn add_commitment(
+        &mut self,
+        position: Position,
+        commitment: Commitment,
+    ) -> Result<(), Self::Error>;
+
+    /// Delete every stored [`struct@Hash`] whose height is less than `below_height` and whose
+    /// position is within the half-open [`Range`] of `positions`, as well as every [`Commitment`]
+    /// whose position is within the range.
+    fn delete_range(
+        &mut self,
+        below_height: u8,
+        positions: Range<Position>,
+    ) -> Result<(), Self::Error>;
+
+    /// Set the stored position of the tree.
+    ///
+    /// This should return an error if the position goes backwards.
+    fn set_position(&mut self, position: StoredPosition) -> Result<(), Self::Error>;
+
+    /// Set the forgotten version of the tree.
+    ///
+    /// This should return an error if the version goes backwards.
+    fn set_forgotten(&mut self, forgotten: Forgotten) -> Result<(), Self::Error>;
+}
+
+/// A single update to the underlying storage, as a data type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Update {
+    /// Set the position of the tree.
+    SetPosition(StoredPosition),
+    /// Set the forgotten version of the tree.
+    SetForgotten(Forgotten),
+    /// Add a commitment to the tree.
+    StoreCommitment(StoreCommitment),
+    /// Add a hash to the tree.
+    StoreHash(StoreHash),
+    /// Delete a range of hashes and commitments from the tree.
+    DeleteRange(DeleteRange),
+}
+
+/// An update to the underlying storage that constitutes storing a single hash.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoreHash {
+    /// The position of the hash.
+    pub position: Position,
+    /// The height of the hash.
+    pub height: u8,
+    /// The hash itself.
+    pub hash: Hash,
+    /// Whether the hash is essential to store, or can be dropped at the discretion of the storage backend.
+    pub essential: bool,
+}
+
+/// An update to the underlying storage that constitutes storing a single commitment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoreCommitment {
+    /// The position of the commitment.
+    pub position: Position,
+    /// The commitment itself.
+    pub commitment: Commitment,
+}
+
+/// An update to the underlying storage that constitutes deleting a range of hashes and commitments.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteRange {
+    /// The height strictly below which hashes should be deleted.
+    pub below_height: u8,
+    /// The half-open range of positions within which hashes and commitments should be deleted.
+    pub positions: Range<Position>,
+}
+
+/// A collection of updates to the underlying storage.
+///
+/// Note that this is both `FromIterator<Update>` and `Iterator<Item = Update>`, so you can
+/// [`.collect()](Iterator::collect) an `impl Iterator<Item = Update>` into this type, and you can
+/// also iterate over its contained updates.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Updates {
+    /// The new position to set, if any.
+    pub set_position: Option<StoredPosition>,
+    /// The new forgotten version to set, if any.
+    pub set_forgotten: Option<Forgotten>,
+    /// The new commitments to store.
+    pub store_commitments: Vec<StoreCommitment>,
+    /// The new hashes to store.
+    pub store_hashes: Vec<StoreHash>,
+    /// The ranges of hashes and commitments to delete.
+    pub delete_ranges: Vec<DeleteRange>,
+}
+
+impl FromIterator<Update> for Updates {
+    fn from_iter<I: IntoIterator<Item = Update>>(iter: I) -> Self {
+        let mut updates = Updates::default();
+        for update in iter {
+            match update {
+                Update::SetPosition(position) => updates.set_position = Some(position),
+                Update::SetForgotten(forgotten) => updates.set_forgotten = Some(forgotten),
+                Update::StoreCommitment(commitment) => updates.store_commitments.push(commitment),
+                Update::StoreHash(hash) => updates.store_hashes.push(hash),
+                Update::DeleteRange(range) => updates.delete_ranges.push(range),
+            }
+        }
+        updates
+    }
+}
+
+impl Iterator for Updates {
+    type Item = Update;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(position) = self.set_position.take() {
+            return Some(Update::SetPosition(position));
+        }
+        if let Some(forgotten) = self.set_forgotten.take() {
+            return Some(Update::SetForgotten(forgotten));
+        }
+        if let Some(commitment) = self.store_commitments.pop() {
+            return Some(Update::StoreCommitment(commitment));
+        }
+        if let Some(hash) = self.store_hashes.pop() {
+            return Some(Update::StoreHash(hash));
+        }
+        if let Some(range) = self.delete_ranges.pop() {
+            return Some(Update::DeleteRange(range));
+        }
+        None
+    }
 }

--- a/tct/src/storage/deserialize.rs
+++ b/tct/src/storage/deserialize.rs
@@ -1,47 +1,146 @@
-#![allow(clippy::unusual_byte_groupings)]
-
 //! Non-incremental deserialization for the [`Tree`](crate::Tree).
 
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 
 use crate::prelude::*;
-use crate::storage::Read;
 
-use super::StoredPosition;
-
-/// Deserialize a [`Tree`] from a storage backend.
-pub async fn from_reader<R: Read>(reader: &mut R) -> Result<Tree, R::Error> {
-    // Make an uninitialized tree with the correct position and forgotten version
-    let position = match reader.position().await? {
-        StoredPosition::Position(position) => Some(position.into()),
-        StoredPosition::Full => None,
-    };
+/// Deserialize a [`Tree`] from an asynchronous storage backend.
+pub async fn from_async_reader<R: AsyncRead>(reader: &mut R) -> Result<Tree, R::Error> {
+    let position = reader.position().await?;
     let forgotten = reader.forgotten().await?;
-    let mut inner: frontier::Top<frontier::Tier<frontier::Tier<frontier::Item>>> =
-        OutOfOrder::uninitialized(position, forgotten);
-
-    // Make an index to track the commitments (we'll assemble this into the final tree)
-    let mut index = HashedMap::default();
-
-    // Insert all the commitments into the tree, simultaneously building the index
+    let mut load_commitments = LoadCommitments::new(position, forgotten);
     let mut commitments = reader.commitments();
     while let Some((position, commitment)) = commitments.next().await.transpose()? {
-        inner.uninitialized_out_of_order_insert_commitment(position.into(), commitment);
-        index.insert(commitment, u64::from(position).into());
+        load_commitments.insert(position, commitment);
     }
-
-    drop(commitments); // explicit drop to satisfy borrow checker
-
-    // Set all the hashes in the tree
+    drop(commitments);
     let mut hashes = reader.hashes();
+    let mut load_hashes = load_commitments.load_hashes();
     while let Some((position, height, hash)) = hashes.next().await.transpose()? {
-        inner.unchecked_set_hash(position.into(), height, hash);
+        load_hashes.insert(position, height, hash);
+    }
+    Ok(load_hashes.finish())
+}
+
+/// Deserialize a [`Tree`] from a synchronous storage backend.
+pub fn from_reader<R: Read>(reader: &mut R) -> Result<Tree, R::Error> {
+    let position = reader.position()?;
+    let forgotten = reader.forgotten()?;
+    let mut load_commitments = LoadCommitments::new(position, forgotten);
+    let mut commitments = reader.commitments();
+    while let Some((position, commitment)) = commitments.next().transpose()? {
+        load_commitments.insert(position, commitment);
+    }
+    drop(commitments);
+    let mut load_hashes = load_commitments.load_hashes();
+    let mut hashes = reader.hashes();
+    while let Some((position, height, hash)) = hashes.next().transpose()? {
+        load_hashes.insert(position, height, hash);
+    }
+    Ok(load_hashes.finish())
+}
+
+/// Load iterators of commitments and hashes into a tree.
+pub fn load<Err>(
+    position: impl Into<StoredPosition>,
+    forgotten: Forgotten,
+    commitments: impl IntoIterator<Item = Result<(Position, Commitment), Err>>,
+    hashes: impl IntoIterator<Item = Result<(Position, u8, Hash), Err>>,
+) -> Result<Tree, Err> {
+    let mut commitments = commitments.into_iter();
+    let mut hashes = hashes.into_iter();
+
+    let mut load_commitments = LoadCommitments::new(position, forgotten);
+    while let Some((position, commitment)) = commitments.next().transpose()? {
+        load_commitments.insert(position, commitment);
+    }
+    let mut load_hashes = load_commitments.load_hashes();
+    while let Some((position, height, hash)) = hashes.next().transpose()? {
+        load_hashes.insert(position, height, hash);
+    }
+    Ok(load_hashes.finish())
+}
+
+/// Load streams of commitments and hashes into a tree.
+pub async fn load_stream<Err>(
+    position: impl Into<StoredPosition>,
+    forgotten: Forgotten,
+    mut commitments: impl Stream<Item = Result<(Position, Commitment), Err>> + Unpin,
+    mut hashes: impl Stream<Item = Result<(Position, u8, Hash), Err>> + Unpin,
+) -> Result<Tree, Err> {
+    let mut load_commitments = LoadCommitments::new(position, forgotten);
+    while let Some((position, commitment)) = commitments.next().await.transpose()? {
+        load_commitments.insert(position, commitment);
+    }
+    let mut load_hashes = load_commitments.load_hashes();
+    while let Some((position, height, hash)) = hashes.next().await.transpose()? {
+        load_hashes.insert(position, height, hash);
+    }
+    Ok(load_hashes.finish())
+}
+
+struct LoadCommitments {
+    inner: frontier::Top<frontier::Tier<frontier::Tier<frontier::Item>>>,
+    index: HashedMap<Commitment, index::within::Tree>,
+}
+
+impl LoadCommitments {
+    pub fn new(position: impl Into<StoredPosition>, forgotten: Forgotten) -> Self {
+        // Make an uninitialized tree with the correct position and forgotten version
+        let position = match position.into() {
+            StoredPosition::Position(position) => Some(position.into()),
+            StoredPosition::Full => None,
+        };
+        Self {
+            inner: OutOfOrder::uninitialized(position, forgotten),
+            index: HashedMap::default(),
+        }
     }
 
-    // Finalize the tree by recomputing all missing hashes
-    inner.finish_initialize();
+    pub fn insert(&mut self, position: Position, commitment: Commitment) {
+        self.inner
+            .uninitialized_out_of_order_insert_commitment(position.into(), commitment);
+        self.index.insert(commitment, u64::from(position).into());
+    }
 
-    Ok(Tree::unchecked_from_parts(index, inner))
+    pub fn load_hashes(self) -> LoadHashes {
+        LoadHashes {
+            inner: self.inner,
+            index: self.index,
+        }
+    }
+}
+
+impl Extend<(Position, Commitment)> for LoadCommitments {
+    fn extend<T: IntoIterator<Item = (Position, Commitment)>>(&mut self, iter: T) {
+        for (position, commitment) in iter {
+            self.insert(position, commitment);
+        }
+    }
+}
+
+pub struct LoadHashes {
+    inner: frontier::Top<frontier::Tier<frontier::Tier<frontier::Item>>>,
+    index: HashedMap<Commitment, index::within::Tree>,
+}
+
+impl LoadHashes {
+    pub fn insert(&mut self, position: Position, height: u8, hash: Hash) {
+        self.inner.unchecked_set_hash(position.into(), height, hash);
+    }
+
+    pub fn finish(mut self) -> Tree {
+        self.inner.finish_initialize();
+        Tree::unchecked_from_parts(self.index, self.inner)
+    }
+}
+
+impl Extend<(Position, u8, Hash)> for LoadHashes {
+    fn extend<T: IntoIterator<Item = (Position, u8, Hash)>>(&mut self, iter: T) {
+        for (position, height, hash) in iter {
+            self.insert(position, height, hash);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/tct/src/storage/deserialize.rs
+++ b/tct/src/storage/deserialize.rs
@@ -3,7 +3,6 @@
 //! Non-incremental deserialization for the [`Tree`](crate::Tree).
 
 use futures::StreamExt;
-use hash_hasher::HashedMap;
 
 use crate::prelude::*;
 use crate::storage::Read;

--- a/tct/src/storage/serialize.rs
+++ b/tct/src/storage/serialize.rs
@@ -108,7 +108,7 @@ impl Serializer {
     ) -> impl Stream<Item = InternalHash> + Send + Unpin + 'tree {
         fn hashes_inner<'a, 'tree: 'a>(
             options: Serializer,
-            node: structure::Node<'a, 'tree>,
+            node: structure::Node<'tree>,
         ) -> Pin<Box<dyn Stream<Item = InternalHash> + Send + 'a>> {
             Box::pin(stream! {
                 let position = node.position();
@@ -177,7 +177,7 @@ impl Serializer {
     ) -> impl Stream<Item = (Position, Commitment)> + Send + Unpin + 'tree {
         fn commitments_inner<'a, 'tree: 'a>(
             options: Serializer,
-            node: structure::Node<'a, 'tree>,
+            node: structure::Node<'tree>,
         ) -> Pin<Box<dyn Stream<Item = (Position, Commitment)> + Send + 'a>> {
             Box::pin(stream! {
                 let position = node.position();
@@ -226,7 +226,7 @@ impl Serializer {
     ) -> impl Stream<Item = InternalHash> + Send + Unpin + 'tree {
         fn forgotten_inner<'a, 'tree: 'a>(
             options: Serializer,
-            node: structure::Node<'a, 'tree>,
+            node: structure::Node<'tree>,
         ) -> Pin<Box<dyn Stream<Item = InternalHash> + Send + 'a>> {
             Box::pin(stream! {
                 // Only report nodes (and their children) which are less than the last stored position

--- a/tct/src/structure.rs
+++ b/tct/src/structure.rs
@@ -475,19 +475,21 @@ mod sealed {
 
     impl Sealed for complete::Item {}
     impl<T: Sealed> Sealed for complete::Leaf<T> {}
-    impl<T: Sealed> Sealed for complete::Node<T> {}
-    impl<T: Sealed + Height + GetHash> Sealed for complete::Tier<T> {}
-    impl<T: Sealed + Height + GetHash> Sealed for complete::Top<T> {}
+    impl<T: Sealed + Clone> Sealed for complete::Node<T> {}
+    impl<T: Sealed + Height + GetHash + Clone> Sealed for complete::Tier<T> {}
+    impl<T: Sealed + Height + GetHash + Clone> Sealed for complete::Top<T> {}
 
     impl Sealed for frontier::Item {}
     impl<T: Sealed> Sealed for frontier::Leaf<T> {}
     impl<T: Sealed + Focus> Sealed for frontier::Node<T> where T::Complete: Send + Sync {}
-    impl<T: Sealed + Height + GetHash + Focus> Sealed for frontier::Tier<T> where
-        T::Complete: Send + Sync
+    impl<T: Sealed + Height + GetHash + Focus + Clone> Sealed for frontier::Tier<T> where
+        T::Complete: Send + Sync + Clone
     {
     }
-    impl<T: Sealed + Height + GetHash + Focus> Sealed for frontier::Top<T> where T::Complete: Send + Sync
-    {}
+    impl<T: Sealed + Height + GetHash + Focus + Clone> Sealed for frontier::Top<T> where
+        T::Complete: Send + Sync + Clone
+    {
+    }
 }
 
 #[cfg(test)]

--- a/tct/src/structure.rs
+++ b/tct/src/structure.rs
@@ -13,15 +13,8 @@ pub use crate::internal::hash::{Forgotten, Hash};
 /// Every kind of node in the tree implements [`Node`], and its methods collectively describe every
 /// salient fact about each node, dynamically rather than statically as in the rest of the crate.
 pub(crate) trait Any<'tree>: GetHash + sealed::Sealed {
-    /// The parent of this node, if any.
-    ///
-    /// This defaults to `None`, but is filled in by the [`Any`] implementation of [`Node`].
-    fn parent<'a>(&'a self) -> Option<Node<'a, 'tree>> {
-        None
-    }
-
     /// The children of this node.
-    fn children<'a>(&'a self) -> Vec<Node<'a, 'tree>>;
+    fn children(&'tree self) -> Vec<HashOrNode<'tree>>;
 
     /// The kind of the node: either a [`Kind::Internal`] with a height, or a [`Kind::Leaf`] with an
     /// optional [`Commitment`].
@@ -29,18 +22,6 @@ pub(crate) trait Any<'tree>: GetHash + sealed::Sealed {
 
     /// The most recent time something underneath this node was forgotten.
     fn forgotten(&self) -> Forgotten;
-
-    /// The index of this node from the left of the tree.
-    ///
-    /// For items at the base, this is the position of the item.
-    ///
-    /// This defaults to 0, but is filled in by the [`Any`] implementation of [`Node`].
-    fn index(&self) -> u64 {
-        0
-    }
-
-    /// The position of the tree within which this node occurs.
-    fn global_position(&self) -> Option<Position>;
 }
 
 impl GetHash for &dyn Any<'_> {
@@ -58,27 +39,15 @@ impl GetHash for &dyn Any<'_> {
 }
 
 impl<'tree, T: Any<'tree>> Any<'tree> for &T {
-    fn index(&self) -> u64 {
-        (**self).index()
-    }
-
     fn kind(&self) -> Kind {
         (**self).kind()
-    }
-
-    fn global_position(&self) -> Option<Position> {
-        (**self).global_position()
-    }
-
-    fn parent(&self) -> Option<Node<'_, 'tree>> {
-        (**self).parent()
     }
 
     fn forgotten(&self) -> Forgotten {
         (**self).forgotten()
     }
 
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
+    fn children(&'tree self) -> Vec<HashOrNode<'tree>> {
         (**self).children()
     }
 }
@@ -129,15 +98,75 @@ impl Display for Place {
 }
 
 /// An arbitrary node somewhere within a tree.
-#[derive(Copy, Clone)]
-pub struct Node<'a, 'tree: 'a> {
+#[derive(Clone, Copy)]
+pub struct Node<'tree> {
     offset: u64,
-    forgotten: Forgotten,
-    parent: Option<&'a Node<'a, 'tree>>,
-    this: Insert<&'a (dyn Any<'tree> + 'a)>,
+    global_position: Option<Position>,
+    this: HashOrNode<'tree>,
 }
 
-impl Debug for Node<'_, '_> {
+impl GetHash for Node<'_> {
+    fn hash(&self) -> Hash {
+        self.this.hash()
+    }
+
+    fn cached_hash(&self) -> Option<Hash> {
+        self.this.cached_hash()
+    }
+
+    fn clear_cached_hash(&self) {
+        self.this.clear_cached_hash()
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum HashOrNode<'tree> {
+    Hash(HashedNode),
+    Node(&'tree dyn Any<'tree>),
+}
+
+impl GetHash for HashOrNode<'_> {
+    fn hash(&self) -> Hash {
+        match self {
+            HashOrNode::Hash(hashed) => hashed.hash(),
+            HashOrNode::Node(node) => node.hash(),
+        }
+    }
+
+    fn cached_hash(&self) -> Option<Hash> {
+        match self {
+            HashOrNode::Hash(hashed) => Some(hashed.hash()),
+            HashOrNode::Node(node) => node.cached_hash(),
+        }
+    }
+
+    fn clear_cached_hash(&self) {
+        if let HashOrNode::Node(node) = self {
+            node.clear_cached_hash()
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct HashedNode {
+    pub hash: Hash,
+    pub height: u8,
+    pub forgotten: Forgotten,
+}
+
+impl GetHash for HashedNode {
+    fn hash(&self) -> Hash {
+        self.hash
+    }
+
+    fn cached_hash(&self) -> Option<Hash> {
+        Some(self.hash)
+    }
+
+    fn clear_cached_hash(&self) {}
+}
+
+impl Debug for Node<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = format!("{}::{}", self.place(), self.kind());
         let mut s = f.debug_struct(&name);
@@ -165,7 +194,7 @@ impl Debug for Node<'_, '_> {
     }
 }
 
-impl Display for Node<'_, '_> {
+impl Display for Node<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct(&format!("{}::{}", self.place(), self.kind()))
             .field("height", &self.height())
@@ -174,35 +203,14 @@ impl Display for Node<'_, '_> {
     }
 }
 
-impl<'a, 'tree: 'a> Node<'a, 'tree> {
+impl<'tree> Node<'tree> {
     /// Make a root node.
-    pub(crate) fn root(this: &'a dyn Any<'tree>) -> Self {
+    pub(crate) fn root<R: Any<'tree> + GetPosition>(node: &'tree R) -> Self {
         Self {
             offset: 0,
-            forgotten: this.forgotten(),
-            parent: None,
-            this: Insert::Keep(this),
+            global_position: node.position().map(Into::into),
+            this: HashOrNode::Node(node),
         }
-    }
-
-    /// Make a new [`Child`] from a reference to something implementing [`Node`].
-    pub(crate) fn child(forgotten: Forgotten, child: Insert<&'a dyn Any<'tree>>) -> Self {
-        Node {
-            offset: 0,
-            forgotten,
-            parent: None,
-            this: child,
-        }
-    }
-
-    /// The parent of this node, if any.
-    pub fn parent(&'a self) -> Option<Node<'a, 'tree>> {
-        (self as &dyn Any<'tree>).parent()
-    }
-
-    /// The children of this node.
-    pub fn children(&'a self) -> Vec<Node<'a, 'tree>> {
-        (self as &dyn Any<'tree>).children()
     }
 
     /// The hash of this node.
@@ -218,19 +226,42 @@ impl<'a, 'tree: 'a> Node<'a, 'tree> {
     /// The kind of the node: either a [`Kind::Internal`] with a height, or a [`Kind::Leaf`] with an
     /// optional [`Commitment`].
     pub fn kind(&self) -> Kind {
-        (self as &dyn Any).kind()
+        match self.this {
+            HashOrNode::Hash(HashedNode { height, .. }) => Kind::Internal { height },
+            HashOrNode::Node(node) => node.kind(),
+        }
     }
 
     /// The most recent time something underneath this node was forgotten.
     pub fn forgotten(&self) -> Forgotten {
-        (self as &dyn Any).forgotten()
+        match self.this {
+            HashOrNode::Hash(HashedNode { forgotten, .. }) => forgotten,
+            HashOrNode::Node(node) => node.forgotten(),
+        }
+    }
+
+    /// The children of this node.
+    pub fn children(&self) -> Vec<Node<'tree>> {
+        match self.this {
+            HashOrNode::Hash(_) => Vec::new(),
+            HashOrNode::Node(node) => node
+                .children()
+                .into_iter()
+                .enumerate()
+                .map(|(i, hash_or_node)| Node {
+                    global_position: self.global_position,
+                    offset: self.offset * 4 + (i as u64),
+                    this: hash_or_node,
+                })
+                .collect(),
+        }
     }
 
     /// The index of this node from the left of the tree.
     ///
     /// For items at the base, this is the position of the item.
     pub fn index(&self) -> u64 {
-        (self as &dyn Any).index()
+        self.offset
     }
 
     /// The height of this node above the base of the tree.
@@ -260,7 +291,7 @@ impl<'a, 'tree: 'a> Node<'a, 'tree> {
 
     /// The global position of the tree inside of which this node exists.
     pub fn global_position(&self) -> Option<Position> {
-        <Self as Any>::global_position(self)
+        self.global_position
     }
 
     /// The place on the tree where this node occurs.
@@ -290,188 +321,13 @@ impl<'a, 'tree: 'a> Node<'a, 'tree> {
     }
 }
 
-impl GetHash for Node<'_, '_> {
-    fn hash(&self) -> Hash {
-        self.this.hash()
-    }
-
-    fn cached_hash(&self) -> Option<Hash> {
-        self.this.cached_hash()
-    }
-}
-
-impl<'a, 'tree: 'a> Any<'tree> for Node<'a, 'tree> {
-    fn index(&self) -> u64 {
-        self.offset
-    }
-
-    fn parent(&self) -> Option<Node<'a, 'tree>> {
-        self.parent.copied()
-    }
-
-    fn kind(&self) -> Kind {
-        match self.this {
-            Insert::Keep(child) => child.kind(),
-            Insert::Hash(_) => {
-                if let Some(parent) = self.parent {
-                    match parent.kind() {
-                        Kind::Internal {
-                            height: height @ 2..=24,
-                        } => Kind::Internal { height: height - 1 },
-                        Kind::Internal { height: 1 } => Kind::Leaf { commitment: None },
-                        Kind::Internal {
-                            height: 0 | 25..=u8::MAX,
-                        } => {
-                            unreachable!("nodes cannot have zero height or height greater than 24")
-                        }
-                        Kind::Leaf { .. } => unreachable!("leaves cannot have children"),
-                    }
-                } else {
-                    // Hashed root node is an internal node of height 24
-                    Kind::Internal { height: 24 }
-                }
-            }
-        }
-    }
-
-    fn forgotten(&self) -> Forgotten {
-        self.forgotten
-    }
-
-    fn global_position(&self) -> Option<Position> {
-        if let Some(parent) = self.parent {
-            parent.global_position()
-        } else {
-            self.this.keep().and_then(Any::global_position)
-        }
-    }
-
-    fn children(&self) -> Vec<Node<'_, 'tree>> {
-        if let Insert::Keep(child) = self.this {
-            child
-                .children()
-                .into_iter()
-                .enumerate()
-                .map(|(nth, child)| {
-                    debug_assert_eq!(
-                        child.offset, 0,
-                        "explicitly constructed children should have zero offset"
-                    );
-                    Node {
-                        forgotten: child.forgotten,
-                        this: child.this,
-                        parent: Some(self),
-                        offset: self.offset * 4 + nth as u64,
-                    }
-                })
-                .collect()
-        } else {
-            vec![]
-        }
-    }
-}
-
-#[doc(inline)]
-pub use traverse::{traverse, traverse_async};
-
-/// Functions to perform traversals of [`Node`]s in synchronous and asynchronous contexts.
-pub mod traverse {
-    use std::{future::Future, pin::Pin};
-
-    use super::Node;
-
-    /// Flag to determine whether the traversal continues downward from this node or stops at the
-    /// current node.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-    pub enum Recur {
-        /// Default: Continue downwards.
-        Down,
-        /// Continue downwards, but traversing children right-to-left.
-        DownBackwards,
-        /// Stop here and don't continue downwards.
-        Stop,
-    }
-
-    impl Default for Recur {
-        fn default() -> Self {
-            Down
-        }
-    }
-
-    impl From<()> for Recur {
-        fn from(_: ()) -> Self {
-            Down
-        }
-    }
-
-    #[doc(inline)]
-    pub use Recur::*;
-
-    /// Synchronously traverse a node depth-first, visiting each node using the given function.
-    ///
-    /// If the function returns [`Stop`], the traversal will stop at this node and not continue
-    /// into the children; otherwise it will recur downwards.
-    ///
-    /// Note that because `(): Into<Recur>`, it is valid to pass a function which returns `()` if
-    /// the traversal should always recur and never stop before reaching a leaf.
-    pub fn traverse<R: Into<Recur>>(node: Node, with: &mut impl FnMut(Node) -> R) {
-        if let down @ (Down | DownBackwards) = with(node).into() {
-            let mut children = node.children();
-            if let DownBackwards = down {
-                children.reverse();
-            }
-            for child in children {
-                traverse(child, with);
-            }
-        }
-    }
-
-    /// Asynchronously traverse a node depth-first, visiting each node using the given function.
-    ///
-    /// If the function returns [`Stop`], the traversal will stop at this node and not continue
-    /// into the children; otherwise it will recur downwards.
-    ///
-    /// Note that because `(): Into<Recur>`, it is valid to pass a function which returns `()` if
-    /// the traversal should always recur and never stop before reaching a leaf.
-    pub async fn traverse_async<'a, 'tree: 'a, R: Send + Into<Recur>, Fut>(
-        node: Node<'a, 'tree>,
-        with: &mut (impl FnMut(Node) -> Fut + Send),
-    ) where
-        Fut: Future<Output = R> + Send,
-    {
-        // We need this inner function to correctly specify the lifetimes for the recursive call
-        fn traverse_async_inner<'a, 'tree: 'a, 'b: 'a, R: Send + Into<Recur>, F, Fut>(
-            node: Node<'a, 'tree>,
-            with: &'b mut F,
-        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>
-        where
-            F: FnMut(Node) -> Fut + Send,
-            Fut: Future<Output = R> + Send,
-        {
-            Box::pin(async move {
-                if let down @ (Down | DownBackwards) = with(node).await.into() {
-                    let mut children = node.children();
-                    if let DownBackwards = down {
-                        children.reverse();
-                    }
-                    for child in children {
-                        traverse_async_inner::<'_, '_, '_, R, F, Fut>(child, with).await;
-                    }
-                }
-            })
-        }
-
-        traverse_async_inner::<'_, '_, '_, R, _, Fut>(node, with).await
-    }
-}
-
 mod sealed {
     use super::*;
 
     pub trait Sealed: Send + Sync {}
 
     impl<T: Sealed> Sealed for &T {}
-    impl Sealed for Node<'_, '_> {}
+    impl Sealed for Node<'_> {}
 
     impl Sealed for complete::Item {}
     impl<T: Sealed> Sealed for complete::Leaf<T> {}
@@ -519,37 +375,14 @@ mod test {
     }
 
     #[test]
-    fn parent_of_child() {
-        let mut top: frontier::Top<Item> = frontier::Top::new(frontier::TrackForgotten::No);
-        top.insert(Commitment(0u8.into()).into()).unwrap();
-
-        // This can't be a loop, it has to be recursive because the lifetime parameter of the parent
-        // is different for each recursive call
-        fn check(parent: Node) {
-            if let Some(child) = parent.children().pop() {
-                let parent_of_child = child.parent().expect("child has no parent");
-                assert_eq!(
-                    parent.hash(),
-                    parent_of_child.hash(),
-                    "parent hash mismatch"
-                );
-                check(child);
-            } else {
-                assert_eq!(parent.height(), 0, "got all the way to a leaf");
-            }
-        }
-
-        let root = Node::root(&top);
-        check(root);
-    }
-
-    #[test]
     fn place_correct() {
         const MAX_SIZE_TO_TEST: u16 = 100;
 
         let mut top: frontier::Top<Item> = frontier::Top::new(frontier::TrackForgotten::No);
         for i in 0..MAX_SIZE_TO_TEST {
             top.insert(Commitment(i.into()).into()).unwrap();
+            let root = Node::root(&top);
+            check(root, Place::Frontier);
         }
 
         fn check(node: Node, expected: Place) {
@@ -577,8 +410,26 @@ mod test {
                 _ => unreachable!("nodes can't have > 4 children"),
             }
         }
+    }
 
-        let root = Node::root(&top);
-        check(root, Place::Frontier);
+    #[test]
+    fn height_correct() {
+        const MAX_SIZE_TO_TEST: u16 = 100;
+
+        let mut tree = crate::Tree::new();
+
+        for i in 0..MAX_SIZE_TO_TEST {
+            tree.insert(crate::Witness::Keep, Commitment(i.into()))
+                .unwrap();
+            let root = tree.structure();
+            check(root, 24);
+        }
+
+        fn check(node: Node, expected: u8) {
+            assert_eq!(node.height(), expected, "{}", node);
+            for child in node.children() {
+                check(child, expected - 1);
+            }
+        }
     }
 }

--- a/tct/src/tree.rs
+++ b/tct/src/tree.rs
@@ -1,7 +1,9 @@
-use std::fmt::{Debug, Display};
+use std::{
+    fmt::{Debug, Display},
+    sync::Arc,
+};
 
 use decaf377::{FieldExt, Fq};
-use hash_hasher::HashedMap;
 use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
 
 use crate::error::*;
@@ -17,14 +19,14 @@ pub(crate) use epoch::block;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tree {
     index: HashedMap<Commitment, index::within::Tree>,
-    inner: frontier::Top<frontier::Tier<frontier::Tier<frontier::Item>>>,
+    inner: Arc<frontier::Top<frontier::Tier<frontier::Tier<frontier::Item>>>>,
 }
 
 impl Default for Tree {
     fn default() -> Self {
         Self {
             index: HashedMap::default(),
-            inner: frontier::Top::new(frontier::TrackForgotten::Yes),
+            inner: Arc::new(frontier::Top::new(frontier::TrackForgotten::Yes)),
         }
     }
 }
@@ -152,7 +154,10 @@ impl Tree {
         index: HashedMap<Commitment, index::within::Tree>,
         inner: frontier::Top<frontier::Tier<frontier::Tier<frontier::Item>>>,
     ) -> Self {
-        Self { index, inner }
+        Self {
+            index,
+            inner: Arc::new(inner),
+        }
     }
 
     /// Get the root hash of this [`Tree`].
@@ -196,7 +201,7 @@ impl Tree {
         let position = (self.inner.position().ok_or(InsertError::Full)?).into();
 
         // Try to insert the commitment into the latest block
-        self.inner
+        Arc::make_mut(&mut self.inner)
             .update(|epoch| {
                 epoch
                     .update(|block| {
@@ -229,7 +234,7 @@ impl Tree {
             // If the latest epoch was finalized already or doesn't exist, create a new epoch and
             // insert into that epoch
             .unwrap_or_else(|| {
-                self.inner
+                Arc::make_mut(&mut self.inner)
                     .insert(frontier::Tier::new(frontier::Tier::new(item)))
                     .expect("inserting a commitment must succeed because we already checked that the tree is not full");
                 Ok(())
@@ -244,7 +249,7 @@ impl Tree {
             if let Some(replaced) = self.index.insert(commitment, position) {
                 // This case is handled for completeness, but should not happen in
                 // practice because commitments should be unique
-                let forgotten = self.inner.forget(replaced);
+                let forgotten = Arc::make_mut(&mut self.inner).forget(replaced);
                 debug_assert!(forgotten);
             }
         }
@@ -298,7 +303,7 @@ impl Tree {
             // We forgot something
             forgotten = true;
             // Forget the index for this element in the tree
-            let forgotten = self.inner.forget(within_epoch);
+            let forgotten = Arc::make_mut(&mut self.inner).forget(within_epoch);
             debug_assert!(forgotten);
             // Remove this entry from the index
             self.index.remove(&commitment);
@@ -374,16 +379,14 @@ impl Tree {
 
         // Finalize the latest block, if it exists and is not yet finalized -- this means that
         // position calculations will be correct, since they will start at the next block
-        self.inner
-            .update(|epoch| epoch.update(|block| block.finalize()));
+        Arc::make_mut(&mut self.inner).update(|epoch| epoch.update(|block| block.finalize()));
 
         // Get the epoch and block index of the next insertion
         let position = self.inner.position();
 
         // Insert the block into the latest epoch, or create a new epoch for it if the latest epoch
         // does not exist or is finalized
-        let block_root = self
-            .inner
+        let block_root = Arc::make_mut(&mut self.inner)
             .update(|epoch| {
                 // If the epoch is finalized, create a new one (below) to insert the block into
                 if epoch.is_finalized() {
@@ -426,7 +429,7 @@ impl Tree {
                 let block_root = block::Root(inner.hash());
 
                 // Create a new epoch and insert the block into it
-                self.inner
+                Arc::make_mut(&mut self.inner)
                     .insert(frontier::Tier::new(inner))
                     .expect("inserting a new epoch must succeed when the tree is not full");
 
@@ -453,7 +456,7 @@ impl Tree {
             ) {
                 // This case is handled for completeness, but should not happen in practice because
                 // commitments should be unique
-                let forgotten = self.inner.forget(replaced);
+                let forgotten = Arc::make_mut(&mut self.inner).forget(replaced);
                 debug_assert!(forgotten);
             }
         }
@@ -467,8 +470,7 @@ impl Tree {
     pub fn end_block(&mut self) -> Result<block::Root, InsertBlockError> {
         // Check to see if the latest block is already finalized, and finalize it if
         // it is not
-        let (already_finalized, finalized_root) = self
-            .inner
+        let (already_finalized, finalized_root) = Arc::make_mut(&mut self.inner)
             .update(|epoch| {
                 epoch.update(|tier| match tier.finalize() {
                     true => (true, block::Finalized::default().root()),
@@ -574,7 +576,7 @@ impl Tree {
 
         // Finalize the latest epoch, if it exists and is not yet finalized -- this means that
         // position calculations will be correct, since they will start at the next epoch
-        self.inner.update(|epoch| epoch.finalize());
+        Arc::make_mut(&mut self.inner).update(|epoch| epoch.finalize());
 
         // Get the epoch index of the next insertion
         let index::within::Tree { epoch, .. } = self
@@ -587,7 +589,7 @@ impl Tree {
         let epoch_root = epoch::Root(inner.hash());
 
         // Insert the inner tree of the epoch into the global tree
-        self.inner
+        Arc::make_mut(&mut self.inner)
             .insert(inner)
             .expect("inserting an epoch must succeed when tree is not full");
 
@@ -605,7 +607,7 @@ impl Tree {
             ) {
                 // This case is handled for completeness, but should not happen in practice because
                 // commitments should be unique
-                let forgotten = self.inner.forget(replaced);
+                let forgotten = Arc::make_mut(&mut self.inner).forget(replaced);
                 debug_assert!(forgotten);
             }
         }
@@ -619,8 +621,7 @@ impl Tree {
     pub fn end_epoch(&mut self) -> Result<epoch::Root, InsertEpochError> {
         // Check to see if the latest block is already finalized, and finalize it if
         // it is not
-        let (already_finalized, finalized_root) = self
-            .inner
+        let (already_finalized, finalized_root) = Arc::make_mut(&mut self.inner)
             .update(|tier| match tier.finalize() {
                 true => (true, epoch::Finalized::default().root()),
                 false => (false, epoch::Root(tier.hash())),
@@ -737,7 +738,7 @@ impl Tree {
     pub fn structure(&self) -> structure::Node {
         let _structure_span = trace_span!("structure");
         // TODO: use the structure span for instrumenting methods of the structure, as it is traversed
-        Node::root(&self.inner)
+        Node::root(&*self.inner)
     }
 
     /// Deserialize a tree from a [`storage::Read`] backend.
@@ -775,6 +776,9 @@ impl From<frontier::Top<frontier::Tier<frontier::Tier<frontier::Item>>>> for Tre
             }
         });
 
-        Self { inner, index }
+        Self {
+            inner: Arc::new(inner),
+            index,
+        }
     }
 }

--- a/tct/src/tree.rs
+++ b/tct/src/tree.rs
@@ -87,7 +87,7 @@ impl Protobuf<pb::MerkleRoot> for Root {}
 
 impl Display for Root {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(&Fq::from(self.0).to_bytes()))
+        write!(f, "{}", hex::encode(Fq::from(self.0).to_bytes()))
     }
 }
 
@@ -767,14 +767,17 @@ impl From<frontier::Top<frontier::Tier<frontier::Tier<frontier::Item>>>> for Tre
         let mut index = HashedMap::default();
 
         // Traverse the tree to reconstruct the index
-        structure::traverse(Node::root(&inner), &mut |node: Node| {
+        let mut stack = vec![Node::root(&inner)];
+        while let Some(node) = stack.pop() {
+            stack.extend(node.children());
+
             if let structure::Kind::Leaf {
                 commitment: Some(commitment),
             } = node.kind()
             {
                 index.insert(commitment, node.position().0);
             }
-        });
+        }
 
         Self {
             inner: Arc::new(inner),

--- a/tct/src/tree.rs
+++ b/tct/src/tree.rs
@@ -730,7 +730,7 @@ impl Tree {
     /// in order, but it may be slower by a constant factor.
     #[instrument(level = "trace", skip(self))]
     pub fn commitments_ordered(&self) -> impl Iterator<Item = (Position, Commitment)> + '_ {
-        crate::storage::serialize::Serializer::default().commitments_iter(self)
+        crate::storage::serialize::Serializer::default().commitments(self)
     }
 
     /// Get a dynamic representation of the internal structure of the tree, which can be traversed

--- a/tct/src/validate.rs
+++ b/tct/src/validate.rs
@@ -25,7 +25,10 @@ pub fn index(tree: &Tree) -> Result<(), IndexMalformed> {
 
     let mut errors = vec![];
 
-    structure::traverse(tree.structure(), &mut |node| {
+    let mut stack = vec![tree.structure()];
+    while let Some(node) = stack.pop() {
+        stack.extend(node.children());
+
         if let Kind::Leaf {
             commitment: Some(actual_commitment),
         } = node.kind()
@@ -58,7 +61,7 @@ pub fn index(tree: &Tree) -> Result<(), IndexMalformed> {
                 });
             };
         }
-    });
+    }
 
     // Return an error if any were discovered
     if errors.is_empty() {
@@ -270,7 +273,7 @@ pub fn forgotten(tree: &Tree) -> Result<(), InvalidForgotten> {
         let actual_max = node
             .children()
             .iter()
-            .map(Any::forgotten)
+            .map(Node::forgotten)
             .max()
             .unwrap_or_default();
 

--- a/tct/src/validate.rs
+++ b/tct/src/validate.rs
@@ -19,7 +19,7 @@ pub fn index(tree: &Tree) -> Result<(), IndexMalformed> {
     // A reverse index from positions back to the commitments that are supposed to map to their
     // hashes
     let reverse_index: BTreeMap<Position, Commitment> = tree
-        .commitments()
+        .commitments_unordered()
         .map(|(commitment, position)| (position, commitment))
         .collect();
 
@@ -127,7 +127,7 @@ pub fn all_proofs(tree: &Tree) -> Result<(), InvalidWitnesses> {
 
     let mut errors = vec![];
 
-    for (commitment, position) in tree.commitments() {
+    for (commitment, position) in tree.commitments_unordered() {
         if let Some(proof) = tree.witness(commitment) {
             if proof.verify(root).is_err() {
                 errors.push(WitnessError::InvalidProof {

--- a/view/src/bin/pviewd.rs
+++ b/view/src/bin/pviewd.rs
@@ -1,4 +1,3 @@
-#![recursion_limit = "256"]
 #![allow(clippy::clone_on_copy)]
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;

--- a/view/src/lib.rs
+++ b/view/src/lib.rs
@@ -1,6 +1,3 @@
-// Required because of NCT type size
-#![recursion_limit = "256"]
-
 mod client;
 mod metrics;
 mod note_record;

--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -347,7 +347,7 @@ impl Storage {
 
     pub async fn note_commitment_tree(&self) -> anyhow::Result<tct::Tree> {
         let mut tx = self.pool.begin().await?;
-        let tree = tct::Tree::deserialize(&mut TreeStore(&mut tx)).await?;
+        let tree = tct::Tree::from_async_reader(&mut TreeStore(&mut tx)).await?;
         tx.commit().await?;
         Ok(tree)
     }
@@ -447,7 +447,7 @@ impl Storage {
                 // quoting the nullifier bytes. tried to get the `sqlx::query_as!` macro to work
                 // but the types didn't work out easily.
                 format!(
-                    "SELECT 
+                    "SELECT
                         notes.note_commitment,
                         notes.height_created,
                         notes.address,
@@ -1028,7 +1028,7 @@ impl Storage {
         }
 
         // Update NCT table with current NCT state
-        nct.serialize(&mut TreeStore(&mut dbtx)).await?;
+        nct.to_async_writer(&mut TreeStore(&mut dbtx)).await?;
 
         // Record all transactions
         for transaction in transactions {

--- a/view/src/storage/nct.rs
+++ b/view/src/storage/nct.rs
@@ -5,7 +5,7 @@ use sqlx::Either;
 use std::{ops::Range, pin::Pin};
 
 use penumbra_tct::{
-    storage::{Read, StoredPosition, Write},
+    storage::{AsyncRead, AsyncWrite, StoredPosition},
     structure::Hash,
     Commitment, Forgotten, Position,
 };
@@ -13,7 +13,7 @@ use penumbra_tct::{
 pub struct TreeStore<'a, 'c: 'a>(pub &'a mut sqlx::Transaction<'c, sqlx::Sqlite>);
 
 #[async_trait]
-impl Read for TreeStore<'_, '_> {
+impl AsyncRead for TreeStore<'_, '_> {
     type Error = anyhow::Error;
 
     async fn position(&mut self) -> Result<StoredPosition, Self::Error> {
@@ -86,7 +86,7 @@ impl Read for TreeStore<'_, '_> {
 }
 
 #[async_trait]
-impl Write for TreeStore<'_, '_> {
+impl AsyncWrite for TreeStore<'_, '_> {
     async fn set_position(&mut self, position: StoredPosition) -> Result<(), Self::Error> {
         let position = Option::from(position).map(|p: Position| u64::from(p) as i64);
         sqlx::query!("UPDATE nct_position SET position = ?", position)

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -1,6 +1,3 @@
-// Required because of NCT type size
-#![recursion_limit = "256"]
-
 mod build;
 mod key_store;
 pub use build::build_transaction;


### PR DESCRIPTION
This obviates #1580 (more commentary on motivation for the clone-on-write changes to be found in that description) and additionally adds a synchronous incremental serialization (and non-incremental deserialization) interface, as well as a slightly lower-level set of interfaces for incremental and non-incremental serialization that don't rely on internally driven iteration with a supplied trait implementor, and instead require external driving by the calling code. This enables using incremental serialization across a restricted boundary like the wasm/javascript boundary, where the storage lies on the other side of the boundary and cannot be accessed from within TCT code.