### PR TITLE
Add methods to random-access hashes and commitments in NCT storage

### DIFF
--- a/tct/src/storage.rs
+++ b/tct/src/storage.rs
@@ -64,11 +64,17 @@ pub trait AsyncRead {
     /// Fetch the current forgotten version.
     async fn forgotten(&mut self) -> Result<Forgotten, Self::Error>;
 
+    /// Fetch the hash at the given position and height, if it exists.
+    async fn hash(&mut self, position: Position, height: u8) -> Result<Option<Hash>, Self::Error>;
+
     /// Get the full list of all internal hashes stored, indexed by position and height.
     #[allow(clippy::type_complexity)]
     fn hashes(
         &mut self,
     ) -> Pin<Box<dyn Stream<Item = Result<(Position, u8, Hash), Self::Error>> + Send + '_>>;
+
+    /// Fetch the commitment at the given position, if it exists.
+    async fn commitment(&mut self, position: Position) -> Result<Option<Commitment>, Self::Error>;
 
     /// Get the full list of all commitments stored, indexed by position.
     #[allow(clippy::type_complexity)]
@@ -137,11 +143,17 @@ pub trait Read {
     /// Fetch the current forgotten version.
     fn forgotten(&mut self) -> Result<Forgotten, Self::Error>;
 
+    /// Fetch a specific hash at the given position and height, if it exists.
+    fn hash(&mut self, position: Position, height: u8) -> Result<Option<Hash>, Self::Error>;
+
     /// Get the full list of all internal hashes stored, indexed by position and height.
     #[allow(clippy::type_complexity)]
     fn hashes(
         &mut self,
     ) -> Box<dyn Iterator<Item = Result<(Position, u8, Hash), Self::Error>> + Send + '_>;
+
+    /// Fetch a specific commitment at the given position, if it exists.
+    fn commitment(&mut self, position: Position) -> Result<Option<Commitment>, Self::Error>;
 
     /// Get the full list of all commitments stored, indexed by position.
     #[allow(clippy::type_complexity)]

--- a/tct/src/storage/in_memory.rs
+++ b/tct/src/storage/in_memory.rs
@@ -88,6 +88,14 @@ impl Read for InMemory {
         Ok(self.forgotten)
     }
 
+    fn hash(&mut self, position: Position, height: u8) -> Result<Option<Hash>, Self::Error> {
+        Ok(self
+            .hashes
+            .get(&position)
+            .and_then(|h| h.get(&height))
+            .cloned())
+    }
+
     fn hashes(
         &mut self,
     ) -> Box<dyn Iterator<Item = Result<(Position, u8, Hash), Self::Error>> + Send + '_> {
@@ -96,6 +104,10 @@ impl Read for InMemory {
                 .iter()
                 .map(move |(&height, &hash)| Ok((position, height, hash)))
         }))
+    }
+
+    fn commitment(&mut self, position: Position) -> Result<Option<Commitment>, Self::Error> {
+        Ok(self.commitments.get(&position).cloned())
     }
 
     fn commitments(

--- a/view/sqlx-data.json
+++ b/view/sqlx-data.json
@@ -152,6 +152,24 @@
     },
     "query": "UPDATE sync_height SET height = ?"
   },
+  "4c9bd2e8b71df9f41b20ea0ff9a6cc2f9edf80c22a2c3c64410ed78fa5b05353": {
+    "describe": {
+      "columns": [
+        {
+          "name": "hash",
+          "ordinal": 0,
+          "type_info": "Blob"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Right": 2
+      }
+    },
+    "query": "SELECT hash FROM nct_hashes WHERE position = ? AND height = ? LIMIT 1"
+  },
   "58e7cd62f2177d2bd0fa3b34c8be3495c9a0d8e331f846b56bf7c756a534ea64": {
     "describe": {
       "columns": [],
@@ -385,6 +403,24 @@
       }
     },
     "query": "SELECT * FROM notes WHERE note_commitment = ?"
+  },
+  "95df7ed7e4e2444a04608f6250f0aeaedf0a054f15787c6c147233cc965dcbbb": {
+    "describe": {
+      "columns": [
+        {
+          "name": "commitment",
+          "ordinal": 0,
+          "type_info": "Blob"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Right": 1
+      }
+    },
+    "query": "SELECT commitment FROM nct_commitments WHERE position = ? LIMIT 1"
   },
   "982b5f03b4628f7fb3ae7ab903b964e77fd3f5b626be440b672f182503204f2d": {
     "describe": {


### PR DESCRIPTION
Having these available to a storage backend means that the backend can pull out selected portions of the tree in its own `hashes` and `commitments` implementations, effectively choosing to selectively deserialize only the frontier of the tree.