### PR TITLE
Revert "Try specifying default BUILDPLATFORM"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-ENV BUILDPLATFORM linux/amd64
 FROM --platform=$BUILDPLATFORM rust:1-bullseye AS build-env
 
 RUN rustup component add rustfmt


### PR DESCRIPTION
This reverts commit e1c94972292fac08764c35d3b0976b15ce4ff2bb.

Fixes buildkit builds such as the docker build and publish github actions workflow