### PR TITLE
storage: fill in nonconsensus_prefix support

### DIFF
--- a/storage/src/state.rs
+++ b/storage/src/state.rs
@@ -15,7 +15,7 @@ pub use write::StateWrite;
 
 use crate::snapshot::Snapshot;
 
-use self::read::prefix_raw_with_cache;
+use self::read::{nonconsensus_prefix_raw_with_cache, prefix_raw_with_cache};
 
 /// A lightweight snapshot of a particular version of the chain state.
 ///
@@ -170,5 +170,12 @@ impl StateRead for State {
         self.ephemeral_objects
             .get(key)
             .and_then(|object| object.downcast_ref())
+    }
+
+    fn nonconsensus_prefix_raw<'a>(
+        &'a self,
+        prefix: &'a [u8],
+    ) -> Pin<Box<dyn Stream<Item = Result<(Vec<u8>, Vec<u8>)>> + Send + Sync + 'a>> {
+        nonconsensus_prefix_raw_with_cache(&self.snapshot, &self.nonconsensus_changes, prefix)
     }
 }

--- a/storage/src/state/transaction.rs
+++ b/storage/src/state/transaction.rs
@@ -7,7 +7,10 @@ use tendermint::abci;
 
 use crate::State;
 
-use super::{read::prefix_raw_with_cache, StateRead, StateWrite};
+use super::{
+    read::{nonconsensus_prefix_raw_with_cache, prefix_raw_with_cache},
+    StateRead, StateWrite,
+};
 
 /// A set of pending changes to a [`State`] instance, supporting both writes and reads.
 pub struct Transaction<'a> {
@@ -125,6 +128,13 @@ impl<'tx> StateRead for Transaction<'tx> {
         prefix: &'a str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, Vec<u8>)>> + Sync + Send + 'a>> {
         prefix_raw_with_cache(self.state, &self.unwritten_changes, prefix)
+    }
+
+    fn nonconsensus_prefix_raw<'a>(
+        &'a self,
+        prefix: &'a [u8],
+    ) -> Pin<Box<dyn Stream<Item = Result<(Vec<u8>, Vec<u8>)>> + Sync + Send + 'a>> {
+        nonconsensus_prefix_raw_with_cache(self.state, &self.nonconsensus_changes, prefix)
     }
 
     fn object_get<T: Any + Send + Sync>(&self, key: &'static str) -> Option<&T> {

--- a/storage/tests/basic.rs
+++ b/storage/tests/basic.rs
@@ -16,6 +16,10 @@ async fn simple_flow() -> anyhow::Result<()> {
     // tx00: c/ab => 1 [object store]
     // tx00: c/ac => 2 [object store]
     // tx00: c/ad => 3 [object store]
+    // tx00: iA => A [nonconsensus store]
+    // tx00: iC => C [nonconsensus store]
+    // tx00: iF => F [nonconsensus store]
+    // tx00: iD => D [nonconsensus store]
     // tx01: a/aa => aa
     // tx01: a/aaa => aaa
     // tx01: a/ab => ab
@@ -27,7 +31,9 @@ async fn simple_flow() -> anyhow::Result<()> {
     // tx10: test => [deleted]
     // tx10: a/aaa => [deleted]
     // tx10: a/c => c
+    // tx10: iB => B [nonconsensus store]
     // tx11: a/ab => ab2
+    // tx11: iD => [deleted] nonconsensus store]
 
     let mut state_init = storage.latest_state();
     // Check that reads on an empty state return Ok(None)
@@ -41,6 +47,10 @@ async fn simple_flow() -> anyhow::Result<()> {
     tx00.object_put("c/ab", 1u64);
     tx00.object_put("c/ac", 2u64);
     tx00.object_put("c/ad", 3u64);
+    tx00.nonconsensus_put_raw(b"iA".to_vec(), b"A".to_vec());
+    tx00.nonconsensus_put_raw(b"iC".to_vec(), b"C".to_vec());
+    tx00.nonconsensus_put_raw(b"iF".to_vec(), b"F".to_vec());
+    tx00.nonconsensus_put_raw(b"iD".to_vec(), b"D".to_vec());
 
     // Check reads against tx00:
     //     This is present in tx00
@@ -56,19 +66,26 @@ async fn simple_flow() -> anyhow::Result<()> {
     assert_eq!(tx00.object_get::<bool>("c/aa"), None);
     //     Missing in tx00 object store
     assert_eq!(tx00.object_get::<bool>("nonexist"), None);
-    //     Object store range checks
-    /*
-    let mut range = tx00.prefix_ephemeral::<u64>("c/");
-    assert_eq!(range.next(), Some(("c/aa", &0u64)));
-    assert_eq!(range.next(), Some(("c/ab", &1u64)));
-    assert_eq!(range.next(), Some(("c/ac", &2u64)));
-    assert_eq!(range.next(), Some(("c/ad", &3u64)));
-    assert_eq!(range.next(), None);
+    //     Nonconsensus range checks
+    let mut range = tx00.nonconsensus_prefix_raw(b"i");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iA".to_vec(), b"A".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iC".to_vec(), b"C".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iD".to_vec(), b"D".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iF".to_vec(), b"F".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
     std::mem::drop(range);
-    let mut range = tx00.prefix_ephemeral::<bool>("c/");
-    assert_eq!(range.next(), None);
-    std::mem::drop(range);
-    */
 
     // Now apply the transaction to state_init
     tx00.apply();
@@ -83,19 +100,26 @@ async fn simple_flow() -> anyhow::Result<()> {
     assert_eq!(state_init.object_get::<bool>("c/aa"), None);
     //     Missing in state_init object store
     assert_eq!(state_init.object_get::<bool>("nonexist"), None);
-    //     Object store range checks
-    /*
-    let mut range = state_init.prefix_ephemeral::<u64>("c/");
-    assert_eq!(range.next(), Some(("c/aa", &0u64)));
-    assert_eq!(range.next(), Some(("c/ab", &1u64)));
-    assert_eq!(range.next(), Some(("c/ac", &2u64)));
-    assert_eq!(range.next(), Some(("c/ad", &3u64)));
-    assert_eq!(range.next(), None);
+    //     Nonconsensus range checks
+    let mut range = state_init.nonconsensus_prefix_raw(b"i");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iA".to_vec(), b"A".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iC".to_vec(), b"C".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iD".to_vec(), b"D".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iF".to_vec(), b"F".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
     std::mem::drop(range);
-    let mut range = state_init.prefix_ephemeral::<bool>("c/");
-    assert_eq!(range.next(), None);
-    std::mem::drop(range);
-    */
 
     // Create a transaction writing the other keys.
     let mut tx01 = state_init.begin_transaction();
@@ -135,15 +159,6 @@ async fn simple_flow() -> anyhow::Result<()> {
     );
     assert_eq!(range.next().await.transpose()?, None);
     std::mem::drop(range);
-    //     Object store range checks
-    /*
-    let mut range = tx01.prefix_ephemeral::<u64>("c/");
-    assert_eq!(range.next(), Some(("c/aa", &0u64)));
-    assert_eq!(range.next(), Some(("c/ab", &10u64)));
-    assert_eq!(range.next(), Some(("c/ad", &3u64)));
-    assert_eq!(range.next(), None);
-    std::mem::drop(range);
-    */
 
     // Now apply the transaction to state_init
     tx01.apply();
@@ -176,15 +191,6 @@ async fn simple_flow() -> anyhow::Result<()> {
     );
     assert_eq!(range.next().await.transpose()?, None);
     std::mem::drop(range);
-    //     Object store range checks
-    /*
-    let mut range = state_init.prefix_ephemeral::<u64>("c/");
-    assert_eq!(range.next(), Some(("c/aa", &0u64)));
-    assert_eq!(range.next(), Some(("c/ab", &10u64)));
-    assert_eq!(range.next(), Some(("c/ad", &3u64)));
-    assert_eq!(range.next(), None);
-    std::mem::drop(range);
-    */
 
     // Now commit state_init to storage
     storage.commit(state_init).await?;
@@ -220,12 +226,33 @@ async fn simple_flow() -> anyhow::Result<()> {
     );
     assert_eq!(range.next().await.transpose()?, None);
     std::mem::drop(range);
+    //     Nonconsensus range checks
+    let mut range = state0.nonconsensus_prefix_raw(b"i");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iA".to_vec(), b"A".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iC".to_vec(), b"C".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iD".to_vec(), b"D".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iF".to_vec(), b"F".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
 
     // Start building a transaction
     let mut tx10 = state0.begin_transaction();
     tx10.delete("test".to_owned());
     tx10.delete("a/aaa".to_owned());
     tx10.put_raw("a/c".to_owned(), b"c".to_vec());
+    tx10.nonconsensus_put_raw(b"iB".to_vec(), b"B".to_vec());
 
     // Check reads against tx10:
     //    This is deleted in tx10, missing in state0, present in JMT
@@ -256,8 +283,30 @@ async fn simple_flow() -> anyhow::Result<()> {
     );
     assert_eq!(range.next().await.transpose()?, None);
     std::mem::drop(range);
-
-    // TODO: Check ranged reads against tx10
+    //     Nonconsensus range checks
+    let mut range = tx10.nonconsensus_prefix_raw(b"i");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iA".to_vec(), b"A".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iB".to_vec(), b"B".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iC".to_vec(), b"C".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iD".to_vec(), b"D".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iF".to_vec(), b"F".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
 
     // Apply tx10 to state0
     tx10.apply();
@@ -295,6 +344,7 @@ async fn simple_flow() -> anyhow::Result<()> {
     // Start building another transaction
     let mut tx11 = state0.begin_transaction();
     tx11.put_raw("a/ab".to_owned(), b"ab2".to_vec());
+    tx11.nonconsensus_delete(b"iD".to_vec());
 
     // Check reads against tx11:
     //    This is present in tx11, missing in state0, present in JMT
@@ -323,6 +373,26 @@ async fn simple_flow() -> anyhow::Result<()> {
     assert_eq!(
         range.next().await.transpose()?,
         Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+    //     Nonconsensus range checks
+    let mut range = tx11.nonconsensus_prefix_raw(b"i");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iA".to_vec(), b"A".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iB".to_vec(), b"B".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iC".to_vec(), b"C".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iF".to_vec(), b"F".to_vec()))
     );
     assert_eq!(range.next().await.transpose()?, None);
     std::mem::drop(range);
@@ -357,6 +427,25 @@ async fn simple_flow() -> anyhow::Result<()> {
     assert_eq!(
         range.next().await.transpose()?,
         Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+    let mut range = state0.nonconsensus_prefix_raw(b"i");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iA".to_vec(), b"A".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iB".to_vec(), b"B".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iC".to_vec(), b"C".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iF".to_vec(), b"F".to_vec()))
     );
     assert_eq!(range.next().await.transpose()?, None);
     std::mem::drop(range);
@@ -397,6 +486,25 @@ async fn simple_flow() -> anyhow::Result<()> {
     );
     assert_eq!(range.next().await.transpose()?, None);
     std::mem::drop(range);
+    let mut range = state1.nonconsensus_prefix_raw(b"i");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iA".to_vec(), b"A".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iB".to_vec(), b"B".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iC".to_vec(), b"C".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iF".to_vec(), b"F".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
 
     // Check reads against state0a
     assert_eq!(state0a.get_raw("test").await?, Some(b"test".to_vec()));
@@ -421,6 +529,26 @@ async fn simple_flow() -> anyhow::Result<()> {
     assert_eq!(
         range.next().await.transpose()?,
         Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+    //     Nonconsensus range checks
+    let mut range = state0a.nonconsensus_prefix_raw(b"i");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iA".to_vec(), b"A".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iC".to_vec(), b"C".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iD".to_vec(), b"D".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iF".to_vec(), b"F".to_vec()))
     );
     assert_eq!(range.next().await.transpose()?, None);
     std::mem::drop(range);
@@ -464,6 +592,26 @@ async fn simple_flow() -> anyhow::Result<()> {
     assert_eq!(
         range.next().await.transpose()?,
         Some(("a/z".to_owned(), b"z".to_vec()))
+    );
+    assert_eq!(range.next().await.transpose()?, None);
+    std::mem::drop(range);
+    //     Nonconsensus range checks
+    let mut range = state1a.nonconsensus_prefix_raw(b"i");
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iA".to_vec(), b"A".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iB".to_vec(), b"B".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iC".to_vec(), b"C".to_vec()))
+    );
+    assert_eq!(
+        range.next().await.transpose()?,
+        Some((b"iF".to_vec(), b"F".to_vec()))
     );
     assert_eq!(range.next().await.transpose()?, None);
     std::mem::drop(range);


### PR DESCRIPTION
Unlocks forward progress on the DEX, since now we'll be able to index liquidity positions.