### PR TITLE
lint(protos): suffixed service names and unspecified enum variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,13 +1227,13 @@ dependencies = [
 [[package]]
 name = "decaf377"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/decaf377#e52a957afeeeec4af0f38d4d6a56cc8bbddb1da8"
+source = "git+https://github.com/penumbra-zone/decaf377#eb7db407b620fec5354e9e19ea6a4bfac201aed5"
 dependencies = [
+ "anyhow",
  "ark-bls12-377",
  "ark-ec",
  "ark-ed-on-bls12-377",
  "ark-ff",
- "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
  "ark-std",
@@ -2296,9 +2296,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "lazy_static"
@@ -4041,9 +4044,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "base64",
  "bytes",
@@ -5877,9 +5880,9 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]

--- a/component/src/stake/validator/bonding.rs
+++ b/component/src/stake/validator/bonding.rs
@@ -58,17 +58,21 @@ impl TryFrom<pb::BondingState> for State {
     type Error = anyhow::Error;
     fn try_from(v: pb::BondingState) -> Result<Self, Self::Error> {
         let unbonding_epoch = v.unbonding_epoch;
-        Ok(
-            match pb::bonding_state::BondingStateEnum::from_i32(v.state)
-                .ok_or_else(|| anyhow::anyhow!("missing bonding state"))?
-            {
-                pb::bonding_state::BondingStateEnum::Bonded => State::Bonded,
-                pb::bonding_state::BondingStateEnum::Unbonded => State::Unbonded,
-                pb::bonding_state::BondingStateEnum::Unbonding => State::Unbonding {
-                    unbonding_epoch: unbonding_epoch
-                        .expect("unbonding epoch should be set for unbonding state"),
-                },
-            },
-        )
+        let Some(bonding_state) = pb::bonding_state::BondingStateEnum::from_i32(v.state) else {
+            return Err(anyhow::anyhow!("invalid bonding state!"))
+        };
+
+        match bonding_state {
+            pb::bonding_state::BondingStateEnum::Bonded => Ok(State::Bonded),
+            pb::bonding_state::BondingStateEnum::Unbonded => Ok(State::Unbonded),
+            pb::bonding_state::BondingStateEnum::Unbonding => Ok(State::Unbonding {
+                // TODO(erwan): should this be handled more gracefully? MERGEBLOCK
+                unbonding_epoch: unbonding_epoch
+                    .expect("unbonding epoch should be set for unbonding state"),
+            }),
+            pb::bonding_state::BondingStateEnum::Unspecified => {
+                Err(anyhow::anyhow!("unspecified bonding state!"))
+            }
+        }
     }
 }

--- a/crypto/src/dex/lp/position.rs
+++ b/crypto/src/dex/lp/position.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use penumbra_proto::{core::dex::v1alpha1 as pb, serializers::bech32str, Protobuf};
 use serde::{Deserialize, Serialize};
 
@@ -195,15 +195,20 @@ impl From<State> for pb::PositionState {
 impl TryFrom<pb::PositionState> for State {
     type Error = anyhow::Error;
     fn try_from(v: pb::PositionState) -> Result<Self, Self::Error> {
-        Ok(
-            match pb::position_state::PositionStateEnum::from_i32(v.state)
-                .ok_or_else(|| anyhow::anyhow!("missing position state"))?
-            {
-                pb::position_state::PositionStateEnum::Opened => State::Opened,
-                pb::position_state::PositionStateEnum::Closed => State::Closed,
-                pb::position_state::PositionStateEnum::Withdrawn => State::Withdrawn,
-                pb::position_state::PositionStateEnum::Claimed => State::Claimed,
-            },
-        )
+        let Some(position_state) = pb::position_state::PositionStateEnum::from_i32(v.state) else {
+            // maps to an invalid position state
+            return Err(anyhow!("invalid position state!"))
+        };
+
+        match position_state {
+            pb::position_state::PositionStateEnum::Opened => Ok(State::Opened),
+            pb::position_state::PositionStateEnum::Closed => Ok(State::Closed),
+            pb::position_state::PositionStateEnum::Withdrawn => Ok(State::Withdrawn),
+            pb::position_state::PositionStateEnum::Claimed => Ok(State::Claimed),
+            pb::position_state::PositionStateEnum::Unspecified => {
+                // maps to a missing position state, or one that's set to zero.
+                Err(anyhow!("unspecified position state!"))
+            }
+        }
     }
 }

--- a/custody/src/client.rs
+++ b/custody/src/client.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use penumbra_proto::custody::v1alpha1::custody_protocol_client::CustodyProtocolClient;
+use penumbra_proto::custody::v1alpha1::custody_protocol_service_client::CustodyProtocolServiceClient;
 use penumbra_transaction::AuthorizationData;
 use tonic::async_trait;
 use tonic::codegen::Bytes;
@@ -18,10 +18,10 @@ use crate::AuthorizeRequest;
 /// understand the transaction and determine whether or not it should be
 /// authorized.
 ///
-/// This trait is a wrapper around the proto-generated [`CustodyProtocolClient`] that serves two goals:
+/// This trait is a wrapper around the proto-generated [`CustodyProtocolServiceClient`] that serves two goals:
 ///
 /// 1. It works on domain types rather than proto-generated types, avoiding conversions;
-/// 2. It's easier to write as a trait bound than the `CustodyProtocolClient`,
+/// 2. It's easier to write as a trait bound than the `CustodyProtocolServiceClient`,
 ///   which requires complex bounds on its inner type to enforce that it is a
 ///   tower `Service`
 #[async_trait(?Send)]
@@ -31,13 +31,13 @@ pub trait CustodyClient: Sized {
 }
 
 // We need to tell `async_trait` not to add a `Send` bound to the boxed
-// futures it generates, because the underlying `CustodyProtocolClient` isn't `Sync`,
+// futures it generates, because the underlying `CustodyProtocolServiceClient` isn't `Sync`,
 // but its `authorize` method takes `&mut self`. This would normally cause a huge
 // amount of problems, because non-`Send` futures don't compose well, but as long
 // as we're calling the method within an async block on a local mutable variable,
 // it should be fine.
 #[async_trait(?Send)]
-impl<T> CustodyClient for CustodyProtocolClient<T>
+impl<T> CustodyClient for CustodyProtocolServiceClient<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::ResponseBody: tonic::codegen::Body<Data = Bytes> + Send + 'static,

--- a/custody/src/soft_hsm.rs
+++ b/custody/src/soft_hsm.rs
@@ -38,7 +38,7 @@ impl SoftHSM {
 }
 
 #[async_trait]
-impl pb::custody_protocol_server::CustodyProtocol for SoftHSM {
+impl pb::custody_protocol_service_server::CustodyProtocolService for SoftHSM {
     async fn authorize(
         &self,
         request: Request<pb::AuthorizeRequest>,

--- a/measure/src/main.rs
+++ b/measure/src/main.rs
@@ -6,7 +6,8 @@ use tracing_subscriber::EnvFilter;
 
 use penumbra_chain::{params::ChainParameters, sync::CompactBlock};
 use penumbra_proto::client::v1alpha1::{
-    oblivious_query_client::ObliviousQueryClient, ChainParamsRequest, CompactBlockRangeRequest,
+    oblivious_query_service_client::ObliviousQueryServiceClient, ChainParamsRequest,
+    CompactBlockRangeRequest,
 };
 
 #[derive(Debug, Parser)]
@@ -56,9 +57,11 @@ impl Opt {
     pub async fn run(&self) -> anyhow::Result<()> {
         match self.cmd {
             Command::StreamBlocks => {
-                let mut client =
-                    ObliviousQueryClient::connect(format!("http://{}:{}", self.node, self.pd_port))
-                        .await?;
+                let mut client = ObliviousQueryServiceClient::connect(format!(
+                    "http://{}:{}",
+                    self.node, self.pd_port
+                ))
+                .await?;
 
                 let params: ChainParameters = client
                     .chain_parameters(tonic::Request::new(ChainParamsRequest {

--- a/pcli/src/command/view.rs
+++ b/pcli/src/command/view.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use penumbra_crypto::FullViewingKey;
-use penumbra_proto::client::v1alpha1::oblivious_query_client::ObliviousQueryClient;
+use penumbra_proto::client::v1alpha1::oblivious_query_service_client::ObliviousQueryServiceClient;
 use penumbra_view::ViewClient;
 use tonic::transport::Channel;
 
@@ -55,7 +55,7 @@ impl ViewCmd {
         &self,
         full_viewing_key: &FullViewingKey,
         view_client: Option<&mut impl ViewClient>,
-        oblivious_client: &mut ObliviousQueryClient<Channel>,
+        oblivious_client: &mut ObliviousQueryServiceClient<Channel>,
     ) -> Result<()> {
         match self {
             ViewCmd::Tx(tx_cmd) => {

--- a/pcli/src/command/view/staked.rs
+++ b/pcli/src/command/view/staked.rs
@@ -6,7 +6,7 @@ use futures::TryStreamExt;
 use penumbra_component::stake::validator;
 use penumbra_crypto::{DelegationToken, FullViewingKey, Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_proto::client::v1alpha1::{
-    oblivious_query_client::ObliviousQueryClient, ValidatorInfoRequest,
+    oblivious_query_service_client::ObliviousQueryServiceClient, ValidatorInfoRequest,
 };
 use penumbra_view::ViewClient;
 use tonic::transport::Channel;
@@ -23,7 +23,7 @@ impl StakedCmd {
         &self,
         full_viewing_key: &FullViewingKey,
         view_client: &mut impl ViewClient,
-        oblivious_client: &mut ObliviousQueryClient<Channel>,
+        oblivious_client: &mut ObliviousQueryServiceClient<Channel>,
     ) -> Result<()> {
         let client = oblivious_client;
 

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -6,8 +6,8 @@ use clap::Parser;
 use futures::StreamExt;
 use penumbra_crypto::FullViewingKey;
 use penumbra_proto::{
-    custody::v1alpha1::custody_protocol_client::CustodyProtocolClient,
-    view::v1alpha1::view_protocol_client::ViewProtocolClient,
+    custody::v1alpha1::custody_protocol_service_client::CustodyProtocolServiceClient,
+    view::v1alpha1::view_protocol_service_client::ViewProtocolServiceClient,
 };
 use penumbra_view::ViewClient;
 use url::Url;
@@ -33,8 +33,8 @@ pub struct App {
     /// view will be `None` when a command indicates that it can be run offline via
     /// `.offline()` and Some(_) otherwise. Assuming `.offline()` has been implemenented
     /// correctly, this can be unwrapped safely.
-    pub view: Option<ViewProtocolClient<BoxGrpcService>>,
-    pub custody: CustodyProtocolClient<BoxGrpcService>,
+    pub view: Option<ViewProtocolServiceClient<BoxGrpcService>>,
+    pub custody: CustodyProtocolServiceClient<BoxGrpcService>,
     pub fvk: FullViewingKey,
     pub wallet: KeyStore,
     pub pd_url: Url,

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -2,7 +2,7 @@ use anyhow::{Context as _, Result};
 use penumbra_crypto::Nullifier;
 use penumbra_proto::{
     client::v1alpha1::{
-        oblivious_query_client::ObliviousQueryClient, specific_query_client::SpecificQueryClient,
+        oblivious_query_service_client::ObliviousQueryServiceClient, specific_query_service_client::SpecificQueryServiceClient,
     },
     Protobuf,
 };
@@ -198,14 +198,14 @@ impl App {
         Ok(())
     }
 
-    pub async fn specific_client(&self) -> Result<SpecificQueryClient<Channel>, anyhow::Error> {
-        SpecificQueryClient::connect(self.pd_url.as_ref().to_owned())
+    pub async fn specific_client(&self) -> Result<SpecificQueryServiceClient<Channel>, anyhow::Error> {
+        SpecificQueryServiceClient::connect(self.pd_url.as_ref().to_owned())
             .await
             .map_err(Into::into)
     }
 
-    pub async fn oblivious_client(&self) -> Result<ObliviousQueryClient<Channel>, anyhow::Error> {
-        ObliviousQueryClient::connect(self.pd_url.as_ref().to_owned())
+    pub async fn oblivious_client(&self) -> Result<ObliviousQueryServiceClient<Channel>, anyhow::Error> {
+        ObliviousQueryServiceClient::connect(self.pd_url.as_ref().to_owned())
             .await
             .map_err(Into::into)
     }

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -2,7 +2,8 @@ use anyhow::{Context as _, Result};
 use penumbra_crypto::Nullifier;
 use penumbra_proto::{
     client::v1alpha1::{
-        oblivious_query_service_client::ObliviousQueryServiceClient, specific_query_service_client::SpecificQueryServiceClient,
+        oblivious_query_service_client::ObliviousQueryServiceClient,
+        specific_query_service_client::SpecificQueryServiceClient,
     },
     Protobuf,
 };
@@ -198,13 +199,17 @@ impl App {
         Ok(())
     }
 
-    pub async fn specific_client(&self) -> Result<SpecificQueryServiceClient<Channel>, anyhow::Error> {
+    pub async fn specific_client(
+        &self,
+    ) -> Result<SpecificQueryServiceClient<Channel>, anyhow::Error> {
         SpecificQueryServiceClient::connect(self.pd_url.as_ref().to_owned())
             .await
             .map_err(Into::into)
     }
 
-    pub async fn oblivious_client(&self) -> Result<ObliviousQueryServiceClient<Channel>, anyhow::Error> {
+    pub async fn oblivious_client(
+        &self,
+    ) -> Result<ObliviousQueryServiceClient<Channel>, anyhow::Error> {
         ObliviousQueryServiceClient::connect(self.pd_url.as_ref().to_owned())
             .await
             .map_err(Into::into)

--- a/pcli/src/opt.rs
+++ b/pcli/src/opt.rs
@@ -10,11 +10,11 @@ use penumbra_crypto::FullViewingKey;
 use penumbra_custody::SoftHSM;
 use penumbra_proto::{
     custody::v1alpha1::{
-        custody_protocol_client::CustodyProtocolClient,
-        custody_protocol_server::CustodyProtocolServer,
+        custody_protocol_service_client::CustodyProtocolServiceClient,
+        custody_protocol_service_server::CustodyProtocolServiceServer,
     },
     view::v1alpha1::{
-        view_protocol_client::ViewProtocolClient, view_protocol_server::ViewProtocolServer,
+        view_protocol_service_client::ViewProtocolServiceClient, view_protocol_service_server::ViewProtocolServiceServer,
     },
 };
 use penumbra_view::ViewService;
@@ -79,8 +79,8 @@ impl Opt {
         // Build the custody service...
         let wallet = KeyStore::load(custody_path)?;
         let soft_hsm = SoftHSM::new(vec![wallet.spend_key.clone()]);
-        let custody_svc = CustodyProtocolServer::new(soft_hsm);
-        let custody = CustodyProtocolClient::new(box_grpc_svc::local(custody_svc));
+        let custody_svc = CustodyProtocolServiceServer::new(soft_hsm);
+        let custody = CustodyProtocolServiceClient::new(box_grpc_svc::local(custody_svc));
 
         let fvk = wallet.spend_key.full_viewing_key().clone();
 
@@ -113,11 +113,11 @@ impl Opt {
         Ok((app, self.cmd))
     }
 
-    /// Constructs a [`ViewProtocolClient`] based on the command-line options.
+    /// Constructs a [`ViewProtocolServiceClient`] based on the command-line options.
     async fn view_client(
         &self,
         fvk: &FullViewingKey,
-    ) -> Result<ViewProtocolClient<BoxGrpcService>> {
+    ) -> Result<ViewProtocolServiceClient<BoxGrpcService>> {
         let svc = if let Some(address) = self.view_address {
             // Use a remote view service.
             tracing::info!(%address, "using remote view service");
@@ -139,11 +139,11 @@ impl Opt {
             .await?;
 
             // Now build the view and custody clients, doing gRPC with ourselves
-            let svc = ViewProtocolServer::new(svc);
+            let svc = ViewProtocolServiceServer::new(svc);
             box_grpc_svc::local(svc)
         };
 
-        Ok(ViewProtocolClient::new(svc))
+        Ok(ViewProtocolServiceClient::new(svc))
     }
 }
 

--- a/pcli/src/opt.rs
+++ b/pcli/src/opt.rs
@@ -14,7 +14,8 @@ use penumbra_proto::{
         custody_protocol_service_server::CustodyProtocolServiceServer,
     },
     view::v1alpha1::{
-        view_protocol_service_client::ViewProtocolServiceClient, view_protocol_service_server::ViewProtocolServiceServer,
+        view_protocol_service_client::ViewProtocolServiceClient,
+        view_protocol_service_server::ViewProtocolServiceServer,
     },
 };
 use penumbra_view::ViewService;

--- a/pd/src/info/oblivious.rs
+++ b/pd/src/info/oblivious.rs
@@ -13,8 +13,9 @@ use penumbra_component::{
 };
 use penumbra_proto::{
     client::v1alpha1::{
-        oblivious_query_server::ObliviousQuery, AssetListRequest, ChainParamsRequest,
-        CompactBlockRangeRequest, MutableParametersRequest, ValidatorInfoRequest,
+        oblivious_query_service_server::ObliviousQueryService, AssetListRequest,
+        ChainParamsRequest, CompactBlockRangeRequest, MutableParametersRequest,
+        ValidatorInfoRequest,
     },
     core::{
         chain::v1alpha1::{ChainParameters, CompactBlock, KnownAssets},
@@ -56,7 +57,7 @@ impl Drop for CompactBlockConnectionCounter {
 use super::Info;
 
 #[tonic::async_trait]
-impl ObliviousQuery for Info {
+impl ObliviousQueryService for Info {
     type CompactBlockRangeStream =
         Pin<Box<dyn futures::Stream<Item = Result<CompactBlock, tonic::Status>> + Send>>;
 

--- a/pd/src/info/specific.rs
+++ b/pd/src/info/specific.rs
@@ -6,7 +6,7 @@ use penumbra_crypto::asset::{self, Asset};
 use penumbra_proto::{
     self as proto,
     client::v1alpha1::{
-        specific_query_server::SpecificQuery, AssetInfoRequest, AssetInfoResponse,
+        specific_query_service_server::SpecificQueryService, AssetInfoRequest, AssetInfoResponse,
         BatchSwapOutputDataRequest, KeyValueRequest, KeyValueResponse, StubCpmmReservesRequest,
         ValidatorStatusRequest,
     },
@@ -30,7 +30,7 @@ use tracing::instrument;
 use super::Info;
 
 #[tonic::async_trait]
-impl SpecificQuery for Info {
+impl SpecificQueryService for Info {
     #[instrument(skip(self, request))]
     async fn key_value(
         &self,

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -16,7 +16,7 @@ use penumbra_chain::{genesis::Allocation, params::ChainParameters};
 use penumbra_component::stake::{validator::Validator, FundingStream, FundingStreams};
 use penumbra_crypto::{keys::SpendKey, DelegationToken, GovernanceKey};
 use penumbra_proto::client::v1alpha1::{
-    oblivious_query_server::ObliviousQueryServer, specific_query_server::SpecificQueryServer,
+    oblivious_query_service_server::ObliviousQueryServer, specific_query_server::SpecificQueryServer,
 };
 use penumbra_storage::Storage;
 use rand::Rng;

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -16,7 +16,8 @@ use penumbra_chain::{genesis::Allocation, params::ChainParameters};
 use penumbra_component::stake::{validator::Validator, FundingStream, FundingStreams};
 use penumbra_crypto::{keys::SpendKey, DelegationToken, GovernanceKey};
 use penumbra_proto::client::v1alpha1::{
-    oblivious_query_service_server::ObliviousQueryServiceServer, specific_query_service_server::SpecificQueryServiceServer,
+    oblivious_query_service_server::ObliviousQueryServiceServer,
+    specific_query_service_server::SpecificQueryServiceServer,
 };
 use penumbra_storage::Storage;
 use rand::Rng;
@@ -206,8 +207,12 @@ async fn main() -> anyhow::Result<()> {
                         // Allow HTTP/1, which will be used by grpc-web connections.
                         .accept_http1(true)
                         // Wrap each of the gRPC services in a tonic-web proxy:
-                        .add_service(tonic_web::enable(ObliviousQueryServiceServer::new(info.clone())))
-                        .add_service(tonic_web::enable(SpecificQueryServiceServer::new(info.clone())))
+                        .add_service(tonic_web::enable(ObliviousQueryServiceServer::new(
+                            info.clone(),
+                        )))
+                        .add_service(tonic_web::enable(SpecificQueryServiceServer::new(
+                            info.clone(),
+                        )))
                         .serve(
                             format!("{}:{}", host, grpc_port)
                                 .parse()

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -16,7 +16,7 @@ use penumbra_chain::{genesis::Allocation, params::ChainParameters};
 use penumbra_component::stake::{validator::Validator, FundingStream, FundingStreams};
 use penumbra_crypto::{keys::SpendKey, DelegationToken, GovernanceKey};
 use penumbra_proto::client::v1alpha1::{
-    oblivious_query_service_server::ObliviousQueryServer, specific_query_server::SpecificQueryServer,
+    oblivious_query_service_server::ObliviousQueryServiceServer, specific_query_service_server::SpecificQueryServiceServer,
 };
 use penumbra_storage::Storage;
 use rand::Rng;
@@ -206,8 +206,8 @@ async fn main() -> anyhow::Result<()> {
                         // Allow HTTP/1, which will be used by grpc-web connections.
                         .accept_http1(true)
                         // Wrap each of the gRPC services in a tonic-web proxy:
-                        .add_service(tonic_web::enable(ObliviousQueryServer::new(info.clone())))
-                        .add_service(tonic_web::enable(SpecificQueryServer::new(info.clone())))
+                        .add_service(tonic_web::enable(ObliviousQueryServiceServer::new(info.clone())))
+                        .add_service(tonic_web::enable(SpecificQueryServiceServer::new(info.clone())))
                         .serve(
                             format!("{}:{}", host, grpc_port)
                                 .parse()

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -16,7 +16,7 @@ import "penumbra/core/governance/v1alpha1/governance.proto";
 // client data.  For instance, requesting all asset denominations is oblivious,
 // but requesting the asset denomination for a specific asset id is not, because
 // it reveals that the client has an interest in that asset specifically.
-service ObliviousQuery {
+service ObliviousQueryService {
   rpc CompactBlockRange(CompactBlockRangeRequest) returns (stream core.chain.v1alpha1.CompactBlock);
   rpc ChainParameters(ChainParamsRequest) returns (core.chain.v1alpha1.ChainParameters);
   rpc MutableParameters(MutableParametersRequest) returns (stream core.governance.v1alpha1.MutableChainParameter);
@@ -71,7 +71,7 @@ message ValidatorInfoRequest {
 // client data.  For instance, requesting all asset denominations is oblivious,
 // but requesting the asset denomination for a specific asset id is not, because
 // it reveals that the client has an interest in that asset specifically.
-service SpecificQuery {
+service SpecificQueryService {
   rpc TransactionByNote(core.crypto.v1alpha1.NoteCommitment) returns (core.chain.v1alpha1.NoteSource);
   rpc ValidatorStatus(ValidatorStatusRequest) returns (core.stake.v1alpha1.ValidatorStatus);
   rpc NextValidatorRate(core.crypto.v1alpha1.IdentityKey) returns (core.stake.v1alpha1.RateData);

--- a/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
+++ b/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
@@ -175,18 +175,19 @@ message PositionId {
 // The state of a position.
 message PositionState {
   enum PositionStateEnum {
+    POSITION_STATE_ENUM_UNSPECIFIED = 0;
     // The position has been opened, is active, has reserves and accumulated
     // fees, and can be traded against.
-    OPENED = 0;
+    POSITION_STATE_ENUM_OPENED = 1;
     // The position has been closed, is inactive and can no longer be traded
     // against, but still has reserves and accumulated fees.
-    CLOSED = 1;
+    POSITION_STATE_ENUM_CLOSED = 2;
     // The final reserves and accumulated fees have been withdrawn, leaving an
     // empty, inactive position awaiting (possible) retroactive rewards.
-    WITHDRAWN = 2;
+    POSITION_STATE_ENUM_WITHDRAWN = 3;
     // Any retroactive rewards have been claimed. The position is now an inert,
     // historical artefact.
-    CLAIMED = 3;
+    POSITION_STATE_ENUM_CLAIMED = 4;
   }
   PositionStateEnum state = 1;
 }

--- a/proto/proto/penumbra/core/governance/v1alpha1/governance.proto
+++ b/proto/proto/penumbra/core/governance/v1alpha1/governance.proto
@@ -7,10 +7,11 @@ package penumbra.core.governance.v1alpha1;
 message Vote {
   // A vote.
   enum Vote {
-    ABSTAIN = 0;
-    YES = 1;
-    NO = 2;
-    NO_WITH_VETO = 3;
+    VOTE_UNSPECIFIED = 0;
+    VOTE_ABSTAIN = 1;
+    VOTE_YES = 2;
+    VOTE_NO = 3;
+    VOTE_NO_WITH_VETO = 4;
   }
 
   // The vote.

--- a/proto/proto/penumbra/core/ibc/v1alpha1/ibc.proto
+++ b/proto/proto/penumbra/core/ibc/v1alpha1/ibc.proto
@@ -14,26 +14,26 @@ import "google/protobuf/any.proto";
 
 message IbcAction {
     oneof action {
-      .ibc.core.connection.v1.MsgConnectionOpenInit connectionOpenInit = 1;
-      .ibc.core.connection.v1.MsgConnectionOpenTry connectionOpenTry = 2;
-      .ibc.core.connection.v1.MsgConnectionOpenAck connectionOpenAck = 3;
-      .ibc.core.connection.v1.MsgConnectionOpenConfirm connectionOpenConfirm = 4;
+      .ibc.core.connection.v1.MsgConnectionOpenInit connection_open_init = 1;
+      .ibc.core.connection.v1.MsgConnectionOpenTry connection_open_try = 2;
+      .ibc.core.connection.v1.MsgConnectionOpenAck connection_open_ack = 3;
+      .ibc.core.connection.v1.MsgConnectionOpenConfirm connection_open_confirm = 4;
 
-      .ibc.core.channel.v1.MsgChannelOpenInit channelOpenInit = 5;
-      .ibc.core.channel.v1.MsgChannelOpenTry channelOpenTry = 6;
-      .ibc.core.channel.v1.MsgChannelOpenAck channelOpenAck = 7;
-      .ibc.core.channel.v1.MsgChannelOpenConfirm channelOpenConfirm = 8;
-      .ibc.core.channel.v1.MsgChannelCloseInit channelCloseInit = 9;
-      .ibc.core.channel.v1.MsgChannelCloseConfirm channelCloseConfirm = 10;
+      .ibc.core.channel.v1.MsgChannelOpenInit channel_open_init = 5;
+      .ibc.core.channel.v1.MsgChannelOpenTry channel_open_try = 6;
+      .ibc.core.channel.v1.MsgChannelOpenAck channel_open_ack = 7;
+      .ibc.core.channel.v1.MsgChannelOpenConfirm channel_open_confirm = 8;
+      .ibc.core.channel.v1.MsgChannelCloseInit channel_close_init = 9;
+      .ibc.core.channel.v1.MsgChannelCloseConfirm channel_close_confirm = 10;
       
-      .ibc.core.channel.v1.MsgRecvPacket recvPacket = 11;
+      .ibc.core.channel.v1.MsgRecvPacket recv_packet = 11;
       .ibc.core.channel.v1.MsgTimeout timeout = 12;
       .ibc.core.channel.v1.MsgAcknowledgement acknowledgement = 13;
 
-      .ibc.core.client.v1.MsgCreateClient createClient = 14;
-      .ibc.core.client.v1.MsgUpdateClient updateClient = 15;
-      .ibc.core.client.v1.MsgUpgradeClient upgradeClient = 16;
-      .ibc.core.client.v1.MsgSubmitMisbehaviour submitMisbehaviour = 17;
+      .ibc.core.client.v1.MsgCreateClient create_client = 14;
+      .ibc.core.client.v1.MsgUpdateClient update_client = 15;
+      .ibc.core.client.v1.MsgUpgradeClient upgrade_client = 16;
+      .ibc.core.client.v1.MsgSubmitMisbehaviour submit_misbehaviour = 17;
   }
 }
 
@@ -82,10 +82,10 @@ message Ics20Withdrawal {
 }
 
 message ClientData {
-  string clientID = 1;
-  google.protobuf.Any clientState = 2; // NOTE: left as Any to allow us to add more client types later
-  string processedTime = 3;
-  uint64 processedHeight = 4;
+  string client_id = 1;
+  google.protobuf.Any client_state = 2; // NOTE: left as Any to allow us to add more client types later
+  string processed_time = 3;
+  uint64 processed_height = 4;
 }
 
 message ClientCounter {
@@ -93,7 +93,7 @@ message ClientCounter {
 }
 
 message ConsensusState {
-  google.protobuf.Any consensusState = 1;
+  google.protobuf.Any consensus_state = 1;
 }
 
 message VerifiedHeights {

--- a/proto/proto/penumbra/core/stake/v1alpha1/stake.proto
+++ b/proto/proto/penumbra/core/stake/v1alpha1/stake.proto
@@ -71,9 +71,10 @@ message ValidatorStatus {
 // Describes the unbonding state of a validator's stake pool.
 message BondingState {
   enum BondingStateEnum {
-    BONDED = 0;
-    UNBONDING = 1;
-    UNBONDED = 2;
+    BONDING_STATE_ENUM_UNSPECIFIED = 0;
+    BONDING_STATE_ENUM_BONDED = 1;
+    BONDING_STATE_ENUM_UNBONDING = 2;
+    BONDING_STATE_ENUM_UNBONDED = 3;
   }
   BondingStateEnum state = 1;
   optional uint64 unbonding_epoch = 2;
@@ -82,11 +83,12 @@ message BondingState {
 // Describes the state of a validator
 message ValidatorState {
   enum ValidatorStateEnum {
-    INACTIVE = 0;
-    ACTIVE = 1;
-    JAILED = 2;
-    TOMBSTONED = 3;
-    DISABLED = 4;
+    VALIDATOR_STATE_ENUM_UNSPECIFIED = 0;
+    VALIDATOR_STATE_ENUM_INACTIVE = 1;
+    VALIDATOR_STATE_ENUM_ACTIVE = 2;
+    VALIDATOR_STATE_ENUM_JAILED = 3;
+    VALIDATOR_STATE_ENUM_TOMBSTONED = 4;
+    VALIDATOR_STATE_ENUM_DISABLED = 5;
   }
   ValidatorStateEnum state = 1;
 }

--- a/proto/proto/penumbra/custody/v1alpha1/custody.proto
+++ b/proto/proto/penumbra/custody/v1alpha1/custody.proto
@@ -17,7 +17,7 @@ import "penumbra/core/crypto/v1alpha1/crypto.proto";
 // custody requests must contain sufficient information for the custodian to
 // understand the transaction and determine whether or not it should be
 // authorized.
-service CustodyProtocol {
+service CustodyProtocolService {
     // Requests authorization of the transaction with the given description.
     rpc Authorize(AuthorizeRequest) returns (core.transaction.v1alpha1.AuthorizationData);
 }

--- a/proto/proto/penumbra/view/v1alpha1/view.proto
+++ b/proto/proto/penumbra/view/v1alpha1/view.proto
@@ -17,7 +17,7 @@ import "penumbra/core/chain/v1alpha1/chain.proto";
 // identify which set of data to query.  This also works as a pseudo-auth system
 // (assuming transport security, the client has to know the FVK to request its
 // data).  (TODO: refine this)
-service ViewProtocol {
+service ViewProtocolService {
     // Get current status of chain sync
     rpc Status(StatusRequest) returns (StatusResponse);
 

--- a/proto/src/gen/penumbra.client.v1alpha1.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.rs
@@ -111,7 +111,7 @@ pub struct KeyValueResponse {
     pub proof: ::core::option::Option<::ics23::CommitmentProof>,
 }
 /// Generated client implementations.
-pub mod oblivious_query_client {
+pub mod oblivious_query_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
     use tonic::codegen::http::Uri;
@@ -121,10 +121,10 @@ pub mod oblivious_query_client {
     /// but requesting the asset denomination for a specific asset id is not, because
     /// it reveals that the client has an interest in that asset specifically.
     #[derive(Debug, Clone)]
-    pub struct ObliviousQueryClient<T> {
+    pub struct ObliviousQueryServiceClient<T> {
         inner: tonic::client::Grpc<T>,
     }
-    impl ObliviousQueryClient<tonic::transport::Channel> {
+    impl ObliviousQueryServiceClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
@@ -135,7 +135,7 @@ pub mod oblivious_query_client {
             Ok(Self::new(conn))
         }
     }
-    impl<T> ObliviousQueryClient<T>
+    impl<T> ObliviousQueryServiceClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
         T::Error: Into<StdError>,
@@ -153,7 +153,7 @@ pub mod oblivious_query_client {
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
-        ) -> ObliviousQueryClient<InterceptedService<T, F>>
+        ) -> ObliviousQueryServiceClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
@@ -167,7 +167,7 @@ pub mod oblivious_query_client {
                 http::Request<tonic::body::BoxBody>,
             >>::Error: Into<StdError> + Send + Sync,
         {
-            ObliviousQueryClient::new(InterceptedService::new(inner, interceptor))
+            ObliviousQueryServiceClient::new(InterceptedService::new(inner, interceptor))
         }
         /// Compress requests with the given encoding.
         ///
@@ -206,7 +206,7 @@ pub mod oblivious_query_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.client.v1alpha1.ObliviousQuery/CompactBlockRange",
+                "/penumbra.client.v1alpha1.ObliviousQueryService/CompactBlockRange",
             );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
@@ -228,7 +228,7 @@ pub mod oblivious_query_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.client.v1alpha1.ObliviousQuery/ChainParameters",
+                "/penumbra.client.v1alpha1.ObliviousQueryService/ChainParameters",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -254,7 +254,7 @@ pub mod oblivious_query_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.client.v1alpha1.ObliviousQuery/MutableParameters",
+                "/penumbra.client.v1alpha1.ObliviousQueryService/MutableParameters",
             );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
@@ -280,7 +280,7 @@ pub mod oblivious_query_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.client.v1alpha1.ObliviousQuery/ValidatorInfo",
+                "/penumbra.client.v1alpha1.ObliviousQueryService/ValidatorInfo",
             );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
@@ -303,14 +303,14 @@ pub mod oblivious_query_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.client.v1alpha1.ObliviousQuery/AssetList",
+                "/penumbra.client.v1alpha1.ObliviousQueryService/AssetList",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
 }
 /// Generated client implementations.
-pub mod specific_query_client {
+pub mod specific_query_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
     use tonic::codegen::http::Uri;
@@ -320,10 +320,10 @@ pub mod specific_query_client {
     /// but requesting the asset denomination for a specific asset id is not, because
     /// it reveals that the client has an interest in that asset specifically.
     #[derive(Debug, Clone)]
-    pub struct SpecificQueryClient<T> {
+    pub struct SpecificQueryServiceClient<T> {
         inner: tonic::client::Grpc<T>,
     }
-    impl SpecificQueryClient<tonic::transport::Channel> {
+    impl SpecificQueryServiceClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
@@ -334,7 +334,7 @@ pub mod specific_query_client {
             Ok(Self::new(conn))
         }
     }
-    impl<T> SpecificQueryClient<T>
+    impl<T> SpecificQueryServiceClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
         T::Error: Into<StdError>,
@@ -352,7 +352,7 @@ pub mod specific_query_client {
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
-        ) -> SpecificQueryClient<InterceptedService<T, F>>
+        ) -> SpecificQueryServiceClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
@@ -366,7 +366,7 @@ pub mod specific_query_client {
                 http::Request<tonic::body::BoxBody>,
             >>::Error: Into<StdError> + Send + Sync,
         {
-            SpecificQueryClient::new(InterceptedService::new(inner, interceptor))
+            SpecificQueryServiceClient::new(InterceptedService::new(inner, interceptor))
         }
         /// Compress requests with the given encoding.
         ///
@@ -403,7 +403,7 @@ pub mod specific_query_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.client.v1alpha1.SpecificQuery/TransactionByNote",
+                "/penumbra.client.v1alpha1.SpecificQueryService/TransactionByNote",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -425,7 +425,7 @@ pub mod specific_query_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.client.v1alpha1.SpecificQuery/ValidatorStatus",
+                "/penumbra.client.v1alpha1.SpecificQueryService/ValidatorStatus",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -449,7 +449,7 @@ pub mod specific_query_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.client.v1alpha1.SpecificQuery/NextValidatorRate",
+                "/penumbra.client.v1alpha1.SpecificQueryService/NextValidatorRate",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -473,7 +473,7 @@ pub mod specific_query_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.client.v1alpha1.SpecificQuery/BatchSwapOutputData",
+                "/penumbra.client.v1alpha1.SpecificQueryService/BatchSwapOutputData",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -495,7 +495,7 @@ pub mod specific_query_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.client.v1alpha1.SpecificQuery/StubCPMMReserves",
+                "/penumbra.client.v1alpha1.SpecificQueryService/StubCPMMReserves",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -514,7 +514,7 @@ pub mod specific_query_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.client.v1alpha1.SpecificQuery/AssetInfo",
+                "/penumbra.client.v1alpha1.SpecificQueryService/AssetInfo",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -535,19 +535,19 @@ pub mod specific_query_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.client.v1alpha1.SpecificQuery/KeyValue",
+                "/penumbra.client.v1alpha1.SpecificQueryService/KeyValue",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
 }
 /// Generated server implementations.
-pub mod oblivious_query_server {
+pub mod oblivious_query_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with ObliviousQueryServer.
+    ///Generated trait containing gRPC methods that should be implemented for use with ObliviousQueryServiceServer.
     #[async_trait]
-    pub trait ObliviousQuery: Send + Sync + 'static {
+    pub trait ObliviousQueryService: Send + Sync + 'static {
         ///Server streaming response type for the CompactBlockRange method.
         type CompactBlockRangeStream: futures_core::Stream<
                 Item = Result<
@@ -609,13 +609,13 @@ pub mod oblivious_query_server {
     /// but requesting the asset denomination for a specific asset id is not, because
     /// it reveals that the client has an interest in that asset specifically.
     #[derive(Debug)]
-    pub struct ObliviousQueryServer<T: ObliviousQuery> {
+    pub struct ObliviousQueryServiceServer<T: ObliviousQueryService> {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
-    impl<T: ObliviousQuery> ObliviousQueryServer<T> {
+    impl<T: ObliviousQueryService> ObliviousQueryServiceServer<T> {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
@@ -649,9 +649,10 @@ pub mod oblivious_query_server {
             self
         }
     }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for ObliviousQueryServer<T>
+    impl<T, B> tonic::codegen::Service<http::Request<B>>
+    for ObliviousQueryServiceServer<T>
     where
-        T: ObliviousQuery,
+        T: ObliviousQueryService,
         B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
@@ -667,11 +668,11 @@ pub mod oblivious_query_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
-                "/penumbra.client.v1alpha1.ObliviousQuery/CompactBlockRange" => {
+                "/penumbra.client.v1alpha1.ObliviousQueryService/CompactBlockRange" => {
                     #[allow(non_camel_case_types)]
-                    struct CompactBlockRangeSvc<T: ObliviousQuery>(pub Arc<T>);
+                    struct CompactBlockRangeSvc<T: ObliviousQueryService>(pub Arc<T>);
                     impl<
-                        T: ObliviousQuery,
+                        T: ObliviousQueryService,
                     > tonic::server::ServerStreamingService<
                         super::CompactBlockRangeRequest,
                     > for CompactBlockRangeSvc<T> {
@@ -709,11 +710,11 @@ pub mod oblivious_query_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.client.v1alpha1.ObliviousQuery/ChainParameters" => {
+                "/penumbra.client.v1alpha1.ObliviousQueryService/ChainParameters" => {
                     #[allow(non_camel_case_types)]
-                    struct ChainParametersSvc<T: ObliviousQuery>(pub Arc<T>);
+                    struct ChainParametersSvc<T: ObliviousQueryService>(pub Arc<T>);
                     impl<
-                        T: ObliviousQuery,
+                        T: ObliviousQueryService,
                     > tonic::server::UnaryService<super::ChainParamsRequest>
                     for ChainParametersSvc<T> {
                         type Response = super::super::super::core::chain::v1alpha1::ChainParameters;
@@ -749,11 +750,11 @@ pub mod oblivious_query_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.client.v1alpha1.ObliviousQuery/MutableParameters" => {
+                "/penumbra.client.v1alpha1.ObliviousQueryService/MutableParameters" => {
                     #[allow(non_camel_case_types)]
-                    struct MutableParametersSvc<T: ObliviousQuery>(pub Arc<T>);
+                    struct MutableParametersSvc<T: ObliviousQueryService>(pub Arc<T>);
                     impl<
-                        T: ObliviousQuery,
+                        T: ObliviousQueryService,
                     > tonic::server::ServerStreamingService<
                         super::MutableParametersRequest,
                     > for MutableParametersSvc<T> {
@@ -791,11 +792,11 @@ pub mod oblivious_query_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.client.v1alpha1.ObliviousQuery/ValidatorInfo" => {
+                "/penumbra.client.v1alpha1.ObliviousQueryService/ValidatorInfo" => {
                     #[allow(non_camel_case_types)]
-                    struct ValidatorInfoSvc<T: ObliviousQuery>(pub Arc<T>);
+                    struct ValidatorInfoSvc<T: ObliviousQueryService>(pub Arc<T>);
                     impl<
-                        T: ObliviousQuery,
+                        T: ObliviousQueryService,
                     > tonic::server::ServerStreamingService<super::ValidatorInfoRequest>
                     for ValidatorInfoSvc<T> {
                         type Response = super::super::super::core::stake::v1alpha1::ValidatorInfo;
@@ -832,11 +833,11 @@ pub mod oblivious_query_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.client.v1alpha1.ObliviousQuery/AssetList" => {
+                "/penumbra.client.v1alpha1.ObliviousQueryService/AssetList" => {
                     #[allow(non_camel_case_types)]
-                    struct AssetListSvc<T: ObliviousQuery>(pub Arc<T>);
+                    struct AssetListSvc<T: ObliviousQueryService>(pub Arc<T>);
                     impl<
-                        T: ObliviousQuery,
+                        T: ObliviousQueryService,
                     > tonic::server::UnaryService<super::AssetListRequest>
                     for AssetListSvc<T> {
                         type Response = super::super::super::core::chain::v1alpha1::KnownAssets;
@@ -885,7 +886,7 @@ pub mod oblivious_query_server {
             }
         }
     }
-    impl<T: ObliviousQuery> Clone for ObliviousQueryServer<T> {
+    impl<T: ObliviousQueryService> Clone for ObliviousQueryServiceServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
             Self {
@@ -895,7 +896,7 @@ pub mod oblivious_query_server {
             }
         }
     }
-    impl<T: ObliviousQuery> Clone for _Inner<T> {
+    impl<T: ObliviousQueryService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
             Self(self.0.clone())
         }
@@ -905,17 +906,18 @@ pub mod oblivious_query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: ObliviousQuery> tonic::server::NamedService for ObliviousQueryServer<T> {
-        const NAME: &'static str = "penumbra.client.v1alpha1.ObliviousQuery";
+    impl<T: ObliviousQueryService> tonic::server::NamedService
+    for ObliviousQueryServiceServer<T> {
+        const NAME: &'static str = "penumbra.client.v1alpha1.ObliviousQueryService";
     }
 }
 /// Generated server implementations.
-pub mod specific_query_server {
+pub mod specific_query_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with SpecificQueryServer.
+    ///Generated trait containing gRPC methods that should be implemented for use with SpecificQueryServiceServer.
     #[async_trait]
-    pub trait SpecificQuery: Send + Sync + 'static {
+    pub trait SpecificQueryService: Send + Sync + 'static {
         async fn transaction_by_note(
             &self,
             request: tonic::Request<
@@ -974,13 +976,13 @@ pub mod specific_query_server {
     /// but requesting the asset denomination for a specific asset id is not, because
     /// it reveals that the client has an interest in that asset specifically.
     #[derive(Debug)]
-    pub struct SpecificQueryServer<T: SpecificQuery> {
+    pub struct SpecificQueryServiceServer<T: SpecificQueryService> {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
-    impl<T: SpecificQuery> SpecificQueryServer<T> {
+    impl<T: SpecificQueryService> SpecificQueryServiceServer<T> {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
@@ -1014,9 +1016,10 @@ pub mod specific_query_server {
             self
         }
     }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for SpecificQueryServer<T>
+    impl<T, B> tonic::codegen::Service<http::Request<B>>
+    for SpecificQueryServiceServer<T>
     where
-        T: SpecificQuery,
+        T: SpecificQueryService,
         B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
@@ -1032,11 +1035,11 @@ pub mod specific_query_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
-                "/penumbra.client.v1alpha1.SpecificQuery/TransactionByNote" => {
+                "/penumbra.client.v1alpha1.SpecificQueryService/TransactionByNote" => {
                     #[allow(non_camel_case_types)]
-                    struct TransactionByNoteSvc<T: SpecificQuery>(pub Arc<T>);
+                    struct TransactionByNoteSvc<T: SpecificQueryService>(pub Arc<T>);
                     impl<
-                        T: SpecificQuery,
+                        T: SpecificQueryService,
                     > tonic::server::UnaryService<
                         super::super::super::core::crypto::v1alpha1::NoteCommitment,
                     > for TransactionByNoteSvc<T> {
@@ -1075,11 +1078,11 @@ pub mod specific_query_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.client.v1alpha1.SpecificQuery/ValidatorStatus" => {
+                "/penumbra.client.v1alpha1.SpecificQueryService/ValidatorStatus" => {
                     #[allow(non_camel_case_types)]
-                    struct ValidatorStatusSvc<T: SpecificQuery>(pub Arc<T>);
+                    struct ValidatorStatusSvc<T: SpecificQueryService>(pub Arc<T>);
                     impl<
-                        T: SpecificQuery,
+                        T: SpecificQueryService,
                     > tonic::server::UnaryService<super::ValidatorStatusRequest>
                     for ValidatorStatusSvc<T> {
                         type Response = super::super::super::core::stake::v1alpha1::ValidatorStatus;
@@ -1115,11 +1118,11 @@ pub mod specific_query_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.client.v1alpha1.SpecificQuery/NextValidatorRate" => {
+                "/penumbra.client.v1alpha1.SpecificQueryService/NextValidatorRate" => {
                     #[allow(non_camel_case_types)]
-                    struct NextValidatorRateSvc<T: SpecificQuery>(pub Arc<T>);
+                    struct NextValidatorRateSvc<T: SpecificQueryService>(pub Arc<T>);
                     impl<
-                        T: SpecificQuery,
+                        T: SpecificQueryService,
                     > tonic::server::UnaryService<
                         super::super::super::core::crypto::v1alpha1::IdentityKey,
                     > for NextValidatorRateSvc<T> {
@@ -1158,11 +1161,11 @@ pub mod specific_query_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.client.v1alpha1.SpecificQuery/BatchSwapOutputData" => {
+                "/penumbra.client.v1alpha1.SpecificQueryService/BatchSwapOutputData" => {
                     #[allow(non_camel_case_types)]
-                    struct BatchSwapOutputDataSvc<T: SpecificQuery>(pub Arc<T>);
+                    struct BatchSwapOutputDataSvc<T: SpecificQueryService>(pub Arc<T>);
                     impl<
-                        T: SpecificQuery,
+                        T: SpecificQueryService,
                     > tonic::server::UnaryService<super::BatchSwapOutputDataRequest>
                     for BatchSwapOutputDataSvc<T> {
                         type Response = super::super::super::core::dex::v1alpha1::BatchSwapOutputData;
@@ -1198,11 +1201,11 @@ pub mod specific_query_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.client.v1alpha1.SpecificQuery/StubCPMMReserves" => {
+                "/penumbra.client.v1alpha1.SpecificQueryService/StubCPMMReserves" => {
                     #[allow(non_camel_case_types)]
-                    struct StubCPMMReservesSvc<T: SpecificQuery>(pub Arc<T>);
+                    struct StubCPMMReservesSvc<T: SpecificQueryService>(pub Arc<T>);
                     impl<
-                        T: SpecificQuery,
+                        T: SpecificQueryService,
                     > tonic::server::UnaryService<super::StubCpmmReservesRequest>
                     for StubCPMMReservesSvc<T> {
                         type Response = super::super::super::core::dex::v1alpha1::Reserves;
@@ -1238,11 +1241,11 @@ pub mod specific_query_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.client.v1alpha1.SpecificQuery/AssetInfo" => {
+                "/penumbra.client.v1alpha1.SpecificQueryService/AssetInfo" => {
                     #[allow(non_camel_case_types)]
-                    struct AssetInfoSvc<T: SpecificQuery>(pub Arc<T>);
+                    struct AssetInfoSvc<T: SpecificQueryService>(pub Arc<T>);
                     impl<
-                        T: SpecificQuery,
+                        T: SpecificQueryService,
                     > tonic::server::UnaryService<super::AssetInfoRequest>
                     for AssetInfoSvc<T> {
                         type Response = super::AssetInfoResponse;
@@ -1276,11 +1279,11 @@ pub mod specific_query_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.client.v1alpha1.SpecificQuery/KeyValue" => {
+                "/penumbra.client.v1alpha1.SpecificQueryService/KeyValue" => {
                     #[allow(non_camel_case_types)]
-                    struct KeyValueSvc<T: SpecificQuery>(pub Arc<T>);
+                    struct KeyValueSvc<T: SpecificQueryService>(pub Arc<T>);
                     impl<
-                        T: SpecificQuery,
+                        T: SpecificQueryService,
                     > tonic::server::UnaryService<super::KeyValueRequest>
                     for KeyValueSvc<T> {
                         type Response = super::KeyValueResponse;
@@ -1329,7 +1332,7 @@ pub mod specific_query_server {
             }
         }
     }
-    impl<T: SpecificQuery> Clone for SpecificQueryServer<T> {
+    impl<T: SpecificQueryService> Clone for SpecificQueryServiceServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
             Self {
@@ -1339,7 +1342,7 @@ pub mod specific_query_server {
             }
         }
     }
-    impl<T: SpecificQuery> Clone for _Inner<T> {
+    impl<T: SpecificQueryService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
             Self(self.0.clone())
         }
@@ -1349,7 +1352,8 @@ pub mod specific_query_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: SpecificQuery> tonic::server::NamedService for SpecificQueryServer<T> {
-        const NAME: &'static str = "penumbra.client.v1alpha1.SpecificQuery";
+    impl<T: SpecificQueryService> tonic::server::NamedService
+    for SpecificQueryServiceServer<T> {
+        const NAME: &'static str = "penumbra.client.v1alpha1.SpecificQueryService";
     }
 }

--- a/proto/src/gen/penumbra.core.dex.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.dex.v1alpha1.rs
@@ -242,18 +242,19 @@ pub mod position_state {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum PositionStateEnum {
+        Unspecified = 0,
         /// The position has been opened, is active, has reserves and accumulated
         /// fees, and can be traded against.
-        Opened = 0,
+        Opened = 1,
         /// The position has been closed, is inactive and can no longer be traded
         /// against, but still has reserves and accumulated fees.
-        Closed = 1,
+        Closed = 2,
         /// The final reserves and accumulated fees have been withdrawn, leaving an
         /// empty, inactive position awaiting (possible) retroactive rewards.
-        Withdrawn = 2,
+        Withdrawn = 3,
         /// Any retroactive rewards have been claimed. The position is now an inert,
         /// historical artefact.
-        Claimed = 3,
+        Claimed = 4,
     }
     impl PositionStateEnum {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -262,10 +263,11 @@ pub mod position_state {
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
-                PositionStateEnum::Opened => "OPENED",
-                PositionStateEnum::Closed => "CLOSED",
-                PositionStateEnum::Withdrawn => "WITHDRAWN",
-                PositionStateEnum::Claimed => "CLAIMED",
+                PositionStateEnum::Unspecified => "POSITION_STATE_ENUM_UNSPECIFIED",
+                PositionStateEnum::Opened => "POSITION_STATE_ENUM_OPENED",
+                PositionStateEnum::Closed => "POSITION_STATE_ENUM_CLOSED",
+                PositionStateEnum::Withdrawn => "POSITION_STATE_ENUM_WITHDRAWN",
+                PositionStateEnum::Claimed => "POSITION_STATE_ENUM_CLAIMED",
             }
         }
     }

--- a/proto/src/gen/penumbra.core.governance.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.governance.v1alpha1.rs
@@ -14,10 +14,11 @@ pub mod vote {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Vote {
-        Abstain = 0,
-        Yes = 1,
-        No = 2,
-        NoWithVeto = 3,
+        Unspecified = 0,
+        Abstain = 1,
+        Yes = 2,
+        No = 3,
+        NoWithVeto = 4,
     }
     impl Vote {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -26,10 +27,11 @@ pub mod vote {
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
-                Vote::Abstain => "ABSTAIN",
-                Vote::Yes => "YES",
-                Vote::No => "NO",
-                Vote::NoWithVeto => "NO_WITH_VETO",
+                Vote::Unspecified => "VOTE_UNSPECIFIED",
+                Vote::Abstain => "VOTE_ABSTAIN",
+                Vote::Yes => "VOTE_YES",
+                Vote::No => "VOTE_NO",
+                Vote::NoWithVeto => "VOTE_NO_WITH_VETO",
             }
         }
     }

--- a/proto/src/gen/penumbra.core.stake.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.stake.v1alpha1.rs
@@ -106,9 +106,10 @@ pub mod bonding_state {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum BondingStateEnum {
-        Bonded = 0,
-        Unbonding = 1,
-        Unbonded = 2,
+        Unspecified = 0,
+        Bonded = 1,
+        Unbonding = 2,
+        Unbonded = 3,
     }
     impl BondingStateEnum {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -117,9 +118,10 @@ pub mod bonding_state {
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
-                BondingStateEnum::Bonded => "BONDED",
-                BondingStateEnum::Unbonding => "UNBONDING",
-                BondingStateEnum::Unbonded => "UNBONDED",
+                BondingStateEnum::Unspecified => "BONDING_STATE_ENUM_UNSPECIFIED",
+                BondingStateEnum::Bonded => "BONDING_STATE_ENUM_BONDED",
+                BondingStateEnum::Unbonding => "BONDING_STATE_ENUM_UNBONDING",
+                BondingStateEnum::Unbonded => "BONDING_STATE_ENUM_UNBONDED",
             }
         }
     }
@@ -137,11 +139,12 @@ pub mod validator_state {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum ValidatorStateEnum {
-        Inactive = 0,
-        Active = 1,
-        Jailed = 2,
-        Tombstoned = 3,
-        Disabled = 4,
+        Unspecified = 0,
+        Inactive = 1,
+        Active = 2,
+        Jailed = 3,
+        Tombstoned = 4,
+        Disabled = 5,
     }
     impl ValidatorStateEnum {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -150,11 +153,12 @@ pub mod validator_state {
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
-                ValidatorStateEnum::Inactive => "INACTIVE",
-                ValidatorStateEnum::Active => "ACTIVE",
-                ValidatorStateEnum::Jailed => "JAILED",
-                ValidatorStateEnum::Tombstoned => "TOMBSTONED",
-                ValidatorStateEnum::Disabled => "DISABLED",
+                ValidatorStateEnum::Unspecified => "VALIDATOR_STATE_ENUM_UNSPECIFIED",
+                ValidatorStateEnum::Inactive => "VALIDATOR_STATE_ENUM_INACTIVE",
+                ValidatorStateEnum::Active => "VALIDATOR_STATE_ENUM_ACTIVE",
+                ValidatorStateEnum::Jailed => "VALIDATOR_STATE_ENUM_JAILED",
+                ValidatorStateEnum::Tombstoned => "VALIDATOR_STATE_ENUM_TOMBSTONED",
+                ValidatorStateEnum::Disabled => "VALIDATOR_STATE_ENUM_DISABLED",
             }
         }
     }

--- a/proto/src/gen/penumbra.custody.v1alpha1.rs
+++ b/proto/src/gen/penumbra.custody.v1alpha1.rs
@@ -8,7 +8,7 @@ pub struct AuthorizeRequest {
     pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
 }
 /// Generated client implementations.
-pub mod custody_protocol_client {
+pub mod custody_protocol_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
     use tonic::codegen::http::Uri;
@@ -24,10 +24,10 @@ pub mod custody_protocol_client {
     /// understand the transaction and determine whether or not it should be
     /// authorized.
     #[derive(Debug, Clone)]
-    pub struct CustodyProtocolClient<T> {
+    pub struct CustodyProtocolServiceClient<T> {
         inner: tonic::client::Grpc<T>,
     }
-    impl CustodyProtocolClient<tonic::transport::Channel> {
+    impl CustodyProtocolServiceClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
@@ -38,7 +38,7 @@ pub mod custody_protocol_client {
             Ok(Self::new(conn))
         }
     }
-    impl<T> CustodyProtocolClient<T>
+    impl<T> CustodyProtocolServiceClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
         T::Error: Into<StdError>,
@@ -56,7 +56,7 @@ pub mod custody_protocol_client {
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
-        ) -> CustodyProtocolClient<InterceptedService<T, F>>
+        ) -> CustodyProtocolServiceClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
@@ -70,7 +70,9 @@ pub mod custody_protocol_client {
                 http::Request<tonic::body::BoxBody>,
             >>::Error: Into<StdError> + Send + Sync,
         {
-            CustodyProtocolClient::new(InterceptedService::new(inner, interceptor))
+            CustodyProtocolServiceClient::new(
+                InterceptedService::new(inner, interceptor),
+            )
         }
         /// Compress requests with the given encoding.
         ///
@@ -108,19 +110,19 @@ pub mod custody_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.custody.v1alpha1.CustodyProtocol/Authorize",
+                "/penumbra.custody.v1alpha1.CustodyProtocolService/Authorize",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
 }
 /// Generated server implementations.
-pub mod custody_protocol_server {
+pub mod custody_protocol_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with CustodyProtocolServer.
+    ///Generated trait containing gRPC methods that should be implemented for use with CustodyProtocolServiceServer.
     #[async_trait]
-    pub trait CustodyProtocol: Send + Sync + 'static {
+    pub trait CustodyProtocolService: Send + Sync + 'static {
         /// Requests authorization of the transaction with the given description.
         async fn authorize(
             &self,
@@ -144,13 +146,13 @@ pub mod custody_protocol_server {
     /// understand the transaction and determine whether or not it should be
     /// authorized.
     #[derive(Debug)]
-    pub struct CustodyProtocolServer<T: CustodyProtocol> {
+    pub struct CustodyProtocolServiceServer<T: CustodyProtocolService> {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
-    impl<T: CustodyProtocol> CustodyProtocolServer<T> {
+    impl<T: CustodyProtocolService> CustodyProtocolServiceServer<T> {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
@@ -184,9 +186,10 @@ pub mod custody_protocol_server {
             self
         }
     }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for CustodyProtocolServer<T>
+    impl<T, B> tonic::codegen::Service<http::Request<B>>
+    for CustodyProtocolServiceServer<T>
     where
-        T: CustodyProtocol,
+        T: CustodyProtocolService,
         B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
@@ -202,11 +205,11 @@ pub mod custody_protocol_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
-                "/penumbra.custody.v1alpha1.CustodyProtocol/Authorize" => {
+                "/penumbra.custody.v1alpha1.CustodyProtocolService/Authorize" => {
                     #[allow(non_camel_case_types)]
-                    struct AuthorizeSvc<T: CustodyProtocol>(pub Arc<T>);
+                    struct AuthorizeSvc<T: CustodyProtocolService>(pub Arc<T>);
                     impl<
-                        T: CustodyProtocol,
+                        T: CustodyProtocolService,
                     > tonic::server::UnaryService<super::AuthorizeRequest>
                     for AuthorizeSvc<T> {
                         type Response = super::super::super::core::transaction::v1alpha1::AuthorizationData;
@@ -255,7 +258,7 @@ pub mod custody_protocol_server {
             }
         }
     }
-    impl<T: CustodyProtocol> Clone for CustodyProtocolServer<T> {
+    impl<T: CustodyProtocolService> Clone for CustodyProtocolServiceServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
             Self {
@@ -265,7 +268,7 @@ pub mod custody_protocol_server {
             }
         }
     }
-    impl<T: CustodyProtocol> Clone for _Inner<T> {
+    impl<T: CustodyProtocolService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
             Self(self.0.clone())
         }
@@ -275,7 +278,8 @@ pub mod custody_protocol_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: CustodyProtocol> tonic::server::NamedService for CustodyProtocolServer<T> {
-        const NAME: &'static str = "penumbra.custody.v1alpha1.CustodyProtocol";
+    impl<T: CustodyProtocolService> tonic::server::NamedService
+    for CustodyProtocolServiceServer<T> {
+        const NAME: &'static str = "penumbra.custody.v1alpha1.CustodyProtocolService";
     }
 }

--- a/proto/src/gen/penumbra.view.v1alpha1.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.rs
@@ -212,7 +212,7 @@ pub struct NullifierStatusResponse {
     pub spent: bool,
 }
 /// Generated client implementations.
-pub mod view_protocol_client {
+pub mod view_protocol_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
     use tonic::codegen::http::Uri;
@@ -226,10 +226,10 @@ pub mod view_protocol_client {
     /// (assuming transport security, the client has to know the FVK to request its
     /// data).  (TODO: refine this)
     #[derive(Debug, Clone)]
-    pub struct ViewProtocolClient<T> {
+    pub struct ViewProtocolServiceClient<T> {
         inner: tonic::client::Grpc<T>,
     }
-    impl ViewProtocolClient<tonic::transport::Channel> {
+    impl ViewProtocolServiceClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
@@ -240,7 +240,7 @@ pub mod view_protocol_client {
             Ok(Self::new(conn))
         }
     }
-    impl<T> ViewProtocolClient<T>
+    impl<T> ViewProtocolServiceClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
         T::Error: Into<StdError>,
@@ -258,7 +258,7 @@ pub mod view_protocol_client {
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
-        ) -> ViewProtocolClient<InterceptedService<T, F>>
+        ) -> ViewProtocolServiceClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
@@ -272,7 +272,7 @@ pub mod view_protocol_client {
                 http::Request<tonic::body::BoxBody>,
             >>::Error: Into<StdError> + Send + Sync,
         {
-            ViewProtocolClient::new(InterceptedService::new(inner, interceptor))
+            ViewProtocolServiceClient::new(InterceptedService::new(inner, interceptor))
         }
         /// Compress requests with the given encoding.
         ///
@@ -305,7 +305,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/Status",
+                "/penumbra.view.v1alpha1.ViewProtocolService/Status",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -328,7 +328,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/StatusStream",
+                "/penumbra.view.v1alpha1.ViewProtocolService/StatusStream",
             );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
@@ -351,7 +351,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/Notes",
+                "/penumbra.view.v1alpha1.ViewProtocolService/Notes",
             );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
@@ -374,7 +374,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/QuarantinedNotes",
+                "/penumbra.view.v1alpha1.ViewProtocolService/QuarantinedNotes",
             );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
@@ -404,7 +404,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/Witness",
+                "/penumbra.view.v1alpha1.ViewProtocolService/Witness",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -431,7 +431,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/Assets",
+                "/penumbra.view.v1alpha1.ViewProtocolService/Assets",
             );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
@@ -454,7 +454,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/ChainParameters",
+                "/penumbra.view.v1alpha1.ViewProtocolService/ChainParameters",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -477,7 +477,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/FMDParameters",
+                "/penumbra.view.v1alpha1.ViewProtocolService/FMDParameters",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -497,7 +497,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/NoteByCommitment",
+                "/penumbra.view.v1alpha1.ViewProtocolService/NoteByCommitment",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -517,7 +517,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/NullifierStatus",
+                "/penumbra.view.v1alpha1.ViewProtocolService/NullifierStatus",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -542,7 +542,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/TransactionHashes",
+                "/penumbra.view.v1alpha1.ViewProtocolService/TransactionHashes",
             );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
@@ -562,7 +562,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/TransactionByHash",
+                "/penumbra.view.v1alpha1.ViewProtocolService/TransactionByHash",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -585,7 +585,7 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/Transactions",
+                "/penumbra.view.v1alpha1.ViewProtocolService/Transactions",
             );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
@@ -608,19 +608,19 @@ pub mod view_protocol_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/penumbra.view.v1alpha1.ViewProtocol/TransactionPerspective",
+                "/penumbra.view.v1alpha1.ViewProtocolService/TransactionPerspective",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
 }
 /// Generated server implementations.
-pub mod view_protocol_server {
+pub mod view_protocol_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with ViewProtocolServer.
+    ///Generated trait containing gRPC methods that should be implemented for use with ViewProtocolServiceServer.
     #[async_trait]
-    pub trait ViewProtocol: Send + Sync + 'static {
+    pub trait ViewProtocolService: Send + Sync + 'static {
         /// Get current status of chain sync
         async fn status(
             &self,
@@ -760,13 +760,13 @@ pub mod view_protocol_server {
     /// (assuming transport security, the client has to know the FVK to request its
     /// data).  (TODO: refine this)
     #[derive(Debug)]
-    pub struct ViewProtocolServer<T: ViewProtocol> {
+    pub struct ViewProtocolServiceServer<T: ViewProtocolService> {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
     }
     struct _Inner<T>(Arc<T>);
-    impl<T: ViewProtocol> ViewProtocolServer<T> {
+    impl<T: ViewProtocolService> ViewProtocolServiceServer<T> {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
@@ -800,9 +800,9 @@ pub mod view_protocol_server {
             self
         }
     }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for ViewProtocolServer<T>
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for ViewProtocolServiceServer<T>
     where
-        T: ViewProtocol,
+        T: ViewProtocolService,
         B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
@@ -818,11 +818,11 @@ pub mod view_protocol_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
-                "/penumbra.view.v1alpha1.ViewProtocol/Status" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/Status" => {
                     #[allow(non_camel_case_types)]
-                    struct StatusSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct StatusSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::UnaryService<super::StatusRequest>
                     for StatusSvc<T> {
                         type Response = super::StatusResponse;
@@ -856,11 +856,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/StatusStream" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/StatusStream" => {
                     #[allow(non_camel_case_types)]
-                    struct StatusStreamSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct StatusStreamSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::ServerStreamingService<super::StatusStreamRequest>
                     for StatusStreamSvc<T> {
                         type Response = super::StatusStreamResponse;
@@ -897,11 +897,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/Notes" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/Notes" => {
                     #[allow(non_camel_case_types)]
-                    struct NotesSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct NotesSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::ServerStreamingService<super::NotesRequest>
                     for NotesSvc<T> {
                         type Response = super::SpendableNoteRecord;
@@ -936,11 +936,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/QuarantinedNotes" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/QuarantinedNotes" => {
                     #[allow(non_camel_case_types)]
-                    struct QuarantinedNotesSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct QuarantinedNotesSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::ServerStreamingService<
                         super::QuarantinedNotesRequest,
                     > for QuarantinedNotesSvc<T> {
@@ -978,11 +978,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/Witness" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/Witness" => {
                     #[allow(non_camel_case_types)]
-                    struct WitnessSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct WitnessSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::UnaryService<super::WitnessRequest>
                     for WitnessSvc<T> {
                         type Response = super::super::super::core::transaction::v1alpha1::WitnessData;
@@ -1016,11 +1016,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/Assets" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/Assets" => {
                     #[allow(non_camel_case_types)]
-                    struct AssetsSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct AssetsSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::ServerStreamingService<super::AssetRequest>
                     for AssetsSvc<T> {
                         type Response = super::super::super::core::crypto::v1alpha1::Asset;
@@ -1055,11 +1055,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/ChainParameters" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/ChainParameters" => {
                     #[allow(non_camel_case_types)]
-                    struct ChainParametersSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct ChainParametersSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::UnaryService<super::ChainParamsRequest>
                     for ChainParametersSvc<T> {
                         type Response = super::super::super::core::chain::v1alpha1::ChainParameters;
@@ -1095,11 +1095,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/FMDParameters" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/FMDParameters" => {
                     #[allow(non_camel_case_types)]
-                    struct FMDParametersSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct FMDParametersSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::UnaryService<super::FmdParametersRequest>
                     for FMDParametersSvc<T> {
                         type Response = super::super::super::core::chain::v1alpha1::FmdParameters;
@@ -1135,11 +1135,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/NoteByCommitment" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/NoteByCommitment" => {
                     #[allow(non_camel_case_types)]
-                    struct NoteByCommitmentSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct NoteByCommitmentSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::UnaryService<super::NoteByCommitmentRequest>
                     for NoteByCommitmentSvc<T> {
                         type Response = super::SpendableNoteRecord;
@@ -1175,11 +1175,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/NullifierStatus" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/NullifierStatus" => {
                     #[allow(non_camel_case_types)]
-                    struct NullifierStatusSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct NullifierStatusSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::UnaryService<super::NullifierStatusRequest>
                     for NullifierStatusSvc<T> {
                         type Response = super::NullifierStatusResponse;
@@ -1215,11 +1215,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/TransactionHashes" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/TransactionHashes" => {
                     #[allow(non_camel_case_types)]
-                    struct TransactionHashesSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct TransactionHashesSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::ServerStreamingService<super::TransactionsRequest>
                     for TransactionHashesSvc<T> {
                         type Response = super::TransactionHashStreamResponse;
@@ -1256,11 +1256,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/TransactionByHash" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/TransactionByHash" => {
                     #[allow(non_camel_case_types)]
-                    struct TransactionByHashSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct TransactionByHashSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::UnaryService<super::TransactionByHashRequest>
                     for TransactionByHashSvc<T> {
                         type Response = super::TransactionByHashResponse;
@@ -1296,11 +1296,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/Transactions" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/Transactions" => {
                     #[allow(non_camel_case_types)]
-                    struct TransactionsSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct TransactionsSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::ServerStreamingService<super::TransactionsRequest>
                     for TransactionsSvc<T> {
                         type Response = super::TransactionStreamResponse;
@@ -1337,11 +1337,11 @@ pub mod view_protocol_server {
                     };
                     Box::pin(fut)
                 }
-                "/penumbra.view.v1alpha1.ViewProtocol/TransactionPerspective" => {
+                "/penumbra.view.v1alpha1.ViewProtocolService/TransactionPerspective" => {
                     #[allow(non_camel_case_types)]
-                    struct TransactionPerspectiveSvc<T: ViewProtocol>(pub Arc<T>);
+                    struct TransactionPerspectiveSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
-                        T: ViewProtocol,
+                        T: ViewProtocolService,
                     > tonic::server::UnaryService<super::TransactionPerspectiveRequest>
                     for TransactionPerspectiveSvc<T> {
                         type Response = super::TransactionPerspectiveResponse;
@@ -1392,7 +1392,7 @@ pub mod view_protocol_server {
             }
         }
     }
-    impl<T: ViewProtocol> Clone for ViewProtocolServer<T> {
+    impl<T: ViewProtocolService> Clone for ViewProtocolServiceServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
             Self {
@@ -1402,7 +1402,7 @@ pub mod view_protocol_server {
             }
         }
     }
-    impl<T: ViewProtocol> Clone for _Inner<T> {
+    impl<T: ViewProtocolService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
             Self(self.0.clone())
         }
@@ -1412,7 +1412,8 @@ pub mod view_protocol_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: ViewProtocol> tonic::server::NamedService for ViewProtocolServer<T> {
-        const NAME: &'static str = "penumbra.view.v1alpha1.ViewProtocol";
+    impl<T: ViewProtocolService> tonic::server::NamedService
+    for ViewProtocolServiceServer<T> {
+        const NAME: &'static str = "penumbra.view.v1alpha1.ViewProtocolService";
     }
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -100,7 +100,7 @@ pub mod client {
     pub mod v1alpha1 {
         include!("gen/penumbra.client.v1alpha1.rs");
 
-        use specific_query_client::SpecificQueryClient;
+        use specific_query_service_client::SpecificQueryServiceClient;
         use tonic::{
             body::BoxBody,
             codegen::{Body, StdError},
@@ -108,7 +108,7 @@ pub mod client {
 
         // Convenience methods for fetching data...
 
-        impl<C> SpecificQueryClient<C> {
+        impl<C> SpecificQueryServiceClient<C> {
             /// Get the Rust protobuf type corresponding to a state key.
             ///
             /// Prefer `key_domain` when applicable, because this gets the validated domain type,

--- a/proto/src/serializers/vote.rs
+++ b/proto/src/serializers/vote.rs
@@ -34,13 +34,7 @@ impl FromStr for Vote {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> anyhow::Result<Vote> {
-        match s
-            .replace('-', "")
-            .replace('_', "")
-            .replace(' ', "")
-            .to_lowercase()
-            .as_str()
-        {
+        match s.replace(['-', '_', ' '], "").to_lowercase().as_str() {
             "yes" | "y" => Ok(Vote::Yes),
             "no" | "n" => Ok(Vote::No),
             "abstain" | "a" => Ok(Vote::Abstain),
@@ -57,6 +51,8 @@ impl Display for Vote {
             Vote::No => write!(f, "no"),
             Vote::Abstain => write!(f, "abstain"),
             Vote::NoWithVeto => write!(f, "no_with_veto"),
+            // TODO(erwan): make sure this is correct, MERGEBLOCK
+            _ => unreachable!(),
         }
     }
 }

--- a/view/src/bin/pviewd.rs
+++ b/view/src/bin/pviewd.rs
@@ -3,9 +3,9 @@ use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand};
 use penumbra_crypto::FullViewingKey;
-use penumbra_proto::client::v1alpha1::oblivious_query_client::ObliviousQueryClient;
+use penumbra_proto::client::v1alpha1::oblivious_query_service_client::ObliviousQueryServiceClient;
 use penumbra_proto::client::v1alpha1::ChainParamsRequest;
-use penumbra_proto::view::v1alpha1::view_protocol_server::ViewProtocolServer;
+use penumbra_proto::view::v1alpha1::view_protocol_service_server::ViewProtocolServiceServer;
 use penumbra_view::ViewService;
 use std::env;
 use std::str::FromStr;
@@ -59,9 +59,11 @@ async fn main() -> Result<()> {
 
     match opt.cmd {
         Command::Init { full_viewing_key } => {
-            let mut client =
-                ObliviousQueryClient::connect(format!("http://{}:{}", opt.node, opt.pd_port))
-                    .await?;
+            let mut client = ObliviousQueryServiceClient::connect(format!(
+                "http://{}:{}",
+                opt.node, opt.pd_port
+            ))
+            .await?;
 
             let params = client
                 .chain_parameters(tonic::Request::new(ChainParamsRequest {
@@ -90,7 +92,7 @@ async fn main() -> Result<()> {
 
             tokio::spawn(
                 Server::builder()
-                    .add_service(ViewProtocolServer::new(service))
+                    .add_service(ViewProtocolServiceServer::new(service))
                     .serve(
                         format!("{}:{}", host, view_port)
                             .parse()

--- a/view/src/client.rs
+++ b/view/src/client.rs
@@ -6,7 +6,7 @@ use penumbra_chain::params::{ChainParameters, FmdParameters};
 use penumbra_crypto::keys::AccountID;
 use penumbra_crypto::{asset, keys::AddressIndex, note, Asset, Nullifier};
 use penumbra_proto::view::v1alpha1::{
-    self as pb, view_protocol_client::ViewProtocolClient, WitnessRequest,
+    self as pb, view_protocol_service_client::ViewProtocolServiceClient, WitnessRequest,
 };
 use penumbra_tct::Proof;
 use penumbra_transaction::{
@@ -25,7 +25,7 @@ use crate::{QuarantinedNoteRecord, SpendableNoteRecord, StatusStreamResponse};
 /// responsible for synchronizing and scanning the public chain state with one
 /// or more full viewing keys.
 ///
-/// This trait is a wrapper around the proto-generated [`ViewProtocolClient`]
+/// This trait is a wrapper around the proto-generated [`ViewProtocolServiceClient`]
 /// that serves two goals:
 ///
 /// 1. It can use domain types rather than proto-generated types, avoiding conversions;
@@ -254,7 +254,7 @@ pub trait ViewClient {
 // as we're calling the method within an async block on a local mutable variable,
 // it should be fine.
 #[async_trait(?Send)]
-impl<T> ViewClient for ViewProtocolClient<T>
+impl<T> ViewClient for ViewProtocolServiceClient<T>
 where
     T: tonic::client::GrpcService<tonic::body::BoxBody>,
     T::ResponseBody: tonic::codegen::Body<Data = Bytes> + Send + 'static,
@@ -292,7 +292,7 @@ where
     async fn chain_params(&mut self) -> Result<ChainParameters> {
         // We have to manually invoke the method on the type, because it has the
         // same name as the one we're implementing.
-        let params = ViewProtocolClient::chain_parameters(
+        let params = ViewProtocolServiceClient::chain_parameters(
             self,
             tonic::Request::new(pb::ChainParamsRequest {}),
         )
@@ -304,7 +304,7 @@ where
     }
 
     async fn fmd_parameters(&mut self) -> Result<FmdParameters> {
-        let params = ViewProtocolClient::fmd_parameters(
+        let params = ViewProtocolServiceClient::fmd_parameters(
             self,
             tonic::Request::new(pb::FmdParametersRequest {}),
         )
@@ -345,7 +345,7 @@ where
         account_id: AccountID,
         note_commitment: note::Commitment,
     ) -> Result<SpendableNoteRecord> {
-        ViewProtocolClient::note_by_commitment(
+        ViewProtocolServiceClient::note_by_commitment(
             self,
             tonic::Request::new(pb::NoteByCommitmentRequest {
                 account_id: Some(account_id.into()),
@@ -366,7 +366,7 @@ where
         account_id: AccountID,
         note_commitment: note::Commitment,
     ) -> Result<SpendableNoteRecord> {
-        ViewProtocolClient::note_by_commitment(
+        ViewProtocolServiceClient::note_by_commitment(
             self,
             tonic::Request::new(pb::NoteByCommitmentRequest {
                 account_id: Some(account_id.into()),
@@ -385,7 +385,7 @@ where
         account_id: AccountID,
         nullifier: Nullifier,
     ) -> Result<bool> {
-        Ok(ViewProtocolClient::nullifier_status(
+        Ok(ViewProtocolServiceClient::nullifier_status(
             self,
             tonic::Request::new(pb::NullifierStatusRequest {
                 account_id: Some(account_id.into()),
@@ -401,7 +401,7 @@ where
     /// Waits for a specific nullifier to be detected, returning immediately if it is already
     /// present, but waiting otherwise.
     async fn await_nullifier(&mut self, account_id: AccountID, nullifier: Nullifier) -> Result<()> {
-        ViewProtocolClient::nullifier_status(
+        ViewProtocolServiceClient::nullifier_status(
             self,
             tonic::Request::new(pb::NullifierStatusRequest {
                 account_id: Some(account_id.into()),
@@ -463,7 +463,7 @@ where
         // We have to manually invoke the method on the type, because it has the
         // same name as the one we're implementing.
         let pb_assets: Vec<_> =
-            ViewProtocolClient::assets(self, tonic::Request::new(pb::AssetRequest {}))
+            ViewProtocolServiceClient::assets(self, tonic::Request::new(pb::AssetRequest {}))
                 .await?
                 .into_inner()
                 .try_collect()
@@ -504,7 +504,7 @@ where
         &mut self,
         tx_hash: abci::transaction::Hash,
     ) -> Result<Option<Transaction>> {
-        ViewProtocolClient::transaction_by_hash(
+        ViewProtocolServiceClient::transaction_by_hash(
             self,
             tonic::Request::new(pb::TransactionByHashRequest {
                 tx_hash: tx_hash.as_bytes().to_vec(),
@@ -521,7 +521,7 @@ where
         &mut self,
         tx_hash: abci::transaction::Hash,
     ) -> Result<TransactionPerspective> {
-        ViewProtocolClient::transaction_perspective(
+        ViewProtocolServiceClient::transaction_perspective(
             self,
             tonic::Request::new(pb::TransactionPerspectiveRequest {
                 tx_hash: tx_hash.as_bytes().to_vec(),

--- a/view/src/service.rs
+++ b/view/src/service.rs
@@ -17,7 +17,7 @@ use penumbra_proto::{
     core::crypto::v1alpha1 as pbc,
     core::transaction::v1alpha1::{self as pbt},
     view::v1alpha1::{
-        self as pb, view_protocol_server::ViewProtocol, StatusResponse,
+        self as pb, view_protocol_service_server::ViewProtocolService, StatusResponse,
         TransactionHashStreamResponse, TransactionStreamResponse,
     },
 };
@@ -220,7 +220,7 @@ impl ViewService {
 }
 
 #[async_trait]
-impl ViewProtocol for ViewService {
+impl ViewProtocolService for ViewService {
     type NotesStream =
         Pin<Box<dyn futures::Stream<Item = Result<pb::SpendableNoteRecord, tonic::Status>> + Send>>;
     type QuarantinedNotesStream = Pin<

--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -8,7 +8,9 @@ use penumbra_crypto::{
     Amount, Asset, FieldExt, FullViewingKey, Nullifier,
 };
 use penumbra_proto::{
-    client::v1alpha1::{oblivious_query_client::ObliviousQueryClient, ChainParamsRequest},
+    client::v1alpha1::{
+        oblivious_query_service_client::ObliviousQueryServiceClient, ChainParamsRequest,
+    },
     Protobuf,
 };
 use penumbra_tct as tct;
@@ -54,7 +56,8 @@ impl Storage {
             Self::load(storage_path.as_str()).await
         } else {
             let mut client =
-                ObliviousQueryClient::connect(format!("http://{}:{}", node, pd_port)).await?;
+                ObliviousQueryServiceClient::connect(format!("http://{}:{}", node, pd_port))
+                    .await?;
             let params = client
                 .chain_parameters(tonic::Request::new(ChainParamsRequest {
                     chain_id: String::new(),

--- a/view/src/worker.rs
+++ b/view/src/worker.rs
@@ -7,7 +7,8 @@ use penumbra_chain::{sync::CompactBlock, Epoch};
 use penumbra_crypto::{Asset, FullViewingKey, Nullifier};
 use penumbra_proto::{
     client::v1alpha1::{
-        oblivious_query_client::ObliviousQueryClient, AssetListRequest, CompactBlockRangeRequest,
+        oblivious_query_service_client::ObliviousQueryServiceClient, AssetListRequest,
+        CompactBlockRangeRequest,
     },
     Protobuf,
 };
@@ -27,7 +28,7 @@ use crate::{
 
 pub struct Worker {
     storage: Storage,
-    client: ObliviousQueryClient<Channel>,
+    client: ObliviousQueryServiceClient<Channel>,
     nct: Arc<RwLock<penumbra_tct::Tree>>,
     fvk: FullViewingKey, // TODO: notifications (see TODOs on ViewService)
     error_slot: Arc<Mutex<Option<anyhow::Error>>>,
@@ -70,7 +71,8 @@ impl Worker {
         // Mark the current height as seen, since it's not new.
         sync_height_rx.borrow_and_update();
 
-        let client = ObliviousQueryClient::connect(format!("http://{}:{}", node, pd_port)).await?;
+        let client =
+            ObliviousQueryServiceClient::connect(format!("http://{}:{}", node, pd_port)).await?;
         #[cfg(feature = "nct-divergence-check")]
         let specific_client =
             SpecificQueryClient::connect(format!("http://{}:{}", node, pd_port)).await?;

--- a/view/src/worker.rs
+++ b/view/src/worker.rs
@@ -19,7 +19,7 @@ use tokio::sync::{watch, RwLock};
 use tonic::transport::Channel;
 
 #[cfg(feature = "nct-divergence-check")]
-use penumbra_proto::client::v1alpha1::specific_query_client::SpecificQueryClient;
+use penumbra_proto::client::v1alpha1::specific_query_service_client::SpecificQueryServiceClient;
 
 use crate::{
     sync::{scan_block, FilteredBlock},
@@ -35,7 +35,7 @@ pub struct Worker {
     sync_height_tx: watch::Sender<u64>,
     tm_client: tendermint_rpc::HttpClient,
     #[cfg(feature = "nct-divergence-check")]
-    specific_client: SpecificQueryClient<Channel>,
+    specific_client: SpecificQueryServiceClient<Channel>,
 }
 
 impl Worker {
@@ -75,7 +75,7 @@ impl Worker {
             ObliviousQueryServiceClient::connect(format!("http://{}:{}", node, pd_port)).await?;
         #[cfg(feature = "nct-divergence-check")]
         let specific_client =
-            SpecificQueryClient::connect(format!("http://{}:{}", node, pd_port)).await?;
+            SpecificQueryServiceClient::connect(format!("http://{}:{}", node, pd_port)).await?;
 
         let tm_client = tendermint_rpc::HttpClient::new(
             format!("http://{}:{}", node, tendermint_port).as_str(),
@@ -309,7 +309,7 @@ impl Worker {
 
 #[cfg(feature = "nct-divergence-check")]
 async fn nct_divergence_check(
-    client: &mut SpecificQueryClient<Channel>,
+    client: &mut SpecificQueryServiceClient<Channel>,
     height: u64,
     actual_root: penumbra_tct::Root,
 ) -> anyhow::Result<()> {

--- a/wallet/src/plan.rs
+++ b/wallet/src/plan.rs
@@ -13,7 +13,9 @@ use penumbra_crypto::{
     Address, FullViewingKey, Note, Value,
 };
 use penumbra_proto::{
-    client::v1alpha1::{specific_query_client::SpecificQueryClient, BatchSwapOutputDataRequest},
+    client::v1alpha1::{
+        specific_query_service_client::SpecificQueryServiceClient, BatchSwapOutputDataRequest,
+    },
     view::v1alpha1::NotesRequest,
 };
 use penumbra_transaction::{
@@ -231,7 +233,7 @@ pub async fn sweep<V, R>(
     fvk: &FullViewingKey,
     view: &mut V,
     mut rng: R,
-    specific_client: SpecificQueryClient<Channel>,
+    specific_client: SpecificQueryServiceClient<Channel>,
 ) -> Result<Vec<TransactionPlan>, anyhow::Error>
 where
     V: ViewClient,
@@ -254,7 +256,7 @@ pub async fn claim_unclaimed_swaps<V, R>(
     fvk: &FullViewingKey,
     view: &mut V,
     mut rng: R,
-    mut specific_client: SpecificQueryClient<Channel>,
+    mut specific_client: SpecificQueryServiceClient<Channel>,
 ) -> Result<Vec<TransactionPlan>, anyhow::Error>
 where
     V: ViewClient,


### PR DESCRIPTION
This PR is a partial solution for #1469, here's a summary of what this PR does:

- [x] Follow linting advice about naming enum variants, and services
- [x] Make all semantically meaningful proto3 enum variants start at `1`, and label the `= 0` variants as `_UNSPECIFIED`
- [x] Update rust conversion traits to handle "invalid states" vs. "unspecified state" with distinct error messages
- [x] Propagate those changes throughout the codebase