### PR TITLE
zk: add r1cs note commitment integrity gadget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-crypto-primitives"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff773c0ef8c655c98071d3026a63950798a66b2f45baef22d8334c1756f1bd18"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "ark-std",
+ "blake2",
+ "derivative",
+ "digest 0.9.0",
+ "rayon",
+]
+
+[[package]]
 name = "ark-ec"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +136,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "num-traits",
+ "rayon",
  "zeroize",
 ]
 
@@ -148,6 +167,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
+ "rayon",
  "rustc_version 0.3.3",
  "zeroize",
 ]
@@ -172,6 +192,22 @@ dependencies = [
  "num-traits",
  "quote 1.0.21",
  "syn 1.0.103",
+]
+
+[[package]]
+name = "ark-groth16"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f8fff7468e947130b5caf9bdd27de8b913cf30e15104b4f0cd301726b3d897"
+dependencies = [
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+ "rayon",
 ]
 
 [[package]]
@@ -203,6 +239,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.11.2",
+ "rayon",
 ]
 
 [[package]]
@@ -256,9 +293,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-snark"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc3dff1a5f67a9c0b34df32b079752d8dd17f1e9d06253da0453db6c1b7cc8a"
+dependencies = [
+ "ark-ff",
+ "ark-relations",
+ "ark-std",
+]
+
+[[package]]
 name = "ark-sponge"
 version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/sponge?branch=split-sponge#d82203c69427a852ef4abdc262e4e40784485c0c"
+source = "git+https://github.com/penumbra-zone/sponge?branch=r1cs#113469aef48a9c5f458dbf523a509d4769affbf2"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -279,8 +327,10 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
+ "colored",
  "num-traits",
  "rand",
+ "rayon",
 ]
 
 [[package]]
@@ -570,6 +620,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +910,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "colored_json"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1174,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,8 +1316,11 @@ dependencies = [
  "ark-ec",
  "ark-ed-on-bls12-377",
  "ark-ff",
+ "ark-groth16",
+ "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
+ "ark-snark",
  "ark-std",
  "hex",
  "num-bigint",
@@ -1331,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -1900,7 +1985,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2187,9 +2272,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -2480,7 +2565,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2955,7 +3040,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "hmac",
  "password-hash",
  "sha2 0.10.6",
@@ -3196,7 +3281,11 @@ dependencies = [
  "aes 0.8.2",
  "anyhow",
  "ark-ff",
+ "ark-groth16",
+ "ark-r1cs-std",
+ "ark-relations",
  "ark-serialize",
+ "ark-snark",
  "ark-std",
  "bech32",
  "bincode",
@@ -3630,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "poseidon-paramgen"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?branch=main#8e29a2434a751727e23d9b92026d4c218a4fbc17"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=main#cbbe8ef14d1acc95917ad62dd5348406cd33582c"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -3644,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "poseidon-permutation"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?branch=main#8e29a2434a751727e23d9b92026d4c218a4fbc17"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=main#cbbe8ef14d1acc95917ad62dd5348406cd33582c"
 dependencies = [
  "ark-ff",
  "once_cell",
@@ -3654,11 +3743,16 @@ dependencies = [
 [[package]]
 name = "poseidon377"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?branch=main#8e29a2434a751727e23d9b92026d4c218a4fbc17"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=main#cbbe8ef14d1acc95917ad62dd5348406cd33582c"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
+ "ark-groth16",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-snark",
  "ark-sponge",
+ "decaf377",
  "num-bigint",
  "once_cell",
  "poseidon-paramgen",
@@ -4100,7 +4194,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -4463,7 +4557,7 @@ checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -4474,7 +4568,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -4498,7 +4592,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -4507,7 +4601,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "keccak",
 ]
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,9 +13,9 @@ penumbra-proto = { path = "../proto/" }
 penumbra-tct = { path = "../tct/" }
 
 # Git deps
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
+decaf377 = { git = "https://github.com/penumbra-zone/decaf377", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
-poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "main" }
+poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "main", features = ["r1cs"] }
 poseidon-paramgen = { git = "https://github.com/penumbra-zone/poseidon377", branch = "main" }
 f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
 
@@ -44,6 +44,10 @@ chacha20poly1305 = "0.9.0"
 # only needed because ark-ff doesn't display correctly
 num-bigint = "0.4"
 tracing = "0.1"
+ark-groth16 = "0.3"
+ark-snark = "0.3"
+ark-r1cs-std = "0.3"
+ark-relations = "0.3"
 
 [dev-dependencies]
 proptest = "1"

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -39,7 +39,7 @@ pub struct Note {
 }
 
 /// The domain separator used to generate note commitments.
-static NOTECOMMIT_DOMAIN_SEP: Lazy<Fq> = Lazy::new(|| {
+pub(crate) static NOTECOMMIT_DOMAIN_SEP: Lazy<Fq> = Lazy::new(|| {
     Fq::from_le_bytes_mod_order(blake2b_simd::blake2b(b"penumbra.notecommit").as_bytes())
 });
 

--- a/crypto/src/proofs.rs
+++ b/crypto/src/proofs.rs
@@ -1,2 +1,3 @@
+mod groth16_gadgets;
 pub mod transparent;
 mod transparent_gadgets;

--- a/crypto/src/proofs/groth16_gadgets.rs
+++ b/crypto/src/proofs/groth16_gadgets.rs
@@ -9,6 +9,7 @@ use decaf377::{
 use crate::note::NOTECOMMIT_DOMAIN_SEP;
 
 /// Check the integrity of the note commitment.
+#[allow(dead_code)]
 pub(crate) fn note_commitment_integrity(
     cs: ConstraintSystemRef<Fq>,
     // Witnesses
@@ -39,4 +40,189 @@ pub(crate) fn note_commitment_integrity(
 
     note_commitment.enforce_equal(&note_commitment_test)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_ff::{One, PrimeField, ToConstraintField};
+    use ark_groth16::{Groth16, ProvingKey, VerifyingKey};
+    use ark_relations::r1cs::ConstraintSynthesizer;
+    use ark_snark::SNARK;
+    use proptest::prelude::*;
+    use rand_core::OsRng;
+    use std::str::FromStr;
+
+    use super::*;
+
+    use crate::{keys::Diversifier, Address, Note, Value};
+    use decaf377::{r1cs::CountConstraints, Bls12_377, Element};
+    use decaf377_fmd as fmd;
+    use decaf377_ka as ka;
+
+    #[derive(Clone)]
+    struct TestNoteCommitmentCircuit {
+        // Witnesses
+        note: Note,
+
+        // Public input
+        pub note_commitment: Fq,
+    }
+
+    impl ConstraintSynthesizer<Fq> for TestNoteCommitmentCircuit {
+        fn generate_constraints(
+            self,
+            cs: ark_relations::r1cs::ConstraintSystemRef<Fq>,
+        ) -> ark_relations::r1cs::Result<()> {
+            // Add witness variables for the note.
+            // These variables may be needed for multiple integrity checks, so we do this outside the gadget functions.
+            let note_blinding_var =
+                FqVar::new_witness(cs.clone(), || Ok(self.note.note_blinding().clone()))?;
+            let value_amount_var =
+                FqVar::new_witness(cs.clone(), || Ok(Fq::from(self.note.value().amount)))?;
+            let value_asset_id_var =
+                FqVar::new_witness(cs.clone(), || Ok(self.note.value().asset_id.0))?;
+            let diversified_generator_var =
+                AllocVar::<Element, Fq>::new_witness(cs.clone(), || {
+                    Ok(self.note.diversified_generator().clone())
+                })?;
+            let transmission_key_s_var =
+                FqVar::new_witness(cs.clone(), || Ok(self.note.transmission_key_s().clone()))?;
+            let clue_key_var = FqVar::new_witness(cs.clone(), || {
+                Ok(Fq::from_le_bytes_mod_order(&self.note.clue_key().0[..]))
+            })?;
+
+            // Add public input variable.
+            let note_commitment_var = FqVar::new_input(cs.clone(), || Ok(self.note_commitment))?;
+
+            note_commitment_integrity(
+                cs,
+                note_blinding_var,
+                value_amount_var,
+                value_asset_id_var,
+                diversified_generator_var,
+                transmission_key_s_var,
+                clue_key_var,
+                note_commitment_var,
+            )?;
+
+            Ok(())
+        }
+    }
+
+    impl TestNoteCommitmentCircuit {
+        fn generate_test_parameters() -> (ProvingKey<Bls12_377>, VerifyingKey<Bls12_377>) {
+            let diversifier_bytes = [1u8; 16];
+            let pk_d_bytes = [1u8; 32];
+            let clue_key_bytes = [1; 32];
+            let diversifier = Diversifier(diversifier_bytes);
+            let address = Address::from_components(
+                diversifier,
+                ka::Public(pk_d_bytes),
+                fmd::ClueKey(clue_key_bytes),
+            )
+            .expect("generated 1 address");
+            let note = Note::from_parts(
+                address,
+                Value::from_str("1upenumbra").expect("valid value"),
+                Fq::from(1),
+            )
+            .expect("can make a note");
+            let circuit = TestNoteCommitmentCircuit {
+                note: note.clone(),
+                note_commitment: note.commit().0,
+            };
+            let (pk, vk) = Groth16::circuit_specific_setup(circuit, &mut OsRng)
+                .expect("can perform circuit specific setup");
+            (pk, vk)
+        }
+    }
+
+    fn fq_strategy() -> BoxedStrategy<Fq> {
+        any::<[u8; 32]>()
+            .prop_map(|bytes| Fq::from_le_bytes_mod_order(&bytes[..]))
+            .boxed()
+    }
+
+    proptest! {
+    #![proptest_config(ProptestConfig::with_cases(2))]
+    #[test]
+        fn groth16_note_commitment_proof_happy_path(note_blinding in fq_strategy()) {
+            let (pk, vk) = TestNoteCommitmentCircuit::generate_test_parameters();
+            let mut rng = OsRng;
+
+            // Prover POV
+            let diversifier = Diversifier([0u8; 16]);
+            let pk_d_bytes = [1u8; 32];
+            let clue_key_bytes = [0u8; 32];
+            let address = Address::from_components(
+                diversifier,
+                ka::Public(pk_d_bytes),
+                fmd::ClueKey(clue_key_bytes),
+            ).unwrap();
+            let value = Value::from_str("1upenumbra").expect("this is a valid value");
+            let note = Note::from_parts(
+                address, value, note_blinding
+            ).expect("can make a note");
+            let note_commitment = note.commit().0;
+            let circuit = TestNoteCommitmentCircuit {
+                note,
+                note_commitment,
+            };
+            dbg!(circuit.clone().num_constraints_and_instance_variables());
+
+            let proof = Groth16::prove(&pk, circuit, &mut rng)
+                .map_err(|_| anyhow::anyhow!("invalid proof"))
+                .expect("can generate proof");
+
+            // Verifier POV
+            let processed_pvk = Groth16::process_vk(&vk).expect("can process verifying key");
+            let public_inputs = note_commitment.to_field_elements().unwrap();
+            let proof_result =
+                Groth16::verify_with_processed_vk(&processed_pvk, &public_inputs, &proof).unwrap();
+
+            assert!(proof_result);
+        }
+    }
+
+    proptest! {
+    #![proptest_config(ProptestConfig::with_cases(2))]
+    #[test]
+        fn groth16_note_commitment_proof_unhappy_path(note_blinding in fq_strategy()) {
+            let (pk, vk) = TestNoteCommitmentCircuit::generate_test_parameters();
+            let mut rng = OsRng;
+
+            // Prover POV
+            let diversifier = Diversifier([0u8; 16]);
+            let pk_d_bytes = [1u8; 32];
+            let clue_key_bytes = [0u8; 32];
+            let address = Address::from_components(
+                diversifier,
+                ka::Public(pk_d_bytes),
+                fmd::ClueKey(clue_key_bytes),
+            ).unwrap();
+            let value = Value::from_str("1upenumbra").expect("this is a valid value");
+            let note = Note::from_parts(
+                address, value, note_blinding
+            ).expect("can make a note");
+            let note_commitment = note.commit().0;
+            let circuit = TestNoteCommitmentCircuit {
+                note,
+                note_commitment,
+            };
+            dbg!(circuit.clone().num_constraints_and_instance_variables());
+
+            let proof = Groth16::prove(&pk, circuit, &mut rng)
+                .map_err(|_| anyhow::anyhow!("invalid proof"))
+                .expect("can generate proof");
+
+            // Verifier POV
+            let processed_pvk = Groth16::process_vk(&vk).expect("can process verifying key");
+            let incorrect_note_commitment = note_commitment + Fq::one();
+            let public_inputs = incorrect_note_commitment.to_field_elements().unwrap();
+            let proof_result =
+                Groth16::verify_with_processed_vk(&processed_pvk, &public_inputs, &proof).unwrap();
+
+            assert!(!proof_result);
+        }
+    }
 }

--- a/crypto/src/proofs/groth16_gadgets.rs
+++ b/crypto/src/proofs/groth16_gadgets.rs
@@ -1,0 +1,42 @@
+#![allow(clippy::too_many_arguments)]
+use ark_r1cs_std::prelude::{AllocVar, EqGadget};
+use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
+use decaf377::{
+    r1cs::{ElementVar, FqVar},
+    Fq,
+};
+
+use crate::note::NOTECOMMIT_DOMAIN_SEP;
+
+/// Check the integrity of the note commitment.
+pub(crate) fn note_commitment_integrity(
+    cs: ConstraintSystemRef<Fq>,
+    // Witnesses
+    note_blinding: FqVar,
+    value_amount: FqVar,
+    value_asset_id: FqVar,
+    diversified_generator: ElementVar,
+    transmission_key_s: FqVar,
+    clue_key: FqVar,
+    // Public inputs
+    note_commitment: FqVar,
+) -> Result<(), SynthesisError> {
+    let value_blinding_generator = FqVar::new_constant(cs.clone(), *NOTECOMMIT_DOMAIN_SEP)?;
+
+    let compressed_g_d = diversified_generator.compress_to_field()?;
+    let note_commitment_test = poseidon377::r1cs::hash_6(
+        cs,
+        &value_blinding_generator,
+        (
+            note_blinding,
+            value_amount,
+            value_asset_id,
+            compressed_g_d,
+            transmission_key_s,
+            clue_key,
+        ),
+    )?;
+
+    note_commitment.enforce_equal(&note_commitment_test)?;
+    Ok(())
+}


### PR DESCRIPTION
Closes #1091. There's a Groth16 proof added in the tests here (`TestNoteCommitmentCircuit`) that uses the note commitment integrity gadget only, its circuit cost is 3201 constraints. 