### PR TITLE
clean-up KV rpc api

### DIFF
--- a/pcli/src/command/query.rs
+++ b/pcli/src/command/query.rs
@@ -72,8 +72,8 @@ impl QueryCmd {
             | QueryCmd::Governance(_) => {
                 unreachable!("query handled in guard");
             }
-            QueryCmd::ShieldedPool(p) => p.key().as_bytes().to_vec(),
-            QueryCmd::Key { key } => key.as_bytes().to_vec(),
+            QueryCmd::ShieldedPool(p) => p.key().clone(),
+            QueryCmd::Key { key } => key.clone(),
         };
 
         let mut client = app.specific_client().await?;

--- a/pd/src/info/specific.rs
+++ b/pd/src/info/specific.rs
@@ -48,7 +48,7 @@ impl SpecificQuery for Info {
         }
 
         let (value, proof) = state
-            .get_with_proof_to_apphash(request.key)
+            .get_with_proof_to_apphash(request.key.into_bytes())
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 

--- a/pd/src/info/specific.rs
+++ b/pd/src/info/specific.rs
@@ -1,3 +1,4 @@
+use penumbra_chain::AppHashRead;
 use penumbra_chain::StateReadExt as _;
 use penumbra_component::dex::StateReadExt as _;
 use penumbra_component::shielded_pool::{StateReadExt as _, SupplyRead as _};
@@ -46,21 +47,25 @@ impl SpecificQuery for Info {
             return Err(Status::invalid_argument("key is empty"));
         }
 
-        // TODO: how does this align with the ABCI k/v implementation?
-        // why do we have two different implementations?
         let (value, proof) = state
-            .get_with_proof(request.key)
+            .get_with_proof_to_apphash(request.key)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
-
-        let commitment_proof = ics23::CommitmentProof {
-            proof: Some(ics23::commitment_proof::Proof::Exist(proof)),
-        };
 
         Ok(tonic::Response::new(KeyValueResponse {
             value,
             proof: if request.proof {
-                Some(commitment_proof)
+                Some(ibc_proto::ibc::core::commitment::v1::MerkleProof {
+                    proofs: proof
+                        .proofs
+                        .into_iter()
+                        .map(|p| {
+                            let mut encoded = Vec::new();
+                            prost::Message::encode(&p, &mut encoded).unwrap();
+                            prost::Message::decode(&*encoded).unwrap()
+                        })
+                        .collect(),
+                })
             } else {
                 None
             },

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -124,7 +124,7 @@ message KeyValueRequest {
   // The expected chain id (empty string if no expectation).
   string chain_id = 1;
   // If set, the key to fetch from storage.
-  bytes key = 2;
+  string key = 2;
   // whether to return a proof
   bool proof = 3;
 }

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -4,6 +4,7 @@ package penumbra.client.v1alpha1;
 
 // TODO: clean up import paths (this is pulling from the ibc-go-vendor root)
 import "proofs.proto";
+import "ibc/core/commitment/v1/commitment.proto";
 
 import "penumbra/core/crypto/v1alpha1/crypto.proto";
 import "penumbra/core/chain/v1alpha1/chain.proto";
@@ -130,6 +131,6 @@ message KeyValueRequest {
 
 message KeyValueResponse {
   bytes value = 1;
-
-  .ics23.CommitmentProof proof = 2;
+  
+  .ibc.core.commitment.v1.MerkleProof proof = 2;
 }

--- a/proto/src/gen/penumbra.client.v1alpha1.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.rs
@@ -108,7 +108,7 @@ pub struct KeyValueResponse {
     #[prost(bytes="vec", tag="1")]
     pub value: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag="2")]
-    pub proof: ::core::option::Option<::ics23::CommitmentProof>,
+    pub proof: ::core::option::Option<::ibc_proto::ibc::core::commitment::v1::MerkleProof>,
 }
 /// Generated client implementations.
 pub mod oblivious_query_client {

--- a/proto/src/gen/penumbra.client.v1alpha1.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.rs
@@ -97,8 +97,8 @@ pub struct KeyValueRequest {
     #[prost(string, tag="1")]
     pub chain_id: ::prost::alloc::string::String,
     /// If set, the key to fetch from storage.
-    #[prost(bytes="vec", tag="2")]
-    pub key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(string, tag="2")]
+    pub key: ::prost::alloc::string::String,
     /// whether to return a proof
     #[prost(bool, tag="3")]
     pub proof: bool,

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -123,7 +123,7 @@ pub mod client {
                 <C::ResponseBody as Body>::Error: Into<StdError> + Send,
             {
                 let request = KeyValueRequest {
-                    key: key.as_ref().as_bytes().to_vec(),
+                    key: key.as_ref().to_string(),
                     ..Default::default()
                 };
 
@@ -145,7 +145,7 @@ pub mod client {
                 <C::ResponseBody as Body>::Error: Into<StdError> + Send,
             {
                 let request = KeyValueRequest {
-                    key: key.as_ref().as_bytes().to_vec(),
+                    key: key.as_ref().to_string(),
                     ..Default::default()
                 };
 

--- a/view/src/worker.rs
+++ b/view/src/worker.rs
@@ -313,7 +313,7 @@ async fn nct_divergence_check(
 ) -> anyhow::Result<()> {
     let value = client
         .key_value(penumbra_proto::client::v1alpha1::KeyValueRequest {
-            key: format!("shielded_pool/anchor/{}", height).into_bytes(),
+            key: format!("shielded_pool/anchor/{}", height),
             ..Default::default()
         })
         .await?


### PR DESCRIPTION
closes #1595, updates our kv query api to produce proofs back to the apphash, using the same method as ABCI queries.