### PR TITLE
lint: use unique types in rpc signatures

### DIFF
--- a/chain/src/known_assets.rs
+++ b/chain/src/known_assets.rs
@@ -1,5 +1,5 @@
 use penumbra_crypto::asset::Asset;
-use penumbra_proto::{core::chain::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{client::v1alpha1::AssetListResponse, core::chain::v1alpha1 as pb, Protobuf};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -29,6 +29,14 @@ impl From<KnownAssets> for pb::KnownAssets {
                 .into_iter()
                 .map(|asset| asset.into())
                 .collect(),
+        }
+    }
+}
+
+impl From<KnownAssets> for AssetListResponse {
+    fn from(assets: KnownAssets) -> Self {
+        Self {
+            asset_list: Some(assets.into()),
         }
     }
 }

--- a/chain/src/sync.rs
+++ b/chain/src/sync.rs
@@ -2,7 +2,9 @@ use std::convert::TryFrom;
 
 use anyhow::Result;
 use penumbra_crypto::{IdentityKey, NotePayload, Nullifier};
-use penumbra_proto::{core::chain::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{
+    client::v1alpha1::CompactBlockRangeResponse, core::chain::v1alpha1 as pb, Protobuf,
+};
 use penumbra_tct::builder::{block, epoch};
 use serde::{Deserialize, Serialize};
 
@@ -168,5 +170,24 @@ impl TryFrom<pb::CompactBlock> for CompactBlock {
             fmd_parameters: value.fmd_parameters.map(TryInto::try_into).transpose()?,
             proposal_started: value.proposal_started,
         })
+    }
+}
+
+impl From<CompactBlock> for CompactBlockRangeResponse {
+    fn from(cb: CompactBlock) -> Self {
+        Self {
+            compact_block: Some(cb.into()),
+        }
+    }
+}
+
+impl TryFrom<CompactBlockRangeResponse> for CompactBlock {
+    type Error = anyhow::Error;
+
+    fn try_from(response: CompactBlockRangeResponse) -> Result<Self, Self::Error> {
+        response
+            .compact_block
+            .ok_or_else(|| anyhow::anyhow!("empty CompactBlockRangeResponse message"))?
+            .try_into()
     }
 }

--- a/component/src/governance/proposal/chain_params.rs
+++ b/component/src/governance/proposal/chain_params.rs
@@ -3,7 +3,9 @@ use std::{collections::BTreeMap, str::FromStr};
 
 use anyhow::{Context as _, Result};
 use penumbra_chain::params::ChainParameters;
-use penumbra_proto::{core::governance::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{
+    client::v1alpha1::MutableParametersResponse, core::governance::v1alpha1 as pb, Protobuf,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -39,7 +41,16 @@ impl From<MutableParam> for pb::MutableChainParameter {
         }
     }
 }
+impl TryFrom<MutableParametersResponse> for MutableParam {
+    type Error = anyhow::Error;
 
+    fn try_from(value: MutableParametersResponse) -> Result<Self, Self::Error> {
+        value
+            .chain_parameter
+            .ok_or_else(|| anyhow::anyhow!("empty MutableParametersResponse message"))?
+            .try_into()
+    }
+}
 impl MutableParam {
     // TODO: would be nicer as a macro but after a bit of fiddling i couldn't get it right
     pub const fn iter() -> [MutableParam; 7] {

--- a/component/src/stake/rate.rs
+++ b/component/src/stake/rate.rs
@@ -1,6 +1,8 @@
 //! Staking reward and delegation token exchange rates.
 
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{
+    client::v1alpha1::NextValidatorRateResponse, core::stake::v1alpha1 as pb, Protobuf,
+};
 use penumbra_transaction::action::{Delegate, Undelegate};
 use serde::{Deserialize, Serialize};
 
@@ -231,5 +233,24 @@ impl TryFrom<pb::BaseRateData> for BaseRateData {
             base_reward_rate: v.base_reward_rate,
             base_exchange_rate: v.base_exchange_rate,
         })
+    }
+}
+
+impl From<RateData> for NextValidatorRateResponse {
+    fn from(r: RateData) -> Self {
+        NextValidatorRateResponse {
+            data: Some(r.into()),
+        }
+    }
+}
+
+impl TryFrom<NextValidatorRateResponse> for RateData {
+    type Error = anyhow::Error;
+
+    fn try_from(value: NextValidatorRateResponse) -> Result<Self, Self::Error> {
+        value
+            .data
+            .ok_or_else(|| anyhow::anyhow!("empty NextValidatorRateResponse message"))?
+            .try_into()
     }
 }

--- a/component/src/stake/validator/info.rs
+++ b/component/src/stake/validator/info.rs
@@ -1,4 +1,6 @@
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{
+    client::v1alpha1::ValidatorInfoResponse, core::stake::v1alpha1 as pb, Protobuf,
+};
 use serde::{Deserialize, Serialize};
 
 use super::{Status, Validator};
@@ -24,6 +26,14 @@ impl From<Info> for pb::ValidatorInfo {
     }
 }
 
+impl From<Info> for ValidatorInfoResponse {
+    fn from(v: Info) -> Self {
+        ValidatorInfoResponse {
+            validator_info: Some(v.into()),
+        }
+    }
+}
+
 impl TryFrom<pb::ValidatorInfo> for Info {
     type Error = anyhow::Error;
     fn try_from(v: pb::ValidatorInfo) -> Result<Self, Self::Error> {
@@ -41,5 +51,16 @@ impl TryFrom<pb::ValidatorInfo> for Info {
                 .ok_or_else(|| anyhow::anyhow!("missing rate_data field in proto"))?
                 .try_into()?,
         })
+    }
+}
+
+impl TryFrom<ValidatorInfoResponse> for Info {
+    type Error = anyhow::Error;
+
+    fn try_from(info_resp: ValidatorInfoResponse) -> Result<Self, Self::Error> {
+        info_resp
+            .validator_info
+            .ok_or_else(|| anyhow::anyhow!("empty ValidatorInfoResponse message"))?
+            .try_into()
     }
 }

--- a/crypto/src/asset.rs
+++ b/crypto/src/asset.rs
@@ -1,6 +1,6 @@
 //! Asset types and identifiers.
 
-use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, view::v1alpha1::AssetsResponse, Protobuf};
 use serde::{Deserialize, Serialize};
 
 mod amount;
@@ -46,6 +46,17 @@ impl From<Asset> for pb::Asset {
             id: Some(asset.id.into()),
             denom: Some(asset.denom.into()),
         }
+    }
+}
+
+impl TryFrom<AssetsResponse> for Asset {
+    type Error = anyhow::Error;
+
+    fn try_from(response: AssetsResponse) -> Result<Self, Self::Error> {
+        response
+            .asset
+            .ok_or_else(|| anyhow::anyhow!("empty AssetsResponse message"))?
+            .try_into()
     }
 }
 

--- a/crypto/src/dex/lp/reserves.rs
+++ b/crypto/src/dex/lp/reserves.rs
@@ -1,5 +1,7 @@
 use crate::asset::Amount;
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{
+    client::v1alpha1::StubCpmmReservesResponse, core::dex::v1alpha1 as pb, Protobuf,
+};
 
 /// The reserves of a position.
 ///
@@ -38,5 +40,16 @@ impl From<Reserves> for pb::Reserves {
             r1: Some(value.r1.into()),
             r2: Some(value.r2.into()),
         }
+    }
+}
+
+impl TryFrom<StubCpmmReservesResponse> for Reserves {
+    type Error = anyhow::Error;
+
+    fn try_from(value: StubCpmmReservesResponse) -> Result<Self, Self::Error> {
+        value
+            .reserves
+            .ok_or_else(|| anyhow::anyhow!("empty StubCpmmReservesResponse message"))?
+            .try_into()
     }
 }

--- a/crypto/src/dex/swap.rs
+++ b/crypto/src/dex/swap.rs
@@ -10,7 +10,9 @@ pub use plaintext::SwapPlaintext;
 
 use once_cell::sync::Lazy;
 
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{
+    client::v1alpha1::BatchSwapOutputDataResponse, core::dex::v1alpha1 as pb, Protobuf,
+};
 
 use super::TradingPair;
 
@@ -93,6 +95,14 @@ impl From<BatchSwapOutputData> for pb::BatchSwapOutputData {
     }
 }
 
+impl From<BatchSwapOutputData> for BatchSwapOutputDataResponse {
+    fn from(s: BatchSwapOutputData) -> Self {
+        BatchSwapOutputDataResponse {
+            data: Some(s.into()),
+        }
+    }
+}
+
 impl TryFrom<pb::BatchSwapOutputData> for BatchSwapOutputData {
     type Error = anyhow::Error;
     fn try_from(s: pb::BatchSwapOutputData) -> Result<Self, Self::Error> {
@@ -108,5 +118,15 @@ impl TryFrom<pb::BatchSwapOutputData> for BatchSwapOutputData {
                 .ok_or_else(|| anyhow!("Missing trading_pair"))?
                 .try_into()?,
         })
+    }
+}
+
+impl TryFrom<BatchSwapOutputDataResponse> for BatchSwapOutputData {
+    type Error = anyhow::Error;
+    fn try_from(value: BatchSwapOutputDataResponse) -> Result<Self, Self::Error> {
+        value
+            .data
+            .ok_or_else(|| anyhow::anyhow!("empty BatchSwapOutputDataResponse message"))?
+            .try_into()
     }
 }

--- a/crypto/src/identity_key.rs
+++ b/crypto/src/identity_key.rs
@@ -1,4 +1,5 @@
 use penumbra_proto::{
+    client::v1alpha1::NextValidatorRateRequest,
     core::crypto::v1alpha1 as pb,
     serializers::bech32str::{self, validator_identity_key::BECH32_PREFIX},
     Protobuf,
@@ -60,5 +61,23 @@ impl TryFrom<pb::IdentityKey> for IdentityKey {
     type Error = anyhow::Error;
     fn try_from(ik: pb::IdentityKey) -> Result<Self, Self::Error> {
         Ok(Self(ik.ik.as_slice().try_into()?))
+    }
+}
+
+impl From<IdentityKey> for NextValidatorRateRequest {
+    fn from(k: IdentityKey) -> Self {
+        NextValidatorRateRequest {
+            identity_key: Some(k.into()),
+        }
+    }
+}
+
+impl TryFrom<NextValidatorRateRequest> for IdentityKey {
+    type Error = anyhow::Error;
+    fn try_from(value: NextValidatorRateRequest) -> Result<Self, Self::Error> {
+        value
+            .identity_key
+            .ok_or_else(|| anyhow::anyhow!("empty NextValidatorRateRequest message"))?
+            .try_into()
     }
 }

--- a/custody/src/client.rs
+++ b/custody/src/client.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use penumbra_proto::custody::v1alpha1::AuthorizeResponse;
 use penumbra_proto::custody::v1alpha1::custody_protocol_service_client::CustodyProtocolServiceClient;
 use penumbra_transaction::AuthorizationData;
 use tonic::async_trait;
@@ -27,7 +28,7 @@ use crate::AuthorizeRequest;
 #[async_trait(?Send)]
 pub trait CustodyClient: Sized {
     /// Requests authorization of the transaction with the given description.
-    async fn authorize(&mut self, request: AuthorizeRequest) -> Result<AuthorizationData>;
+    async fn authorize(&mut self, request: AuthorizeRequest) -> Result<AuthorizeResponse>;
 }
 
 // We need to tell `async_trait` not to add a `Send` bound to the boxed
@@ -44,12 +45,12 @@ where
     T::Error: Into<tonic::codegen::StdError>,
     <T::ResponseBody as tonic::codegen::Body>::Error: Into<tonic::codegen::StdError> + Send,
 {
-    async fn authorize(&mut self, request: AuthorizeRequest) -> Result<AuthorizationData> {
-        let rsp: AuthorizationData = self
-            .authorize(tonic::Request::new(request.into()))
-            .await?
-            .into_inner()
-            .try_into()?;
-        Ok(rsp)
+    async fn authorize(&mut self, request: AuthorizeRequest) -> Result<AuthorizeResponse> {
+        let data = self.authorize(tonic::Request(request.into())).await?;
+        Ok(
+            AuthorizeResponse {
+            data,
+        }
+    )
     }
 }

--- a/custody/src/client.rs
+++ b/custody/src/client.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
-use penumbra_proto::custody::v1alpha1::AuthorizeResponse;
 use penumbra_proto::custody::v1alpha1::custody_protocol_service_client::CustodyProtocolServiceClient;
-use penumbra_transaction::AuthorizationData;
+use penumbra_proto::custody::v1alpha1::AuthorizeResponse;
+
 use tonic::async_trait;
 use tonic::codegen::Bytes;
 
@@ -46,11 +46,9 @@ where
     <T::ResponseBody as tonic::codegen::Body>::Error: Into<tonic::codegen::StdError> + Send,
 {
     async fn authorize(&mut self, request: AuthorizeRequest) -> Result<AuthorizeResponse> {
-        let data = self.authorize(tonic::Request(request.into())).await?;
-        Ok(
-            AuthorizeResponse {
-            data,
-        }
-    )
+        Ok(self
+            .authorize(tonic::Request::new(request.into()))
+            .await?
+            .into_inner())
     }
 }

--- a/measure/src/main.rs
+++ b/measure/src/main.rs
@@ -91,8 +91,8 @@ impl Opt {
                         ));
                 progress_bar.set_position(0);
 
-                while let Some(block) = stream.message().await? {
-                    let block = CompactBlock::try_from(block)?;
+                while let Some(block_rsp) = stream.message().await? {
+                    let block: CompactBlock = block_rsp.try_into()?;
                     progress_bar.set_position(block.height);
                 }
                 progress_bar.finish();

--- a/measure/src/main.rs
+++ b/measure/src/main.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::EnvFilter;
 
 use penumbra_chain::{params::ChainParameters, sync::CompactBlock};
 use penumbra_proto::client::v1alpha1::{
-    oblivious_query_service_client::ObliviousQueryServiceClient, ChainParamsRequest,
+    oblivious_query_service_client::ObliviousQueryServiceClient, ChainParametersRequest,
     CompactBlockRangeRequest,
 };
 
@@ -64,7 +64,7 @@ impl Opt {
                 .await?;
 
                 let params: ChainParameters = client
-                    .chain_parameters(tonic::Request::new(ChainParamsRequest {
+                    .chain_parameters(tonic::Request::new(ChainParametersRequest {
                         chain_id: String::new(),
                     }))
                     .await?

--- a/pcli/src/command/query/governance.rs
+++ b/pcli/src/command/query/governance.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use futures::TryStreamExt;
 use penumbra_component::{
     governance::{
-        proposal::{self, ProposalList},
+        proposal::{self, chain_params::MutableParam, ProposalList},
         state_key::*,
     },
     stake::validator,
@@ -18,6 +18,7 @@ use penumbra_transaction::action::{Proposal, ProposalPayload, Vote};
 use penumbra_view::ViewClient;
 use serde::Serialize;
 use serde_json::json;
+use tokio_stream::StreamExt;
 
 use crate::App;
 
@@ -73,6 +74,11 @@ impl GovernanceCmd {
                     .into_inner()
                     .try_collect::<Vec<_>>()
                     .await?;
+
+                let params: Result<Vec<MutableParam>, _> =
+                    params.into_iter().map(TryInto::try_into).collect();
+
+                let params = params?;
 
                 json(&params)?;
             }

--- a/pd/src/info/oblivious.rs
+++ b/pd/src/info/oblivious.rs
@@ -13,14 +13,10 @@ use penumbra_component::{
 };
 use penumbra_proto::{
     client::v1alpha1::{
-        oblivious_query_service_server::ObliviousQueryService, AssetListRequest,
-        ChainParametersRequest, CompactBlockRangeRequest, MutableParametersRequest,
-        ValidatorInfoRequest,
-    },
-    core::{
-        chain::v1alpha1::{ChainParameters, CompactBlock, KnownAssets},
-        governance::v1alpha1::MutableChainParameter,
-        stake::v1alpha1::ValidatorInfo,
+        oblivious_query_service_server::ObliviousQueryService, AssetListRequest, AssetListResponse,
+        ChainParametersRequest, ChainParametersResponse, CompactBlockRangeRequest,
+        CompactBlockRangeResponse, MutableParametersRequest, MutableParametersResponse,
+        ValidatorInfoRequest, ValidatorInfoResponse,
     },
     Protobuf,
 };
@@ -58,20 +54,22 @@ use super::Info;
 
 #[tonic::async_trait]
 impl ObliviousQueryService for Info {
-    type CompactBlockRangeStream =
-        Pin<Box<dyn futures::Stream<Item = Result<CompactBlock, tonic::Status>> + Send>>;
+    type CompactBlockRangeStream = Pin<
+        Box<dyn futures::Stream<Item = Result<CompactBlockRangeResponse, tonic::Status>> + Send>,
+    >;
 
     type ValidatorInfoStream =
-        Pin<Box<dyn futures::Stream<Item = Result<ValidatorInfo, tonic::Status>> + Send>>;
+        Pin<Box<dyn futures::Stream<Item = Result<ValidatorInfoResponse, tonic::Status>> + Send>>;
 
-    type MutableParametersStream =
-        Pin<Box<dyn futures::Stream<Item = Result<MutableChainParameter, tonic::Status>> + Send>>;
+    type MutableParametersStream = Pin<
+        Box<dyn futures::Stream<Item = Result<MutableParametersResponse, tonic::Status>> + Send>,
+    >;
 
     #[instrument(skip(self, request))]
     async fn chain_parameters(
         &self,
         request: tonic::Request<ChainParametersRequest>,
-    ) -> Result<tonic::Response<ChainParameters>, Status> {
+    ) -> Result<tonic::Response<ChainParametersResponse>, Status> {
         let state = self.storage.latest_state();
         state.check_chain_id(&request.get_ref().chain_id).await?;
 
@@ -79,7 +77,9 @@ impl ObliviousQueryService for Info {
             tonic::Status::unavailable(format!("error getting chain parameters: {}", e))
         })?;
 
-        Ok(tonic::Response::new(chain_params.into()))
+        Ok(tonic::Response::new(ChainParametersResponse {
+            chain_parameters: Some(chain_params.into()),
+        }))
     }
 
     #[instrument(skip(self, request))]
@@ -92,20 +92,24 @@ impl ObliviousQueryService for Info {
 
         let mutable_params = MutableParam::iter();
 
-        let s = try_stream! {
+        let stream = try_stream! {
             for param in mutable_params {
                 yield param.to_proto();
             }
         };
 
         Ok(tonic::Response::new(
-            s.map_err(|e: anyhow::Error| {
-                // Should be impossible, but.
-                tonic::Status::unavailable(format!("error getting mutable params: {}", e))
-            })
-            // TODO: how do we instrument a Stream
-            //.instrument(Span::current())
-            .boxed(),
+            stream
+                .map_ok(|params| MutableParametersResponse {
+                    chain_parameter: Some(params.into()),
+                })
+                .map_err(|e: anyhow::Error| {
+                    // Should be impossible, but.
+                    tonic::Status::unavailable(format!("error getting mutable params: {}", e))
+                })
+                // TODO: how do we instrument a Stream
+                //.instrument(Span::current())
+                .boxed(),
         ))
     }
 
@@ -113,14 +117,16 @@ impl ObliviousQueryService for Info {
     async fn asset_list(
         &self,
         request: tonic::Request<AssetListRequest>,
-    ) -> Result<tonic::Response<KnownAssets>, Status> {
+    ) -> Result<tonic::Response<AssetListResponse>, Status> {
         let state = self.storage.latest_state();
         state.check_chain_id(&request.get_ref().chain_id).await?;
 
         let known_assets = state.known_assets().await.map_err(|e| {
             tonic::Status::unavailable(format!("error getting known assets: {}", e))
         })?;
-        Ok(tonic::Response::new(known_assets.into()))
+        Ok(tonic::Response::new(AssetListResponse {
+            asset_list: Some(known_assets.into()),
+        }))
     }
 
     #[instrument(skip(self, request), fields(show_inactive = request.get_ref().show_inactive))]
@@ -137,7 +143,7 @@ impl ObliviousQueryService for Info {
             .map_err(|e| tonic::Status::unavailable(format!("error listing validators: {}", e)))?;
 
         let show_inactive = request.get_ref().show_inactive;
-        let s = try_stream! {
+        let stream = try_stream! {
             for identity_key in validators {
                 let info = state.validator_info(&identity_key)
                     .await?
@@ -151,12 +157,16 @@ impl ObliviousQueryService for Info {
         };
 
         Ok(tonic::Response::new(
-            s.map_err(|e: anyhow::Error| {
-                tonic::Status::unavailable(format!("error getting validator info: {}", e))
-            })
-            // TODO: how do we instrument a Stream
-            //.instrument(Span::current())
-            .boxed(),
+            stream
+                .map_ok(|info| ValidatorInfoResponse {
+                    validator_info: Some(info.into()),
+                })
+                .map_err(|e: anyhow::Error| {
+                    tonic::Status::unavailable(format!("error getting validator info: {}", e))
+                })
+                // TODO: how do we instrument a Stream
+                //.instrument(Span::current())
+                .boxed(),
         ))
     }
 
@@ -313,9 +323,12 @@ impl ObliviousQueryService for Info {
         // manage load, etc.
         //
         // for now, assume that we can do c10k or whatever and don't worry about it.
-
         Ok(tonic::Response::new(
-            tokio_stream::wrappers::ReceiverStream::new(rx).boxed(),
+            tokio_stream::wrappers::ReceiverStream::new(rx)
+                .map_ok(|block| CompactBlockRangeResponse {
+                    compact_block: Some(block),
+                })
+                .boxed(),
         ))
     }
 }

--- a/pd/src/info/oblivious.rs
+++ b/pd/src/info/oblivious.rs
@@ -14,7 +14,7 @@ use penumbra_component::{
 use penumbra_proto::{
     client::v1alpha1::{
         oblivious_query_service_server::ObliviousQueryService, AssetListRequest,
-        ChainParamsRequest, CompactBlockRangeRequest, MutableParametersRequest,
+        ChainParametersRequest, CompactBlockRangeRequest, MutableParametersRequest,
         ValidatorInfoRequest,
     },
     core::{
@@ -70,7 +70,7 @@ impl ObliviousQueryService for Info {
     #[instrument(skip(self, request))]
     async fn chain_parameters(
         &self,
-        request: tonic::Request<ChainParamsRequest>,
+        request: tonic::Request<ChainParametersRequest>,
     ) -> Result<tonic::Response<ChainParameters>, Status> {
         let state = self.storage.latest_state();
         state.check_chain_id(&request.get_ref().chain_id).await?;

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -2,15 +2,14 @@ syntax = "proto3";
 
 package penumbra.client.v1alpha1;
 
-// TODO: clean up import paths (this is pulling from the ibc-go-vendor root)
-import "proofs.proto";
 import "ibc/core/commitment/v1/commitment.proto";
-
-import "penumbra/core/crypto/v1alpha1/crypto.proto";
 import "penumbra/core/chain/v1alpha1/chain.proto";
-import "penumbra/core/stake/v1alpha1/stake.proto";
+import "penumbra/core/crypto/v1alpha1/crypto.proto";
 import "penumbra/core/dex/v1alpha1/dex.proto";
 import "penumbra/core/governance/v1alpha1/governance.proto";
+import "penumbra/core/stake/v1alpha1/stake.proto";
+// TODO: clean up import paths (this is pulling from the ibc-go-vendor root)
+import "proofs.proto";
 
 // Methods for accessing chain state that are "oblivious" in the sense that they
 // do not request specific portions of the chain state that could reveal private
@@ -18,18 +17,11 @@ import "penumbra/core/governance/v1alpha1/governance.proto";
 // but requesting the asset denomination for a specific asset id is not, because
 // it reveals that the client has an interest in that asset specifically.
 service ObliviousQueryService {
-  rpc CompactBlockRange(CompactBlockRangeRequest) returns (stream core.chain.v1alpha1.CompactBlock);
-  rpc ChainParameters(ChainParamsRequest) returns (core.chain.v1alpha1.ChainParameters);
-  rpc MutableParameters(MutableParametersRequest) returns (stream core.governance.v1alpha1.MutableChainParameter);
-  rpc ValidatorInfo(ValidatorInfoRequest) returns (stream core.stake.v1alpha1.ValidatorInfo);
-  // TODO: deprecate in favor of SpecificQuery.AssetInfo
-  rpc AssetList(AssetListRequest) returns (core.chain.v1alpha1.KnownAssets);
-}
-
-// Lists all assets in Asset Registry
-message AssetListRequest {
-  // The expected chain id (empty string if no expectation).
-  string chain_id = 1;
+  rpc CompactBlockRange(CompactBlockRangeRequest) returns (CompactBlockRangeResponse);
+  rpc ChainParameters(ChainParametersRequest) returns (ChainParametersResponse);
+  rpc MutableParameters(MutableParametersRequest) returns (stream MutableParametersResponse);
+  rpc ValidatorInfo(ValidatorInfoRequest) returns (stream ValidatorInfoResponse);
+  rpc AssetList(AssetListRequest) returns (AssetListResponse);
 }
 
 // Requests a range of compact block data.
@@ -38,13 +30,25 @@ message CompactBlockRangeRequest {
   string chain_id = 1;
   // The start height of the range.
   uint64 start_height = 2;
-  // The end height of the range.
-  //
-  // If unset, defaults to the latest block height.
+  // The end height of the range, defaults to the latest block height.
   uint64 end_height = 3;
-  // If set, keep the connection alive past end_height,
+  // If set, keeps the connection alive past `end_height`,
   // streaming new compact blocks as they are created.
   bool keep_alive = 4;
+}
+
+message CompactBlockRangeResponse {
+  core.chain.v1alpha1.CompactBlock compact_block = 1;
+}
+
+// Requests the global configuration data for the chain.
+message ChainParametersRequest {
+  // The expected chain id (empty string if no expectation).
+  string chain_id = 1;
+}
+
+message ChainParametersResponse {
+  core.chain.v1alpha1.ChainParameters chain_parameters = 1;
 }
 
 // Requests the governance-mutable parameters available for the chain.
@@ -53,10 +57,8 @@ message MutableParametersRequest {
   string chain_id = 1;
 }
 
-// Requests the global configuration data for the chain.
-message ChainParamsRequest {
-  // The expected chain id (empty string if no expectation).
-  string chain_id = 1;
+message MutableParametersResponse {
+  core.governance.v1alpha1.MutableChainParameter chain_parameter = 1;
 }
 
 // Requests information on the chain's validators.
@@ -67,22 +69,82 @@ message ValidatorInfoRequest {
   bool show_inactive = 2;
 }
 
+message ValidatorInfoResponse {
+  core.stake.v1alpha1.ValidatorInfo validator_info = 1;
+}
+
+// Lists all assets in Asset Registry
+message AssetListRequest {
+  // The expected chain id (empty string if no expectation).
+  string chain_id = 1;
+}
+
+message AssetListResponse {
+  // TODO: deprecate in favor of SpecificQuery.AssetInfo
+  core.chain.v1alpha1.KnownAssets asset_list = 1;
+}
+
 // Methods for accessing chain state that are "specific" in the sense that they
 // request specific portions of the chain state that could reveal private
 // client data.  For instance, requesting all asset denominations is oblivious,
 // but requesting the asset denomination for a specific asset id is not, because
 // it reveals that the client has an interest in that asset specifically.
 service SpecificQueryService {
-  rpc TransactionByNote(core.crypto.v1alpha1.NoteCommitment) returns (core.chain.v1alpha1.NoteSource);
-  rpc ValidatorStatus(ValidatorStatusRequest) returns (core.stake.v1alpha1.ValidatorStatus);
-  rpc NextValidatorRate(core.crypto.v1alpha1.IdentityKey) returns (core.stake.v1alpha1.RateData);
-  rpc BatchSwapOutputData(BatchSwapOutputDataRequest) returns (core.dex.v1alpha1.BatchSwapOutputData);
-  rpc StubCPMMReserves(StubCPMMReservesRequest) returns (core.dex.v1alpha1.Reserves);
+  rpc TransactionByNote(TransactionByNoteRequest) returns (TransactionByNoteResponse);
+  rpc ValidatorStatus(ValidatorStatusRequest) returns (ValidatorStatusResponse);
+  rpc NextValidatorRate(NextValidatorRateRequest) returns (NextValidatorRateResponse);
+  rpc BatchSwapOutputData(BatchSwapOutputDataRequest) returns (BatchSwapOutputDataResponse);
+  rpc StubCPMMReserves(StubCPMMReservesRequest) returns (StubCPMMReservesResponse);
   rpc AssetInfo(AssetInfoRequest) returns (AssetInfoResponse);
 
   // General-purpose key-value state query API, that can be used to query
   // arbitrary keys in the JMT storage.
   rpc KeyValue(KeyValueRequest) returns (KeyValueResponse);
+}
+
+message TransactionByNoteRequest {
+  core.crypto.v1alpha1.NoteCommitment note_commitment = 1;
+}
+
+message TransactionByNoteResponse {
+  core.chain.v1alpha1.NoteSource note_source = 1;
+}
+
+message ValidatorStatusRequest {
+  // The expected chain id (empty string if no expectation).
+  string chain_id = 1;
+  core.crypto.v1alpha1.IdentityKey identity_key = 2;
+}
+
+message ValidatorStatusResponse {
+  core.stake.v1alpha1.ValidatorStatus status = 1;
+}
+
+message NextValidatorRateRequest {
+  core.crypto.v1alpha1.IdentityKey identity_key = 1;
+}
+
+message NextValidatorRateResponse {
+  core.stake.v1alpha1.RateData data = 1;
+}
+
+// Requests batch swap data associated with a given height and trading pair from the view service.
+message BatchSwapOutputDataRequest {
+  uint64 height = 1;
+  core.dex.v1alpha1.TradingPair trading_pair = 2;
+}
+
+message BatchSwapOutputDataResponse {
+  core.dex.v1alpha1.BatchSwapOutputData data = 1;
+}
+
+// Requests CPMM reserves data associated with a given trading pair from the view service.
+message StubCPMMReservesRequest {
+  core.dex.v1alpha1.TradingPair trading_pair = 1;
+}
+
+message StubCPMMReservesResponse {
+  core.dex.v1alpha1.Reserves reserves = 1;
 }
 
 // Requests information on an asset by asset id
@@ -100,23 +162,6 @@ message AssetInfoResponse {
   core.crypto.v1alpha1.Asset asset = 1;
 }
 
-// Requests batch swap data associated with a given height and trading pair from the view service.
-message BatchSwapOutputDataRequest {
-    uint64 height = 1;
-    core.dex.v1alpha1.TradingPair trading_pair = 2;
-}
-
-// Requests CPMM reserves data associated with a given trading pair from the view service.
-message StubCPMMReservesRequest {
-    core.dex.v1alpha1.TradingPair trading_pair = 1;
-}
-
-message ValidatorStatusRequest {
-  // The expected chain id (empty string if no expectation).
-  string chain_id = 1;
-  core.crypto.v1alpha1.IdentityKey identity_key = 2;
-}
-
 // Performs a key-value query, either by key or by key hash.
 //
 // Proofs are only supported by key.
@@ -131,6 +176,5 @@ message KeyValueRequest {
 
 message KeyValueResponse {
   bytes value = 1;
-  
   .ibc.core.commitment.v1.MerkleProof proof = 2;
 }

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -17,7 +17,7 @@ import "penumbra/core/stake/v1alpha1/stake.proto";
 // but requesting the asset denomination for a specific asset id is not, because
 // it reveals that the client has an interest in that asset specifically.
 service ObliviousQueryService {
-  rpc CompactBlockRange(CompactBlockRangeRequest) returns (CompactBlockRangeResponse);
+  rpc CompactBlockRange(CompactBlockRangeRequest) returns (stream CompactBlockRangeResponse);
   rpc ChainParameters(ChainParametersRequest) returns (ChainParametersResponse);
   rpc MutableParameters(MutableParametersRequest) returns (stream MutableParametersResponse);
   rpc ValidatorInfo(ValidatorInfoRequest) returns (stream ValidatorInfoResponse);

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -9,7 +9,7 @@ import "penumbra/core/dex/v1alpha1/dex.proto";
 import "penumbra/core/governance/v1alpha1/governance.proto";
 import "penumbra/core/stake/v1alpha1/stake.proto";
 // TODO: clean up import paths (this is pulling from the ibc-go-vendor root)
-import "proofs.proto";
+// import "proofs.proto";
 
 // Methods for accessing chain state that are "oblivious" in the sense that they
 // do not request specific portions of the chain state that could reveal private

--- a/proto/proto/penumbra/custody/v1alpha1/custody.proto
+++ b/proto/proto/penumbra/custody/v1alpha1/custody.proto
@@ -1,30 +1,35 @@
 syntax = "proto3";
-option go_package = "github.com/penumbra-zone/penumbra/proto/go-proto";
 
 package penumbra.custody.v1alpha1;
 
-import "penumbra/core/transaction/v1alpha1/transaction.proto";
 import "penumbra/core/crypto/v1alpha1/crypto.proto";
+import "penumbra/core/transaction/v1alpha1/transaction.proto";
+
+option go_package = "github.com/penumbra-zone/penumbra/proto/go-proto";
 
 // The custody protocol is used by a wallet client to request authorization for
 // a transaction they've constructed.
-// 
+//
 // Modeling transaction authorization as an asynchronous RPC call encourages
 // software to be written in a way that has a compatible data flow with a "soft
 // HSM", threshold signing, a hardware wallet, etc.
-// 
+//
 // The custody protocol does not trust the client to authorize spends, so
 // custody requests must contain sufficient information for the custodian to
 // understand the transaction and determine whether or not it should be
 // authorized.
 service CustodyProtocolService {
-    // Requests authorization of the transaction with the given description.
-    rpc Authorize(AuthorizeRequest) returns (core.transaction.v1alpha1.AuthorizationData);
+  // Requests authorization of the transaction with the given description.
+  rpc Authorize(AuthorizeRequest) returns (AuthorizeResponse);
 }
 
 message AuthorizeRequest {
-    // The transaction plan to authorize.
-    core.transaction.v1alpha1.TransactionPlan plan = 1;
-    // Identifies the FVK (and hence the spend authorization key) to use for signing.
-    core.crypto.v1alpha1.AccountID account_id = 2;
+  // The transaction plan to authorize.
+  core.transaction.v1alpha1.TransactionPlan plan = 1;
+  // Identifies the FVK (and hence the spend authorization key) to use for signing.
+  core.crypto.v1alpha1.AccountID account_id = 2;
+}
+
+message AuthorizeResponse {
+  core.transaction.v1alpha1.AuthorizationData data = 1;
 }

--- a/proto/proto/penumbra/view/v1alpha1/view.proto
+++ b/proto/proto/penumbra/view/v1alpha1/view.proto
@@ -177,15 +177,11 @@ message NullifierStatusResponse {
   bool spent = 1;
 }
 
-message Range {
+message TransactionHashesRequest {
   // If present, return only transactions after this height.
   optional uint64 start_height = 1;
   // If present, return only transactions before this height.
   optional uint64 end_height = 2;
-}
-
-message TransactionHashesRequest {
-  Range range = 1;
 }
 
 message TransactionHashesResponse {
@@ -204,7 +200,10 @@ message TransactionByHashResponse {
 }
 
 message TransactionsRequest {
-  Range range = 1;
+  // If present, return only transactions after this height.
+  optional uint64 start_height = 1;
+  // If present, return only transactions before this height.
+  optional uint64 end_height = 2;
 }
 
 // A streaming full transaction response

--- a/proto/proto/penumbra/view/v1alpha1/view.proto
+++ b/proto/proto/penumbra/view/v1alpha1/view.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-option go_package = "github.com/penumbra-zone/penumbra/proto/go-proto";
-
 package penumbra.view.v1alpha1;
 
-import "penumbra/core/transaction/v1alpha1/transaction.proto";
-import "penumbra/core/crypto/v1alpha1/crypto.proto";
 import "penumbra/core/chain/v1alpha1/chain.proto";
+import "penumbra/core/crypto/v1alpha1/crypto.proto";
+import "penumbra/core/transaction/v1alpha1/transaction.proto";
+
+option go_package = "github.com/penumbra-zone/penumbra/proto/go-proto";
 
 // The view protocol is used by a view client, who wants to do some
 // transaction-related actions, to request data from a view service, which is
@@ -18,87 +18,142 @@ import "penumbra/core/chain/v1alpha1/chain.proto";
 // (assuming transport security, the client has to know the FVK to request its
 // data).  (TODO: refine this)
 service ViewProtocolService {
-    // Get current status of chain sync
-    rpc Status(StatusRequest) returns (StatusResponse);
+  // Get current status of chain sync
+  rpc Status(StatusRequest) returns (StatusResponse);
 
-    // Stream sync status updates until the view service has caught up with the core.chain.v1alpha1.
-    rpc StatusStream(StatusStreamRequest) returns (stream StatusStreamResponse);
+  // Stream sync status updates until the view service has caught up with the core.chain.v1alpha1.
+  rpc StatusStream(StatusStreamRequest) returns (stream StatusStreamResponse);
 
-    // Queries for notes that have been accepted by the core.chain.v1alpha1.
-    rpc Notes(NotesRequest) returns (stream SpendableNoteRecord);
+  // Queries for notes that have been accepted by the core.chain.v1alpha1.
+  rpc Notes(NotesRequest) returns (stream NotesResponse);
 
-    // Queries for notes that have been quarantined until the end of an unbonding period.
-    rpc QuarantinedNotes(QuarantinedNotesRequest) returns (stream QuarantinedNoteRecord);
+  // Queries for notes that have been quarantined until the end of an unbonding period.
+  rpc QuarantinedNotes(QuarantinedNotesRequest) returns (stream QuarantinedNotesResponse);
 
-    // Returns authentication paths for the given note commitments.
-    //
-    // This method takes a batch of input commitments, rather than just one, so
-    // that the client can get a consistent set of authentication paths to a
-    // common root.  (Otherwise, if a client made multiple requests, the wallet
-    // service could have advanced the note commitment tree state between queries).
-    rpc Witness(WitnessRequest) returns (core.transaction.v1alpha1.WitnessData);
+  // Returns authentication paths for the given note commitments.
+  //
+  // This method takes a batch of input commitments, rather than just one, so
+  // that the client can get a consistent set of authentication paths to a
+  // common root.  (Otherwise, if a client made multiple requests, the wallet
+  // service could have advanced the note commitment tree state between queries).
+  rpc Witness(WitnessRequest) returns (WitnessResponse);
 
-    // Queries for assets.
-    rpc Assets(AssetRequest) returns (stream core.crypto.v1alpha1.Asset);
+  // Queries for assets.
+  rpc Assets(AssetsRequest) returns (AssetsResponse);
 
-    // Query for the current chain parameters.
-    rpc ChainParameters(ChainParamsRequest) returns (core.chain.v1alpha1.ChainParameters);
+  // Query for the current chain parameters.
+  rpc ChainParameters(ChainParametersRequest) returns (ChainParametersResponse);
 
-    // Query for the current FMD parameters.
-    rpc FMDParameters(FMDParametersRequest) returns (core.chain.v1alpha1.FmdParameters);
+  // Query for the current FMD parameters.
+  rpc FMDParameters(FMDParametersRequest) returns (FMDParametersResponse);
 
-    // Query for a note by its note commitment, optionally waiting until the note is detected.
-    rpc NoteByCommitment(NoteByCommitmentRequest) returns (SpendableNoteRecord);
+  // Query for a note by its note commitment, optionally waiting until the note is detected.
+  rpc NoteByCommitment(NoteByCommitmentRequest) returns (NoteByCommitmentResponse);
 
-    // Query for whether a nullifier has been spent, optionally waiting until it is spent.
-    rpc NullifierStatus(NullifierStatusRequest) returns (NullifierStatusResponse);
+  // Query for whether a nullifier has been spent, optionally waiting until it is spent.
+  rpc NullifierStatus(NullifierStatusRequest) returns (NullifierStatusResponse);
 
-    // Query for the transaction hashes in the given range of blocks.
-    rpc TransactionHashes(TransactionsRequest) returns (stream TransactionHashStreamResponse);
-    // Query for a given transaction hash.
-    rpc TransactionByHash(TransactionByHashRequest) returns (TransactionByHashResponse);
-    // Query for the full transactions in the given range of blocks.
-    rpc Transactions(TransactionsRequest) returns (stream TransactionStreamResponse);
-    // Query for the transaction perspective of the given transaction
-    rpc TransactionPerspective(TransactionPerspectiveRequest) returns (TransactionPerspectiveResponse);
+  // Query for the transaction hashes in the given range of blocks.
+  rpc TransactionHashes(TransactionHashesRequest) returns (stream TransactionHashesResponse);
+  // Query for a given transaction hash.
+  rpc TransactionByHash(TransactionByHashRequest) returns (TransactionByHashResponse);
+  // Query for the full transactions in the given range of blocks.
+  rpc Transactions(TransactionsRequest) returns (stream TransactionsResponse);
+  // Query for the transaction perspective of the given transaction
+  rpc TransactionPerspective(TransactionPerspectiveRequest) returns (TransactionPerspectiveResponse);
 }
 
-message TransactionPerspectiveRequest {
-    bytes tx_hash = 1;
+// Requests sync status of the view service.
+message StatusRequest {
+  // Identifies the FVK for the notes to query.
+  core.crypto.v1alpha1.AccountID account_id = 1;
 }
 
-message TransactionPerspectiveResponse {
-    core.transaction.v1alpha1.TransactionPerspective txp = 1;
-    core.transaction.v1alpha1.Transaction tx = 2;
+// Returns the status of the view service and whether it is synchronized with the chain state.
+message StatusResponse {
+  // The height the view service has synchronized to so far
+  uint64 sync_height = 1;
+  // Whether the view service is catching up with the chain state
+  bool catching_up = 2;
 }
 
-message TransactionsRequest {
-    // If present, return only transactions after this height.
-    optional uint64 start_height = 1;
-    // If present, return only transactions before this height.
-    optional uint64 end_height = 2;
+// Requests streaming updates on the sync height until the view service is synchronized.
+message StatusStreamRequest {
+  // Identifies the FVK for the notes to query.
+  core.crypto.v1alpha1.AccountID account_id = 1;
 }
 
-message TransactionByHashRequest {
-    // The transaction hash to query for.
-    bytes tx_hash = 1;
+// A streaming sync status update
+message StatusStreamResponse {
+  uint64 latest_known_block_height = 1;
+  uint64 sync_height = 2;
 }
 
-message TransactionHashStreamResponse {
-    uint64 block_height = 1;
-    bytes tx_hash = 2;
+// A query for notes known by the view service.
+//
+// This message uses the fact that all proto fields are optional
+// to allow various filtering on the returned notes.
+message NotesRequest {
+  // Identifies the FVK for the notes to query.
+  core.crypto.v1alpha1.AccountID account_id = 1;
+
+  // If set, return spent notes as well as unspent notes.
+  bool include_spent = 2;
+
+  // If set, only return notes with the specified asset id.
+  core.crypto.v1alpha1.AssetId asset_id = 3;
+
+  // If set, only return notes with the specified address incore.dex.v1alpha1.
+  core.crypto.v1alpha1.AddressIndex address_index = 4;
+
+  // If set, stop returning notes once the total exceeds this amount.
+  //
+  // Ignored if `asset_id` is unset or if `include_spent` is set.
+  uint64 amount_to_spend = 5;
 }
 
-// A streaming full transaction response
-message TransactionStreamResponse {
-    uint64 block_height = 1;
-    bytes tx_hash = 2;
-    core.transaction.v1alpha1.Transaction tx = 3;
+// A query for quarantined notes known by the view service.
+message QuarantinedNotesRequest {
+  // Identifies the FVK for the notes to query.
+  core.crypto.v1alpha1.AccountID account_id = 1;
 }
 
-// A full transaction response
-message TransactionByHashResponse {
-    core.transaction.v1alpha1.Transaction tx = 1;
+message QuarantinedNotesResponse {
+  QuarantinedNoteRecord note_record = 1;
+}
+
+message WitnessRequest {
+  // Identifies the FVK for the note commitments to query.
+  core.crypto.v1alpha1.AccountID account_id = 1;
+
+  // The note commitments to obtain auth paths for.
+  repeated core.crypto.v1alpha1.NoteCommitment note_commitments = 2;
+}
+
+message WitnessResponse {
+  core.transaction.v1alpha1.WitnessData witness_data = 1;
+}
+
+// Requests all assets known to the view service.
+message AssetsRequest {}
+
+// Requests all assets known to the view service.
+message AssetsResponse {
+  core.crypto.v1alpha1.Asset asset = 1;
+}
+
+// Requests the current chain parameters from the view service.
+message ChainParametersRequest {}
+
+message ChainParametersResponse {
+  core.chain.v1alpha1.ChainParameters parameters = 1;
+}
+
+// Requests the current FMD parameters from the view service.
+message FMDParametersRequest {}
+
+message FMDParametersResponse {
+  core.chain.v1alpha1.FmdParameters parameters = 1;
 }
 
 message NoteByCommitmentRequest {
@@ -108,117 +163,8 @@ message NoteByCommitmentRequest {
   bool await_detection = 3;
 }
 
-// Requests the current chain parameters from the view service.
-message ChainParamsRequest {
-}
-
-// Requests the current FMD parameters from the view service.
-message FMDParametersRequest {
-}
-
-// Requests all assets known to the view service.
-message AssetRequest {
-}
-
-// Requests sync status of the view service.
-message StatusRequest {
-    // Identifies the FVK for the notes to query.
-    core.crypto.v1alpha1.AccountID account_id = 1;
-}
-
-// Returns the status of the view service and whether it is synchronized with the chain state.
-message StatusResponse {
-    // The height the view service has synchronized to so far
-    uint64 sync_height = 1;
-    // Whether the view service is catching up with the chain state
-    bool catching_up = 2;
-}
-
-// Requests streaming updates on the sync height until the view service is synchronized.
-message StatusStreamRequest {
-    // Identifies the FVK for the notes to query.
-    core.crypto.v1alpha1.AccountID account_id = 1;
-}
-
-// A streaming sync status update
-message StatusStreamResponse {
-    uint64 latest_known_block_height = 1;
-    uint64 sync_height = 2;
-}
-
-// A note plaintext with associated metadata about its status.
-message SpendableNoteRecord {
-    // The note commitment, identifying the note.
-    core.crypto.v1alpha1.NoteCommitment note_commitment = 1;
-    // The note plaintext itself.
-    core.crypto.v1alpha1.Note note = 2;
-    // A precomputed decryption of the note's address incore.dex.v1alpha1.
-    core.crypto.v1alpha1.AddressIndex address_index = 3;
-    // The note's nullifier.
-    core.crypto.v1alpha1.Nullifier nullifier = 4;
-    // The height at which the note was created.
-    uint64 height_created = 5;
-    // Records whether the note was spent (and if so, at what height).
-    optional uint64 height_spent = 6;
-    // The note position.
-    uint64 position = 7;
-    // The source of the note (a tx hash or otherwise)
-    core.chain.v1alpha1.NoteSource source = 8;
-}
-
-// A query for notes known by the view service.
-//
-// This message uses the fact that all proto fields are optional
-// to allow various filtering on the returned notes.
-message NotesRequest {
-    // Identifies the FVK for the notes to query.
-    core.crypto.v1alpha1.AccountID account_id = 1;
-
-    // If set, return spent notes as well as unspent notes.
-    bool include_spent = 2;
-
-    // If set, only return notes with the specified asset id.
-    core.crypto.v1alpha1.AssetId asset_id = 3;
-
-    // If set, only return notes with the specified address incore.dex.v1alpha1.
-    core.crypto.v1alpha1.AddressIndex address_index = 4;
-
-    // If set, stop returning notes once the total exceeds this amount.
-    //
-    // Ignored if `asset_id` is unset or if `include_spent` is set.
-    uint64 amount_to_spend = 5;
-}
-
-message WitnessRequest {
-    // Identifies the FVK for the note commitments to query.
-    core.crypto.v1alpha1.AccountID account_id = 1;
-
-    // The note commitments to obtain auth paths for.
-    repeated core.crypto.v1alpha1.NoteCommitment note_commitments = 2;
-}
-
-// The plaintext of a note that has been quarantined until the end of an unbonding period.
-message QuarantinedNoteRecord {
-    // The note commitment, identifying the note.
-    core.crypto.v1alpha1.NoteCommitment note_commitment = 1;
-    // The note plaintext itself.
-    core.crypto.v1alpha1.Note note = 2;
-    // A precomputed decryption of the note's address incore.dex.v1alpha1.
-    core.crypto.v1alpha1.AddressIndex address_index = 3;
-    // The height at which the note was created.
-    uint64 height_created = 4;
-    // The epoch at which the note will exit quarantine, if unbonding is not interrupted by slashing.
-    uint64 unbonding_epoch = 5;
-    // The validator identity the quarantining is bound to.
-    core.crypto.v1alpha1.IdentityKey identity_key = 6;
-    // The source of the note (a tx hash or otherwise)
-    core.chain.v1alpha1.NoteSource source = 7;
-}
-
-// A query for quarantined notes known by the view service.
-message QuarantinedNotesRequest {
-    // Identifies the FVK for the notes to query.
-    core.crypto.v1alpha1.AccountID account_id = 1;
+message NoteByCommitmentResponse {
+  SpendableNoteRecord spendable_note = 1;
 }
 
 message NullifierStatusRequest {
@@ -229,4 +175,92 @@ message NullifierStatusRequest {
 
 message NullifierStatusResponse {
   bool spent = 1;
+}
+
+message Range {
+  // If present, return only transactions after this height.
+  optional uint64 start_height = 1;
+  // If present, return only transactions before this height.
+  optional uint64 end_height = 2;
+}
+
+message TransactionHashesRequest {
+  optional Range range = 1;
+}
+
+message TransactionHashesResponse {
+  uint64 block_height = 1;
+  bytes tx_hash = 2;
+}
+
+message TransactionByHashRequest {
+  // The transaction hash to query for.
+  bytes tx_hash = 1;
+}
+
+// A full transaction response
+message TransactionByHashResponse {
+  core.transaction.v1alpha1.Transaction tx = 1;
+}
+
+message TransactionsRequest {
+  optional Range range = 1;
+}
+
+// A streaming full transaction response
+message TransactionsResponse {
+  uint64 block_height = 1;
+  bytes tx_hash = 2;
+  core.transaction.v1alpha1.Transaction tx = 3;
+}
+
+message TransactionPerspectiveRequest {
+  bytes tx_hash = 1;
+}
+
+message TransactionPerspectiveResponse {
+  core.transaction.v1alpha1.TransactionPerspective txp = 1;
+  core.transaction.v1alpha1.Transaction tx = 2;
+}
+
+message NotesResponse {
+  SpendableNoteRecord note_record = 1;
+}
+
+// A note plaintext with associated metadata about its status.
+message SpendableNoteRecord {
+  // The note commitment, identifying the note.
+  core.crypto.v1alpha1.NoteCommitment note_commitment = 1;
+  // The note plaintext itself.
+  core.crypto.v1alpha1.Note note = 2;
+  // A precomputed decryption of the note's address incore.dex.v1alpha1.
+  core.crypto.v1alpha1.AddressIndex address_index = 3;
+  // The note's nullifier.
+  core.crypto.v1alpha1.Nullifier nullifier = 4;
+  // The height at which the note was created.
+  uint64 height_created = 5;
+  // Records whether the note was spent (and if so, at what height).
+  optional uint64 height_spent = 6;
+  // The note position.
+  uint64 position = 7;
+  // The source of the note (a tx hash or otherwise)
+  core.chain.v1alpha1.NoteSource source = 8;
+}
+
+// The plaintext of a note that has been quarantined until the end of an unbonding period.
+message QuarantinedNoteRecord {
+  // The note commitment, identifying the note.
+  core.crypto.v1alpha1.NoteCommitment note_commitment = 1;
+  // The note plaintext itself.
+  core.crypto.v1alpha1.Note note = 2;
+  // A precomputed decryption of the note's address incore.dex.v1alpha1.
+  core.crypto.v1alpha1.AddressIndex address_index = 3;
+  // The height at which the note was created.
+  uint64 height_created = 4;
+  // The epoch at which the note will exit quarantine, if unbonding is not interrupted by slashing.
+  uint64 unbonding_epoch = 5;
+  // The validator identity the quarantining is bound to.
+  core.crypto.v1alpha1.IdentityKey identity_key = 6;
+  // The source of the note (a tx hash or otherwise)
+  core.chain.v1alpha1.NoteSource source = 7;
 }

--- a/proto/proto/penumbra/view/v1alpha1/view.proto
+++ b/proto/proto/penumbra/view/v1alpha1/view.proto
@@ -39,7 +39,7 @@ service ViewProtocolService {
   rpc Witness(WitnessRequest) returns (WitnessResponse);
 
   // Queries for assets.
-  rpc Assets(AssetsRequest) returns (AssetsResponse);
+  rpc Assets(AssetsRequest) returns (stream AssetsResponse);
 
   // Query for the current chain parameters.
   rpc ChainParameters(ChainParametersRequest) returns (ChainParametersResponse);
@@ -185,7 +185,7 @@ message Range {
 }
 
 message TransactionHashesRequest {
-  optional Range range = 1;
+  Range range = 1;
 }
 
 message TransactionHashesResponse {
@@ -204,7 +204,7 @@ message TransactionByHashResponse {
 }
 
 message TransactionsRequest {
-  optional Range range = 1;
+  Range range = 1;
 }
 
 // A streaming full transaction response

--- a/proto/src/gen/penumbra.client.v1alpha1.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.rs
@@ -1,10 +1,3 @@
-/// Lists all assets in Asset Registry
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AssetListRequest {
-    /// The expected chain id (empty string if no expectation).
-    #[prost(string, tag="1")]
-    pub chain_id: ::prost::alloc::string::String,
-}
 /// Requests a range of compact block data.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompactBlockRangeRequest {
@@ -14,15 +7,30 @@ pub struct CompactBlockRangeRequest {
     /// The start height of the range.
     #[prost(uint64, tag="2")]
     pub start_height: u64,
-    /// The end height of the range.
-    ///
-    /// If unset, defaults to the latest block height.
+    /// The end height of the range, defaults to the latest block height.
     #[prost(uint64, tag="3")]
     pub end_height: u64,
-    /// If set, keep the connection alive past end_height,
+    /// If set, keeps the connection alive past `end_height`,
     /// streaming new compact blocks as they are created.
     #[prost(bool, tag="4")]
     pub keep_alive: bool,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CompactBlockRangeResponse {
+    #[prost(message, optional, tag="1")]
+    pub compact_block: ::core::option::Option<super::super::core::chain::v1alpha1::CompactBlock>,
+}
+/// Requests the global configuration data for the chain.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChainParametersRequest {
+    /// The expected chain id (empty string if no expectation).
+    #[prost(string, tag="1")]
+    pub chain_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChainParametersResponse {
+    #[prost(message, optional, tag="1")]
+    pub chain_parameters: ::core::option::Option<super::super::core::chain::v1alpha1::ChainParameters>,
 }
 /// Requests the governance-mutable parameters available for the chain.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -31,12 +39,10 @@ pub struct MutableParametersRequest {
     #[prost(string, tag="1")]
     pub chain_id: ::prost::alloc::string::String,
 }
-/// Requests the global configuration data for the chain.
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ChainParamsRequest {
-    /// The expected chain id (empty string if no expectation).
-    #[prost(string, tag="1")]
-    pub chain_id: ::prost::alloc::string::String,
+pub struct MutableParametersResponse {
+    #[prost(message, optional, tag="1")]
+    pub chain_parameter: ::core::option::Option<super::super::core::governance::v1alpha1::MutableChainParameter>,
 }
 /// Requests information on the chain's validators.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -47,6 +53,81 @@ pub struct ValidatorInfoRequest {
     /// Whether or not to return inactive validators
     #[prost(bool, tag="2")]
     pub show_inactive: bool,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValidatorInfoResponse {
+    #[prost(message, optional, tag="1")]
+    pub validator_info: ::core::option::Option<super::super::core::stake::v1alpha1::ValidatorInfo>,
+}
+/// Lists all assets in Asset Registry
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AssetListRequest {
+    /// The expected chain id (empty string if no expectation).
+    #[prost(string, tag="1")]
+    pub chain_id: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AssetListResponse {
+    /// TODO: deprecate in favor of SpecificQuery.AssetInfo
+    #[prost(message, optional, tag="1")]
+    pub asset_list: ::core::option::Option<super::super::core::chain::v1alpha1::KnownAssets>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionByNoteRequest {
+    #[prost(message, optional, tag="1")]
+    pub note_commitment: ::core::option::Option<super::super::core::crypto::v1alpha1::NoteCommitment>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionByNoteResponse {
+    #[prost(message, optional, tag="1")]
+    pub note_source: ::core::option::Option<super::super::core::chain::v1alpha1::NoteSource>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValidatorStatusRequest {
+    /// The expected chain id (empty string if no expectation).
+    #[prost(string, tag="1")]
+    pub chain_id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub identity_key: ::core::option::Option<super::super::core::crypto::v1alpha1::IdentityKey>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValidatorStatusResponse {
+    #[prost(message, optional, tag="1")]
+    pub status: ::core::option::Option<super::super::core::stake::v1alpha1::ValidatorStatus>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NextValidatorRateRequest {
+    #[prost(message, optional, tag="1")]
+    pub identity_key: ::core::option::Option<super::super::core::crypto::v1alpha1::IdentityKey>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NextValidatorRateResponse {
+    #[prost(message, optional, tag="1")]
+    pub data: ::core::option::Option<super::super::core::stake::v1alpha1::RateData>,
+}
+/// Requests batch swap data associated with a given height and trading pair from the view service.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BatchSwapOutputDataRequest {
+    #[prost(uint64, tag="1")]
+    pub height: u64,
+    #[prost(message, optional, tag="2")]
+    pub trading_pair: ::core::option::Option<super::super::core::dex::v1alpha1::TradingPair>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BatchSwapOutputDataResponse {
+    #[prost(message, optional, tag="1")]
+    pub data: ::core::option::Option<super::super::core::dex::v1alpha1::BatchSwapOutputData>,
+}
+/// Requests CPMM reserves data associated with a given trading pair from the view service.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StubCpmmReservesRequest {
+    #[prost(message, optional, tag="1")]
+    pub trading_pair: ::core::option::Option<super::super::core::dex::v1alpha1::TradingPair>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StubCpmmReservesResponse {
+    #[prost(message, optional, tag="1")]
+    pub reserves: ::core::option::Option<super::super::core::dex::v1alpha1::Reserves>,
 }
 /// Requests information on an asset by asset id
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -65,28 +146,6 @@ pub struct AssetInfoResponse {
     /// If the requested asset was unknown, this field will not be present.
     #[prost(message, optional, tag="1")]
     pub asset: ::core::option::Option<super::super::core::crypto::v1alpha1::Asset>,
-}
-/// Requests batch swap data associated with a given height and trading pair from the view service.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct BatchSwapOutputDataRequest {
-    #[prost(uint64, tag="1")]
-    pub height: u64,
-    #[prost(message, optional, tag="2")]
-    pub trading_pair: ::core::option::Option<super::super::core::dex::v1alpha1::TradingPair>,
-}
-/// Requests CPMM reserves data associated with a given trading pair from the view service.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StubCpmmReservesRequest {
-    #[prost(message, optional, tag="1")]
-    pub trading_pair: ::core::option::Option<super::super::core::dex::v1alpha1::TradingPair>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ValidatorStatusRequest {
-    /// The expected chain id (empty string if no expectation).
-    #[prost(string, tag="1")]
-    pub chain_id: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="2")]
-    pub identity_key: ::core::option::Option<super::super::core::crypto::v1alpha1::IdentityKey>,
 }
 /// Performs a key-value query, either by key or by key hash.
 ///
@@ -187,14 +246,7 @@ pub mod oblivious_query_service_client {
         pub async fn compact_block_range(
             &mut self,
             request: impl tonic::IntoRequest<super::CompactBlockRangeRequest>,
-        ) -> Result<
-            tonic::Response<
-                tonic::codec::Streaming<
-                    super::super::super::core::chain::v1alpha1::CompactBlock,
-                >,
-            >,
-            tonic::Status,
-        > {
+        ) -> Result<tonic::Response<super::CompactBlockRangeResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -208,15 +260,12 @@ pub mod oblivious_query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.client.v1alpha1.ObliviousQueryService/CompactBlockRange",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            self.inner.unary(request.into_request(), path, codec).await
         }
         pub async fn chain_parameters(
             &mut self,
-            request: impl tonic::IntoRequest<super::ChainParamsRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::core::chain::v1alpha1::ChainParameters>,
-            tonic::Status,
-        > {
+            request: impl tonic::IntoRequest<super::ChainParametersRequest>,
+        ) -> Result<tonic::Response<super::ChainParametersResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -236,11 +285,7 @@ pub mod oblivious_query_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MutableParametersRequest>,
         ) -> Result<
-            tonic::Response<
-                tonic::codec::Streaming<
-                    super::super::super::core::governance::v1alpha1::MutableChainParameter,
-                >,
-            >,
+            tonic::Response<tonic::codec::Streaming<super::MutableParametersResponse>>,
             tonic::Status,
         > {
             self.inner
@@ -262,11 +307,7 @@ pub mod oblivious_query_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ValidatorInfoRequest>,
         ) -> Result<
-            tonic::Response<
-                tonic::codec::Streaming<
-                    super::super::super::core::stake::v1alpha1::ValidatorInfo,
-                >,
-            >,
+            tonic::Response<tonic::codec::Streaming<super::ValidatorInfoResponse>>,
             tonic::Status,
         > {
             self.inner
@@ -284,14 +325,10 @@ pub mod oblivious_query_service_client {
             );
             self.inner.server_streaming(request.into_request(), path, codec).await
         }
-        /// TODO: deprecate in favor of SpecificQuery.AssetInfo
         pub async fn asset_list(
             &mut self,
             request: impl tonic::IntoRequest<super::AssetListRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::core::chain::v1alpha1::KnownAssets>,
-            tonic::Status,
-        > {
+        ) -> Result<tonic::Response<super::AssetListResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -385,13 +422,8 @@ pub mod specific_query_service_client {
         }
         pub async fn transaction_by_note(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::super::core::crypto::v1alpha1::NoteCommitment,
-            >,
-        ) -> Result<
-            tonic::Response<super::super::super::core::chain::v1alpha1::NoteSource>,
-            tonic::Status,
-        > {
+            request: impl tonic::IntoRequest<super::TransactionByNoteRequest>,
+        ) -> Result<tonic::Response<super::TransactionByNoteResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -410,10 +442,7 @@ pub mod specific_query_service_client {
         pub async fn validator_status(
             &mut self,
             request: impl tonic::IntoRequest<super::ValidatorStatusRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::core::stake::v1alpha1::ValidatorStatus>,
-            tonic::Status,
-        > {
+        ) -> Result<tonic::Response<super::ValidatorStatusResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -431,13 +460,8 @@ pub mod specific_query_service_client {
         }
         pub async fn next_validator_rate(
             &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::super::core::crypto::v1alpha1::IdentityKey,
-            >,
-        ) -> Result<
-            tonic::Response<super::super::super::core::stake::v1alpha1::RateData>,
-            tonic::Status,
-        > {
+            request: impl tonic::IntoRequest<super::NextValidatorRateRequest>,
+        ) -> Result<tonic::Response<super::NextValidatorRateResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -456,12 +480,7 @@ pub mod specific_query_service_client {
         pub async fn batch_swap_output_data(
             &mut self,
             request: impl tonic::IntoRequest<super::BatchSwapOutputDataRequest>,
-        ) -> Result<
-            tonic::Response<
-                super::super::super::core::dex::v1alpha1::BatchSwapOutputData,
-            >,
-            tonic::Status,
-        > {
+        ) -> Result<tonic::Response<super::BatchSwapOutputDataResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -480,10 +499,7 @@ pub mod specific_query_service_client {
         pub async fn stub_cpmm_reserves(
             &mut self,
             request: impl tonic::IntoRequest<super::StubCpmmReservesRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::core::dex::v1alpha1::Reserves>,
-            tonic::Status,
-        > {
+        ) -> Result<tonic::Response<super::StubCpmmReservesResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -548,32 +564,17 @@ pub mod oblivious_query_service_server {
     ///Generated trait containing gRPC methods that should be implemented for use with ObliviousQueryServiceServer.
     #[async_trait]
     pub trait ObliviousQueryService: Send + Sync + 'static {
-        ///Server streaming response type for the CompactBlockRange method.
-        type CompactBlockRangeStream: futures_core::Stream<
-                Item = Result<
-                    super::super::super::core::chain::v1alpha1::CompactBlock,
-                    tonic::Status,
-                >,
-            >
-            + Send
-            + 'static;
         async fn compact_block_range(
             &self,
             request: tonic::Request<super::CompactBlockRangeRequest>,
-        ) -> Result<tonic::Response<Self::CompactBlockRangeStream>, tonic::Status>;
+        ) -> Result<tonic::Response<super::CompactBlockRangeResponse>, tonic::Status>;
         async fn chain_parameters(
             &self,
-            request: tonic::Request<super::ChainParamsRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::core::chain::v1alpha1::ChainParameters>,
-            tonic::Status,
-        >;
+            request: tonic::Request<super::ChainParametersRequest>,
+        ) -> Result<tonic::Response<super::ChainParametersResponse>, tonic::Status>;
         ///Server streaming response type for the MutableParameters method.
         type MutableParametersStream: futures_core::Stream<
-                Item = Result<
-                    super::super::super::core::governance::v1alpha1::MutableChainParameter,
-                    tonic::Status,
-                >,
+                Item = Result<super::MutableParametersResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -583,10 +584,7 @@ pub mod oblivious_query_service_server {
         ) -> Result<tonic::Response<Self::MutableParametersStream>, tonic::Status>;
         ///Server streaming response type for the ValidatorInfo method.
         type ValidatorInfoStream: futures_core::Stream<
-                Item = Result<
-                    super::super::super::core::stake::v1alpha1::ValidatorInfo,
-                    tonic::Status,
-                >,
+                Item = Result<super::ValidatorInfoResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -594,14 +592,10 @@ pub mod oblivious_query_service_server {
             &self,
             request: tonic::Request<super::ValidatorInfoRequest>,
         ) -> Result<tonic::Response<Self::ValidatorInfoStream>, tonic::Status>;
-        /// TODO: deprecate in favor of SpecificQuery.AssetInfo
         async fn asset_list(
             &self,
             request: tonic::Request<super::AssetListRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::core::chain::v1alpha1::KnownAssets>,
-            tonic::Status,
-        >;
+        ) -> Result<tonic::Response<super::AssetListResponse>, tonic::Status>;
     }
     /// Methods for accessing chain state that are "oblivious" in the sense that they
     /// do not request specific portions of the chain state that could reveal private
@@ -673,13 +667,11 @@ pub mod oblivious_query_service_server {
                     struct CompactBlockRangeSvc<T: ObliviousQueryService>(pub Arc<T>);
                     impl<
                         T: ObliviousQueryService,
-                    > tonic::server::ServerStreamingService<
-                        super::CompactBlockRangeRequest,
-                    > for CompactBlockRangeSvc<T> {
-                        type Response = super::super::super::core::chain::v1alpha1::CompactBlock;
-                        type ResponseStream = T::CompactBlockRangeStream;
+                    > tonic::server::UnaryService<super::CompactBlockRangeRequest>
+                    for CompactBlockRangeSvc<T> {
+                        type Response = super::CompactBlockRangeResponse;
                         type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
+                            tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
@@ -705,7 +697,7 @@ pub mod oblivious_query_service_server {
                                 accept_compression_encodings,
                                 send_compression_encodings,
                             );
-                        let res = grpc.server_streaming(method, req).await;
+                        let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
@@ -715,16 +707,16 @@ pub mod oblivious_query_service_server {
                     struct ChainParametersSvc<T: ObliviousQueryService>(pub Arc<T>);
                     impl<
                         T: ObliviousQueryService,
-                    > tonic::server::UnaryService<super::ChainParamsRequest>
+                    > tonic::server::UnaryService<super::ChainParametersRequest>
                     for ChainParametersSvc<T> {
-                        type Response = super::super::super::core::chain::v1alpha1::ChainParameters;
+                        type Response = super::ChainParametersResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::ChainParamsRequest>,
+                            request: tonic::Request<super::ChainParametersRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move {
@@ -758,7 +750,7 @@ pub mod oblivious_query_service_server {
                     > tonic::server::ServerStreamingService<
                         super::MutableParametersRequest,
                     > for MutableParametersSvc<T> {
-                        type Response = super::super::super::core::governance::v1alpha1::MutableChainParameter;
+                        type Response = super::MutableParametersResponse;
                         type ResponseStream = T::MutableParametersStream;
                         type Future = BoxFuture<
                             tonic::Response<Self::ResponseStream>,
@@ -799,7 +791,7 @@ pub mod oblivious_query_service_server {
                         T: ObliviousQueryService,
                     > tonic::server::ServerStreamingService<super::ValidatorInfoRequest>
                     for ValidatorInfoSvc<T> {
-                        type Response = super::super::super::core::stake::v1alpha1::ValidatorInfo;
+                        type Response = super::ValidatorInfoResponse;
                         type ResponseStream = T::ValidatorInfoStream;
                         type Future = BoxFuture<
                             tonic::Response<Self::ResponseStream>,
@@ -840,7 +832,7 @@ pub mod oblivious_query_service_server {
                         T: ObliviousQueryService,
                     > tonic::server::UnaryService<super::AssetListRequest>
                     for AssetListSvc<T> {
-                        type Response = super::super::super::core::chain::v1alpha1::KnownAssets;
+                        type Response = super::AssetListResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -920,45 +912,24 @@ pub mod specific_query_service_server {
     pub trait SpecificQueryService: Send + Sync + 'static {
         async fn transaction_by_note(
             &self,
-            request: tonic::Request<
-                super::super::super::core::crypto::v1alpha1::NoteCommitment,
-            >,
-        ) -> Result<
-            tonic::Response<super::super::super::core::chain::v1alpha1::NoteSource>,
-            tonic::Status,
-        >;
+            request: tonic::Request<super::TransactionByNoteRequest>,
+        ) -> Result<tonic::Response<super::TransactionByNoteResponse>, tonic::Status>;
         async fn validator_status(
             &self,
             request: tonic::Request<super::ValidatorStatusRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::core::stake::v1alpha1::ValidatorStatus>,
-            tonic::Status,
-        >;
+        ) -> Result<tonic::Response<super::ValidatorStatusResponse>, tonic::Status>;
         async fn next_validator_rate(
             &self,
-            request: tonic::Request<
-                super::super::super::core::crypto::v1alpha1::IdentityKey,
-            >,
-        ) -> Result<
-            tonic::Response<super::super::super::core::stake::v1alpha1::RateData>,
-            tonic::Status,
-        >;
+            request: tonic::Request<super::NextValidatorRateRequest>,
+        ) -> Result<tonic::Response<super::NextValidatorRateResponse>, tonic::Status>;
         async fn batch_swap_output_data(
             &self,
             request: tonic::Request<super::BatchSwapOutputDataRequest>,
-        ) -> Result<
-            tonic::Response<
-                super::super::super::core::dex::v1alpha1::BatchSwapOutputData,
-            >,
-            tonic::Status,
-        >;
+        ) -> Result<tonic::Response<super::BatchSwapOutputDataResponse>, tonic::Status>;
         async fn stub_cpmm_reserves(
             &self,
             request: tonic::Request<super::StubCpmmReservesRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::core::dex::v1alpha1::Reserves>,
-            tonic::Status,
-        >;
+        ) -> Result<tonic::Response<super::StubCpmmReservesResponse>, tonic::Status>;
         async fn asset_info(
             &self,
             request: tonic::Request<super::AssetInfoRequest>,
@@ -1040,19 +1011,16 @@ pub mod specific_query_service_server {
                     struct TransactionByNoteSvc<T: SpecificQueryService>(pub Arc<T>);
                     impl<
                         T: SpecificQueryService,
-                    > tonic::server::UnaryService<
-                        super::super::super::core::crypto::v1alpha1::NoteCommitment,
-                    > for TransactionByNoteSvc<T> {
-                        type Response = super::super::super::core::chain::v1alpha1::NoteSource;
+                    > tonic::server::UnaryService<super::TransactionByNoteRequest>
+                    for TransactionByNoteSvc<T> {
+                        type Response = super::TransactionByNoteResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<
-                                super::super::super::core::crypto::v1alpha1::NoteCommitment,
-                            >,
+                            request: tonic::Request<super::TransactionByNoteRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move {
@@ -1085,7 +1053,7 @@ pub mod specific_query_service_server {
                         T: SpecificQueryService,
                     > tonic::server::UnaryService<super::ValidatorStatusRequest>
                     for ValidatorStatusSvc<T> {
-                        type Response = super::super::super::core::stake::v1alpha1::ValidatorStatus;
+                        type Response = super::ValidatorStatusResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -1123,19 +1091,16 @@ pub mod specific_query_service_server {
                     struct NextValidatorRateSvc<T: SpecificQueryService>(pub Arc<T>);
                     impl<
                         T: SpecificQueryService,
-                    > tonic::server::UnaryService<
-                        super::super::super::core::crypto::v1alpha1::IdentityKey,
-                    > for NextValidatorRateSvc<T> {
-                        type Response = super::super::super::core::stake::v1alpha1::RateData;
+                    > tonic::server::UnaryService<super::NextValidatorRateRequest>
+                    for NextValidatorRateSvc<T> {
+                        type Response = super::NextValidatorRateResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<
-                                super::super::super::core::crypto::v1alpha1::IdentityKey,
-                            >,
+                            request: tonic::Request<super::NextValidatorRateRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move {
@@ -1168,7 +1133,7 @@ pub mod specific_query_service_server {
                         T: SpecificQueryService,
                     > tonic::server::UnaryService<super::BatchSwapOutputDataRequest>
                     for BatchSwapOutputDataSvc<T> {
-                        type Response = super::super::super::core::dex::v1alpha1::BatchSwapOutputData;
+                        type Response = super::BatchSwapOutputDataResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -1208,7 +1173,7 @@ pub mod specific_query_service_server {
                         T: SpecificQueryService,
                     > tonic::server::UnaryService<super::StubCpmmReservesRequest>
                     for StubCPMMReservesSvc<T> {
-                        type Response = super::super::super::core::dex::v1alpha1::Reserves;
+                        type Response = super::StubCpmmReservesResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,

--- a/proto/src/gen/penumbra.custody.v1alpha1.rs
+++ b/proto/src/gen/penumbra.custody.v1alpha1.rs
@@ -7,6 +7,11 @@ pub struct AuthorizeRequest {
     #[prost(message, optional, tag="2")]
     pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuthorizeResponse {
+    #[prost(message, optional, tag="1")]
+    pub data: ::core::option::Option<super::super::core::transaction::v1alpha1::AuthorizationData>,
+}
 /// Generated client implementations.
 pub mod custody_protocol_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -93,12 +98,7 @@ pub mod custody_protocol_service_client {
         pub async fn authorize(
             &mut self,
             request: impl tonic::IntoRequest<super::AuthorizeRequest>,
-        ) -> Result<
-            tonic::Response<
-                super::super::super::core::transaction::v1alpha1::AuthorizationData,
-            >,
-            tonic::Status,
-        > {
+        ) -> Result<tonic::Response<super::AuthorizeResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -127,12 +127,7 @@ pub mod custody_protocol_service_server {
         async fn authorize(
             &self,
             request: tonic::Request<super::AuthorizeRequest>,
-        ) -> Result<
-            tonic::Response<
-                super::super::super::core::transaction::v1alpha1::AuthorizationData,
-            >,
-            tonic::Status,
-        >;
+        ) -> Result<tonic::Response<super::AuthorizeResponse>, tonic::Status>;
     }
     /// The custody protocol is used by a wallet client to request authorization for
     /// a transaction they've constructed.
@@ -212,7 +207,7 @@ pub mod custody_protocol_service_server {
                         T: CustodyProtocolService,
                     > tonic::server::UnaryService<super::AuthorizeRequest>
                     for AuthorizeSvc<T> {
-                        type Response = super::super::super::core::transaction::v1alpha1::AuthorizationData;
+                        type Response = super::AuthorizeResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,

--- a/proto/src/gen/penumbra.view.v1alpha1.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.rs
@@ -1,75 +1,3 @@
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransactionPerspectiveRequest {
-    #[prost(bytes="vec", tag="1")]
-    pub tx_hash: ::prost::alloc::vec::Vec<u8>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransactionPerspectiveResponse {
-    #[prost(message, optional, tag="1")]
-    pub txp: ::core::option::Option<super::super::core::transaction::v1alpha1::TransactionPerspective>,
-    #[prost(message, optional, tag="2")]
-    pub tx: ::core::option::Option<super::super::core::transaction::v1alpha1::Transaction>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransactionsRequest {
-    /// If present, return only transactions after this height.
-    #[prost(uint64, optional, tag="1")]
-    pub start_height: ::core::option::Option<u64>,
-    /// If present, return only transactions before this height.
-    #[prost(uint64, optional, tag="2")]
-    pub end_height: ::core::option::Option<u64>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransactionByHashRequest {
-    /// The transaction hash to query for.
-    #[prost(bytes="vec", tag="1")]
-    pub tx_hash: ::prost::alloc::vec::Vec<u8>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransactionHashStreamResponse {
-    #[prost(uint64, tag="1")]
-    pub block_height: u64,
-    #[prost(bytes="vec", tag="2")]
-    pub tx_hash: ::prost::alloc::vec::Vec<u8>,
-}
-/// A streaming full transaction response
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransactionStreamResponse {
-    #[prost(uint64, tag="1")]
-    pub block_height: u64,
-    #[prost(bytes="vec", tag="2")]
-    pub tx_hash: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="3")]
-    pub tx: ::core::option::Option<super::super::core::transaction::v1alpha1::Transaction>,
-}
-/// A full transaction response
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransactionByHashResponse {
-    #[prost(message, optional, tag="1")]
-    pub tx: ::core::option::Option<super::super::core::transaction::v1alpha1::Transaction>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct NoteByCommitmentRequest {
-    #[prost(message, optional, tag="1")]
-    pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
-    #[prost(message, optional, tag="2")]
-    pub note_commitment: ::core::option::Option<super::super::core::crypto::v1alpha1::NoteCommitment>,
-    /// If set to true, waits to return until the requested note is detected.
-    #[prost(bool, tag="3")]
-    pub await_detection: bool,
-}
-/// Requests the current chain parameters from the view service.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ChainParamsRequest {
-}
-/// Requests the current FMD parameters from the view service.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct FmdParametersRequest {
-}
-/// Requests all assets known to the view service.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AssetRequest {
-}
 /// Requests sync status of the view service.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StatusRequest {
@@ -102,6 +30,178 @@ pub struct StatusStreamResponse {
     #[prost(uint64, tag="2")]
     pub sync_height: u64,
 }
+/// A query for notes known by the view service.
+///
+/// This message uses the fact that all proto fields are optional
+/// to allow various filtering on the returned notes.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NotesRequest {
+    /// Identifies the FVK for the notes to query.
+    #[prost(message, optional, tag="1")]
+    pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
+    /// If set, return spent notes as well as unspent notes.
+    #[prost(bool, tag="2")]
+    pub include_spent: bool,
+    /// If set, only return notes with the specified asset id.
+    #[prost(message, optional, tag="3")]
+    pub asset_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AssetId>,
+    /// If set, only return notes with the specified address incore.dex.v1alpha1.
+    #[prost(message, optional, tag="4")]
+    pub address_index: ::core::option::Option<super::super::core::crypto::v1alpha1::AddressIndex>,
+    /// If set, stop returning notes once the total exceeds this amount.
+    ///
+    /// Ignored if `asset_id` is unset or if `include_spent` is set.
+    #[prost(uint64, tag="5")]
+    pub amount_to_spend: u64,
+}
+/// A query for quarantined notes known by the view service.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuarantinedNotesRequest {
+    /// Identifies the FVK for the notes to query.
+    #[prost(message, optional, tag="1")]
+    pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QuarantinedNotesResponse {
+    #[prost(message, optional, tag="1")]
+    pub note_record: ::core::option::Option<QuarantinedNoteRecord>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WitnessRequest {
+    /// Identifies the FVK for the note commitments to query.
+    #[prost(message, optional, tag="1")]
+    pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
+    /// The note commitments to obtain auth paths for.
+    #[prost(message, repeated, tag="2")]
+    pub note_commitments: ::prost::alloc::vec::Vec<super::super::core::crypto::v1alpha1::NoteCommitment>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WitnessResponse {
+    #[prost(message, optional, tag="1")]
+    pub witness_data: ::core::option::Option<super::super::core::transaction::v1alpha1::WitnessData>,
+}
+/// Requests all assets known to the view service.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AssetsRequest {
+}
+/// Requests all assets known to the view service.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AssetsResponse {
+    #[prost(message, optional, tag="1")]
+    pub asset: ::core::option::Option<super::super::core::crypto::v1alpha1::Asset>,
+}
+/// Requests the current chain parameters from the view service.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChainParametersRequest {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChainParametersResponse {
+    #[prost(message, optional, tag="1")]
+    pub parameters: ::core::option::Option<super::super::core::chain::v1alpha1::ChainParameters>,
+}
+/// Requests the current FMD parameters from the view service.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FmdParametersRequest {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FmdParametersResponse {
+    #[prost(message, optional, tag="1")]
+    pub parameters: ::core::option::Option<super::super::core::chain::v1alpha1::FmdParameters>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NoteByCommitmentRequest {
+    #[prost(message, optional, tag="1")]
+    pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
+    #[prost(message, optional, tag="2")]
+    pub note_commitment: ::core::option::Option<super::super::core::crypto::v1alpha1::NoteCommitment>,
+    /// If set to true, waits to return until the requested note is detected.
+    #[prost(bool, tag="3")]
+    pub await_detection: bool,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NoteByCommitmentResponse {
+    #[prost(message, optional, tag="1")]
+    pub spendable_note: ::core::option::Option<SpendableNoteRecord>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NullifierStatusRequest {
+    #[prost(message, optional, tag="1")]
+    pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
+    #[prost(message, optional, tag="2")]
+    pub nullifier: ::core::option::Option<super::super::core::crypto::v1alpha1::Nullifier>,
+    #[prost(bool, tag="3")]
+    pub await_detection: bool,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NullifierStatusResponse {
+    #[prost(bool, tag="1")]
+    pub spent: bool,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Range {
+    /// If present, return only transactions after this height.
+    #[prost(uint64, optional, tag="1")]
+    pub start_height: ::core::option::Option<u64>,
+    /// If present, return only transactions before this height.
+    #[prost(uint64, optional, tag="2")]
+    pub end_height: ::core::option::Option<u64>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionHashesRequest {
+    #[prost(message, optional, tag="1")]
+    pub range: ::core::option::Option<Range>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionHashesResponse {
+    #[prost(uint64, tag="1")]
+    pub block_height: u64,
+    #[prost(bytes="vec", tag="2")]
+    pub tx_hash: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionByHashRequest {
+    /// The transaction hash to query for.
+    #[prost(bytes="vec", tag="1")]
+    pub tx_hash: ::prost::alloc::vec::Vec<u8>,
+}
+/// A full transaction response
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionByHashResponse {
+    #[prost(message, optional, tag="1")]
+    pub tx: ::core::option::Option<super::super::core::transaction::v1alpha1::Transaction>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionsRequest {
+    #[prost(message, optional, tag="1")]
+    pub range: ::core::option::Option<Range>,
+}
+/// A streaming full transaction response
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionsResponse {
+    #[prost(uint64, tag="1")]
+    pub block_height: u64,
+    #[prost(bytes="vec", tag="2")]
+    pub tx_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag="3")]
+    pub tx: ::core::option::Option<super::super::core::transaction::v1alpha1::Transaction>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionPerspectiveRequest {
+    #[prost(bytes="vec", tag="1")]
+    pub tx_hash: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionPerspectiveResponse {
+    #[prost(message, optional, tag="1")]
+    pub txp: ::core::option::Option<super::super::core::transaction::v1alpha1::TransactionPerspective>,
+    #[prost(message, optional, tag="2")]
+    pub tx: ::core::option::Option<super::super::core::transaction::v1alpha1::Transaction>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NotesResponse {
+    #[prost(message, optional, tag="1")]
+    pub note_record: ::core::option::Option<SpendableNoteRecord>,
+}
 /// A note plaintext with associated metadata about its status.
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -131,39 +231,6 @@ pub struct SpendableNoteRecord {
     #[prost(message, optional, tag="8")]
     pub source: ::core::option::Option<super::super::core::chain::v1alpha1::NoteSource>,
 }
-/// A query for notes known by the view service.
-///
-/// This message uses the fact that all proto fields are optional
-/// to allow various filtering on the returned notes.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct NotesRequest {
-    /// Identifies the FVK for the notes to query.
-    #[prost(message, optional, tag="1")]
-    pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
-    /// If set, return spent notes as well as unspent notes.
-    #[prost(bool, tag="2")]
-    pub include_spent: bool,
-    /// If set, only return notes with the specified asset id.
-    #[prost(message, optional, tag="3")]
-    pub asset_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AssetId>,
-    /// If set, only return notes with the specified address incore.dex.v1alpha1.
-    #[prost(message, optional, tag="4")]
-    pub address_index: ::core::option::Option<super::super::core::crypto::v1alpha1::AddressIndex>,
-    /// If set, stop returning notes once the total exceeds this amount.
-    ///
-    /// Ignored if `asset_id` is unset or if `include_spent` is set.
-    #[prost(uint64, tag="5")]
-    pub amount_to_spend: u64,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct WitnessRequest {
-    /// Identifies the FVK for the note commitments to query.
-    #[prost(message, optional, tag="1")]
-    pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
-    /// The note commitments to obtain auth paths for.
-    #[prost(message, repeated, tag="2")]
-    pub note_commitments: ::prost::alloc::vec::Vec<super::super::core::crypto::v1alpha1::NoteCommitment>,
-}
 /// The plaintext of a note that has been quarantined until the end of an unbonding period.
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -189,27 +256,6 @@ pub struct QuarantinedNoteRecord {
     /// The source of the note (a tx hash or otherwise)
     #[prost(message, optional, tag="7")]
     pub source: ::core::option::Option<super::super::core::chain::v1alpha1::NoteSource>,
-}
-/// A query for quarantined notes known by the view service.
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QuarantinedNotesRequest {
-    /// Identifies the FVK for the notes to query.
-    #[prost(message, optional, tag="1")]
-    pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct NullifierStatusRequest {
-    #[prost(message, optional, tag="1")]
-    pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
-    #[prost(message, optional, tag="2")]
-    pub nullifier: ::core::option::Option<super::super::core::crypto::v1alpha1::Nullifier>,
-    #[prost(bool, tag="3")]
-    pub await_detection: bool,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct NullifierStatusResponse {
-    #[prost(bool, tag="1")]
-    pub spent: bool,
 }
 /// Generated client implementations.
 pub mod view_protocol_service_client {
@@ -337,7 +383,7 @@ pub mod view_protocol_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::NotesRequest>,
         ) -> Result<
-            tonic::Response<tonic::codec::Streaming<super::SpendableNoteRecord>>,
+            tonic::Response<tonic::codec::Streaming<super::NotesResponse>>,
             tonic::Status,
         > {
             self.inner
@@ -360,7 +406,7 @@ pub mod view_protocol_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::QuarantinedNotesRequest>,
         ) -> Result<
-            tonic::Response<tonic::codec::Streaming<super::QuarantinedNoteRecord>>,
+            tonic::Response<tonic::codec::Streaming<super::QuarantinedNotesResponse>>,
             tonic::Status,
         > {
             self.inner
@@ -387,12 +433,7 @@ pub mod view_protocol_service_client {
         pub async fn witness(
             &mut self,
             request: impl tonic::IntoRequest<super::WitnessRequest>,
-        ) -> Result<
-            tonic::Response<
-                super::super::super::core::transaction::v1alpha1::WitnessData,
-            >,
-            tonic::Status,
-        > {
+        ) -> Result<tonic::Response<super::WitnessResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -411,15 +452,8 @@ pub mod view_protocol_service_client {
         /// Queries for assets.
         pub async fn assets(
             &mut self,
-            request: impl tonic::IntoRequest<super::AssetRequest>,
-        ) -> Result<
-            tonic::Response<
-                tonic::codec::Streaming<
-                    super::super::super::core::crypto::v1alpha1::Asset,
-                >,
-            >,
-            tonic::Status,
-        > {
+            request: impl tonic::IntoRequest<super::AssetsRequest>,
+        ) -> Result<tonic::Response<super::AssetsResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -433,16 +467,13 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/Assets",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            self.inner.unary(request.into_request(), path, codec).await
         }
         /// Query for the current chain parameters.
         pub async fn chain_parameters(
             &mut self,
-            request: impl tonic::IntoRequest<super::ChainParamsRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::core::chain::v1alpha1::ChainParameters>,
-            tonic::Status,
-        > {
+            request: impl tonic::IntoRequest<super::ChainParametersRequest>,
+        ) -> Result<tonic::Response<super::ChainParametersResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -462,10 +493,7 @@ pub mod view_protocol_service_client {
         pub async fn fmd_parameters(
             &mut self,
             request: impl tonic::IntoRequest<super::FmdParametersRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::core::chain::v1alpha1::FmdParameters>,
-            tonic::Status,
-        > {
+        ) -> Result<tonic::Response<super::FmdParametersResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -485,7 +513,7 @@ pub mod view_protocol_service_client {
         pub async fn note_by_commitment(
             &mut self,
             request: impl tonic::IntoRequest<super::NoteByCommitmentRequest>,
-        ) -> Result<tonic::Response<super::SpendableNoteRecord>, tonic::Status> {
+        ) -> Result<tonic::Response<super::NoteByCommitmentResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -524,11 +552,9 @@ pub mod view_protocol_service_client {
         /// Query for the transaction hashes in the given range of blocks.
         pub async fn transaction_hashes(
             &mut self,
-            request: impl tonic::IntoRequest<super::TransactionsRequest>,
+            request: impl tonic::IntoRequest<super::TransactionHashesRequest>,
         ) -> Result<
-            tonic::Response<
-                tonic::codec::Streaming<super::TransactionHashStreamResponse>,
-            >,
+            tonic::Response<tonic::codec::Streaming<super::TransactionHashesResponse>>,
             tonic::Status,
         > {
             self.inner
@@ -571,7 +597,7 @@ pub mod view_protocol_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::TransactionsRequest>,
         ) -> Result<
-            tonic::Response<tonic::codec::Streaming<super::TransactionStreamResponse>>,
+            tonic::Response<tonic::codec::Streaming<super::TransactionsResponse>>,
             tonic::Status,
         > {
             self.inner
@@ -639,7 +665,7 @@ pub mod view_protocol_service_server {
         ) -> Result<tonic::Response<Self::StatusStreamStream>, tonic::Status>;
         ///Server streaming response type for the Notes method.
         type NotesStream: futures_core::Stream<
-                Item = Result<super::SpendableNoteRecord, tonic::Status>,
+                Item = Result<super::NotesResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -650,7 +676,7 @@ pub mod view_protocol_service_server {
         ) -> Result<tonic::Response<Self::NotesStream>, tonic::Status>;
         ///Server streaming response type for the QuarantinedNotes method.
         type QuarantinedNotesStream: futures_core::Stream<
-                Item = Result<super::QuarantinedNoteRecord, tonic::Status>,
+                Item = Result<super::QuarantinedNotesResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -668,47 +694,27 @@ pub mod view_protocol_service_server {
         async fn witness(
             &self,
             request: tonic::Request<super::WitnessRequest>,
-        ) -> Result<
-            tonic::Response<
-                super::super::super::core::transaction::v1alpha1::WitnessData,
-            >,
-            tonic::Status,
-        >;
-        ///Server streaming response type for the Assets method.
-        type AssetsStream: futures_core::Stream<
-                Item = Result<
-                    super::super::super::core::crypto::v1alpha1::Asset,
-                    tonic::Status,
-                >,
-            >
-            + Send
-            + 'static;
+        ) -> Result<tonic::Response<super::WitnessResponse>, tonic::Status>;
         /// Queries for assets.
         async fn assets(
             &self,
-            request: tonic::Request<super::AssetRequest>,
-        ) -> Result<tonic::Response<Self::AssetsStream>, tonic::Status>;
+            request: tonic::Request<super::AssetsRequest>,
+        ) -> Result<tonic::Response<super::AssetsResponse>, tonic::Status>;
         /// Query for the current chain parameters.
         async fn chain_parameters(
             &self,
-            request: tonic::Request<super::ChainParamsRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::core::chain::v1alpha1::ChainParameters>,
-            tonic::Status,
-        >;
+            request: tonic::Request<super::ChainParametersRequest>,
+        ) -> Result<tonic::Response<super::ChainParametersResponse>, tonic::Status>;
         /// Query for the current FMD parameters.
         async fn fmd_parameters(
             &self,
             request: tonic::Request<super::FmdParametersRequest>,
-        ) -> Result<
-            tonic::Response<super::super::super::core::chain::v1alpha1::FmdParameters>,
-            tonic::Status,
-        >;
+        ) -> Result<tonic::Response<super::FmdParametersResponse>, tonic::Status>;
         /// Query for a note by its note commitment, optionally waiting until the note is detected.
         async fn note_by_commitment(
             &self,
             request: tonic::Request<super::NoteByCommitmentRequest>,
-        ) -> Result<tonic::Response<super::SpendableNoteRecord>, tonic::Status>;
+        ) -> Result<tonic::Response<super::NoteByCommitmentResponse>, tonic::Status>;
         /// Query for whether a nullifier has been spent, optionally waiting until it is spent.
         async fn nullifier_status(
             &self,
@@ -716,14 +722,14 @@ pub mod view_protocol_service_server {
         ) -> Result<tonic::Response<super::NullifierStatusResponse>, tonic::Status>;
         ///Server streaming response type for the TransactionHashes method.
         type TransactionHashesStream: futures_core::Stream<
-                Item = Result<super::TransactionHashStreamResponse, tonic::Status>,
+                Item = Result<super::TransactionHashesResponse, tonic::Status>,
             >
             + Send
             + 'static;
         /// Query for the transaction hashes in the given range of blocks.
         async fn transaction_hashes(
             &self,
-            request: tonic::Request<super::TransactionsRequest>,
+            request: tonic::Request<super::TransactionHashesRequest>,
         ) -> Result<tonic::Response<Self::TransactionHashesStream>, tonic::Status>;
         /// Query for a given transaction hash.
         async fn transaction_by_hash(
@@ -732,7 +738,7 @@ pub mod view_protocol_service_server {
         ) -> Result<tonic::Response<super::TransactionByHashResponse>, tonic::Status>;
         ///Server streaming response type for the Transactions method.
         type TransactionsStream: futures_core::Stream<
-                Item = Result<super::TransactionStreamResponse, tonic::Status>,
+                Item = Result<super::TransactionsResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -904,7 +910,7 @@ pub mod view_protocol_service_server {
                         T: ViewProtocolService,
                     > tonic::server::ServerStreamingService<super::NotesRequest>
                     for NotesSvc<T> {
-                        type Response = super::SpendableNoteRecord;
+                        type Response = super::NotesResponse;
                         type ResponseStream = T::NotesStream;
                         type Future = BoxFuture<
                             tonic::Response<Self::ResponseStream>,
@@ -944,7 +950,7 @@ pub mod view_protocol_service_server {
                     > tonic::server::ServerStreamingService<
                         super::QuarantinedNotesRequest,
                     > for QuarantinedNotesSvc<T> {
-                        type Response = super::QuarantinedNoteRecord;
+                        type Response = super::QuarantinedNotesResponse;
                         type ResponseStream = T::QuarantinedNotesStream;
                         type Future = BoxFuture<
                             tonic::Response<Self::ResponseStream>,
@@ -985,7 +991,7 @@ pub mod view_protocol_service_server {
                         T: ViewProtocolService,
                     > tonic::server::UnaryService<super::WitnessRequest>
                     for WitnessSvc<T> {
-                        type Response = super::super::super::core::transaction::v1alpha1::WitnessData;
+                        type Response = super::WitnessResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -1021,17 +1027,16 @@ pub mod view_protocol_service_server {
                     struct AssetsSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
                         T: ViewProtocolService,
-                    > tonic::server::ServerStreamingService<super::AssetRequest>
+                    > tonic::server::UnaryService<super::AssetsRequest>
                     for AssetsSvc<T> {
-                        type Response = super::super::super::core::crypto::v1alpha1::Asset;
-                        type ResponseStream = T::AssetsStream;
+                        type Response = super::AssetsResponse;
                         type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
+                            tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::AssetRequest>,
+                            request: tonic::Request<super::AssetsRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move { (*inner).assets(request).await };
@@ -1050,7 +1055,7 @@ pub mod view_protocol_service_server {
                                 accept_compression_encodings,
                                 send_compression_encodings,
                             );
-                        let res = grpc.server_streaming(method, req).await;
+                        let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
@@ -1060,16 +1065,16 @@ pub mod view_protocol_service_server {
                     struct ChainParametersSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
                         T: ViewProtocolService,
-                    > tonic::server::UnaryService<super::ChainParamsRequest>
+                    > tonic::server::UnaryService<super::ChainParametersRequest>
                     for ChainParametersSvc<T> {
-                        type Response = super::super::super::core::chain::v1alpha1::ChainParameters;
+                        type Response = super::ChainParametersResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::ChainParamsRequest>,
+                            request: tonic::Request<super::ChainParametersRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move {
@@ -1102,7 +1107,7 @@ pub mod view_protocol_service_server {
                         T: ViewProtocolService,
                     > tonic::server::UnaryService<super::FmdParametersRequest>
                     for FMDParametersSvc<T> {
-                        type Response = super::super::super::core::chain::v1alpha1::FmdParameters;
+                        type Response = super::FmdParametersResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -1142,7 +1147,7 @@ pub mod view_protocol_service_server {
                         T: ViewProtocolService,
                     > tonic::server::UnaryService<super::NoteByCommitmentRequest>
                     for NoteByCommitmentSvc<T> {
-                        type Response = super::SpendableNoteRecord;
+                        type Response = super::NoteByCommitmentResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
@@ -1220,9 +1225,10 @@ pub mod view_protocol_service_server {
                     struct TransactionHashesSvc<T: ViewProtocolService>(pub Arc<T>);
                     impl<
                         T: ViewProtocolService,
-                    > tonic::server::ServerStreamingService<super::TransactionsRequest>
-                    for TransactionHashesSvc<T> {
-                        type Response = super::TransactionHashStreamResponse;
+                    > tonic::server::ServerStreamingService<
+                        super::TransactionHashesRequest,
+                    > for TransactionHashesSvc<T> {
+                        type Response = super::TransactionHashesResponse;
                         type ResponseStream = T::TransactionHashesStream;
                         type Future = BoxFuture<
                             tonic::Response<Self::ResponseStream>,
@@ -1230,7 +1236,7 @@ pub mod view_protocol_service_server {
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::TransactionsRequest>,
+                            request: tonic::Request<super::TransactionHashesRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
                             let fut = async move {
@@ -1303,7 +1309,7 @@ pub mod view_protocol_service_server {
                         T: ViewProtocolService,
                     > tonic::server::ServerStreamingService<super::TransactionsRequest>
                     for TransactionsSvc<T> {
-                        type Response = super::TransactionStreamResponse;
+                        type Response = super::TransactionsResponse;
                         type ResponseStream = T::TransactionsStream;
                         type Future = BoxFuture<
                             tonic::Response<Self::ResponseStream>,

--- a/proto/src/gen/penumbra.view.v1alpha1.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.rs
@@ -138,18 +138,13 @@ pub struct NullifierStatusResponse {
     pub spent: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Range {
+pub struct TransactionHashesRequest {
     /// If present, return only transactions after this height.
     #[prost(uint64, optional, tag="1")]
     pub start_height: ::core::option::Option<u64>,
     /// If present, return only transactions before this height.
     #[prost(uint64, optional, tag="2")]
     pub end_height: ::core::option::Option<u64>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TransactionHashesRequest {
-    #[prost(message, optional, tag="1")]
-    pub range: ::core::option::Option<Range>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionHashesResponse {
@@ -172,8 +167,12 @@ pub struct TransactionByHashResponse {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionsRequest {
-    #[prost(message, optional, tag="1")]
-    pub range: ::core::option::Option<Range>,
+    /// If present, return only transactions after this height.
+    #[prost(uint64, optional, tag="1")]
+    pub start_height: ::core::option::Option<u64>,
+    /// If present, return only transactions before this height.
+    #[prost(uint64, optional, tag="2")]
+    pub end_height: ::core::option::Option<u64>,
 }
 /// A streaming full transaction response
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/proto/src/serializers/vote.rs
+++ b/proto/src/serializers/vote.rs
@@ -51,8 +51,9 @@ impl Display for Vote {
             Vote::No => write!(f, "no"),
             Vote::Abstain => write!(f, "abstain"),
             Vote::NoWithVeto => write!(f, "no_with_veto"),
-            // TODO(erwan): make sure this is correct, MERGEBLOCK
-            _ => unreachable!(),
+            // Invalid vote, this is unreachable because it should
+            // never be allowed to be deserialized successfully.
+            Vote::Unspecified => unreachable!(),
         }
     }
 }

--- a/view/src/bin/pviewd.rs
+++ b/view/src/bin/pviewd.rs
@@ -4,7 +4,7 @@ use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand};
 use penumbra_crypto::FullViewingKey;
 use penumbra_proto::client::v1alpha1::oblivious_query_service_client::ObliviousQueryServiceClient;
-use penumbra_proto::client::v1alpha1::ChainParamsRequest;
+use penumbra_proto::client::v1alpha1::ChainParametersRequest;
 use penumbra_proto::view::v1alpha1::view_protocol_service_server::ViewProtocolServiceServer;
 use penumbra_view::ViewService;
 use std::env;
@@ -66,7 +66,7 @@ async fn main() -> Result<()> {
             .await?;
 
             let params = client
-                .chain_parameters(tonic::Request::new(ChainParamsRequest {
+                .chain_parameters(tonic::Request::new(ChainParametersRequest {
                     chain_id: String::new(),
                 }))
                 .await?

--- a/view/src/client.rs
+++ b/view/src/client.rs
@@ -5,6 +5,7 @@ use futures::{Stream, StreamExt, TryStreamExt};
 use penumbra_chain::params::{ChainParameters, FmdParameters};
 use penumbra_crypto::keys::AccountID;
 use penumbra_crypto::{asset, keys::AddressIndex, note, Asset, Nullifier};
+use penumbra_proto::view::v1alpha1::Range;
 use penumbra_proto::view::v1alpha1::{
     self as pb, view_protocol_service_client::ViewProtocolServiceClient, WitnessRequest,
 };
@@ -294,7 +295,7 @@ where
         // same name as the one we're implementing.
         let params = ViewProtocolServiceClient::chain_parameters(
             self,
-            tonic::Request::new(pb::ChainParamsRequest {}),
+            tonic::Request::new(pb::ChainParametersRequest {}),
         )
         .await?
         .into_inner()
@@ -463,7 +464,7 @@ where
         // We have to manually invoke the method on the type, because it has the
         // same name as the one we're implementing.
         let pb_assets: Vec<_> =
-            ViewProtocolServiceClient::assets(self, tonic::Request::new(pb::AssetRequest {}))
+            ViewProtocolServiceClient::assets(self, tonic::Request::new(pb::AssetsRequest {}))
                 .await?
                 .into_inner()
                 .try_collect()
@@ -541,8 +542,10 @@ where
     ) -> Result<Vec<(u64, Transaction)>> {
         let pb_txs: Vec<_> = self
             .transactions(tonic::Request::new(pb::TransactionsRequest {
-                start_height,
-                end_height,
+                range: Some(Range {
+                    start_height,
+                    end_height,
+                }),
             }))
             .await?
             .into_inner()

--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -9,7 +9,7 @@ use penumbra_crypto::{
 };
 use penumbra_proto::{
     client::v1alpha1::{
-        oblivious_query_service_client::ObliviousQueryServiceClient, ChainParamsRequest,
+        oblivious_query_service_client::ObliviousQueryServiceClient, ChainParametersRequest,
     },
     Protobuf,
 };
@@ -59,7 +59,7 @@ impl Storage {
                 ObliviousQueryServiceClient::connect(format!("http://{}:{}", node, pd_port))
                     .await?;
             let params = client
-                .chain_parameters(tonic::Request::new(ChainParamsRequest {
+                .chain_parameters(tonic::Request::new(ChainParametersRequest {
                     chain_id: String::new(),
                 }))
                 .await?

--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -65,6 +65,7 @@ impl Storage {
                 .await?
                 .into_inner()
                 .try_into()?;
+
             Self::initialize(storage_path, fvk.clone(), params).await
         }
     }

--- a/view/src/worker.rs
+++ b/view/src/worker.rs
@@ -121,6 +121,8 @@ impl Worker {
             .asset_list(tonic::Request::new(AssetListRequest { chain_id }))
             .await?
             .into_inner()
+            .asset_list
+            .ok_or_else(|| anyhow::anyhow!("empty AssetListResponse message"))?
             .assets;
 
         for new_asset in assets {
@@ -233,7 +235,8 @@ impl Worker {
         });
 
         while let Some(block) = buffered_stream.recv().await {
-            let block = CompactBlock::try_from(block?)?;
+            let block: CompactBlock = block?.try_into()?;
+
             let height = block.height;
 
             // Lock the NCT only while processing this block.

--- a/wallet/src/build.rs
+++ b/wallet/src/build.rs
@@ -23,7 +23,10 @@ where
             account_id: fvk.hash(),
             plan: plan.clone(),
         })
-        .await?;
+        .await?
+        .data
+        .ok_or_else(|| anyhow::anyhow!("empty AuthorizeResponse message"))?
+        .try_into()?;
 
     // Send a witness request to the view service to get witness data
     let witness_data = view.witness(fvk.hash(), &mut rng, &plan).await?;

--- a/wallet/src/plan.rs
+++ b/wallet/src/plan.rs
@@ -309,6 +309,8 @@ where
                     })
                     .await?
                     .into_inner()
+                    .data
+                    .ok_or_else(|| anyhow::anyhow!("empty BatchSwapOutputResponse message"))?
                     .try_into()
                     .context("cannot parse batch swap output data")?;
 


### PR DESCRIPTION
This is the second half of #1469

- [x] define nested message types for all rpc methods
- [x] update rpc services to take in unique request/response types
- [x] define conversion traits for rpc "envelope" types, when relevant
    - [x] `From<DomainType> for SomeRpcRequest`
    - [x] `TryFrom<pb::SomeRpcResponse> for DomainType`
- [x] propagate changes through-out the codebase:
    - [x] pd (specific / oblivious)
    - [x] view service
    - [x] custody service
    - [x] pcli