### PR TITLE
ci: use authenticated pulls from docker hub

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,11 +1,14 @@
 name: Create and publish a Docker image
 
+# Build strategy: we want to build new containers
+# on merges into main branch (for testnet-preview)
+# and every tag (weekly testnet iterations).
 on:
   push:
     tags:
     - '**'
     branches:
-    - '**'
+    - main
 
 jobs:
   build-and-push-image:
@@ -24,12 +27,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Log in to the Container registry
+      - name: Log in to the GitHub container registry (for pushes)
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to the Docker Hub container registry (for pulls)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -15,7 +15,13 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-            
+
+      - name: Log in to the Docker Hub container registry (for pulls)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build the testnet.
         run: |
           ./scripts/docker_compose_freshstart.sh
@@ -30,7 +36,7 @@ jobs:
       - name: Now start testnet in the background so we can run integration tests.
         run: |
           docker-compose up --detach
-          
+
       # DOC: please update the devnet guide if you change this (see "How to run smoke-tests")
       - name: Run integration tests against localhost.
         run: cargo test --features nct-divergence-check --package pcli -- --ignored --test-threads 1 --nocapture


### PR DESCRIPTION
We hit API ratelimits for non-authenticated pulls from docker hub [0] while running a lot of CI jobs concurrently. The long-term solution to this problem is to add auth, which we've done, but in the process we decided that we were a bit overzealous with the frequency of container image builds.
    
[0] https://docs.docker.com/docker-hub/download-rate-limit/

Closes #1648.

Changes made out of band and not reflected in the diff:

* registered a docker hub account
* stored credentials in the usual place
* generated api token for hub account
* added api token to GitHub Actions "secrets", so it can be referenced in workflows
