### PR TITLE
deployment: use `rust:1.65.0-bullseye`

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
         with:
           input: 'proto'
-       - uses: bufbuild/buf-lint-action@v1
+      - uses: bufbuild/buf-lint-action@v1
         with:
           input: 'proto'
       # Disabled because we don't have any changes to compare against

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM rust:1-bullseye AS build-env
+FROM --platform=$BUILDPLATFORM rust:1.65.0-bullseye AS build-env
 
 RUN rustup component add rustfmt
 
@@ -75,7 +75,7 @@ RUN addgroup --gid 1000 -S penumbra && adduser --uid 1000 -S penumbra -G penumbr
 FROM busybox:1.34.1-musl AS busybox-full
 
 # Use TARGETARCH image for determining necessary libs
-FROM rust:1-bullseye as target-arch-libs
+FROM rust:1.65.0-bullseye as target-arch-libs
 RUN apt update && apt install -y clang libssl1.1 openssl
 
 # Determine library dependencies of built binaries and copy to indexed path in /root/lib_abs for copying to final image.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM rust:1-bullseye AS build-env
+FROM rust:1.65.0-bullseye AS build-env
 
 # Specify the cargo cache dir as a volume to improve build speed
 VOLUME ["/root/.cargo"]

--- a/docker-compose.multinode.override.yml
+++ b/docker-compose.multinode.override.yml
@@ -41,7 +41,7 @@ services:
 
   # The Tendermint node
   tendermint-node1:
-    image: "tendermint/tendermint:v0.34.21"
+    image: "tendermint/tendermint:v0.34.23"
     container_name: tendermint-node1
     ports:
       - "27656:26656"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
   # The Tendermint node
   tendermint-node0:
-    image: "tendermint/tendermint:v0.34.21"
+    image: "tendermint/tendermint:v0.34.23"
     container_name: tendermint-node0
     ports:
       - "26656:26656"

--- a/docs/guide/src/pcli/install.md
+++ b/docs/guide/src/pcli/install.md
@@ -56,7 +56,7 @@ latest tag for the current
 [testnet](https://github.com/penumbra-zone/penumbra/releases):
 
 ```bash
-cd penumbra && git fetch && git checkout 036-iocaste && cargo update
+cd penumbra && git fetch && git checkout 036-iocaste.1 && cargo update
 ```
 
 ### Building the `pcli` client software

--- a/docs/guide/src/pcli/update.md
+++ b/docs/guide/src/pcli/update.md
@@ -3,7 +3,7 @@
 Follow the [same steps](https://guide.penumbra.zone/main/pcli/install.html#cloning-the-repository) to update to the latest testnet [release](https://github.com/penumbra-zone/penumbra/releases)
 
 ```
-cd penumbra && git fetch && git checkout 036-iocaste && cargo update
+cd penumbra && git fetch && git checkout 036-iocaste.1 && cargo update
 ```
 
 Once again, build `pcli` with cargo


### PR DESCRIPTION
Testnet deployment failed because we use a stale docker rust image. This is a change to use `rust:1.65.0-bullseye`.