### PR TITLE
docs: no 'cargo update' during testnet upgrades

### DIFF
--- a/docs/guide/src/pcli/install.md
+++ b/docs/guide/src/pcli/install.md
@@ -56,7 +56,7 @@ latest tag for the current
 [testnet](https://github.com/penumbra-zone/penumbra/releases):
 
 ```bash
-cd penumbra && git fetch && git checkout 036-iocaste.2 && cargo update
+cd penumbra && git fetch && git checkout 036-iocaste.2
 ```
 
 ### Building the `pcli` client software

--- a/docs/guide/src/pcli/update.md
+++ b/docs/guide/src/pcli/update.md
@@ -3,7 +3,7 @@
 Follow the [same steps](https://guide.penumbra.zone/main/pcli/install.html#cloning-the-repository) to update to the latest testnet [release](https://github.com/penumbra-zone/penumbra/releases)
 
 ```
-cd penumbra && git fetch && git checkout 036-iocaste.2 && cargo update
+cd penumbra && git fetch && git checkout 036-iocaste.2
 ```
 
 Once again, build `pcli` with cargo


### PR DESCRIPTION
Running `cargo update` as currently recommended in the docs will cause local dependencies to get out of sync with tagged testnet version. We commit the `Cargo.lock` file in order to version lock dependencies; `cargo update` breaks that strict version locking. Worse, `cargo update` will result in a dirty git working tree, requiring manual cleanup (or `git stash`) on subsequent testnet upgrades. We don't document that manual cleanup, nor should we: we should expect that all nodes run exactly the versions of dependencies that we specify in Cargo.lock.