### PR TITLE
k8s testnet - public peering

### DIFF
--- a/deployments/networks/testnet/helm/templates/fn-deployments.yaml
+++ b/deployments/networks/testnet/helm/templates/fn-deployments.yaml
@@ -36,7 +36,7 @@ spec:
             claimName: "pvc-fn-{{ include "tendermint.name" $ }}-{{$i}}"
         - name: tm-config
           configMap:
-            name: tm-config-fn
+            name: "tm-config-fn-{{$i}}"
             items:
               - key: "config.toml"
                 path: "config.toml"

--- a/deployments/networks/testnet/helm/templates/fn-p2p-svcs.yaml
+++ b/deployments/networks/testnet/helm/templates/fn-p2p-svcs.yaml
@@ -24,6 +24,6 @@ spec:
     - protocol: TCP
       port: 8080
       targetPort: grpc
-      name: pd-grpc      
+      name: pd-grpc
 {{ end }}
 {{ end }}

--- a/deployments/networks/testnet/helm/templates/fn-tm-config.yaml
+++ b/deployments/networks/testnet/helm/templates/fn-tm-config.yaml
@@ -1,7 +1,10 @@
+{{ $count := (.Values.numFullNodes | int) }}
+{{ range $i,$e := until $count }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: tm-config-fn
+  name: "tm-config-fn-{{$i}}"
 data:
   config.toml: |
     proxy_app = "tcp://localhost:26658"
@@ -14,10 +17,11 @@ data:
     max_num_outbound-peers = 50
 
     persistent_peers = "{{ $.Files.Get "pdcli/persistent_peers.txt" | trim }}"
-    private_peer_ids = "{{ $.Files.Get "pdcli/private_peers.txt" | trim }}"
+    external_address = "{{ $.Files.Get (printf "pdcli/external_address_fn_%d.txt" $i) | trim }}"
 
     [tx_index]
     indexer = "null"
 
     [instrumentation]
     prometheus = true
+{{ end }}

--- a/deployments/networks/testnet/helm/templates/val-tm-configs.yaml
+++ b/deployments/networks/testnet/helm/templates/val-tm-configs.yaml
@@ -14,7 +14,7 @@ data:
     max_num_outbound-peers = 50
 
     persistent_peers = "{{ $.Files.Get (printf "pdcli/persistent_peers_%d.txt" $i) | trim }}"
-    private_peer_ids = "{{ $.Files.Get "pdcli/private_peers.txt" | trim }}"
+    external_address = "{{ $.Files.Get (printf "pdcli/external_address_val_%d.txt" $i) | trim }}"
 
     [tx_index]
     indexer = "null"


### PR DESCRIPTION
- Multi-stage deploy to inject tendermint p2p kube service IPs as the tendermint external p2p addr in each node's config.
- Removes private peers from config since external_address on each node is now be publicly routable