### PR TITLE
docs: add talks & presentations to resources page

### DIFF
--- a/docs/guide/src/resources.md
+++ b/docs/guide/src/resources.md
@@ -29,3 +29,13 @@ The protobuf documentation is rendered at [buf.build/penumbra-zone/penumbra][pro
 [rustdoc]: https://rustdoc.penumbra.zone
 [guide]: https://guide.penumbra.zone
 [protobuf]: https://buf.build/penumbra-zone/penumbra
+
+### Talks and presentations
+
+These talks were given at various conferences and events,
+describing different aspects of the Penumbra ecosystem.
+
+* [DevCon 2022: Building a Private DEX with ZKPs and Threshold Cryptography](https://www.youtube.com/watch?v=JjmOelgfqNo)
+* [ZK8: How to build a private DEX](https://www.youtube.com/watch?v=-ap9ja36EYU)
+* [ZK8: Tiered Merkle Topiary in Rust](https://www.youtube.com/watch?v=mHoe7lQMcxU)
+* [ZK Whiteboard Session: ZK Swaps](https://www.youtube.com/watch?v=ziUZyQmHh4c)


### PR DESCRIPTION
Simple change, trying to collect a few useful talks for folks who want to understand the platform better. There's an argument that this content should go on https://penumbra.zone, rather than https://guide.penumbra.zone, but we can always cross link later.

Things to check as part of review:

1. Are these talks reasonable ones to call attention to?
2. Are the links and titles accurate?
3. Is the guide a good enough place to link to these talks for now?