### PR TITLE
pd: clean up App message handling wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,7 +3069,6 @@ dependencies = [
  "hex",
  "http-body",
  "indicatif",
- "pd",
  "penumbra-chain",
  "penumbra-component",
  "penumbra-crypto",

--- a/component/src/app/mod.rs
+++ b/component/src/app/mod.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use anyhow::Result;
 use penumbra_chain::params::FmdParameters;
 use penumbra_chain::{genesis, AppHash, StateWriteExt as _};
-use penumbra_proto::StateWriteProto;
-use penumbra_storage::{State, StateTransaction, Storage};
+use penumbra_proto::{Protobuf, StateWriteProto};
+use penumbra_storage::{State, Storage};
 use penumbra_transaction::Transaction;
 use tendermint::abci::{self, types::ValidatorUpdate};
 use tracing::instrument;
@@ -90,10 +90,19 @@ impl App {
         state_tx.apply()
     }
 
+    /// Wrapper function for [`Self::deliver_tx`]  that decodes from bytes.
+    pub async fn deliver_tx_bytes(&mut self, tx_bytes: &[u8]) -> Result<Vec<abci::Event>> {
+        let tx = Arc::new(Transaction::decode(tx_bytes)?);
+        self.deliver_tx(tx).await
+    }
+
     #[instrument(skip(self, tx))]
     pub async fn deliver_tx(&mut self, tx: Arc<Transaction>) -> Result<Vec<abci::Event>> {
-        Self::check_tx_stateless(tx.clone())?;
-        Self::check_tx_stateful(self.state.clone(), tx.clone()).await?;
+        // Both stateful and stateless checks take the transaction as
+        // verification context.  The separate clone of the Arc<Transaction>
+        // means it can be passed through the whole tree of checks.
+        tx.check_stateless(tx.clone())?;
+        tx.check_stateful(self.state.clone(), tx.clone()).await?;
 
         // We need to get a mutable reference to the State here, so we use
         // `Arc::get_mut`. At this point, the stateful checks should have completed,
@@ -101,8 +110,7 @@ impl App {
         let state =
             Arc::get_mut(&mut self.state).expect("state Arc should not be referenced elsewhere");
         let mut state_tx = state.begin_transaction();
-
-        Self::execute_tx(&mut state_tx, tx).await?;
+        tx.execute(&mut state_tx).await?;
 
         // At this point, we've completed execution successfully with no errors,
         // so we can apply the transaction to the State. Otherwise, we'd have
@@ -134,14 +142,17 @@ impl App {
     ///
     /// TODO: why does this return Result?
     #[instrument(skip(self, storage))]
-    pub async fn commit(&mut self, storage: Storage) -> Result<AppHash> {
+    pub async fn commit(&mut self, storage: Storage) -> AppHash {
         // We need to extract the State we've built up to commit it.  Fill in a dummy state.
         let dummy_state = storage.latest_state();
         let state = Arc::try_unwrap(std::mem::replace(&mut self.state, Arc::new(dummy_state)))
             .expect("we have exclusive ownership of the State at commit()");
 
         // Commit the pending writes, clearing the state.
-        let jmt_root = storage.commit(state).await?;
+        let jmt_root = storage
+            .commit(state)
+            .await
+            .expect("must be able to successfully commit to storage");
         let app_hash: AppHash = jmt_root.into();
 
         tracing::debug!(?app_hash, "finished committing state");
@@ -149,7 +160,7 @@ impl App {
         // Get the latest version of the state, now that we've committed it.
         self.state = Arc::new(storage.latest_state());
 
-        Ok(app_hash)
+        app_hash
     }
 
     // TODO: should this just be returned by `commit`? both are called during every `EndBlock`
@@ -162,15 +173,5 @@ impl App {
     #[instrument(skip(tx))]
     pub fn check_tx_stateless(tx: Arc<Transaction>) -> Result<()> {
         tx.check_stateless(tx.clone())
-    }
-
-    #[instrument(skip(state, tx))]
-    async fn check_tx_stateful(state: Arc<State>, tx: Arc<Transaction>) -> Result<()> {
-        tx.check_stateful(state.clone(), tx.clone()).await
-    }
-
-    #[instrument(skip(state, tx))]
-    async fn execute_tx(state: &mut StateTransaction<'_>, tx: Arc<Transaction>) -> Result<()> {
-        tx.execute(state).await
     }
 }

--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -3,13 +3,15 @@ use penumbra_chain::genesis;
 use penumbra_storage::StateTransaction;
 use tendermint::abci;
 
-pub mod action_handler;
+mod action_handler;
 pub mod app;
 pub mod dex;
 pub mod governance;
 pub mod ibc;
 pub mod shielded_pool;
 pub mod stake;
+
+pub use action_handler::ActionHandler;
 
 /// A component of the Penumbra application.
 #[async_trait]

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -27,7 +27,6 @@ penumbra-custody = { path = "../custody" }
 penumbra-tct = { path = "../tct" }
 # TODO: replace by a penumbra-app
 penumbra-component = { path = "../component" }
-pd = { path = "../pd" }
 
 # Penumbra dependencies
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
@@ -53,7 +52,7 @@ tokio-util = "0.6"
 tower = { version = "0.4", features = ["full"] }
 tracing = "0.1"
 tonic = "0.8.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
 pin-project = "1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context as _, Result};
+use penumbra_component::ActionHandler;
 use penumbra_crypto::Nullifier;
 use penumbra_proto::{
     client::v1alpha1::{
@@ -61,7 +62,6 @@ impl App {
         await_detection_of_nullifier: Option<Nullifier>,
     ) -> Result<(), anyhow::Error> {
         println!("pre-checking transaction...");
-        use penumbra_component::ActionHandler;
         transaction
             .check_stateless(std::sync::Arc::new(transaction.clone()))
             .context("transaction pre-submission checks failed")?;

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -61,7 +61,9 @@ impl App {
         await_detection_of_nullifier: Option<Nullifier>,
     ) -> Result<(), anyhow::Error> {
         println!("pre-checking transaction...");
-        pd::App::check_tx_stateless(std::sync::Arc::new(transaction.clone()))
+        use penumbra_component::ActionHandler;
+        transaction
+            .check_stateless(std::sync::Arc::new(transaction.clone()))
             .context("transaction pre-submission checks failed")?;
 
         println!("broadcasting transaction...");


### PR DESCRIPTION
This does some minor tidying on the code we use to pass messages into the `App`, and breaks the dependency of `pcli` on `pd` (which we don't really need, we only want to be able to do stateless checks pre-submission).