### PR TITLE
pd: avoid two levels of defaults in ChainParameters

### DIFF
--- a/chain/src/params.rs
+++ b/chain/src/params.rs
@@ -181,8 +181,8 @@ impl Default for ChainParameters {
         Self {
             chain_id: String::new(),
             epoch_duration: 719,
-            unbonding_epochs: 30,
-            active_validator_limit: 10,
+            unbonding_epochs: 2,
+            active_validator_limit: 80,
             // copied from cosmos hub
             signed_blocks_window_len: 10000,
             missed_blocks_maximum: 9500,

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -80,14 +80,14 @@ enum TestnetCommand {
     /// configuration.
     Generate {
         /// Number of blocks per epoch.
-        #[clap(long, default_value = "719")]
-        epoch_duration: u64,
+        #[clap(long)]
+        epoch_duration: Option<u64>,
         /// Number of epochs before unbonding stake is released.
-        #[clap(long, default_value = "2")]
-        unbonding_epochs: u64,
+        #[clap(long)]
+        unbonding_epochs: Option<u64>,
         /// Maximum number of validators in the consensus set.
-        #[clap(long, default_value = "32")]
-        active_validator_limit: u64,
+        #[clap(long)]
+        active_validator_limit: Option<u64>,
         /// Whether to preserve the chain ID (useful for public testnets) or append a random suffix (useful for dev/testing).
         #[clap(long)]
         preserve_chain_id: bool,
@@ -516,6 +516,12 @@ async fn main() -> anyhow::Result<()> {
                     })
                 })
                 .collect::<Result<Vec<Validator>, anyhow::Error>>()?;
+
+            let default_params = ChainParameters::default();
+            let active_validator_limit =
+                active_validator_limit.unwrap_or(default_params.active_validator_limit);
+            let epoch_duration = epoch_duration.unwrap_or(default_params.epoch_duration);
+            let unbonding_epochs = unbonding_epochs.unwrap_or(default_params.unbonding_epochs);
 
             let app_state = genesis::AppState {
                 allocations: allocations.clone(),


### PR DESCRIPTION
This commit changes the Clap arguments for `pd testnet generate` to not include a second set of default values for chain parameters beyond those already specified in `ChainParameters::default()`, so we only have one place to look.

Also increase the default validator limit to 80.

Co-Authored-By: Conor Schaefer <conor@penumbra.zone>