### PR TITLE
component: better test infrastructure

### DIFF
--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -4,6 +4,10 @@ use penumbra_storage::StateTransaction;
 use tendermint::abci;
 
 mod action_handler;
+
+mod temp_storage_ext;
+pub use temp_storage_ext::TempStorageExt;
+
 pub mod app;
 pub mod dex;
 pub mod governance;

--- a/component/src/temp_storage_ext.rs
+++ b/component/src/temp_storage_ext.rs
@@ -1,0 +1,34 @@
+use std::ops::Deref;
+
+use async_trait::async_trait;
+use penumbra_chain::genesis;
+use penumbra_storage::TempStorage;
+
+use crate::app::App;
+
+#[async_trait]
+pub trait TempStorageExt: Sized {
+    async fn apply_genesis(self, genesis: genesis::AppState) -> anyhow::Result<Self>;
+    async fn apply_default_genesis(self) -> anyhow::Result<Self>;
+}
+
+#[async_trait]
+impl TempStorageExt for TempStorage {
+    async fn apply_genesis(self, genesis: genesis::AppState) -> anyhow::Result<Self> {
+        // Check that we haven't already applied a genesis state:
+        if self.latest_version() != u64::MAX {
+            return Err(anyhow::anyhow!("database already initialized"));
+        }
+
+        // Apply the genesis state to the storage
+        let mut app = App::new(self.latest_state());
+        app.init_chain(&genesis).await;
+        app.commit(self.deref().clone()).await;
+
+        Ok(self)
+    }
+
+    async fn apply_default_genesis(self) -> anyhow::Result<Self> {
+        self.apply_genesis(Default::default()).await
+    }
+}

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -45,5 +45,5 @@ mod storage;
 pub use crate::metrics::register_metrics;
 pub use jmt::{ics23_spec, RootHash};
 pub use snapshot::Snapshot;
-pub use state::{State, StateRead, StateTransaction, StateWrite};
-pub use storage::{StateNotification, Storage};
+pub use state::{ArcStateExt, State, StateRead, StateTransaction, StateWrite};
+pub use storage::{StateNotification, Storage, TempStorage};

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -14,6 +14,9 @@ use crate::snapshot::Snapshot;
 use crate::snapshot_cache::SnapshotCache;
 use crate::State;
 
+mod temp;
+pub use temp::TempStorage;
+
 /// A handle for a storage instance, backed by RocksDB.
 ///
 /// The handle is cheaply clonable; all clones share the same backing data store.

--- a/storage/src/storage/temp.rs
+++ b/storage/src/storage/temp.rs
@@ -1,0 +1,30 @@
+use crate::Storage;
+use anyhow;
+use std::ops::Deref;
+use tempfile::TempDir;
+
+/// A [`Storage`] instance backed by a [`tempfile::TempDir`] for testing.
+///
+/// The `TempDir` handle is bundled into the `TempStorage`, so the temporary
+/// directory is cleaned up when the `TempStorage` instance is dropped.
+pub struct TempStorage {
+    inner: Storage,
+    _dir: TempDir,
+}
+
+impl Deref for TempStorage {
+    type Target = Storage;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl TempStorage {
+    pub async fn new() -> Result<Self, anyhow::Error> {
+        let dir = tempfile::tempdir()?;
+        let db_filepath = dir.path().join("storage.db");
+        let inner = Storage::load(db_filepath.clone()).await?;
+
+        Ok(TempStorage { inner, _dir: dir })
+    }
+}

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -45,6 +45,23 @@ pub struct Transaction {
     pub anchor: tct::Root,
 }
 
+impl Default for Transaction {
+    fn default() -> Self {
+        Transaction {
+            transaction_body: TransactionBody {
+                actions: Default::default(),
+                expiry_height: Default::default(),
+                chain_id: Default::default(),
+                fee: Default::default(),
+                fmd_clues: Default::default(),
+                memo: None,
+            },
+            binding_sig: [0u8; 64].into(),
+            anchor: tct::Tree::new().root(),
+        }
+    }
+}
+
 impl Transaction {
     pub fn payload_keys(
         &self,


### PR DESCRIPTION
Work towards #1664

Closes #853

This commit cleans up the IBC client test as an example case of the new API.

Along the way, we also clean up some other ergonomic pain points, notably adding an `Arc<State>::try_begin_transaction()` method.

Co-Authored-By: Conor Schaefer <conor@penumbra.zone>