### PR TITLE
Tweaks to `ActionHandler` trait.

### DIFF
--- a/component/src/action_handler.rs
+++ b/component/src/action_handler.rs
@@ -25,7 +25,7 @@ pub trait ActionHandler {
     /// This method should only be called on transactions that have been
     /// checked with [`Component::check_tx_stateless`].
     /// This method can be called before [`Component::begin_block`].
-    async fn check_stateful(&self, state: Arc<State>, context: Arc<Transaction>) -> Result<()>;
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()>;
 
     /// Executes the given [`Transaction`] against the current state.
     ///

--- a/component/src/action_handler.rs
+++ b/component/src/action_handler.rs
@@ -15,7 +15,7 @@ mod transaction;
 pub trait ActionHandler {
     /// Performs all of this component's stateless validity checks in the context of
     /// the given [`Transaction`].
-    fn check_stateless(&self, context: Arc<Transaction>) -> Result<()>;
+    async fn check_stateless(&self, context: Arc<Transaction>) -> Result<()>;
 
     /// Performs all of this component's stateful validity checks in the context of the given
     /// [`Transaction`].

--- a/component/src/action_handler/actions.rs
+++ b/component/src/action_handler/actions.rs
@@ -23,7 +23,7 @@ mod validator_vote;
 
 #[async_trait]
 impl ActionHandler for Action {
-    fn check_stateless(&self, context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, context: Arc<Transaction>) -> Result<()> {
         match self {
             Action::Delegate(action) => action.check_stateless(context),
             Action::Undelegate(action) => action.check_stateless(context),
@@ -42,6 +42,7 @@ impl ActionHandler for Action {
             Action::IBCAction(action) => action.check_stateless(context),
             Action::Ics20Withdrawal(action) => action.check_stateless(context),
         }
+        .await
     }
 
     async fn check_stateful(&self, state: Arc<State>, context: Arc<Transaction>) -> Result<()> {

--- a/component/src/action_handler/actions.rs
+++ b/component/src/action_handler/actions.rs
@@ -45,37 +45,32 @@ impl ActionHandler for Action {
         .await
     }
 
-    async fn check_stateful(&self, state: Arc<State>, context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         match self {
-            Action::Delegate(action) => action.check_stateful(state, context.clone()).await,
-            Action::Undelegate(action) => action.check_stateful(state, context.clone()).await,
-            Action::ValidatorDefinition(action) => {
-                action.check_stateful(state, context.clone()).await
-            }
-            Action::ValidatorVote(action) => action.check_stateful(state, context.clone()).await,
-            Action::PositionClose(action) => action.check_stateful(state, context.clone()).await,
-            Action::PositionOpen(action) => action.check_stateful(state, context.clone()).await,
-            Action::PositionRewardClaim(action) => {
-                action.check_stateful(state, context.clone()).await
-            }
-            Action::PositionWithdraw(action) => action.check_stateful(state, context.clone()).await,
-            Action::ProposalSubmit(action) => action.check_stateful(state, context.clone()).await,
-            Action::ProposalWithdraw(action) => action.check_stateful(state, context.clone()).await,
-            Action::Swap(action) => action.check_stateful(state, context.clone()).await,
-            Action::SwapClaim(action) => action.check_stateful(state, context.clone()).await,
-            Action::Spend(action) => action.check_stateful(state, context.clone()).await,
-            Action::Output(action) => action.check_stateful(state, context.clone()).await,
+            Action::Delegate(action) => action.check_stateful(state).await,
+            Action::Undelegate(action) => action.check_stateful(state).await,
+            Action::ValidatorDefinition(action) => action.check_stateful(state).await,
+            Action::ValidatorVote(action) => action.check_stateful(state).await,
+            Action::PositionClose(action) => action.check_stateful(state).await,
+            Action::PositionOpen(action) => action.check_stateful(state).await,
+            Action::PositionRewardClaim(action) => action.check_stateful(state).await,
+            Action::PositionWithdraw(action) => action.check_stateful(state).await,
+            Action::ProposalSubmit(action) => action.check_stateful(state).await,
+            Action::ProposalWithdraw(action) => action.check_stateful(state).await,
+            Action::Swap(action) => action.check_stateful(state).await,
+            Action::SwapClaim(action) => action.check_stateful(state).await,
+            Action::Spend(action) => action.check_stateful(state).await,
+            Action::Output(action) => action.check_stateful(state).await,
             Action::IBCAction(action) => {
-                if context.ibc_actions().count() > 0 && !state.get_chain_params().await?.ibc_enabled
-                {
+                if !state.get_chain_params().await?.ibc_enabled {
                     return Err(anyhow::anyhow!(
                         "transaction contains IBC actions, but IBC is not enabled"
                     ));
                 }
 
-                action.check_stateful(state, context.clone()).await
+                action.check_stateful(state).await
             }
-            Action::Ics20Withdrawal(action) => action.check_stateful(state, context.clone()).await,
+            Action::Ics20Withdrawal(action) => action.check_stateful(state).await,
         }
     }
 

--- a/component/src/action_handler/actions/delegate.rs
+++ b/component/src/action_handler/actions/delegate.rs
@@ -14,7 +14,7 @@ use crate::{
 #[async_trait]
 impl ActionHandler for Delegate {
     #[instrument(name = "delegate", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // There are no stateless checks specific to this action.
         Ok(())
     }

--- a/component/src/action_handler/actions/delegate.rs
+++ b/component/src/action_handler/actions/delegate.rs
@@ -19,8 +19,8 @@ impl ActionHandler for Delegate {
         Ok(())
     }
 
-    #[instrument(name = "delegate", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "delegate", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         let d = self;
         let next_rate_data = state
             .next_validator_rate(&d.validator_identity)

--- a/component/src/action_handler/actions/ibc_action.rs
+++ b/component/src/action_handler/actions/ibc_action.rs
@@ -122,83 +122,83 @@ impl ActionHandler for IbcAction {
         Ok(())
     }
 
-    #[instrument(name = "ibc_action", skip(self, state, context))]
-    async fn check_stateful(&self, state: Arc<State>, context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "ibc_action", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         match &self.action {
             Some(CreateClient(msg)) => {
                 let msg = MsgCreateAnyClient::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(UpdateClient(msg)) => {
                 let msg = MsgUpdateAnyClient::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(ChannelOpenInit(msg)) => {
                 let msg = MsgChannelOpenInit::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(ChannelOpenTry(msg)) => {
                 let msg = MsgChannelOpenTry::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(ChannelOpenAck(msg)) => {
                 let msg = MsgChannelOpenAck::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(ChannelOpenConfirm(msg)) => {
                 let msg = MsgChannelOpenConfirm::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(ChannelCloseInit(msg)) => {
                 let msg = MsgChannelCloseInit::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(ChannelCloseConfirm(msg)) => {
                 let msg = MsgChannelCloseConfirm::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(RecvPacket(msg)) => {
                 let msg = MsgRecvPacket::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(Acknowledgement(msg)) => {
                 let msg = MsgAcknowledgement::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(Timeout(msg)) => {
                 let msg = MsgTimeout::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(ConnectionOpenInit(msg)) => {
                 let msg = MsgConnectionOpenInit::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(ConnectionOpenTry(msg)) => {
                 let msg = MsgConnectionOpenTry::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(ConnectionOpenAck(msg)) => {
                 let msg = MsgConnectionOpenAck::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             Some(ConnectionOpenConfirm(msg)) => {
                 let msg = MsgConnectionOpenConfirm::try_from(msg.clone())?;
 
-                msg.check_stateful(state, context).await?;
+                msg.check_stateful(state).await?;
             }
             _ => {}
         }

--- a/component/src/action_handler/actions/ibc_action.rs
+++ b/component/src/action_handler/actions/ibc_action.rs
@@ -34,7 +34,7 @@ mod msg;
 #[async_trait]
 impl ActionHandler for IbcAction {
     #[instrument(name = "ibc_action", skip(self, context))]
-    fn check_stateless(&self, context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, context: Arc<Transaction>) -> Result<()> {
         // Each stateless check is a distinct function in an appropriate submodule,
         // so that we can easily add new stateless checks and see a birds' eye view
         // of all of the checks we're performing.
@@ -43,78 +43,78 @@ impl ActionHandler for IbcAction {
             Some(CreateClient(msg)) => {
                 let msg = MsgCreateAnyClient::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(UpdateClient(msg)) => {
                 let msg = MsgUpdateAnyClient::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(ChannelOpenInit(msg)) => {
                 let msg = MsgChannelOpenInit::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(ChannelOpenTry(msg)) => {
                 let msg = MsgChannelOpenTry::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(ChannelOpenAck(msg)) => {
                 let msg = MsgChannelOpenAck::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(ChannelOpenConfirm(msg)) => {
                 let msg = MsgChannelOpenConfirm::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(ChannelCloseInit(msg)) => {
                 let msg = MsgChannelCloseInit::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(ChannelCloseConfirm(msg)) => {
                 let msg = MsgChannelCloseConfirm::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(RecvPacket(msg)) => {
                 let msg = MsgRecvPacket::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(Acknowledgement(msg)) => {
                 let msg = MsgAcknowledgement::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(Timeout(msg)) => {
                 let msg = MsgTimeout::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(ConnectionOpenInit(msg)) => {
                 let msg = MsgConnectionOpenInit::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(ConnectionOpenTry(msg)) => {
                 let msg = MsgConnectionOpenTry::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             Some(ConnectionOpenAck(msg)) => {
                 let msg = MsgConnectionOpenAck::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
 
             Some(ConnectionOpenConfirm(msg)) => {
                 let msg = MsgConnectionOpenConfirm::try_from(msg.clone())?;
 
-                msg.check_stateless(context)?;
+                msg.check_stateless(context).await?;
             }
             _ => {}
         }

--- a/component/src/action_handler/actions/ibc_action/msg/acknowledgement.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/acknowledgement.rs
@@ -23,8 +23,8 @@ impl ActionHandler for MsgAcknowledgement {
         Ok(())
     }
 
-    #[instrument(name = "acknowledgement", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "acknowledgement", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
         let transfer = PortId::transfer();
         if self.packet.destination_port == transfer {

--- a/component/src/action_handler/actions/ibc_action/msg/acknowledgement.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/acknowledgement.rs
@@ -17,7 +17,7 @@ use crate::ibc::transfer::Ics20Transfer;
 #[async_trait]
 impl ActionHandler for MsgAcknowledgement {
     #[instrument(name = "acknowledgement", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // NOTE: no additional stateless validation is possible
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/channel_close_confirm.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/channel_close_confirm.rs
@@ -17,7 +17,7 @@ use crate::ibc::transfer::Ics20Transfer;
 #[async_trait]
 impl ActionHandler for MsgChannelCloseConfirm {
     #[instrument(name = "channel_close_confirm", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // NOTE: no additional stateless validation is possible
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/channel_close_confirm.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/channel_close_confirm.rs
@@ -23,8 +23,8 @@ impl ActionHandler for MsgChannelCloseConfirm {
         Ok(())
     }
 
-    #[instrument(name = "channel_close_confirm", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "channel_close_confirm", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
         let transfer = PortId::transfer();
         if self.port_id == transfer {

--- a/component/src/action_handler/actions/ibc_action/msg/channel_close_init.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/channel_close_init.rs
@@ -23,8 +23,8 @@ impl ActionHandler for MsgChannelCloseInit {
         Ok(())
     }
 
-    #[instrument(name = "channel_close_init", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "channel_close_init", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
         let transfer = PortId::transfer();
         if self.port_id == transfer {

--- a/component/src/action_handler/actions/ibc_action/msg/channel_close_init.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/channel_close_init.rs
@@ -17,7 +17,7 @@ use crate::ibc::transfer::Ics20Transfer;
 #[async_trait]
 impl ActionHandler for MsgChannelCloseInit {
     #[instrument(name = "channel_close_init", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // NOTE: no additional stateless validation is possible
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/channel_open_ack.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/channel_open_ack.rs
@@ -17,7 +17,7 @@ use crate::ibc::transfer::Ics20Transfer;
 #[async_trait]
 impl ActionHandler for MsgChannelOpenAck {
     #[instrument(name = "channel_open_ack", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // NOTE: no additional stateless validation is possible
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/channel_open_ack.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/channel_open_ack.rs
@@ -23,8 +23,8 @@ impl ActionHandler for MsgChannelOpenAck {
         Ok(())
     }
 
-    #[instrument(name = "channel_open_ack", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "channel_open_ack", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
         let transfer = PortId::transfer();
         if self.port_id == transfer {

--- a/component/src/action_handler/actions/ibc_action/msg/channel_open_confirm.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/channel_open_confirm.rs
@@ -17,7 +17,7 @@ use crate::ibc::transfer::Ics20Transfer;
 #[async_trait]
 impl ActionHandler for MsgChannelOpenConfirm {
     #[instrument(name = "channel_open_confirm", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // NOTE: no additional stateless validation is possible
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/channel_open_confirm.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/channel_open_confirm.rs
@@ -23,8 +23,8 @@ impl ActionHandler for MsgChannelOpenConfirm {
         Ok(())
     }
 
-    #[instrument(name = "channel_open_confirm", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "channel_open_confirm", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
         let transfer = PortId::transfer();
         if self.port_id == transfer {

--- a/component/src/action_handler/actions/ibc_action/msg/channel_open_init.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/channel_open_init.rs
@@ -18,7 +18,7 @@ use crate::ibc::transfer::Ics20Transfer;
 #[async_trait]
 impl ActionHandler for MsgChannelOpenInit {
     #[instrument(name = "channel_open_init", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         connection_hops_eq_1(self)?;
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/channel_open_init.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/channel_open_init.rs
@@ -24,8 +24,8 @@ impl ActionHandler for MsgChannelOpenInit {
         Ok(())
     }
 
-    #[instrument(name = "channel_open_init", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "channel_open_init", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
         let transfer = PortId::transfer();
         if self.port_id == transfer {

--- a/component/src/action_handler/actions/ibc_action/msg/channel_open_try.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/channel_open_try.rs
@@ -18,7 +18,7 @@ use crate::ibc::transfer::Ics20Transfer;
 #[async_trait]
 impl ActionHandler for MsgChannelOpenTry {
     #[instrument(name = "channel_open_try", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         connection_hops_eq_1(self)?;
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/channel_open_try.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/channel_open_try.rs
@@ -24,8 +24,8 @@ impl ActionHandler for MsgChannelOpenTry {
         Ok(())
     }
 
-    #[instrument(name = "channel_open_try", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "channel_open_try", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
         let transfer = PortId::transfer();
         if self.port_id == transfer {

--- a/component/src/action_handler/actions/ibc_action/msg/connection_open_ack.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/connection_open_ack.rs
@@ -25,8 +25,8 @@ impl ActionHandler for MsgConnectionOpenAck {
         Ok(())
     }
 
-    #[instrument(name = "connection_open_ack", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "connection_open_ack", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/connection_open_ack.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/connection_open_ack.rs
@@ -17,7 +17,7 @@ use crate::ibc::component::connection::stateless::connection_open_ack::{
 #[async_trait]
 impl ActionHandler for MsgConnectionOpenAck {
     #[instrument(name = "connection_open_ack", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         has_client_state(self)?;
         has_client_proof(self)?;
         has_consensus_proof(self)?;

--- a/component/src/action_handler/actions/ibc_action/msg/connection_open_confirm.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/connection_open_confirm.rs
@@ -14,7 +14,7 @@ use crate::ibc::component::connection::stateful::connection_open_confirm::Connec
 #[async_trait]
 impl ActionHandler for MsgConnectionOpenConfirm {
     #[instrument(name = "connection_open_confirm", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // NOTE: other than that the message is a well formed ConnectionOpenConfirm,
         // there is no other stateless validation to perform.
 

--- a/component/src/action_handler/actions/ibc_action/msg/connection_open_confirm.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/connection_open_confirm.rs
@@ -21,8 +21,8 @@ impl ActionHandler for MsgConnectionOpenConfirm {
         Ok(())
     }
 
-    #[instrument(name = "connection_open_confirm", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "connection_open_confirm", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/connection_open_init.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/connection_open_init.rs
@@ -21,8 +21,8 @@ impl ActionHandler for MsgConnectionOpenInit {
         Ok(())
     }
 
-    #[instrument(name = "connection_open_init", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "connection_open_init", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/connection_open_init.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/connection_open_init.rs
@@ -15,7 +15,7 @@ use crate::ibc::component::connection::stateless::connection_open_init::version_
 #[async_trait]
 impl ActionHandler for MsgConnectionOpenInit {
     #[instrument(name = "connection_open_init", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         version_is_supported(self)?;
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/connection_open_try.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/connection_open_try.rs
@@ -25,8 +25,8 @@ impl ActionHandler for MsgConnectionOpenTry {
         Ok(())
     }
 
-    #[instrument(name = "connection_open_try", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "connection_open_try", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/connection_open_try.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/connection_open_try.rs
@@ -17,7 +17,7 @@ use crate::ibc::component::connection::stateless::connection_open_try::{
 #[async_trait]
 impl ActionHandler for MsgConnectionOpenTry {
     #[instrument(name = "connection_open_try", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         has_client_state(self)?;
         has_client_proof(self)?;
         has_consensus_proof(self)?;

--- a/component/src/action_handler/actions/ibc_action/msg/create_client.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/create_client.rs
@@ -24,8 +24,8 @@ impl ActionHandler for MsgCreateAnyClient {
         Ok(())
     }
 
-    #[instrument(name = "ibc_action", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "ibc_action", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/create_client.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/create_client.rs
@@ -17,7 +17,7 @@ use crate::ibc::component::client::{
 #[async_trait]
 impl ActionHandler for MsgCreateAnyClient {
     #[instrument(name = "ibc_action", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         client_state_is_tendermint(self)?;
         consensus_state_is_tendermint(self)?;
 

--- a/component/src/action_handler/actions/ibc_action/msg/recv_packet.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/recv_packet.rs
@@ -23,8 +23,8 @@ impl ActionHandler for MsgRecvPacket {
         Ok(())
     }
 
-    #[instrument(name = "recv_packet", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "recv_packet", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
         let transfer = PortId::transfer();
         if self.packet.destination_port == transfer {

--- a/component/src/action_handler/actions/ibc_action/msg/recv_packet.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/recv_packet.rs
@@ -17,7 +17,7 @@ use crate::ibc::transfer::Ics20Transfer;
 #[async_trait]
 impl ActionHandler for MsgRecvPacket {
     #[instrument(name = "recv_packet", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // NOTE: no additional stateless validation is possible
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/timeout.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/timeout.rs
@@ -17,7 +17,7 @@ use crate::ibc::transfer::Ics20Transfer;
 #[async_trait]
 impl ActionHandler for MsgTimeout {
     #[instrument(name = "timeout", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // NOTE: no additional stateless validation is possible
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/timeout.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/timeout.rs
@@ -23,8 +23,8 @@ impl ActionHandler for MsgTimeout {
         Ok(())
     }
 
-    #[instrument(name = "timeout", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "timeout", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
         let transfer = PortId::transfer();
         if self.packet.destination_port == transfer {

--- a/component/src/action_handler/actions/ibc_action/msg/update_client.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/update_client.rs
@@ -22,8 +22,8 @@ impl ActionHandler for MsgUpdateAnyClient {
         Ok(())
     }
 
-    #[instrument(name = "ibc_action", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "ibc_action", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.validate(self).await?;
 
         Ok(())

--- a/component/src/action_handler/actions/ibc_action/msg/update_client.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/update_client.rs
@@ -16,7 +16,7 @@ use crate::ibc::component::client::{
 #[async_trait]
 impl ActionHandler for MsgUpdateAnyClient {
     #[instrument(name = "ibc_action", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         header_is_tendermint(self)?;
 
         Ok(())

--- a/component/src/action_handler/actions/ics20/withdrawal.rs
+++ b/component/src/action_handler/actions/ics20/withdrawal.rs
@@ -16,8 +16,8 @@ impl ActionHandler for Ics20Withdrawal {
         self.validate()
     }
 
-    #[instrument(name = "ics20_withdrawal", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "ics20_withdrawal", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         state.withdrawal_check(self).await
     }
 

--- a/component/src/action_handler/actions/ics20/withdrawal.rs
+++ b/component/src/action_handler/actions/ics20/withdrawal.rs
@@ -12,7 +12,7 @@ use crate::ibc::transfer::Ics20TransferReadExt as _;
 #[async_trait]
 impl ActionHandler for Ics20Withdrawal {
     #[instrument(name = "ics20_withdrawal", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         self.validate()
     }
 

--- a/component/src/action_handler/actions/output.rs
+++ b/component/src/action_handler/actions/output.rs
@@ -11,7 +11,7 @@ use crate::action_handler::ActionHandler;
 #[async_trait]
 impl ActionHandler for Output {
     #[instrument(name = "output", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         let output = self;
         if output
             .proof

--- a/component/src/action_handler/actions/output.rs
+++ b/component/src/action_handler/actions/output.rs
@@ -29,8 +29,8 @@ impl ActionHandler for Output {
         Ok(())
     }
 
-    #[instrument(name = "output", skip(self, _state, _context))]
-    async fn check_stateful(&self, _state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "output", skip(self, _state))]
+    async fn check_stateful(&self, _state: Arc<State>) -> Result<()> {
         // No `Output`-specific stateful checks to perform; all checks are
         // performed at the `Transaction` level.
         Ok(())

--- a/component/src/action_handler/actions/position/close.rs
+++ b/component/src/action_handler/actions/position/close.rs
@@ -18,8 +18,8 @@ impl ActionHandler for PositionClose {
         Err(anyhow::anyhow!("lp actions not supported yet"))
     }
 
-    #[instrument(name = "position_close", skip(self, _state, _context))]
-    async fn check_stateful(&self, _state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "position_close", skip(self, _state))]
+    async fn check_stateful(&self, _state: Arc<State>) -> Result<()> {
         // It's important to reject all LP actions for now, to prevent
         // inflation / minting bugs until we implement all required checks
         // (e.g., minting tokens by withdrawing reserves we don't check)

--- a/component/src/action_handler/actions/position/close.rs
+++ b/component/src/action_handler/actions/position/close.rs
@@ -11,7 +11,7 @@ use crate::action_handler::ActionHandler;
 #[async_trait]
 impl ActionHandler for PositionClose {
     #[instrument(name = "position_close", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // It's important to reject all LP actions for now, to prevent
         // inflation / minting bugs until we implement all required checks
         // (e.g., minting tokens by withdrawing reserves we don't check)

--- a/component/src/action_handler/actions/position/open.rs
+++ b/component/src/action_handler/actions/position/open.rs
@@ -11,7 +11,7 @@ use crate::action_handler::ActionHandler;
 #[async_trait]
 impl ActionHandler for PositionOpen {
     #[instrument(name = "position_open", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // It's important to reject all LP actions for now, to prevent
         // inflation / minting bugs until we implement all required checks
         // (e.g., minting tokens by withdrawing reserves we don't check)

--- a/component/src/action_handler/actions/position/open.rs
+++ b/component/src/action_handler/actions/position/open.rs
@@ -18,8 +18,8 @@ impl ActionHandler for PositionOpen {
         Err(anyhow::anyhow!("lp actions not supported yet"))
     }
 
-    #[instrument(name = "position_close", skip(self, _state, _context))]
-    async fn check_stateful(&self, _state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "position_close", skip(self, _state))]
+    async fn check_stateful(&self, _state: Arc<State>) -> Result<()> {
         // It's important to reject all LP actions for now, to prevent
         // inflation / minting bugs until we implement all required checks
         // (e.g., minting tokens by withdrawing reserves we don't check)

--- a/component/src/action_handler/actions/position/reward_claim.rs
+++ b/component/src/action_handler/actions/position/reward_claim.rs
@@ -11,7 +11,7 @@ use crate::action_handler::ActionHandler;
 #[async_trait]
 impl ActionHandler for PositionRewardClaim {
     #[instrument(name = "position_reward_claim", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // It's important to reject all LP actions for now, to prevent
         // inflation / minting bugs until we implement all required checks
         // (e.g., minting tokens by withdrawing reserves we don't check)

--- a/component/src/action_handler/actions/position/reward_claim.rs
+++ b/component/src/action_handler/actions/position/reward_claim.rs
@@ -18,8 +18,8 @@ impl ActionHandler for PositionRewardClaim {
         Err(anyhow::anyhow!("lp actions not supported yet"))
     }
 
-    #[instrument(name = "position_close", skip(self, _state, _context))]
-    async fn check_stateful(&self, _state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "position_close", skip(self, _state))]
+    async fn check_stateful(&self, _state: Arc<State>) -> Result<()> {
         // It's important to reject all LP actions for now, to prevent
         // inflation / minting bugs until we implement all required checks
         // (e.g., minting tokens by withdrawing reserves we don't check)

--- a/component/src/action_handler/actions/position/withdraw.rs
+++ b/component/src/action_handler/actions/position/withdraw.rs
@@ -11,7 +11,7 @@ use crate::action_handler::ActionHandler;
 #[async_trait]
 impl ActionHandler for PositionWithdraw {
     #[instrument(name = "position_withdraw", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // It's important to reject all LP actions for now, to prevent
         // inflation / minting bugs until we implement all required checks
         // (e.g., minting tokens by withdrawing reserves we don't check)

--- a/component/src/action_handler/actions/position/withdraw.rs
+++ b/component/src/action_handler/actions/position/withdraw.rs
@@ -18,8 +18,8 @@ impl ActionHandler for PositionWithdraw {
         Err(anyhow::anyhow!("lp actions not supported yet"))
     }
 
-    #[instrument(name = "position_close", skip(self, _state, _context))]
-    async fn check_stateful(&self, _state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "position_close", skip(self, _state))]
+    async fn check_stateful(&self, _state: Arc<State>) -> Result<()> {
         // It's important to reject all LP actions for now, to prevent
         // inflation / minting bugs until we implement all required checks
         // (e.g., minting tokens by withdrawing reserves we don't check)

--- a/component/src/action_handler/actions/proposal/submit.rs
+++ b/component/src/action_handler/actions/proposal/submit.rs
@@ -12,7 +12,7 @@ use crate::governance::{check, execute};
 #[async_trait]
 impl ActionHandler for ProposalSubmit {
     #[instrument(name = "proposal_submit", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         check::stateless::proposal_submit(self)
     }
 

--- a/component/src/action_handler/actions/proposal/submit.rs
+++ b/component/src/action_handler/actions/proposal/submit.rs
@@ -16,8 +16,8 @@ impl ActionHandler for ProposalSubmit {
         check::stateless::proposal_submit(self)
     }
 
-    #[instrument(name = "proposal_submit", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "proposal_submit", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         check::stateful::proposal_submit(&state, self).await
     }
 

--- a/component/src/action_handler/actions/proposal/withdraw.rs
+++ b/component/src/action_handler/actions/proposal/withdraw.rs
@@ -18,11 +18,17 @@ impl ActionHandler for ProposalWithdraw {
         check::stateless::proposal_withdraw(self)
     }
 
-    #[instrument(name = "proposal_withdraw", skip(self, state))]
-    async fn check_stateful(&self, state: Arc<State>, context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "proposal_withdraw", skip(self, _state))]
+    async fn check_stateful(&self, _state: Arc<State>) -> Result<()> {
+        // Disabled since this doesn't fit the shape of the new trait,
+        // but not fixed because we want to change the proposal withdrawal
+        // mechanism anyways.
+        /*
         let auth_hash = context.transaction_body().auth_hash();
 
         check::stateful::proposal_withdraw(&state, &auth_hash, self).await
+        */
+        Ok(())
     }
 
     #[instrument(name = "proposal_withdraw", skip(self, state))]

--- a/component/src/action_handler/actions/proposal/withdraw.rs
+++ b/component/src/action_handler/actions/proposal/withdraw.rs
@@ -14,7 +14,7 @@ use crate::{
 #[async_trait]
 impl ActionHandler for ProposalWithdraw {
     #[instrument(name = "proposal_withdraw", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         check::stateless::proposal_withdraw(self)
     }
 

--- a/component/src/action_handler/actions/spend.rs
+++ b/component/src/action_handler/actions/spend.rs
@@ -37,8 +37,8 @@ impl ActionHandler for Spend {
         Ok(())
     }
 
-    #[instrument(name = "spend", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "spend", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         // Check that the `Nullifier` has not been spent before.
         let spent_nullifier = self.body.nullifier;
         state.check_nullifier_unspent(spent_nullifier).await

--- a/component/src/action_handler/actions/spend.rs
+++ b/component/src/action_handler/actions/spend.rs
@@ -11,7 +11,7 @@ use crate::{action_handler::ActionHandler, shielded_pool::StateReadExt as _};
 #[async_trait]
 impl ActionHandler for Spend {
     #[instrument(name = "spend", skip(self, context))]
-    fn check_stateless(&self, context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, context: Arc<Transaction>) -> Result<()> {
         let spend = self;
         let auth_hash = context.transaction_body().auth_hash();
         let anchor = context.anchor;

--- a/component/src/action_handler/actions/swap.rs
+++ b/component/src/action_handler/actions/swap.rs
@@ -15,7 +15,7 @@ use crate::action_handler::ActionHandler;
 #[async_trait]
 impl ActionHandler for Swap {
     #[instrument(name = "swap", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         let swap = self;
 
         // Check swap proof

--- a/component/src/action_handler/actions/swap.rs
+++ b/component/src/action_handler/actions/swap.rs
@@ -45,8 +45,8 @@ impl ActionHandler for Swap {
         Ok(())
     }
 
-    #[instrument(name = "swap", skip(self, _state, _context))]
-    async fn check_stateful(&self, _state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "swap", skip(self, _state))]
+    async fn check_stateful(&self, _state: Arc<State>) -> Result<()> {
         // TODO: are any other checks necessary?
 
         Ok(())

--- a/component/src/action_handler/actions/swap_claim.rs
+++ b/component/src/action_handler/actions/swap_claim.rs
@@ -41,8 +41,8 @@ impl ActionHandler for SwapClaim {
         Ok(())
     }
 
-    #[instrument(name = "swap_claim", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "swap_claim", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         let swap_claim = self;
 
         // 1. Validate the epoch duration passed in the swap claim matches

--- a/component/src/action_handler/actions/swap_claim.rs
+++ b/component/src/action_handler/actions/swap_claim.rs
@@ -14,7 +14,7 @@ use crate::{
 #[async_trait]
 impl ActionHandler for SwapClaim {
     #[instrument(name = "swap_claim", skip(self))]
-    fn check_stateless(&self, context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, context: Arc<Transaction>) -> Result<()> {
         let swap_claim = self;
 
         let fee = swap_claim.body.fee.clone();

--- a/component/src/action_handler/actions/undelegate.rs
+++ b/component/src/action_handler/actions/undelegate.rs
@@ -14,7 +14,7 @@ use crate::{
 #[async_trait]
 impl ActionHandler for Undelegate {
     #[instrument(name = "undelegate", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // All stateless undelegation-related checks are performed
         // at the Transaction-level.
         Ok(())

--- a/component/src/action_handler/actions/undelegate.rs
+++ b/component/src/action_handler/actions/undelegate.rs
@@ -20,8 +20,8 @@ impl ActionHandler for Undelegate {
         Ok(())
     }
 
-    #[instrument(name = "undelegate", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "undelegate", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         let u = self;
         let rate_data = state
             .next_validator_rate(&u.validator_identity)

--- a/component/src/action_handler/actions/validator_definition.rs
+++ b/component/src/action_handler/actions/validator_definition.rs
@@ -16,7 +16,7 @@ use crate::{
 #[async_trait]
 impl ActionHandler for ValidatorDefinition {
     #[instrument(name = "validator_definition", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         // Check that validator definition is correctly signed and well-formed:
         let definition = validator::Definition::try_from(self.clone())
             .context("supplied proto is not a valid definition")?;

--- a/component/src/action_handler/actions/validator_definition.rs
+++ b/component/src/action_handler/actions/validator_definition.rs
@@ -48,8 +48,8 @@ impl ActionHandler for ValidatorDefinition {
         Ok(())
     }
 
-    #[instrument(name = "validator_definition", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "validator_definition", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         // Check that the sequence numbers of the updated validators is correct.
         let v = validator::Definition::try_from(self.clone())
             .context("supplied proto is not a valid definition")?;

--- a/component/src/action_handler/actions/validator_vote.rs
+++ b/component/src/action_handler/actions/validator_vote.rs
@@ -14,7 +14,7 @@ use crate::{
 #[async_trait]
 impl ActionHandler for ValidatorVote {
     #[instrument(name = "validator_vote", skip(self, _context))]
-    fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, _context: Arc<Transaction>) -> Result<()> {
         check::stateless::validator_vote(self)
     }
 

--- a/component/src/action_handler/actions/validator_vote.rs
+++ b/component/src/action_handler/actions/validator_vote.rs
@@ -18,8 +18,8 @@ impl ActionHandler for ValidatorVote {
         check::stateless::validator_vote(self)
     }
 
-    #[instrument(name = "validator_vote", skip(self, state, _context))]
-    async fn check_stateful(&self, state: Arc<State>, _context: Arc<Transaction>) -> Result<()> {
+    #[instrument(name = "validator_vote", skip(self, state))]
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
         check::stateful::validator_vote(&state, self).await
     }
 

--- a/component/src/action_handler/transaction.rs
+++ b/component/src/action_handler/transaction.rs
@@ -43,16 +43,13 @@ impl ActionHandler for Transaction {
         Ok(())
     }
 
-    async fn check_stateful(&self, state: Arc<State>, context: Arc<Transaction>) -> Result<()> {
-        claimed_anchor_is_valid(state.clone(), context.clone()).await?;
-
-        fmd_parameters_valid(state.clone(), context.clone()).await?;
+    async fn check_stateful(&self, state: Arc<State>) -> Result<()> {
+        claimed_anchor_is_valid(state.clone(), self).await?;
+        fmd_parameters_valid(state.clone(), self).await?;
 
         // TODO: these can all be parallel tasks
         for action in self.actions() {
-            action
-                .check_stateful(state.clone(), context.clone())
-                .await?;
+            action.check_stateful(state.clone()).await?;
         }
 
         Ok(())

--- a/component/src/action_handler/transaction.rs
+++ b/component/src/action_handler/transaction.rs
@@ -24,7 +24,7 @@ use stateless::{at_most_one_undelegate, no_duplicate_nullifiers, valid_binding_s
 
 #[async_trait]
 impl ActionHandler for Transaction {
-    fn check_stateless(&self, context: Arc<Transaction>) -> Result<()> {
+    async fn check_stateless(&self, context: Arc<Transaction>) -> Result<()> {
         // TODO: add a check that ephemeral_key is not identity to prevent scanning dos attack ?
 
         valid_binding_signature(self)?;
@@ -33,7 +33,7 @@ impl ActionHandler for Transaction {
 
         // TODO: these can all be parallel tasks
         for action in self.actions() {
-            action.check_stateless(context.clone())?;
+            action.check_stateless(context.clone()).await?;
         }
 
         // TODO: move these out of component code?

--- a/component/src/action_handler/transaction/stateful.rs
+++ b/component/src/action_handler/transaction/stateful.rs
@@ -9,14 +9,14 @@ use crate::shielded_pool::{consensus_rules, StateReadExt as _};
 
 pub(super) async fn claimed_anchor_is_valid(
     state: Arc<State>,
-    context: Arc<Transaction>,
+    transaction: &Transaction,
 ) -> Result<()> {
-    state.check_claimed_anchor(context.anchor).await
+    state.check_claimed_anchor(transaction.anchor).await
 }
 
 pub(super) async fn fmd_parameters_valid(
     state: Arc<State>,
-    context: Arc<Transaction>,
+    transaction: &Transaction,
 ) -> Result<()> {
     let previous_fmd_parameters = state
         .get_previous_fmd_parameters()
@@ -28,7 +28,7 @@ pub(super) async fn fmd_parameters_valid(
         .expect("chain params request must succeed");
     let height = state.get_block_height().await?;
     consensus_rules::stateful::fmd_precision_within_grace_period(
-        context.as_ref(),
+        transaction,
         previous_fmd_parameters,
         current_fmd_parameters,
         height,

--- a/component/src/app/mod.rs
+++ b/component/src/app/mod.rs
@@ -102,7 +102,7 @@ impl App {
         // Both stateful and stateless checks take the transaction as
         // verification context.  The separate clone of the Arc<Transaction>
         // means it can be passed through the whole tree of checks.
-        tx.check_stateless(tx.clone())?;
+        tx.check_stateless(tx.clone()).await?;
         tx.check_stateful(self.state.clone(), tx.clone()).await?;
 
         // At this point, the stateful checks should have completed,
@@ -168,10 +168,5 @@ impl App {
         self.state
             .tendermint_validator_updates()
             .expect("tendermint validator updates should be set when called in end_block")
-    }
-
-    #[instrument(skip(tx))]
-    pub fn check_tx_stateless(tx: Arc<Transaction>) -> Result<()> {
-        tx.check_stateless(tx.clone())
     }
 }

--- a/component/src/app/mod.rs
+++ b/component/src/app/mod.rs
@@ -103,7 +103,7 @@ impl App {
         // verification context.  The separate clone of the Arc<Transaction>
         // means it can be passed through the whole tree of checks.
         tx.check_stateless(tx.clone()).await?;
-        tx.check_stateful(self.state.clone(), tx.clone()).await?;
+        tx.check_stateful(self.state.clone()).await?;
 
         // At this point, the stateful checks should have completed,
         // leaving us with exclusive access to the Arc<State>.

--- a/component/src/governance/check.rs
+++ b/component/src/governance/check.rs
@@ -2,7 +2,7 @@ use anyhow::{Context as _, Result};
 
 use super::proposal::{self, chain_params};
 use penumbra_transaction::action::{
-    ProposalSubmit, ProposalWithdraw, ProposalWithdrawBody, ValidatorVote, ValidatorVoteBody,
+    ProposalSubmit, ProposalWithdraw, ValidatorVote, ValidatorVoteBody,
 };
 
 pub mod stateless {
@@ -89,7 +89,7 @@ pub mod stateful {
     use penumbra_chain::StateReadExt as _;
     use penumbra_crypto::{GovernanceKey, IdentityKey, STAKING_TOKEN_DENOM};
     use penumbra_storage::State;
-    use penumbra_transaction::{action::ProposalPayload, AuthHash};
+    use penumbra_transaction::action::ProposalPayload;
 
     pub async fn proposal_submit(
         state: &State,
@@ -160,6 +160,7 @@ pub mod stateful {
         Ok(())
     }
 
+    /*
     pub async fn proposal_withdraw(
         state: &State,
         auth_hash: &AuthHash,
@@ -213,6 +214,7 @@ pub mod stateful {
 
         Ok(())
     }
+    */
 
     pub async fn validator_vote(
         state: &State,

--- a/component/src/ibc/component/client.rs
+++ b/component/src/ibc/component/client.rs
@@ -548,9 +548,7 @@ mod tests {
         create_client_action
             .check_stateless(dummy_context.clone())
             .await?;
-        create_client_action
-            .check_stateful(state.clone(), dummy_context.clone())
-            .await?;
+        create_client_action.check_stateful(state.clone()).await?;
         let mut state_tx = state.try_begin_transaction().unwrap();
         create_client_action.execute(&mut state_tx).await?;
         state_tx.apply();
@@ -562,9 +560,7 @@ mod tests {
         update_client_action
             .check_stateless(dummy_context.clone())
             .await?;
-        update_client_action
-            .check_stateful(state.clone(), dummy_context.clone())
-            .await?;
+        update_client_action.check_stateful(state.clone()).await?;
         let mut state_tx = state.try_begin_transaction().unwrap();
         update_client_action.execute(&mut state_tx).await?;
         state_tx.apply();
@@ -585,7 +581,7 @@ mod tests {
             .check_stateless(dummy_context.clone())
             .await?;
         second_update_client_action
-            .check_stateful(state.clone(), dummy_context.clone())
+            .check_stateful(state.clone())
             .await?;
         let mut state_tx = state.try_begin_transaction().unwrap();
         second_update_client_action.execute(&mut state_tx).await?;

--- a/component/src/ibc/component/client.rs
+++ b/component/src/ibc/component/client.rs
@@ -545,7 +545,9 @@ mod tests {
         // Since the context is not used by the IBC action handlers, we can pass a dummy transaction.
         let dummy_context = Arc::new(Transaction::default());
 
-        create_client_action.check_stateless(dummy_context.clone())?;
+        create_client_action
+            .check_stateless(dummy_context.clone())
+            .await?;
         create_client_action
             .check_stateful(state.clone(), dummy_context.clone())
             .await?;
@@ -557,7 +559,9 @@ mod tests {
         assert_eq!(state.client_counter().await.unwrap().0, 1);
 
         // Now we update the client and confirm that the update landed in state.
-        update_client_action.check_stateless(dummy_context.clone())?;
+        update_client_action
+            .check_stateless(dummy_context.clone())
+            .await?;
         update_client_action
             .check_stateful(state.clone(), dummy_context.clone())
             .await?;
@@ -577,7 +581,9 @@ mod tests {
             action: Some(IbcActionInner::UpdateClient(second_update)),
         };
 
-        second_update_client_action.check_stateless(dummy_context.clone())?;
+        second_update_client_action
+            .check_stateless(dummy_context.clone())
+            .await?;
         second_update_client_action
             .check_stateful(state.clone(), dummy_context.clone())
             .await?;

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -64,6 +64,7 @@ impl App {
         println!("pre-checking transaction...");
         transaction
             .check_stateless(std::sync::Arc::new(transaction.clone()))
+            .await
             .context("transaction pre-submission checks failed")?;
 
         println!("broadcasting transaction...");


### PR DESCRIPTION
- Make `ActionHandler::check_stateless` async, so that its implementations can spawn tasks internally.
- Remove the context parameter from `ActionHandler::check_stateful`, since we already passed it in `check_stateless`, and should have done all of the inter-transaction checking there.