### PR TITLE
chain: add allocations to `genesis::AppState::default()`

### DIFF
--- a/chain/src/genesis/app_state.rs
+++ b/chain/src/genesis/app_state.rs
@@ -5,7 +5,7 @@ use super::Allocation;
 use crate::params::ChainParameters;
 
 /// The application state at genesis.
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(try_from = "pb::GenesisAppState", into = "pb::GenesisAppState")]
 pub struct AppState {
     /// Global configuration for the chain, such as chain ID and epoch duration.
@@ -14,6 +14,33 @@ pub struct AppState {
     pub validators: Vec<pb_stake::Validator>,
     /// The initial token allocations.
     pub allocations: Vec<Allocation>,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            chain_params: Default::default(),
+            // TODO: create a test validator
+            validators: Default::default(),
+            allocations: vec![
+                Allocation {
+                    amount: 1000,
+                    denom: "penumbra".parse().unwrap(),
+                    address: crate::test::TEST_ADDRESS_0.parse().unwrap(),
+                },
+                Allocation {
+                    amount: 100,
+                    denom: "gm".parse().unwrap(),
+                    address: crate::test::TEST_ADDRESS_1.parse().unwrap(),
+                },
+                Allocation {
+                    amount: 100,
+                    denom: "gn".parse().unwrap(),
+                    address: crate::test::TEST_ADDRESS_1.parse().unwrap(),
+                },
+            ],
+        }
+    }
 }
 
 impl From<AppState> for pb::GenesisAppState {

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -16,3 +16,15 @@ pub use known_assets::KnownAssets;
 pub use note_source::NoteSource;
 pub use sync::{AnnotatedNotePayload, CompactBlock};
 pub use view::{StateReadExt, StateWriteExt};
+
+/// Hardcoded test data.
+pub mod test {
+    /// This address is for test purposes, allocations were added beginning with
+    /// the 016-Pandia testnet.
+    pub const TEST_SEED_PHRASE: &str = "benefit cherry cannon tooth exhibit law avocado spare tooth that amount pumpkin scene foil tape mobile shine apology add crouch situate sun business explain";
+
+    /// These addresses both correspond to the test wallet above.
+    pub const TEST_ADDRESS_0: &str = "penumbrav2t13vh0fkf3qkqjacpm59g23ufea9n5us45e4p5h6hty8vg73r2t8g5l3kynad87u0n9eragf3hhkgkhqe5vhngq2cw493k48c9qg9ms4epllcmndd6ly4v4dw2jcnxaxzjqnlvnw";
+    /// These addresses both correspond to the test wallet above.
+    pub const TEST_ADDRESS_1: &str = "penumbrav2t1gl609fq6xzjcqn3hz3crysw2s0nkt330lyhaq403ztmrm3yygsgdklt9uxfs0gedwp6sypp5k5ln9t62lvs9t0a990q832wnxak8r939g5u6uz5aessd8saxvv7ewlz4hhqnws";
+}

--- a/pcli/tests/network_integration.rs
+++ b/pcli/tests/network_integration.rs
@@ -19,13 +19,7 @@ use regex::Regex;
 use serde_json::Value;
 use tempfile::{tempdir, NamedTempFile, TempDir};
 
-// This address is for test purposes, allocations were added beginning with
-// the 016-Pandia testnet.
-const TEST_SEED_PHRASE: &str = "benefit cherry cannon tooth exhibit law avocado spare tooth that amount pumpkin scene foil tape mobile shine apology add crouch situate sun business explain";
-
-// These addresses both correspond to the test wallet above.
-const TEST_ADDRESS_0: &str = "penumbrav2t13vh0fkf3qkqjacpm59g23ufea9n5us45e4p5h6hty8vg73r2t8g5l3kynad87u0n9eragf3hhkgkhqe5vhngq2cw493k48c9qg9ms4epllcmndd6ly4v4dw2jcnxaxzjqnlvnw";
-const TEST_ADDRESS_1: &str = "penumbrav2t1gl609fq6xzjcqn3hz3crysw2s0nkt330lyhaq403ztmrm3yygsgdklt9uxfs0gedwp6sypp5k5ln9t62lvs9t0a990q832wnxak8r939g5u6uz5aessd8saxvv7ewlz4hhqnws";
+use penumbra_chain::test::{TEST_ADDRESS_0, TEST_ADDRESS_1, TEST_SEED_PHRASE};
 
 const TEST_ASSET: &str = "1cube";
 


### PR DESCRIPTION
This commit moves the hardcoded test address from the pcli integration tests into the `chain` crate's `Default` impl for `genesis::AppState`, so that unit tests written against a default genesis state can test spends, outputs, etc, or other functionality involving moving value around in the shielded pool.