### PR TITLE
ci: run buf build on tags, too

### DIFF
--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -1,8 +1,14 @@
 name: buf-push
+
+# We want to rebuild on every commit to main, and also for named testnet tags,
+# so that API users can pick a tagged version of the protobuf definitions
+# to use against a matching testnet.
 on:
   push:
     branches:
       - main
+    tags:
+      - '**'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We want to ensure that API users can track protobuf definitions from a specific tag. Updates the GH Actions workflow accordingly.

Closes #1667.