### PR TITLE
docs: update testnet tag to 037-megaclite.1

### DIFF
--- a/docs/guide/src/pcli/install.md
+++ b/docs/guide/src/pcli/install.md
@@ -56,7 +56,7 @@ latest tag for the current
 [testnet](https://github.com/penumbra-zone/penumbra/releases):
 
 ```bash
-cd penumbra && git fetch && git checkout 037-megaclite
+cd penumbra && git fetch && git checkout 037-megaclite.1
 ```
 
 ### Building the `pcli` client software

--- a/docs/guide/src/pcli/update.md
+++ b/docs/guide/src/pcli/update.md
@@ -3,7 +3,7 @@
 Follow the [same steps](https://guide.penumbra.zone/main/pcli/install.html#cloning-the-repository) to update to the latest testnet [release](https://github.com/penumbra-zone/penumbra/releases)
 
 ```
-cd penumbra && git fetch && git checkout 037-megaclite
+cd penumbra && git fetch && git checkout 037-megaclite.1
 ```
 
 Once again, build `pcli` with cargo


### PR DESCRIPTION
We had a chain halt on 037-megaclite, so this release contains a hotfix from https://github.com/penumbra-zone/penumbra/pull/1704.

Refs #1699 