### PR TITLE
CI run testing cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3066,9 +3066,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.43"
+version = "0.10.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
+checksum = "29d971fd5722fec23977260f6e81aa67d2f22cadbdc2aa049f1022d9a3be1566"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3098,9 +3098,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.78"
+version = "0.9.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
+checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
 dependencies = [
  "autocfg",
  "cc",
@@ -5634,8 +5634,8 @@ dependencies = [
 
 [[package]]
 name = "tower-abci"
-version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/tower-abci?branch=tendermint-026#96b37134da0da6ac662f258c78b3268105fad54a"
+version = "0.2.0"
+source = "git+https://github.com/penumbra-zone/tower-abci?branch=tendermint-026#822220416d60e7388f668d87b4dc2b6c0971133b"
 dependencies = [
  "bytes",
  "futures",


### PR DESCRIPTION
My branch is segfaulting, wondering if it has something to do with an updated version of a dependency, since my code changes are pure rust