### PR TITLE
ci: adds testnet-preview k8s deploy workflow

### DIFF
--- a/.github/workflows/deploy-preview-new.yml
+++ b/.github/workflows/deploy-preview-new.yml
@@ -1,7 +1,7 @@
 ---
-# Deploys the most recent tagged testnet (e.g. "037-iocaste.2") to cluster
-# at testnet.penumbra.zone.
-name: Deploy Testnet (Kubernetes)
+# Deploys the latest changes on 'main' branch, via a container
+# image tagged with 'main', to testnet-preview.penumbra.zone.
+name: Deploy Testnet Preview (Kubernetes)
 on:
   workflow_dispatch:
     inputs:
@@ -19,24 +19,25 @@ on:
         default: 'ghcr.io/penumbra-zone/penumbra'
       image_tag:
         description: 'Docker image tag to deploy'
+        default: "main"
         required: true
       image_uid_gid:
         description: 'Docker image user uid:gid'
         required: true
         default: '1000:1000'
   push:
-    tags:
-      - '[0-9][0-9][0-9]-*'
+    branches:
+      - main
 
 jobs:
   deploy:
     permissions:
       contents: 'read'
       id-token: 'write'
-    name: Deploy to Testnet
+    name: Deploy to Testnet Preview
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: testnet
+    environment: testnet-preview
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -62,5 +63,5 @@ jobs:
           export IMAGE='${{ github.event.inputs.image_repository }}'
           export PENUMBRA_VERSION='${{ github.event.inputs.image_tag }}'
           export PENUMBRA_UID_GID='${{ github.event.inputs.image_uid_gid }}'
-          export HELM_RELEASE='penumbra-testnet'
+          export HELM_RELEASE='penumbra-testnet-preview'
           ./ci.sh

--- a/deployments/ci.sh
+++ b/deployments/ci.sh
@@ -28,6 +28,8 @@ HELM_RELEASE="${HELM_RELEASE:=penumbra-testnet}"
 # Check that the network we're trying to configure has a valid config.
 if [[ "$HELM_RELEASE" =~ ^penumbra-testnet$ ]] ; then
     HELM_VARS_FILE="networks/testnet/helm-values-for-${HELM_RELEASE}.yml"
+elif [[ "$HELM_RELEASE" =~ ^penumbra-testnet-preview$ ]] ; then
+    HELM_VARS_FILE="networks/testnet-preview/helm-values-for-${HELM_RELEASE}.yml"
 else
     >&2 echo "ERROR: helm release name '$HELM_RELEASE' not supported"
     exit 1
@@ -90,7 +92,7 @@ container_cli="$(get_container_cli)"
     --entrypoint pd \
     "${IMAGE}:${PENUMBRA_VERSION}" \
     testnet generate \
-    "$preserve_chain_opt" \
+    $preserve_chain_opt \
     --validators-input-file "${CONTAINERHOME}/vals.json" > /dev/null
 
 PERSISTENT_PEERS=""

--- a/deployments/networks/testnet-preview/README.md
+++ b/deployments/networks/testnet-preview/README.md
@@ -1,0 +1,8 @@
+# Penumbra Testnet Preview Deployment
+This directory contains files related to rapid-release
+"testnet-preview.penumbra.zone" setup. New deploys
+are triggered on every merge into the `main` branch.
+
+Helm vars files provide environment-specific config like FQDNs.
+There are no Terraform config files; see `../testnet/` for
+cluster config options.

--- a/deployments/networks/testnet-preview/helm-values-for-penumbra-testnet-preview.yml
+++ b/deployments/networks/testnet-preview/helm-values-for-penumbra-testnet-preview.yml
@@ -1,0 +1,10 @@
+---
+# Values file for "testnet-preview.penumbra.zone" CI deploys.
+# Mostly sets the FQDNs on the ingress.
+ingress:
+  enabled: true
+  hosts:
+    # The Tendermint RPC port.
+    rpc: rpc.testnet-preview.penumbra.zone
+    # The pd gRPC port.
+    grpc: grpc.testnet-preview.penumbra.zone

--- a/deployments/networks/testnet/README.md
+++ b/deployments/networks/testnet/README.md
@@ -1,2 +1,5 @@
 # Penumbra Testnet Deployment
 This directory contains files related to the weekly penumbra testnet deployment.
+It includes Helm vars files and Terraform config logic.
+The Terraform config contains some "testnet-preview" logic, as well.
+This is because we use a single cluster to host multiple deployments.

--- a/deployments/networks/testnet/cluster.tf
+++ b/deployments/networks/testnet/cluster.tf
@@ -1,0 +1,22 @@
+// Cluster configuration for testnet deployments.
+// As of 2022Q4, we're reusing a single cluster to host
+// multiple environments, e.g. "testnet" and "testnet-preview".
+// We may migrate to multiple clusters in the future.
+module "gcp_terraform_state_testnet" {
+  source = "../../terraform/modules/gcp/terraform_state/chain"
+
+  chain_name          = "penumbra"
+  labels              = {}
+  location            = "US"
+  network_environment = "testnet"
+}
+
+module "gke_testnet" {
+  source = "../../terraform/modules/node/v1"
+
+  project_id    = "penumbra-sl-testnet"
+  cluster_name  = "testnet"
+  region        = "us-central1"
+  cluster_zones = ["us-central1-a", "us-central1-b"]
+  machine_type  = "n2d-standard-4"
+}

--- a/deployments/networks/testnet/main.tf
+++ b/deployments/networks/testnet/main.tf
@@ -1,22 +1,3 @@
-module "gcp_terraform_state_testnet" {
-  source = "../../terraform/modules/gcp/terraform_state/chain"
-
-  chain_name          = "penumbra"
-  labels              = {}
-  location            = "US"
-  network_environment = "testnet"
-}
-
-module "gke_testnet" {
-  source = "../../terraform/modules/node/v1"
-
-  project_id    = "penumbra-sl-testnet"
-  cluster_name  = "testnet"
-  region        = "us-central1"
-  cluster_zones = ["us-central1-a", "us-central1-b"]
-  machine_type  = "n2d-standard-4"
-}
-
 // The IPv4 address used for URLs like `rpc.testnet.penumbra.zone`.
 // We reserve this ahead of time, so that the DNS records can be static,
 // and point to the currently running deployment.
@@ -41,3 +22,14 @@ output "testnet_reserved_ip" {
 //       --output jsonpath='{.status.loadBalancer.ingress[0].ip}'
 //
 // The resulting IP should have an A record for "fullnode.<network>.penumbra.zone".
+
+// BEGIN values for testnet-preview.penumbra.zone //
+resource "google_compute_global_address" "testnet-preview-ingress" {
+  name    = "penumbra-testnet-preview-ingress-ip"
+  project = "penumbra-sl-testnet"
+}
+
+output "testnet_preview_reserved_ip" {
+  value = google_compute_global_address.testnet-preview-ingress.address
+}
+// END values for testnet-preview.penumbra.zone //


### PR DESCRIPTION
Depends on #1707, so would prefer to land that first. Then this diff becomes pretty small.

Duplicates the "testnet" logic for "testnet-preview", targeting k8s cluster. Does not spin up a discrete cluster; we reuse a single cluster, with carefully labelled resources, and manage the configs via helm.
