### PR TITLE
view: refactor notes table to just do note commitment lookups

### DIFF
--- a/view/migrations/20220908223928_notes.sql
+++ b/view/migrations/20220908223928_notes.sql
@@ -1,40 +1,44 @@
+-- This table just records the mapping from note commitments to note plaintexts.
+-- This is also used as a way to give advice about out-of-band notes during scanning,
+-- by allowing the user to add notes to the database before they are scanned.
 CREATE TABLE notes (
     note_commitment         BLOB PRIMARY KEY NOT NULL,
     address                 BLOB NOT NULL,
     amount                  BIGINT NOT NULL,
     asset_id                BLOB NOT NULL,
-    blinding_factor         BLOB NOT NULL,
-    height_created          BIGINT NOT NULL,
-    -- precomputed decryption of the diversifier
-    address_index           BLOB NOT NULL,
-    -- the source of the note (a tx hash or structured data jammed into one)
-    source                  BLOB NOT NULL
+    blinding_factor         BLOB NOT NULL
 );
 
 -- general purpose note queries
 CREATE INDEX notes_idx ON notes (
     address,            
     asset_id,           
-    amount,
-    height_created,
-    address_index,
-    source
+    amount
 );
 
 -- Minimal data required for balance tracking
 -- Meant to represent notes which have been accepted into the note set
 CREATE TABLE spendable_notes (
     note_commitment         BLOB PRIMARY KEY NOT NULL,
-    --null if unspent, otherwise spent at height_spent 
-    height_spent            BIGINT, 
     -- the nullifier for this note, used to detect when it is spent
     nullifier               BLOB NOT NULL,
     -- the position of the note in the note commitment tree
-    position                BIGINT NOT NULL
+    position                BIGINT NOT NULL,
+    -- the height at which the note was created
+    height_created          BIGINT NOT NULL,
+    -- precomputed decryption of the diversifier
+    address_index           BLOB NOT NULL,
+    -- the source of the note (a tx hash or structured data jammed into one)
+    source                  BLOB NOT NULL,
+    --null if unspent, otherwise spent at height_spent 
+    height_spent            BIGINT 
 );
 
 -- general purpose note queries
 CREATE INDEX spendable_notes_idx ON spendable_notes (
-    height_spent,       -- null if unspent, so spent/unspent is first
-    nullifier
+    address_index,
+    source,
+    height_created,
+    nullifier,
+    height_spent       -- null if unspent, so spent/unspent is first
 );

--- a/view/sqlx-data.json
+++ b/view/sqlx-data.json
@@ -58,16 +58,6 @@
     },
     "query": "INSERT INTO sync_height (height) VALUES (?)"
   },
-  "240f35a686d912511ad6db5342cf7f3eafa0452b0979233f48eb5c56871ad152": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 3
-      }
-    },
-    "query": "INSERT INTO spendable_notes\n                    (\n                        note_commitment,\n                        height_spent,\n                        nullifier,\n                        position\n                    )\n                    VALUES\n                    (\n                        ?,\n                        NULL,\n                        ?,\n                        ?\n                    )"
-  },
   "2547294717840bcb1bef870394b99cf275bcba98d005f1f18b03c7a3d93909e1": {
     "describe": {
       "columns": [],
@@ -77,6 +67,16 @@
       }
     },
     "query": "INSERT INTO assets\n                    (\n                        asset_id,\n                        denom\n                    )\n                    VALUES\n                    (\n                        ?,\n                        ?\n                    )"
+  },
+  "2ea376bc5364276b0aa3a2b7a436ad3dc56a4c0b22813635320aa67f3952af0c": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 5
+      }
+    },
+    "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        address,\n                        amount,\n                        asset_id,\n                        blinding_factor\n                    )\n                VALUES (?, ?, ?, ?, ?)"
   },
   "3330ad89b630f87f1ed502363de779624f72710fb59f2133c5db2c1dc8d30b2d": {
     "describe": {
@@ -169,16 +169,6 @@
       }
     },
     "query": "SELECT hash FROM nct_hashes WHERE position = ? AND height = ? LIMIT 1"
-  },
-  "5b0931e85f189748ade34b5b64f218ae43800c48283a98fbbb4755a9b4231035": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 8
-      }
-    },
-    "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        height_created,\n                        address,\n                        amount,\n                        asset_id,\n                        blinding_factor,\n                        address_index,\n                        source\n                    )\n                VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
   },
   "63aad4faac1ffefd5525595f9ca5a82186181368251da9fbacf65a4d48671a01": {
     "describe": {
@@ -385,6 +375,16 @@
       }
     },
     "query": "UPDATE spendable_notes SET height_spent = ? WHERE nullifier = ? RETURNING note_commitment"
+  },
+  "c883f3f9af27f775ef238515f88a55e5ece0402a72d3c1fde0b07bbe321cbecc": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 6
+      }
+    },
+    "query": "INSERT INTO spendable_notes\n                    (\n                        note_commitment,\n                        nullifier,\n                        position,\n                        height_created,\n                        address_index,\n                        source,\n                        height_spent\n                    )\n                    VALUES\n                    (?, ?, ?, ?, ?, ?, NULL)"
   },
   "ccf9c7b45b2a68b2323a357b9780e79e359cf0de78da122ac8db978f9d834471": {
     "describe": {

--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -179,13 +179,13 @@ impl Storage {
                 format!(
                     "SELECT
                         notes.note_commitment,
-                        notes.height_created,
+                        spendable_notes.height_created,
                         notes.address,
                         notes.amount,
                         notes.asset_id,
                         notes.blinding_factor,
-                        notes.address_index,
-                        notes.source,
+                        spendable_notes.address_index,
+                        spendable_notes.source,
                         spendable_notes.height_spent,
                         spendable_notes.nullifier,
                         spendable_notes.position
@@ -453,13 +453,13 @@ impl Storage {
                 format!(
                     "SELECT
                         notes.note_commitment,
-                        notes.height_created,
+                        spendable_notes.height_created,
                         notes.address,
                         notes.amount,
                         notes.asset_id,
                         notes.blinding_factor,
-                        notes.address_index,
-                        notes.source,
+                        spendable_notes.address_index,
+                        spendable_notes.source,
                         spendable_notes.height_spent,
                         spendable_notes.nullifier,
                         spendable_notes.position
@@ -564,13 +564,13 @@ impl Storage {
         let result = sqlx::query_as::<_, SpendableNoteRecord>(
             format!(
                 "SELECT notes.note_commitment,
-                        notes.height_created,
+                        spendable_notes.height_created,
                         notes.address,
                         notes.amount,
                         notes.asset_id,
                         notes.blinding_factor,
-                        notes.address_index,
-                        notes.source,
+                        spendable_notes.address_index,
+                        spendable_notes.source,
                         spendable_notes.height_spent,
                         spendable_notes.nullifier,
                         spendable_notes.position
@@ -578,7 +578,7 @@ impl Storage {
             JOIN spendable_notes ON notes.note_commitment = spendable_notes.note_commitment
             WHERE spendable_notes.height_spent IS {}
             AND notes.asset_id IS {}
-            AND notes.address_index IS {}",
+            AND spendable_notes.address_index IS {}",
                 spent_clause, asset_clause, address_clause
             )
             .as_str(),
@@ -685,13 +685,13 @@ impl Storage {
         Ok(sqlx::query_as::<_, SpendableNoteRecord>(
             format!(
                 "SELECT notes.note_commitment,
-                        notes.height_created,
+                        spendable_notes.height_created,
                         notes.address,
                         notes.amount,
                         notes.asset_id,
                         notes.blinding_factor,
-                        notes.address_index,
-                        notes.source,
+                        spendable_notes.address_index,
+                        spendable_notes.source,
                         spendable_notes.height_spent,
                         spendable_notes.nullifier,
                         spendable_notes.position
@@ -760,23 +760,17 @@ impl Storage {
                 "INSERT INTO notes
                     (
                         note_commitment,
-                        height_created,
                         address,
                         amount,
                         asset_id,
-                        blinding_factor,
-                        address_index,
-                        source
+                        blinding_factor
                     )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                VALUES (?, ?, ?, ?, ?)",
                 note_commitment,
-                height_created,
                 address,
                 amount,
                 asset_id,
                 blinding_factor,
-                address_index,
-                source,
             )
             .execute(&mut dbtx)
             .await?;
@@ -785,21 +779,22 @@ impl Storage {
                 "INSERT INTO spendable_notes
                     (
                         note_commitment,
-                        height_spent,
                         nullifier,
-                        position
+                        position,
+                        height_created,
+                        address_index,
+                        source,
+                        height_spent
                     )
                     VALUES
-                    (
-                        ?,
-                        NULL,
-                        ?,
-                        ?
-                    )",
+                    (?, ?, ?, ?, ?, ?, NULL)",
                 note_commitment,
-                // height_spent is NULL
                 nullifier,
-                position
+                position,
+                height_created,
+                address_index,
+                source,
+                // height_spent is NULL
             )
             .execute(&mut dbtx)
             .await?;


### PR DESCRIPTION
This change allows the notes table to act as an advice mechanism for
out-of-band note commitments during scanning: we can add notes to the notes
table in anticipation of their appearance, and then crossreference out-of-band
notes against known notes in the table.

Note: needs to be rebased on `main` after #1710 lands.