### PR TITLE
crypto: generic `Nullifier` derivation

### DIFF
--- a/crypto/src/keys/fvk.rs
+++ b/crypto/src/keys/fvk.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 
 use super::{DiversifierKey, IncomingViewingKey, NullifierKey, OutgoingViewingKey};
 use crate::{
-    ka, note, prf,
+    ka,
+    note::Commitment,
+    prf,
     rdsa::{SpendAuth, VerificationKey},
     Fq, Fr, Note, Nullifier,
 };
@@ -87,14 +89,14 @@ impl FullViewingKey {
         &self.nk
     }
 
-    /// Derive the [`Nullifier`] for a positioned note given its [`merkle::Position`] and
-    /// [`note::Commitment`].
+    /// Derive the [`Nullifier`] for a positioned note or swap given its [`merkle::Position`]
+    /// and [`Commitment`].
     pub fn derive_nullifier(
         &self,
         pos: penumbra_tct::Position,
-        note_commitment: &note::Commitment,
+        state_commitment: &Commitment,
     ) -> Nullifier {
-        self.nk.derive_nullifier(pos, note_commitment)
+        self.nk.derive_nullifier(pos, state_commitment)
     }
 
     /// Returns the spend verification key contained in this full viewing key.

--- a/crypto/src/keys/nullifier.rs
+++ b/crypto/src/keys/nullifier.rs
@@ -1,14 +1,14 @@
 use poseidon377::hash_3;
 
 use crate::{
-    note,
+    note::Commitment,
     nullifier::{Nullifier, NULLIFIER_DOMAIN_SEP},
     Fq,
 };
 
 pub const NK_LEN_BYTES: usize = 32;
 
-/// Allows deriving the nullifier associated with a note.
+/// Allows deriving the nullifier associated with a positioned piece of state.
 #[derive(Clone, Copy, Debug)]
 pub struct NullifierKey(pub Fq);
 
@@ -16,11 +16,11 @@ impl NullifierKey {
     pub fn derive_nullifier(
         &self,
         pos: penumbra_tct::Position,
-        note_commitment: &note::Commitment,
+        state_commitment: &Commitment,
     ) -> Nullifier {
         Nullifier(hash_3(
             &NULLIFIER_DOMAIN_SEP,
-            (self.0, note_commitment.0, (u64::from(pos)).into()),
+            (self.0, state_commitment.0, (u64::from(pos)).into()),
         ))
     }
 }


### PR DESCRIPTION
Closes #1712
A nullifier should be derivable for any element of state added to the state commitment tree (i.e. any positioned state commitment). Nullifiers will be unique as they are derived from the position in the TCT. 