### PR TITLE
penumbra: make `tonic` an optional dependency

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -10,7 +10,7 @@ decaf377-fmd = { path ="../decaf377-fmd" }
 decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 bytes = { version = "1", features = ["serde"] }
 prost = "0.11"
-tonic = "0.8.1"
+tonic = { version = "0.8.1", optional = true }
 serde = { version = "1", features = ["derive"] }
 hex = "0.4"
 anyhow = "1.0"
@@ -23,10 +23,13 @@ async-stream = "0.2.0"
 tracing = "0.1"
 futures = "0.3"
 
-ibc-proto = "0.22.0"
+ibc-proto = { version = "0.22.0", default-features = false, features = ["std"] }
 ibc = "0.23.0"
 ics23 = "0.8.1"
 tendermint = "0.26.0"
 
 # TODO(erwan): remove
 num-rational = "0.4"
+
+[features]
+rpc = ["dep:tonic", "ibc-proto/client"]

--- a/proto/src/gen/cosmos.base.tendermint.v1beta1.rs
+++ b/proto/src/gen/cosmos.base.tendermint.v1beta1.rs
@@ -266,6 +266,7 @@ pub struct ProofOps {
     pub ops: ::prost::alloc::vec::Vec<ProofOp>,
 }
 /// Generated client implementations.
+#[cfg(feature = "rpc")]
 pub mod service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
@@ -488,6 +489,7 @@ pub mod service_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "rpc")]
 pub mod service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;

--- a/proto/src/gen/penumbra.client.v1alpha1.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.rs
@@ -376,6 +376,7 @@ pub struct GetBlockByHeightResponse {
     pub block: ::core::option::Option<super::super::super::tendermint::types::Block>,
 }
 /// Generated client implementations.
+#[cfg(feature = "rpc")]
 pub mod oblivious_query_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
@@ -556,6 +557,7 @@ pub mod oblivious_query_service_client {
     }
 }
 /// Generated client implementations.
+#[cfg(feature = "rpc")]
 pub mod specific_query_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
@@ -810,6 +812,7 @@ pub mod specific_query_service_client {
     }
 }
 /// Generated client implementations.
+#[cfg(feature = "rpc")]
 pub mod tendermint_proxy_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
@@ -1006,6 +1009,7 @@ pub mod tendermint_proxy_service_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "rpc")]
 pub mod oblivious_query_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
@@ -1360,6 +1364,7 @@ pub mod oblivious_query_service_server {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "rpc")]
 pub mod specific_query_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
@@ -1876,6 +1881,7 @@ pub mod specific_query_service_server {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "rpc")]
 pub mod tendermint_proxy_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;

--- a/proto/src/gen/penumbra.custody.v1alpha1.rs
+++ b/proto/src/gen/penumbra.custody.v1alpha1.rs
@@ -29,6 +29,7 @@ pub struct PreAuthorization {
     pub sig: ::prost::alloc::vec::Vec<u8>,
 }
 /// Generated client implementations.
+#[cfg(feature = "rpc")]
 pub mod custody_protocol_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
@@ -133,6 +134,7 @@ pub mod custody_protocol_service_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "rpc")]
 pub mod custody_protocol_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;

--- a/proto/src/gen/penumbra.view.v1alpha1.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.rs
@@ -297,6 +297,7 @@ pub struct SwapRecord {
     pub source: ::core::option::Option<super::super::core::chain::v1alpha1::NoteSource>,
 }
 /// Generated client implementations.
+#[cfg(feature = "rpc")]
 pub mod view_protocol_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
@@ -680,6 +681,7 @@ pub mod view_protocol_service_client {
     }
 }
 /// Generated client implementations.
+#[cfg(feature = "rpc")]
 pub mod view_auth_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
@@ -770,6 +772,7 @@ pub mod view_auth_service_client {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "rpc")]
 pub mod view_protocol_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
@@ -1552,6 +1555,7 @@ pub mod view_protocol_service_server {
     }
 }
 /// Generated server implementations.
+#[cfg(feature = "rpc")]
 pub mod view_auth_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -105,7 +105,6 @@ pub mod penumbra {
 
             // TODO(erwan): this is one way to flatten the complex proto hierarchy, should be easy to lift
             pub mod tendermint_proxy {
-                #[cfg(feature = "rpc")]
                 pub use crate::cosmos::base::tendermint::v1beta1::*;
             }
 
@@ -217,7 +216,6 @@ pub mod penumbra {
     /// Custody protocol structures.
     pub mod custody {
         pub mod v1alpha1 {
-            #[cfg(feature = "rpc")]
             include!("gen/penumbra.custody.v1alpha1.rs");
         }
     }
@@ -228,14 +226,12 @@ pub mod cosmos {
     pub mod base {
         pub mod query {
             pub mod v1beta1 {
-                #[cfg(feature = "rpc")]
                 include!("gen/cosmos.base.query.v1beta1.rs");
             }
         }
 
         pub mod tendermint {
             pub mod v1beta1 {
-                #[cfg(feature = "rpc")]
                 include!("gen/cosmos.base.tendermint.v1beta1.rs");
             }
         }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -105,21 +105,24 @@ pub mod penumbra {
 
             // TODO(erwan): this is one way to flatten the complex proto hierarchy, should be easy to lift
             pub mod tendermint_proxy {
+                #[cfg(feature = "rpc")]
                 pub use crate::cosmos::base::tendermint::v1beta1::*;
             }
 
             use async_stream::try_stream;
             use futures::Stream;
             use futures::StreamExt;
-            use specific_query_service_client::SpecificQueryServiceClient;
             use std::pin::Pin;
+            #[cfg(feature = "rpc")]
             use tonic::{
                 body::BoxBody,
                 codegen::{Body, StdError},
             };
 
             // Convenience methods for fetching data...
-
+            #[cfg(feature = "rpc")]
+            use specific_query_service_client::SpecificQueryServiceClient;
+            #[cfg(feature = "rpc")]
             impl<C> SpecificQueryServiceClient<C> {
                 /// Get the Rust protobuf type corresponding to a state key.
                 ///
@@ -214,6 +217,7 @@ pub mod penumbra {
     /// Custody protocol structures.
     pub mod custody {
         pub mod v1alpha1 {
+            #[cfg(feature = "rpc")]
             include!("gen/penumbra.custody.v1alpha1.rs");
         }
     }
@@ -224,12 +228,14 @@ pub mod cosmos {
     pub mod base {
         pub mod query {
             pub mod v1beta1 {
+                #[cfg(feature = "rpc")]
                 include!("gen/cosmos.base.query.v1beta1.rs");
             }
         }
 
         pub mod tendermint {
             pub mod v1beta1 {
+                #[cfg(feature = "rpc")]
                 include!("gen/cosmos.base.tendermint.v1beta1.rs");
             }
         }

--- a/tools/proto-compiler/src/main.rs
+++ b/tools/proto-compiler/src/main.rs
@@ -80,6 +80,10 @@ fn main() -> Result<()> {
     // For the client code, we also want to generate RPC instances, so compile via tonic:
     tonic_build::configure()
         .out_dir(&target_dir)
+        .server_mod_attribute("penumbra.client.v1alpha1", "#[cfg(feature = \"rpc\")]")
+        .client_mod_attribute("penumbra.client.v1alpha1", "#[cfg(feature = \"rpc\")]")
+        .server_mod_attribute("penumbra.view.v1alpha1", "#[cfg(feature = \"rpc\")]")
+        .client_mod_attribute("penumbra.view.v1alpha1", "#[cfg(feature = \"rpc\")]")
         .compile_with_config(
             config,
             &[

--- a/tools/proto-compiler/src/main.rs
+++ b/tools/proto-compiler/src/main.rs
@@ -84,6 +84,10 @@ fn main() -> Result<()> {
         .client_mod_attribute("penumbra.client.v1alpha1", "#[cfg(feature = \"rpc\")]")
         .server_mod_attribute("penumbra.view.v1alpha1", "#[cfg(feature = \"rpc\")]")
         .client_mod_attribute("penumbra.view.v1alpha1", "#[cfg(feature = \"rpc\")]")
+        .server_mod_attribute("penumbra.custody.v1alpha1", "#[cfg(feature = \"rpc\")]")
+        .client_mod_attribute("penumbra.custody.v1alpha1", "#[cfg(feature = \"rpc\")]")
+        .server_mod_attribute("cosmos.base.tendermint.v1beta1", "#[cfg(feature = \"rpc\")]")
+        .client_mod_attribute("cosmos.base.tendermint.v1beta1", "#[cfg(feature = \"rpc\")]")
         .compile_with_config(
             config,
             &[

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -16,7 +16,7 @@ decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
 decaf377-rdsa = { git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "main" }
 ibc = "0.23.0"
-ibc-proto = "0.22.0"
+ibc-proto = { version = "0.22.0", features = ["std"] }
 
 
 # Crates.io deps

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -19,7 +19,7 @@ nct-divergence-check = []
 
 [dependencies]
 # Workspace dependencies
-penumbra-proto = { path = "../proto" }
+penumbra-proto = { path = "../proto", features = ["rpc"] }
 penumbra-chain = { path = "../chain" }
 penumbra-crypto = { path = "../crypto" }
 penumbra-tct = { path = "../tct" }


### PR DESCRIPTION
Fixes #1717  - uses [`tonic_build::client_mod_attribute`](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.client_mod_attribute), [`tonic_build::server_mod_attribute`](https://docs.rs/tonic-build/latest/tonic_build/struct.Builder.html#method.client_mod_attribute), to encapsulate tonic generated client/servers behind an `rpc` feature flag.