### PR TITLE
chore(pd): use `tower-abci@0.2.0` from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5639,7 +5639,8 @@ dependencies = [
 [[package]]
 name = "tower-abci"
 version = "0.2.0"
-source = "git+https://github.com/penumbra-zone/tower-abci?branch=tendermint-026#822220416d60e7388f668d87b4dc2b6c0971133b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a278d99d5bd940fcfc82941e75eb6a88c2e3c6ae0f677b97eba7f1dda82087"
 dependencies = [
  "bytes",
  "futures",

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -26,7 +26,7 @@ penumbra-wallet = { path = "../wallet" }
 
 # Penumbra dependencies
 decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
-tower-abci = { git = "https://github.com/penumbra-zone/tower-abci", branch = "tendermint-026" }
+tower-abci = "0.2.0"
  jmt = { git = "https://github.com/penumbra-zone/jmt", branch = "upstream-ics23" }
 
 


### PR DESCRIPTION
Fixes #1703 