### PR TITLE
component(ibc): make message execution faillible

### DIFF
--- a/component/src/action_handler/actions/ibc_action/msg/create_client.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/create_client.rs
@@ -33,7 +33,7 @@ impl ActionHandler for MsgCreateClient {
 
     #[instrument(name = "ibc_action", skip(self, state))]
     async fn execute(&self, state: &mut StateTransaction) -> Result<()> {
-        state.execute_create_client(self).await;
+        state.execute_create_client(self).await?;
 
         Ok(())
     }

--- a/component/src/action_handler/actions/ibc_action/msg/update_client.rs
+++ b/component/src/action_handler/actions/ibc_action/msg/update_client.rs
@@ -31,7 +31,7 @@ impl ActionHandler for MsgUpdateClient {
 
     #[instrument(name = "ibc_action", skip(self, state))]
     async fn execute(&self, state: &mut StateTransaction) -> Result<()> {
-        state.execute_update_client(self).await;
+        state.execute_update_client(self).await?;
 
         Ok(())
     }

--- a/component/src/ibc/component/client/stateless.rs
+++ b/component/src/ibc/component/client/stateless.rs
@@ -2,20 +2,22 @@ pub mod create_client {
     use super::super::*;
 
     pub fn client_state_is_tendermint(msg: &MsgCreateClient) -> anyhow::Result<()> {
-        match msg.client_state.type_url.as_str() {
-            TENDERMINT_CLIENT_STATE_TYPE_URL => Ok(()),
-            _ => Err(anyhow::anyhow!(
-                "invalid client state: not a Tendermint client state"
-            )),
+        if ics02_validation::is_tendermint_client_state(&msg.client_state) {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "MsgCreateClient: not a tendermint client state"
+            ))
         }
     }
 
     pub fn consensus_state_is_tendermint(msg: &MsgCreateClient) -> anyhow::Result<()> {
-        match msg.consensus_state.type_url.as_str() {
-            TENDERMINT_CONSENSUS_STATE_TYPE_URL => Ok(()),
-            _ => Err(anyhow::anyhow!(
-                "invalid consensus state: not a Tendermint consensus state"
-            )),
+        if ics02_validation::is_tendermint_consensus_state(&msg.consensus_state) {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "MsgCreateClient: not a tendermint consensus state"
+            ))
         }
     }
 }
@@ -24,9 +26,10 @@ pub mod update_client {
     use super::super::*;
 
     pub fn header_is_tendermint(msg: &MsgUpdateClient) -> anyhow::Result<()> {
-        match msg.header.type_url.as_str() {
-            TENDERMINT_HEADER_TYPE_URL => Ok(()),
-            _ => Err(anyhow::anyhow!("invalid header: not a Tendermint header")),
+        if ics02_validation::is_tendermint_header_state(&msg.header) {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("MsgUpdateClient: not a tendermint header"))
         }
     }
 }


### PR DESCRIPTION
Fixes #1697 (partially).

Context: the newer versions of ibc-rs defer deserialization of lightclient state (consensus, header, client etc.). As a result, execution ibc actions is faillible. This PR refactors some of the validation code (`ics02_validation`) to avoid windy and repetitive match statements, and propagates errors when lightclient state fails to deserialize. 