### PR TITLE
Mark genesis block as voted

### DIFF
--- a/component/src/stake/component.rs
+++ b/component/src/stake/component.rs
@@ -637,7 +637,13 @@ pub(crate) trait StakingImpl: StateWriteExt {
                     .try_into()
                     .unwrap();
 
-                let voted = did_address_vote.get(&addr).cloned().unwrap_or(false);
+                let voted = did_address_vote
+                    .get(&addr)
+                    .cloned()
+                    // If the height is `1`, then the `LastCommitInfo` refers to the genesis block,
+                    // which has no signers -- so we'll mark all validators as having signed.
+                    // https://github.com/penumbra-zone/penumbra/issues/1050
+                    .unwrap_or(height == 1);
                 let mut uptime =
                     self.validator_uptime(&v.identity_key)
                         .await?


### PR DESCRIPTION
There's an issue hinted at by an existing comment: the `LastCommitInfo` refers to the commit for the _last_ block, not the block in progress, i.e. during block 1 you're receiving commit info for the genesis block -- which has no commit info.

So, the fix introduced here is to consider all validators present to have voted during the genesis block to prevent the uptime tracking from reporting a single missed block in blocks 1+.

Closes #1050 