### PR TITLE
ci: fix cluster-based preview deployment

### DIFF
--- a/deployments/helm/templates/_helpers.tpl
+++ b/deployments/helm/templates/_helpers.tpl
@@ -42,9 +42,6 @@ app.kubernetes.io/name: {{ include "penumbra.name" . }}
 helm.sh/chart: {{ include "penumbra.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/deployments/helm/templates/fn-deployments.yaml
+++ b/deployments/helm/templates/fn-deployments.yaml
@@ -152,6 +152,8 @@ spec:
             - start
             - --home
             - /home/pd
+            - --host
+            - 0.0.0.0
         - name: health-check
           image: "{{ $.Values.health.image }}:{{ $.Values.health.version }}"
           imagePullPolicy: IfNotPresent

--- a/deployments/test.sh
+++ b/deployments/test.sh
@@ -3,11 +3,26 @@
 # as expected. Use these checks to increase visibility on service behavior.
 # Useful during changes to provisioning / config-management logic,
 # when run by a human, interactively; not intended to run in CI regularly.
+#
+# Usage:
+#
+#   ./test.sh testnet-preview.penumbra.zone
+#
 set -euo pipefail
+
+
+TEST_TARGET="${1:-testnet-preview.penumbra.zone}"
+RELEASE_NAME="${TEST_TARGET%.penumbra.zone}"
+
+echo "Running tests against host: $TEST_TARGET"
+echo "Inferred release name '$RELEASE_NAME' for k8s resources"
+
+error_counter=0
 
 # Ensure the service backends are "healthy".
 function get_service_health() {
-    kubectl get ingress penumbra-testnet-ingress -o json \
+    ing_name="penumbra-${RELEASE_NAME}-ingress"
+    kubectl get ingress "$ing_name" -o json \
         | jq -r '.metadata.annotations["ingress.kubernetes.io/backends"]' \
         | jq -r '.[]' \
         | sort -u
@@ -16,6 +31,7 @@ printf 'Checking backend service health... '
 svc_health="$(get_service_health)"
 if [[ "$svc_health" != "HEALTHY" ]] ; then
     >&2 echo "ERROR: service endpoints are not healthy"
+    error_counter="$((error_counter + 1))"
 else
     echo "OK"
 fi
@@ -31,6 +47,41 @@ pod_status="$(get_pod_status)"
 if [[ "$pod_status" != "Running" ]] ; then
     >&2 echo "ERROR: pods are not all running"
     >&2 echo "output was: '$pod_status'"
+    error_counter="$((error_counter + 1))"
 else
     echo "OK"
 fi
+
+function get_fn_ip() {
+    kubectl get svc "penumbra-${RELEASE_NAME}-p2p-fn-0" --output jsonpath='{.status.loadBalancer.ingress[0].ip}'
+}
+fn_ip="$(get_fn_ip)"
+# Ensure DNS matches expectations
+printf 'Checking that DNS A record matches expectations... '
+if host "$TEST_TARGET" | grep -qF "$TEST_TARGET has address $fn_ip" ; then
+    echo "OK"
+else
+    >&2 echo "ERROR: DNS lookup failed"
+    >&2 echo "Expected '$TEST_TARGET' to point to $fn_ip"
+    error_counter="$((error_counter + 1))"
+fi
+
+# Now we want to ensure that we can connect pcli to pd over 8080/tcp.
+pcli view reset || true
+printf 'Trying to connect via pcli... '
+# TODO: pcli surprisingly prints to stdout; we should make it stderr
+if pcli --node "$fn_ip" view sync > /dev/null; then
+    echo "OK"
+else
+    >&2 echo "ERROR: pcli could not connect to '$fn_ip'"
+    error_counter="$((error_counter + 1))"
+fi
+
+# Error reporting for readability
+if [[ "$error_counter" -gt 0 ]] ; then
+    echo "Encountered $error_counter errors"
+else
+    echo "All tests passed!"
+fi
+
+exit "$error_counter"


### PR DESCRIPTION
During the release of 038-kaylke, we declined to cut over to the cluster deployment pipelines, due to an obscure misconfiguration. The bug was subtle: the local container used for building the config files prior to deployment was properly referred to by its "main" tag, but without a `--pull=always` flag, stale containers were being used from the local cache. This caused old config-generation code to be used to create the genesis, which lacked updates for new slashing penalty logic.

The above is enough to unbreak `pd/tm` node functionality, but there's an additional tweak required to honor requests from client-side `pcli` over 8080/TCP: the `pd` service now binds to `0.0.0.0`, rather than localhost, ensuring that traffic to the NodePort for "fullnode" reaches pd as intended.

Makes a few other small changes, some pointed out by @aubrika during pairing on deploy:

  * remove AppVersion from Helm annotations, to avoid confusion
  * updates the bash parameter substitution to be more explicit about assignment
  * runs "shellcheck" and applies quoting where it was missed.
  * sprinkles in a few more test.sh examples for debugging

With these changes, there are now two k8s deployments active:

  * testnet-preview.penumbra.zone # preview
  * fullnode.testnet.penumbra.zone  # testnet 038-kalyke

Let's continue to bang on the preview deployment.