### PR TITLE
dex: create `BareTradingFunction`

### DIFF
--- a/crypto/src/dex/lp.rs
+++ b/crypto/src/dex/lp.rs
@@ -6,4 +6,4 @@ pub mod position;
 
 pub use nft::LpNft;
 pub use reserves::Reserves;
-pub use trading_function::TradingFunction;
+pub use trading_function::BareTradingFunction;

--- a/crypto/src/dex/lp/nft.rs
+++ b/crypto/src/dex/lp/nft.rs
@@ -147,6 +147,8 @@ impl From<LpNft> for pb::LpNft {
 
 #[cfg(test)]
 mod tests {
+    use crate::dex::lp::trading_function::TradingFunction;
+
     use super::*;
 
     use super::super::{super::TradingPair, position::*, BareTradingFunction};
@@ -159,14 +161,16 @@ mod tests {
             asset_1: crate::STAKING_TOKEN_ASSET_ID.clone(),
             asset_2: crate::asset::REGISTRY.parse_denom("cube").unwrap().id(),
         };
-        let phi = BareTradingFunction {
+        let component = BareTradingFunction {
             fee: 1,
             p: 1u64.into(),
             q: 1u64.into(),
         };
+
+        let phi = TradingFunction { component, pair };
+
         let position = Position {
             phi,
-            pair,
             nonce: [1u8; 32],
         };
         let position_id = position.id();

--- a/crypto/src/dex/lp/nft.rs
+++ b/crypto/src/dex/lp/nft.rs
@@ -149,7 +149,7 @@ impl From<LpNft> for pb::LpNft {
 mod tests {
     use super::*;
 
-    use super::super::{super::TradingPair, position::*, TradingFunction};
+    use super::super::{super::TradingPair, position::*, BareTradingFunction};
 
     #[test]
     fn lpnft_denom_parsing_roundtrip() {
@@ -159,7 +159,7 @@ mod tests {
             asset_1: crate::STAKING_TOKEN_ASSET_ID.clone(),
             asset_2: crate::asset::REGISTRY.parse_denom("cube").unwrap().id(),
         };
-        let phi = TradingFunction {
+        let phi = BareTradingFunction {
             fee: 1,
             p: 1u64.into(),
             q: 1u64.into(),

--- a/crypto/src/dex/lp/position.rs
+++ b/crypto/src/dex/lp/position.rs
@@ -2,14 +2,14 @@ use anyhow::{anyhow, Context};
 use penumbra_proto::{core::dex::v1alpha1 as pb, serializers::bech32str, Protobuf};
 use serde::{Deserialize, Serialize};
 
-use super::{super::TradingPair, TradingFunction};
+use super::{super::TradingPair, BareTradingFunction};
 
 /// Data identifying a position.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(try_from = "pb::Position", into = "pb::Position")]
 pub struct Position {
     pub pair: TradingPair,
-    pub phi: TradingFunction,
+    pub phi: BareTradingFunction,
     /// A random value used to disambiguate different positions with the exact same
     /// trading function.  The chain should reject newly created positions with the
     /// same nonce as an existing position.  This ensures that [`Id`]s will

--- a/crypto/src/dex/lp/trading_function.rs
+++ b/crypto/src/dex/lp/trading_function.rs
@@ -6,32 +6,37 @@ use crate::{dex::TradingPair, Amount};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(try_from = "pb::TradingFunction", into = "pb::TradingFunction")]
 pub struct TradingFunction {
-    pub phi: BareTradingFunction,
+    pub component: BareTradingFunction,
     pub pair: TradingPair,
 }
 
 impl TryFrom<pb::TradingFunction> for TradingFunction {
     type Error = anyhow::Error;
 
-    fn try_from(value: pb::TradingFunction) -> Result<Self, Self::Error> {
+    fn try_from(phi: pb::TradingFunction) -> Result<Self, Self::Error> {
         Ok(Self {
-            phi: value.phi.ok_or_else(|| anyhow::anyhow!("missing BareTradingFunction")).try_into()?,
-            pair: value.pair.ok_or_else(|| anyhow::anyhow!("missing TradingPair")).try_into()?,
+            component: phi
+                .component
+                .ok_or_else(|| anyhow::anyhow!("missing BareTradingFunction"))?
+                .try_into()?,
+            pair: phi
+                .pair
+                .ok_or_else(|| anyhow::anyhow!("missing TradingPair"))?
+                .try_into()?,
         })
     }
 }
 
 impl From<TradingFunction> for pb::TradingFunction {
-    fn from(f: TradingFunction) -> Self {
+    fn from(phi: TradingFunction) -> Self {
         Self {
-            phi: Some(f.phi),
-            pair: Some(f.pair),
+            component: Some(phi.component.into()),
+            pair: Some(phi.pair.into()),
+        }
     }
-}
 }
 
 impl Protobuf<pb::TradingFunction> for TradingFunction {}
-
 
 /// The data describing a trading function.
 ///

--- a/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
+++ b/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
@@ -1,9 +1,10 @@
 syntax = "proto3";
-option go_package = "github.com/penumbra-zone/penumbra/proto/go-proto";
 
 package penumbra.core.dex.v1alpha1;
 
 import "penumbra/core/crypto/v1alpha1/crypto.proto";
+
+option go_package = "github.com/penumbra-zone/penumbra/proto/go-proto";
 
 // A transaction action that submits a swap to the dex.
 message Swap {
@@ -70,54 +71,54 @@ message SwapPayload {
 }
 
 message SwapPlaintext {
-    // The trading pair to swap.
-    TradingPair trading_pair = 1;
-    // Input amount of asset 1
-    crypto.v1alpha1.Amount delta_1_i = 2;
-    // Input amount of asset 2
-    crypto.v1alpha1.Amount delta_2_i = 3;
-    // Pre-paid fee to claim the swap
-    crypto.v1alpha1.Fee claim_fee = 4;
-    // Address that will claim the swap outputs via SwapClaim.
-    crypto.v1alpha1.Address claim_address = 5;
-    // Swap blinding factor
-    bytes swap_blinding = 6;
+  // The trading pair to swap.
+  TradingPair trading_pair = 1;
+  // Input amount of asset 1
+  crypto.v1alpha1.Amount delta_1_i = 2;
+  // Input amount of asset 2
+  crypto.v1alpha1.Amount delta_2_i = 3;
+  // Pre-paid fee to claim the swap
+  crypto.v1alpha1.Fee claim_fee = 4;
+  // Address that will claim the swap outputs via SwapClaim.
+  crypto.v1alpha1.Address claim_address = 5;
+  // Swap blinding factor
+  bytes swap_blinding = 6;
 }
 
 message MockFlowCiphertext {
-    // Represents this transaction's contribution to flow's value.
-    uint64 value = 1;
+  // Represents this transaction's contribution to flow's value.
+  uint64 value = 1;
 }
 
 message SwapPlan {
-    // The plaintext version of the swap to be performed.
-    dex.v1alpha1.SwapPlaintext swap_plaintext = 1;
-    // The blinding factor for the fee commitment. The fee in the SwapPlan is private to prevent linkability with the SwapClaim.
-    bytes fee_blinding = 2;
-    // The ephemeral secret used to encrypt the swap payload.
-    bytes esk = 3;
+  // The plaintext version of the swap to be performed.
+  dex.v1alpha1.SwapPlaintext swap_plaintext = 1;
+  // The blinding factor for the fee commitment. The fee in the SwapPlan is private to prevent linkability with the SwapClaim.
+  bytes fee_blinding = 2;
+  // The ephemeral secret used to encrypt the swap payload.
+  bytes esk = 3;
 }
 
 message SwapClaimPlan {
-    // The plaintext version of the swap to be performed.
-    dex.v1alpha1.SwapPlaintext swap_plaintext = 1;
-    // The position of the swap commitment.
-    uint64 position = 2;
-    // Input and output amounts for the Swap.
-    dex.v1alpha1.BatchSwapOutputData output_data = 3;
-    // The epoch duration, used in proving.
-    uint64 epoch_duration = 4;
+  // The plaintext version of the swap to be performed.
+  dex.v1alpha1.SwapPlaintext swap_plaintext = 1;
+  // The position of the swap commitment.
+  uint64 position = 2;
+  // Input and output amounts for the Swap.
+  dex.v1alpha1.BatchSwapOutputData output_data = 3;
+  // The epoch duration, used in proving.
+  uint64 epoch_duration = 4;
 }
 
 message SwapView {
-    dex.v1alpha1.Swap swap = 1;
-    dex.v1alpha1.SwapPlaintext swap_plaintext = 3;
+  dex.v1alpha1.Swap swap = 1;
+  dex.v1alpha1.SwapPlaintext swap_plaintext = 3;
 }
 
 message SwapClaimView {
-    dex.v1alpha1.SwapClaim swap_claim = 1;
-    crypto.v1alpha1.Note output_1 = 2;
-    crypto.v1alpha1.Note output_2 = 3;
+  dex.v1alpha1.SwapClaim swap_claim = 1;
+  crypto.v1alpha1.Note output_1 = 2;
+  crypto.v1alpha1.Note output_2 = 3;
 }
 
 // Holds two asset IDs. Ordering doesn't reflect trading direction. Instead, we
@@ -151,14 +152,20 @@ message BatchSwapOutputData {
   TradingPair trading_pair = 7;
 }
 
-// The data describing a trading function.
+// A trading function along with a `TradingPair`
+message TradingFunction {
+  BareTradingFunction phi = 1;
+  TradingPair pair = 2;
+}
+
+// The minimum amount of data describing a trading function.
 //
 // This implicitly treats the trading function as being between assets 1 and 2,
 // without specifying what those assets are, to avoid duplicating data (each
 // asset ID alone is twice the size of the trading function).
 //
 // The trading function is `phi(R) = p*R_1 + q*R_2`, with fee parameter `gamma = 1 - fee`.
-message TradingFunction {
+message BareTradingFunction {
   uint32 fee = 2;
   // This is not actually an amount, it's an integer the same width as an amount
   crypto.v1alpha1.Amount p = 4;

--- a/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
+++ b/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
@@ -152,9 +152,12 @@ message BatchSwapOutputData {
   TradingPair trading_pair = 7;
 }
 
-// A trading function along with a `TradingPair`
+// The trading function for a specific pair.
+// For a pair (asset_1, asset_2), a trading function is defined by:
+// `phi(R) = p*R_1 + q*R_2` and `gamma = 1 - fee`.
+// The trading function is frequently referred to as "phi".
 message TradingFunction {
-  BareTradingFunction phi = 1;
+  BareTradingFunction component = 1;
   TradingPair pair = 2;
 }
 
@@ -163,14 +166,12 @@ message TradingFunction {
 // This implicitly treats the trading function as being between assets 1 and 2,
 // without specifying what those assets are, to avoid duplicating data (each
 // asset ID alone is twice the size of the trading function).
-//
-// The trading function is `phi(R) = p*R_1 + q*R_2`, with fee parameter `gamma = 1 - fee`.
 message BareTradingFunction {
-  uint32 fee = 2;
+  uint32 fee = 1;
   // This is not actually an amount, it's an integer the same width as an amount
-  crypto.v1alpha1.Amount p = 4;
+  crypto.v1alpha1.Amount p = 2;
   // This is not actually an amount, it's an integer the same width as an amount
-  crypto.v1alpha1.Amount q = 5;
+  crypto.v1alpha1.Amount q = 3;
 }
 
 // The reserves of a position.
@@ -186,14 +187,13 @@ message Reserves {
 
 // Data identifying a position.
 message Position {
-  TradingPair pair = 1;
-  TradingFunction phi = 2;
+  TradingFunction phi = 1;
   // A random value used to disambiguate different positions with the exact same
   // trading function.  The chain should reject newly created positions with the
   // same nonce as an existing position.  This ensures that `PositionId`s will
   // be unique, and allows us to track position ownership with a
   // sequence of stateful NFTs based on the `PositionId`.
-  bytes nonce = 3;
+  bytes nonce = 2;
 }
 
 // A hash of a `Position`.

--- a/proto/src/gen/penumbra.core.dex.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.dex.v1alpha1.rs
@@ -208,12 +208,15 @@ pub struct BatchSwapOutputData {
     #[prost(message, optional, tag="7")]
     pub trading_pair: ::core::option::Option<TradingPair>,
 }
-/// A trading function along with a `TradingPair`
+/// The trading function for a specific pair.
+/// For a pair (asset_1, asset_2), a trading function is defined by:
+/// `phi(R) = p*R_1 + q*R_2` and `gamma = 1 - fee`.
+/// The trading function is frequently referred to as "phi".
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TradingFunction {
     #[prost(message, optional, tag="1")]
-    pub phi: ::core::option::Option<BareTradingFunction>,
+    pub component: ::core::option::Option<BareTradingFunction>,
     #[prost(message, optional, tag="2")]
     pub pair: ::core::option::Option<TradingPair>,
 }
@@ -222,18 +225,16 @@ pub struct TradingFunction {
 /// This implicitly treats the trading function as being between assets 1 and 2,
 /// without specifying what those assets are, to avoid duplicating data (each
 /// asset ID alone is twice the size of the trading function).
-///
-/// The trading function is `phi(R) = p*R_1 + q*R_2`, with fee parameter `gamma = 1 - fee`.
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BareTradingFunction {
-    #[prost(uint32, tag="2")]
+    #[prost(uint32, tag="1")]
     pub fee: u32,
     /// This is not actually an amount, it's an integer the same width as an amount
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag="2")]
     pub p: ::core::option::Option<super::super::crypto::v1alpha1::Amount>,
     /// This is not actually an amount, it's an integer the same width as an amount
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag="3")]
     pub q: ::core::option::Option<super::super::crypto::v1alpha1::Amount>,
 }
 /// The reserves of a position.
@@ -255,15 +256,13 @@ pub struct Reserves {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Position {
     #[prost(message, optional, tag="1")]
-    pub pair: ::core::option::Option<TradingPair>,
-    #[prost(message, optional, tag="2")]
     pub phi: ::core::option::Option<TradingFunction>,
     /// A random value used to disambiguate different positions with the exact same
     /// trading function.  The chain should reject newly created positions with the
     /// same nonce as an existing position.  This ensures that `PositionId`s will
     /// be unique, and allows us to track position ownership with a
     /// sequence of stateful NFTs based on the `PositionId`.
-    #[prost(bytes="vec", tag="3")]
+    #[prost(bytes="vec", tag="2")]
     #[serde(with = "crate::serializers::hexstr")]
     pub nonce: ::prost::alloc::vec::Vec<u8>,
 }

--- a/proto/src/gen/penumbra.core.dex.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.dex.v1alpha1.rs
@@ -208,7 +208,16 @@ pub struct BatchSwapOutputData {
     #[prost(message, optional, tag="7")]
     pub trading_pair: ::core::option::Option<TradingPair>,
 }
-/// The data describing a trading function.
+/// A trading function along with a `TradingPair`
+#[derive(::serde::Deserialize, ::serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TradingFunction {
+    #[prost(message, optional, tag="1")]
+    pub phi: ::core::option::Option<BareTradingFunction>,
+    #[prost(message, optional, tag="2")]
+    pub pair: ::core::option::Option<TradingPair>,
+}
+/// The minimum amount of data describing a trading function.
 ///
 /// This implicitly treats the trading function as being between assets 1 and 2,
 /// without specifying what those assets are, to avoid duplicating data (each
@@ -217,7 +226,7 @@ pub struct BatchSwapOutputData {
 /// The trading function is `phi(R) = p*R_1 + q*R_2`, with fee parameter `gamma = 1 - fee`.
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TradingFunction {
+pub struct BareTradingFunction {
     #[prost(uint32, tag="2")]
     pub fee: u32,
     /// This is not actually an amount, it's an integer the same width as an amount

--- a/tools/proto-compiler/src/main.rs
+++ b/tools/proto-compiler/src/main.rs
@@ -361,6 +361,7 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
         ".penumbra.core.dex.v1alpha1.MockFlowCiphertext",
         SERDE_TRANSPARENT,
     ),
+    (".penumbra.core.dex.v1alpha1.BareTradingFunction", SERIALIZE),
     (".penumbra.core.dex.v1alpha1.TradingPair", SERIALIZE),
     (".penumbra.core.dex.v1alpha1.TradingFunction", SERIALIZE),
     (".penumbra.core.dex.v1alpha1.Reserves", SERIALIZE),

--- a/transaction/src/action/position.rs
+++ b/transaction/src/action/position.rs
@@ -51,12 +51,12 @@ impl PositionOpen {
 
         let r1 = Value {
             amount: self.initial_reserves.r1,
-            asset_id: self.position.pair.asset_1(),
+            asset_id: self.position.phi.pair.asset_1(),
         };
 
         let r2 = Value {
             amount: self.initial_reserves.r2,
-            asset_id: self.position.pair.asset_2(),
+            asset_id: self.position.phi.pair.asset_2(),
         };
 
         let reserves = Balance::from(r1) + r2;


### PR DESCRIPTION
Fixes #1762 .

Nomenclature: A `TradingFunction` (φ) is associated to a trading pair (`TradingPair`) and an internal component (`BareTradingFunction`) that specifies its parameters (`p`, `q`, `fee`).