### PR TITLE
update vendored IBC protos to v5

### DIFF
--- a/proto/ibc-go-vendor/ibc/applications/fee/v1/ack.proto
+++ b/proto/ibc-go-vendor/ibc/applications/fee/v1/ack.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package ibc.applications.fee.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/29-fee/types";
+
+import "gogoproto/gogo.proto";
+
+// IncentivizedAcknowledgement is the acknowledgement format to be used by applications wrapped in the fee middleware
+message IncentivizedAcknowledgement {
+  // the underlying app acknowledgement bytes
+  bytes app_acknowledgement = 1 [(gogoproto.moretags) = "yaml:\"app_acknowledgement\""];
+  // the relayer address which submits the recv packet message
+  string forward_relayer_address = 2 [(gogoproto.moretags) = "yaml:\"forward_relayer_address\""];
+  // success flag of the base application callback
+  bool underlying_app_success = 3 [(gogoproto.moretags) = "yaml:\"underlying_app_successl\""];
+}

--- a/proto/ibc-go-vendor/ibc/applications/fee/v1/fee.proto
+++ b/proto/ibc-go-vendor/ibc/applications/fee/v1/fee.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+
+package ibc.applications.fee.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/29-fee/types";
+
+import "cosmos/base/v1beta1/coin.proto";
+import "gogoproto/gogo.proto";
+import "ibc/core/channel/v1/channel.proto";
+
+// Fee defines the ICS29 receive, acknowledgement and timeout fees
+message Fee {
+  // the packet receive fee
+  repeated cosmos.base.v1beta1.Coin recv_fee = 1 [
+    (gogoproto.moretags)     = "yaml:\"recv_fee\"",
+    (gogoproto.nullable)     = false,
+    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
+  ];
+  // the packet acknowledgement fee
+  repeated cosmos.base.v1beta1.Coin ack_fee = 2 [
+    (gogoproto.moretags)     = "yaml:\"ack_fee\"",
+    (gogoproto.nullable)     = false,
+    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
+  ];
+  // the packet timeout fee
+  repeated cosmos.base.v1beta1.Coin timeout_fee = 3 [
+    (gogoproto.moretags)     = "yaml:\"timeout_fee\"",
+    (gogoproto.nullable)     = false,
+    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
+  ];
+}
+
+// PacketFee contains ICS29 relayer fees, refund address and optional list of permitted relayers
+message PacketFee {
+  // fee encapsulates the recv, ack and timeout fees associated with an IBC packet
+  Fee fee = 1 [(gogoproto.nullable) = false];
+  // the refund address for unspent fees
+  string refund_address = 2 [(gogoproto.moretags) = "yaml:\"refund_address\""];
+  // optional list of relayers permitted to receive fees
+  repeated string relayers = 3;
+}
+
+// PacketFees contains a list of type PacketFee
+message PacketFees {
+  // list of packet fees
+  repeated PacketFee packet_fees = 1 [(gogoproto.moretags) = "yaml:\"packet_fees\"", (gogoproto.nullable) = false];
+}
+
+// IdentifiedPacketFees contains a list of type PacketFee and associated PacketId
+message IdentifiedPacketFees {
+  // unique packet identifier comprised of the channel ID, port ID and sequence
+  ibc.core.channel.v1.PacketId packet_id = 1
+      [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"packet_id\""];
+  // list of packet fees
+  repeated PacketFee packet_fees = 2 [(gogoproto.moretags) = "yaml:\"packet_fees\"", (gogoproto.nullable) = false];
+}

--- a/proto/ibc-go-vendor/ibc/applications/fee/v1/genesis.proto
+++ b/proto/ibc-go-vendor/ibc/applications/fee/v1/genesis.proto
@@ -1,0 +1,66 @@
+syntax = "proto3";
+
+package ibc.applications.fee.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/29-fee/types";
+
+import "gogoproto/gogo.proto";
+import "ibc/applications/fee/v1/fee.proto";
+import "ibc/core/channel/v1/channel.proto";
+
+// GenesisState defines the ICS29 fee middleware genesis state
+message GenesisState {
+  // list of identified packet fees
+  repeated IdentifiedPacketFees identified_fees = 1
+      [(gogoproto.moretags) = "yaml:\"identified_fees\"", (gogoproto.nullable) = false];
+  // list of fee enabled channels
+  repeated FeeEnabledChannel fee_enabled_channels = 2
+      [(gogoproto.moretags) = "yaml:\"fee_enabled_channels\"", (gogoproto.nullable) = false];
+  // list of registered payees
+  repeated RegisteredPayee registered_payees = 3
+      [(gogoproto.moretags) = "yaml:\"registered_payees\"", (gogoproto.nullable) = false];
+  // list of registered counterparty payees
+  repeated RegisteredCounterpartyPayee registered_counterparty_payees = 4
+      [(gogoproto.moretags) = "yaml:\"registered_counterparty_payees\"", (gogoproto.nullable) = false];
+  // list of forward relayer addresses
+  repeated ForwardRelayerAddress forward_relayers = 5
+      [(gogoproto.moretags) = "yaml:\"forward_relayers\"", (gogoproto.nullable) = false];
+}
+
+// FeeEnabledChannel contains the PortID & ChannelID for a fee enabled channel
+message FeeEnabledChannel {
+  // unique port identifier
+  string port_id = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
+  // unique channel identifier
+  string channel_id = 2 [(gogoproto.moretags) = "yaml:\"channel_id\""];
+}
+
+// RegisteredPayee contains the relayer address and payee address for a specific channel
+message RegisteredPayee {
+  // unique channel identifier
+  string channel_id = 1 [(gogoproto.moretags) = "yaml:\"channel_id\""];
+  // the relayer address
+  string relayer = 2;
+  // the payee address
+  string payee = 3;
+}
+
+// RegisteredCounterpartyPayee contains the relayer address and counterparty payee address for a specific channel (used
+// for recv fee distribution)
+message RegisteredCounterpartyPayee {
+  // unique channel identifier
+  string channel_id = 1 [(gogoproto.moretags) = "yaml:\"channel_id\""];
+  // the relayer address
+  string relayer = 2;
+  // the counterparty payee address
+  string counterparty_payee = 3 [(gogoproto.moretags) = "yaml:\"counterparty_payee\""];
+}
+
+// ForwardRelayerAddress contains the forward relayer address and PacketId used for async acknowledgements
+message ForwardRelayerAddress {
+  // the forward relayer address
+  string address = 1;
+  // unique packet identifer comprised of the channel ID, port ID and sequence
+  ibc.core.channel.v1.PacketId packet_id = 2
+      [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"packet_id\""];
+}

--- a/proto/ibc-go-vendor/ibc/applications/fee/v1/metadata.proto
+++ b/proto/ibc-go-vendor/ibc/applications/fee/v1/metadata.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package ibc.applications.fee.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/29-fee/types";
+
+import "gogoproto/gogo.proto";
+
+// Metadata defines the ICS29 channel specific metadata encoded into the channel version bytestring
+// See ICS004: https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#Versioning
+message Metadata {
+  // fee_version defines the ICS29 fee version
+  string fee_version = 1 [(gogoproto.moretags) = "yaml:\"fee_version\""];
+  // app_version defines the underlying application version, which may or may not be a JSON encoded bytestring
+  string app_version = 2 [(gogoproto.moretags) = "yaml:\"app_version\""];
+}

--- a/proto/ibc-go-vendor/ibc/applications/fee/v1/query.proto
+++ b/proto/ibc-go-vendor/ibc/applications/fee/v1/query.proto
@@ -1,0 +1,222 @@
+syntax = "proto3";
+
+package ibc.applications.fee.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/29-fee/types";
+
+import "gogoproto/gogo.proto";
+import "google/api/annotations.proto";
+import "cosmos/base/v1beta1/coin.proto";
+import "cosmos/base/query/v1beta1/pagination.proto";
+import "ibc/applications/fee/v1/fee.proto";
+import "ibc/applications/fee/v1/genesis.proto";
+import "ibc/core/channel/v1/channel.proto";
+
+// Query defines the ICS29 gRPC querier service.
+service Query {
+  // IncentivizedPackets returns all incentivized packets and their associated fees
+  rpc IncentivizedPackets(QueryIncentivizedPacketsRequest) returns (QueryIncentivizedPacketsResponse) {
+    option (google.api.http).get = "/ibc/apps/fee/v1/incentivized_packets";
+  }
+
+  // IncentivizedPacket returns all packet fees for a packet given its identifier
+  rpc IncentivizedPacket(QueryIncentivizedPacketRequest) returns (QueryIncentivizedPacketResponse) {
+    option (google.api.http).get =
+        "/ibc/apps/fee/v1/channels/{packet_id.channel_id}/ports/{packet_id.port_id}/sequences/"
+        "{packet_id.sequence}/incentivized_packet";
+  }
+
+  // Gets all incentivized packets for a specific channel
+  rpc IncentivizedPacketsForChannel(QueryIncentivizedPacketsForChannelRequest)
+      returns (QueryIncentivizedPacketsForChannelResponse) {
+    option (google.api.http).get = "/ibc/apps/fee/v1/channels/{channel_id}/ports/{port_id}/incentivized_packets";
+  }
+
+  // TotalRecvFees returns the total receive fees for a packet given its identifier
+  rpc TotalRecvFees(QueryTotalRecvFeesRequest) returns (QueryTotalRecvFeesResponse) {
+    option (google.api.http).get = "/ibc/apps/fee/v1/channels/{packet_id.channel_id}/ports/{packet_id.port_id}/"
+                                   "sequences/{packet_id.sequence}/total_recv_fees";
+  }
+
+  // TotalAckFees returns the total acknowledgement fees for a packet given its identifier
+  rpc TotalAckFees(QueryTotalAckFeesRequest) returns (QueryTotalAckFeesResponse) {
+    option (google.api.http).get = "/ibc/apps/fee/v1/channels/{packet_id.channel_id}/ports/{packet_id.port_id}/"
+                                   "sequences/{packet_id.sequence}/total_ack_fees";
+  }
+
+  // TotalTimeoutFees returns the total timeout fees for a packet given its identifier
+  rpc TotalTimeoutFees(QueryTotalTimeoutFeesRequest) returns (QueryTotalTimeoutFeesResponse) {
+    option (google.api.http).get = "/ibc/apps/fee/v1/channels/{packet_id.channel_id}/ports/{packet_id.port_id}/"
+                                   "sequences/{packet_id.sequence}/total_timeout_fees";
+  }
+
+  // Payee returns the registered payee address for a specific channel given the relayer address
+  rpc Payee(QueryPayeeRequest) returns (QueryPayeeResponse) {
+    option (google.api.http).get = "/ibc/apps/fee/v1/channels/{channel_id}/relayers/{relayer}/payee";
+  }
+
+  // CounterpartyPayee returns the registered counterparty payee for forward relaying
+  rpc CounterpartyPayee(QueryCounterpartyPayeeRequest) returns (QueryCounterpartyPayeeResponse) {
+    option (google.api.http).get = "/ibc/apps/fee/v1/channels/{channel_id}/relayers/{relayer}/counterparty_payee";
+  }
+
+  // FeeEnabledChannels returns a list of all fee enabled channels
+  rpc FeeEnabledChannels(QueryFeeEnabledChannelsRequest) returns (QueryFeeEnabledChannelsResponse) {
+    option (google.api.http).get = "/ibc/apps/fee/v1/fee_enabled";
+  }
+
+  // FeeEnabledChannel returns true if the provided port and channel identifiers belong to a fee enabled channel
+  rpc FeeEnabledChannel(QueryFeeEnabledChannelRequest) returns (QueryFeeEnabledChannelResponse) {
+    option (google.api.http).get = "/ibc/apps/fee/v1/channels/{channel_id}/ports/{port_id}/fee_enabled";
+  }
+}
+
+// QueryIncentivizedPacketsRequest defines the request type for the IncentivizedPackets rpc
+message QueryIncentivizedPacketsRequest {
+  // pagination defines an optional pagination for the request.
+  cosmos.base.query.v1beta1.PageRequest pagination = 1;
+  // block height at which to query
+  uint64 query_height = 2;
+}
+
+// QueryIncentivizedPacketsResponse defines the response type for the IncentivizedPackets rpc
+message QueryIncentivizedPacketsResponse {
+  // list of identified fees for incentivized packets
+  repeated ibc.applications.fee.v1.IdentifiedPacketFees incentivized_packets = 1 [(gogoproto.nullable) = false];
+}
+
+// QueryIncentivizedPacketRequest defines the request type for the IncentivizedPacket rpc
+message QueryIncentivizedPacketRequest {
+  // unique packet identifier comprised of channel ID, port ID and sequence
+  ibc.core.channel.v1.PacketId packet_id = 1 [(gogoproto.nullable) = false];
+  // block height at which to query
+  uint64 query_height = 2;
+}
+
+// QueryIncentivizedPacketsResponse defines the response type for the IncentivizedPacket rpc
+message QueryIncentivizedPacketResponse {
+  // the identified fees for the incentivized packet
+  ibc.applications.fee.v1.IdentifiedPacketFees incentivized_packet = 1 [(gogoproto.nullable) = false];
+}
+
+// QueryIncentivizedPacketsForChannelRequest defines the request type for querying for all incentivized packets
+// for a specific channel
+message QueryIncentivizedPacketsForChannelRequest {
+  // pagination defines an optional pagination for the request.
+  cosmos.base.query.v1beta1.PageRequest pagination = 1;
+  string                                port_id    = 2;
+  string                                channel_id = 3;
+  // Height to query at
+  uint64 query_height = 4;
+}
+
+// QueryIncentivizedPacketsResponse defines the response type for the incentivized packets RPC
+message QueryIncentivizedPacketsForChannelResponse {
+  // Map of all incentivized_packets
+  repeated ibc.applications.fee.v1.IdentifiedPacketFees incentivized_packets = 1;
+}
+
+// QueryTotalRecvFeesRequest defines the request type for the TotalRecvFees rpc
+message QueryTotalRecvFeesRequest {
+  // the packet identifier for the associated fees
+  ibc.core.channel.v1.PacketId packet_id = 1 [(gogoproto.nullable) = false];
+}
+
+// QueryTotalRecvFeesResponse defines the response type for the TotalRecvFees rpc
+message QueryTotalRecvFeesResponse {
+  // the total packet receive fees
+  repeated cosmos.base.v1beta1.Coin recv_fees = 1 [
+    (gogoproto.moretags)     = "yaml:\"recv_fees\"",
+    (gogoproto.nullable)     = false,
+    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
+  ];
+}
+
+// QueryTotalAckFeesRequest defines the request type for the TotalAckFees rpc
+message QueryTotalAckFeesRequest {
+  // the packet identifier for the associated fees
+  ibc.core.channel.v1.PacketId packet_id = 1 [(gogoproto.nullable) = false];
+}
+
+// QueryTotalAckFeesResponse defines the response type for the TotalAckFees rpc
+message QueryTotalAckFeesResponse {
+  // the total packet acknowledgement fees
+  repeated cosmos.base.v1beta1.Coin ack_fees = 1 [
+    (gogoproto.moretags)     = "yaml:\"ack_fees\"",
+    (gogoproto.nullable)     = false,
+    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
+  ];
+}
+
+// QueryTotalTimeoutFeesRequest defines the request type for the TotalTimeoutFees rpc
+message QueryTotalTimeoutFeesRequest {
+  // the packet identifier for the associated fees
+  ibc.core.channel.v1.PacketId packet_id = 1 [(gogoproto.nullable) = false];
+}
+
+// QueryTotalTimeoutFeesResponse defines the response type for the TotalTimeoutFees rpc
+message QueryTotalTimeoutFeesResponse {
+  // the total packet timeout fees
+  repeated cosmos.base.v1beta1.Coin timeout_fees = 1 [
+    (gogoproto.moretags)     = "yaml:\"timeout_fees\"",
+    (gogoproto.nullable)     = false,
+    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
+  ];
+}
+
+// QueryPayeeRequest defines the request type for the Payee rpc
+message QueryPayeeRequest {
+  // unique channel identifier
+  string channel_id = 1 [(gogoproto.moretags) = "yaml:\"channel_id\""];
+  // the relayer address to which the distribution address is registered
+  string relayer = 2;
+}
+
+// QueryPayeeResponse defines the response type for the Payee rpc
+message QueryPayeeResponse {
+  // the payee address to which packet fees are paid out
+  string payee_address = 1 [(gogoproto.moretags) = "yaml:\"payee_address\""];
+}
+
+// QueryCounterpartyPayeeRequest defines the request type for the CounterpartyPayee rpc
+message QueryCounterpartyPayeeRequest {
+  // unique channel identifier
+  string channel_id = 1 [(gogoproto.moretags) = "yaml:\"channel_id\""];
+  // the relayer address to which the counterparty is registered
+  string relayer = 2;
+}
+
+// QueryCounterpartyPayeeResponse defines the response type for the CounterpartyPayee rpc
+message QueryCounterpartyPayeeResponse {
+  // the counterparty payee address used to compensate forward relaying
+  string counterparty_payee = 1 [(gogoproto.moretags) = "yaml:\"counterparty_payee\""];
+}
+
+// QueryFeeEnabledChannelsRequest defines the request type for the FeeEnabledChannels rpc
+message QueryFeeEnabledChannelsRequest {
+  // pagination defines an optional pagination for the request.
+  cosmos.base.query.v1beta1.PageRequest pagination = 1;
+  // block height at which to query
+  uint64 query_height = 2;
+}
+
+// QueryFeeEnabledChannelsResponse defines the response type for the FeeEnabledChannels rpc
+message QueryFeeEnabledChannelsResponse {
+  // list of fee enabled channels
+  repeated ibc.applications.fee.v1.FeeEnabledChannel fee_enabled_channels = 1
+      [(gogoproto.moretags) = "yaml:\"fee_enabled_channels\"", (gogoproto.nullable) = false];
+}
+
+// QueryFeeEnabledChannelRequest defines the request type for the FeeEnabledChannel rpc
+message QueryFeeEnabledChannelRequest {
+  // unique port identifier
+  string port_id = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
+  // unique channel identifier
+  string channel_id = 2 [(gogoproto.moretags) = "yaml:\"channel_id\""];
+}
+
+// QueryFeeEnabledChannelResponse defines the response type for the FeeEnabledChannel rpc
+message QueryFeeEnabledChannelResponse {
+  // boolean flag representing the fee enabled channel status
+  bool fee_enabled = 1 [(gogoproto.moretags) = "yaml:\"fee_enabled\""];
+}

--- a/proto/ibc-go-vendor/ibc/applications/fee/v1/tx.proto
+++ b/proto/ibc-go-vendor/ibc/applications/fee/v1/tx.proto
@@ -1,0 +1,112 @@
+syntax = "proto3";
+
+package ibc.applications.fee.v1;
+
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/29-fee/types";
+
+import "gogoproto/gogo.proto";
+import "ibc/applications/fee/v1/fee.proto";
+import "ibc/core/channel/v1/channel.proto";
+
+// Msg defines the ICS29 Msg service.
+service Msg {
+  // RegisterPayee defines a rpc handler method for MsgRegisterPayee
+  // RegisterPayee is called by the relayer on each channelEnd and allows them to set an optional
+  // payee to which reverse and timeout relayer packet fees will be paid out. The payee should be registered on
+  // the source chain from which packets originate as this is where fee distribution takes place. This function may be
+  // called more than once by a relayer, in which case, the latest payee is always used.
+  rpc RegisterPayee(MsgRegisterPayee) returns (MsgRegisterPayeeResponse);
+
+  // RegisterCounterpartyPayee defines a rpc handler method for MsgRegisterCounterpartyPayee
+  // RegisterCounterpartyPayee is called by the relayer on each channelEnd and allows them to specify the counterparty
+  // payee address before relaying. This ensures they will be properly compensated for forward relaying since
+  // the destination chain must include the registered counterparty payee address in the acknowledgement. This function
+  // may be called more than once by a relayer, in which case, the latest counterparty payee address is always used.
+  rpc RegisterCounterpartyPayee(MsgRegisterCounterpartyPayee) returns (MsgRegisterCounterpartyPayeeResponse);
+
+  // PayPacketFee defines a rpc handler method for MsgPayPacketFee
+  // PayPacketFee is an open callback that may be called by any module/user that wishes to escrow funds in order to
+  // incentivize the relaying of the packet at the next sequence
+  // NOTE: This method is intended to be used within a multi msg transaction, where the subsequent msg that follows
+  // initiates the lifecycle of the incentivized packet
+  rpc PayPacketFee(MsgPayPacketFee) returns (MsgPayPacketFeeResponse);
+
+  // PayPacketFeeAsync defines a rpc handler method for MsgPayPacketFeeAsync
+  // PayPacketFeeAsync is an open callback that may be called by any module/user that wishes to escrow funds in order to
+  // incentivize the relaying of a known packet (i.e. at a particular sequence)
+  rpc PayPacketFeeAsync(MsgPayPacketFeeAsync) returns (MsgPayPacketFeeAsyncResponse);
+}
+
+// MsgRegisterPayee defines the request type for the RegisterPayee rpc
+message MsgRegisterPayee {
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  // unique port identifier
+  string port_id = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
+  // unique channel identifier
+  string channel_id = 2 [(gogoproto.moretags) = "yaml:\"channel_id\""];
+  // the relayer address
+  string relayer = 3;
+  // the payee address
+  string payee = 4;
+}
+
+// MsgRegisterPayeeResponse defines the response type for the RegisterPayee rpc
+message MsgRegisterPayeeResponse {}
+
+// MsgRegisterCounterpartyPayee defines the request type for the RegisterCounterpartyPayee rpc
+message MsgRegisterCounterpartyPayee {
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  // unique port identifier
+  string port_id = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
+  // unique channel identifier
+  string channel_id = 2 [(gogoproto.moretags) = "yaml:\"channel_id\""];
+  // the relayer address
+  string relayer = 3;
+  // the counterparty payee address
+  string counterparty_payee = 4 [(gogoproto.moretags) = "yaml:\"counterparty_payee\""];
+}
+
+// MsgRegisterCounterpartyPayeeResponse defines the response type for the RegisterCounterpartyPayee rpc
+message MsgRegisterCounterpartyPayeeResponse {}
+
+// MsgPayPacketFee defines the request type for the PayPacketFee rpc
+// This Msg can be used to pay for a packet at the next sequence send & should be combined with the Msg that will be
+// paid for
+message MsgPayPacketFee {
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  // fee encapsulates the recv, ack and timeout fees associated with an IBC packet
+  ibc.applications.fee.v1.Fee fee = 1 [(gogoproto.nullable) = false];
+  // the source port unique identifier
+  string source_port_id = 2 [(gogoproto.moretags) = "yaml:\"source_port_id\""];
+  // the source channel unique identifer
+  string source_channel_id = 3 [(gogoproto.moretags) = "yaml:\"source_channel_id\""];
+  // account address to refund fee if necessary
+  string signer = 4;
+  // optional list of relayers permitted to the receive packet fees
+  repeated string relayers = 5;
+}
+
+// MsgPayPacketFeeResponse defines the response type for the PayPacketFee rpc
+message MsgPayPacketFeeResponse {}
+
+// MsgPayPacketFeeAsync defines the request type for the PayPacketFeeAsync rpc
+// This Msg can be used to pay for a packet at a specified sequence (instead of the next sequence send)
+message MsgPayPacketFeeAsync {
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  // unique packet identifier comprised of the channel ID, port ID and sequence
+  ibc.core.channel.v1.PacketId packet_id = 1
+      [(gogoproto.moretags) = "yaml:\"packet_id\"", (gogoproto.nullable) = false];
+  // the packet fee associated with a particular IBC packet
+  PacketFee packet_fee = 2 [(gogoproto.moretags) = "yaml:\"packet_fee\"", (gogoproto.nullable) = false];
+}
+
+// MsgPayPacketFeeAsyncResponse defines the response type for the PayPacketFeeAsync rpc
+message MsgPayPacketFeeAsyncResponse {}

--- a/proto/ibc-go-vendor/ibc/applications/interchain_accounts/controller/v1/controller.proto
+++ b/proto/ibc-go-vendor/ibc/applications/interchain_accounts/controller/v1/controller.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.applications.interchain_accounts.controller.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/controller/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/controller/types";
 
 import "gogoproto/gogo.proto";
 

--- a/proto/ibc-go-vendor/ibc/applications/interchain_accounts/controller/v1/query.proto
+++ b/proto/ibc-go-vendor/ibc/applications/interchain_accounts/controller/v1/query.proto
@@ -2,17 +2,35 @@ syntax = "proto3";
 
 package ibc.applications.interchain_accounts.controller.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/controller/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/controller/types";
 
 import "ibc/applications/interchain_accounts/controller/v1/controller.proto";
+import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 
 // Query provides defines the gRPC querier service.
 service Query {
+  // InterchainAccount returns the interchain account address for a given owner address on a given connection
+  rpc InterchainAccount(QueryInterchainAccountRequest) returns (QueryInterchainAccountResponse) {
+    option (google.api.http).get =
+        "/ibc/apps/interchain_accounts/controller/v1/owners/{owner}/connections/{connection_id}";
+  }
+
   // Params queries all parameters of the ICA controller submodule.
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
     option (google.api.http).get = "/ibc/apps/interchain_accounts/controller/v1/params";
   }
+}
+
+// QueryInterchainAccountRequest is the request type for the Query/InterchainAccount RPC method.
+message QueryInterchainAccountRequest {
+  string owner         = 1;
+  string connection_id = 2 [(gogoproto.moretags) = "yaml:\"connection_id\""];
+}
+
+// QueryInterchainAccountResponse the response type for the Query/InterchainAccount RPC method.
+message QueryInterchainAccountResponse {
+  string address = 1;
 }
 
 // QueryParamsRequest is the request type for the Query/Params RPC method.

--- a/proto/ibc-go-vendor/ibc/applications/interchain_accounts/host/v1/host.proto
+++ b/proto/ibc-go-vendor/ibc/applications/interchain_accounts/host/v1/host.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.applications.interchain_accounts.host.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/host/types";
 
 import "gogoproto/gogo.proto";
 

--- a/proto/ibc-go-vendor/ibc/applications/interchain_accounts/host/v1/query.proto
+++ b/proto/ibc-go-vendor/ibc/applications/interchain_accounts/host/v1/query.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.applications.interchain_accounts.host.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/host/types";
 
 import "google/api/annotations.proto";
 import "ibc/applications/interchain_accounts/host/v1/host.proto";

--- a/proto/ibc-go-vendor/ibc/applications/interchain_accounts/v1/account.proto
+++ b/proto/ibc-go-vendor/ibc/applications/interchain_accounts/v1/account.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.applications.interchain_accounts.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/types";
 
 import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";

--- a/proto/ibc-go-vendor/ibc/applications/interchain_accounts/v1/genesis.proto
+++ b/proto/ibc-go-vendor/ibc/applications/interchain_accounts/v1/genesis.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.applications.interchain_accounts.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/applications/interchain_accounts/controller/v1/controller.proto";

--- a/proto/ibc-go-vendor/ibc/applications/interchain_accounts/v1/metadata.proto
+++ b/proto/ibc-go-vendor/ibc/applications/interchain_accounts/v1/metadata.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.applications.interchain_accounts.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/types";
 
 import "gogoproto/gogo.proto";
 

--- a/proto/ibc-go-vendor/ibc/applications/interchain_accounts/v1/packet.proto
+++ b/proto/ibc-go-vendor/ibc/applications/interchain_accounts/v1/packet.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.applications.interchain_accounts.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/27-interchain-accounts/types";
 
 import "google/protobuf/any.proto";
 import "gogoproto/gogo.proto";

--- a/proto/ibc-go-vendor/ibc/applications/transfer/v1/genesis.proto
+++ b/proto/ibc-go-vendor/ibc/applications/transfer/v1/genesis.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.applications.transfer.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types";
 
 import "ibc/applications/transfer/v1/transfer.proto";
 import "gogoproto/gogo.proto";

--- a/proto/ibc-go-vendor/ibc/applications/transfer/v1/query.proto
+++ b/proto/ibc-go-vendor/ibc/applications/transfer/v1/query.proto
@@ -7,7 +7,7 @@ import "cosmos/base/query/v1beta1/pagination.proto";
 import "ibc/applications/transfer/v1/transfer.proto";
 import "google/api/annotations.proto";
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types";
 
 // Query provides defines the gRPC querier service.
 service Query {
@@ -30,12 +30,17 @@ service Query {
   rpc DenomHash(QueryDenomHashRequest) returns (QueryDenomHashResponse) {
     option (google.api.http).get = "/ibc/apps/transfer/v1/denom_hashes/{trace}";
   }
+
+  // EscrowAddress returns the escrow address for a particular port and channel id.
+  rpc EscrowAddress(QueryEscrowAddressRequest) returns (QueryEscrowAddressResponse) {
+    option (google.api.http).get = "/ibc/apps/transfer/v1/channels/{channel_id}/ports/{port_id}/escrow_address";
+  }
 }
 
 // QueryDenomTraceRequest is the request type for the Query/DenomTrace RPC
 // method
 message QueryDenomTraceRequest {
-  // hash (in hex format) of the denomination trace information.
+  // hash (in hex format) or denom (full denom with ibc prefix) of the denomination trace information.
   string hash = 1;
 }
 
@@ -83,4 +88,18 @@ message QueryDenomHashRequest {
 message QueryDenomHashResponse {
   // hash (in hex format) of the denomination trace information.
   string hash = 1;
+}
+
+// QueryEscrowAddressRequest is the request type for the EscrowAddress RPC method.
+message QueryEscrowAddressRequest {
+  // unique port identifier
+  string port_id = 1;
+  // unique channel identifier
+  string channel_id = 2;
+}
+
+// QueryEscrowAddressResponse is the response type of the EscrowAddress RPC method.
+message QueryEscrowAddressResponse {
+  // the escrow account address
+  string escrow_address = 1;
 }

--- a/proto/ibc-go-vendor/ibc/applications/transfer/v1/transfer.proto
+++ b/proto/ibc-go-vendor/ibc/applications/transfer/v1/transfer.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.applications.transfer.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types";
 
 import "gogoproto/gogo.proto";
 

--- a/proto/ibc-go-vendor/ibc/applications/transfer/v1/tx.proto
+++ b/proto/ibc-go-vendor/ibc/applications/transfer/v1/tx.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.applications.transfer.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types";
 
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
@@ -38,7 +38,12 @@ message MsgTransfer {
   // Timeout timestamp in absolute nanoseconds since unix epoch.
   // The timeout is disabled when set to 0.
   uint64 timeout_timestamp = 7 [(gogoproto.moretags) = "yaml:\"timeout_timestamp\""];
+  // optional memo
+  string memo = 8;
 }
 
 // MsgTransferResponse defines the Msg/Transfer response type.
-message MsgTransferResponse {}
+message MsgTransferResponse {
+  // sequence number of the transfer packet sent
+  uint64 sequence = 1;
+}

--- a/proto/ibc-go-vendor/ibc/applications/transfer/v2/packet.proto
+++ b/proto/ibc-go-vendor/ibc/applications/transfer/v2/packet.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.applications.transfer.v2;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/apps/transfer/types";
 
 // FungibleTokenPacketData defines a struct for the packet payload
 // See FungibleTokenPacketData spec:
@@ -16,4 +16,6 @@ message FungibleTokenPacketData {
   string sender = 3;
   // the recipient address on the destination chain
   string receiver = 4;
+  // optional memo
+  string memo = 5;
 }

--- a/proto/ibc-go-vendor/ibc/core/channel/v1/channel.proto
+++ b/proto/ibc-go-vendor/ibc/core/channel/v1/channel.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.channel.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/client/v1/client.proto";
@@ -130,6 +130,20 @@ message PacketState {
   uint64 sequence = 3;
   // embedded data that represents packet state.
   bytes data = 4;
+}
+
+// PacketId is an identifer for a unique Packet
+// Source chains refer to packets by source port/channel
+// Destination chains refer to packets by destination port/channel
+message PacketId {
+  option (gogoproto.goproto_getters) = false;
+
+  // channel port identifier
+  string port_id = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
+  // channel unique identifier
+  string channel_id = 2 [(gogoproto.moretags) = "yaml:\"channel_id\""];
+  // packet sequence
+  uint64 sequence = 3;
 }
 
 // Acknowledgement is the recommended acknowledgement format to be used by

--- a/proto/ibc-go-vendor/ibc/core/channel/v1/genesis.proto
+++ b/proto/ibc-go-vendor/ibc/core/channel/v1/genesis.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.channel.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/channel/v1/channel.proto";

--- a/proto/ibc-go-vendor/ibc/core/channel/v1/query.proto
+++ b/proto/ibc-go-vendor/ibc/core/channel/v1/query.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.channel.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types";
 
 import "ibc/core/client/v1/client.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";

--- a/proto/ibc-go-vendor/ibc/core/channel/v1/tx.proto
+++ b/proto/ibc-go-vendor/ibc/core/channel/v1/tx.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.channel.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/04-channel/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/client/v1/client.proto";
@@ -42,6 +42,18 @@ service Msg {
   rpc Acknowledgement(MsgAcknowledgement) returns (MsgAcknowledgementResponse);
 }
 
+// ResponseResultType defines the possible outcomes of the execution of a message
+enum ResponseResultType {
+  option (gogoproto.goproto_enum_prefix) = false;
+
+  // Default zero value enumeration
+  RESPONSE_RESULT_TYPE_UNSPECIFIED = 0 [(gogoproto.enumvalue_customname) = "UNSPECIFIED"];
+  // The message did not call the IBC application callbacks (because, for example, the packet had already been relayed)
+  RESPONSE_RESULT_TYPE_NOOP = 1 [(gogoproto.enumvalue_customname) = "NOOP"];
+  // The message was executed successfully
+  RESPONSE_RESULT_TYPE_SUCCESS = 2 [(gogoproto.enumvalue_customname) = "SUCCESS"];
+}
+
 // MsgChannelOpenInit defines an sdk.Msg to initialize a channel handshake. It
 // is called by a relayer on Chain A.
 message MsgChannelOpenInit {
@@ -56,6 +68,7 @@ message MsgChannelOpenInit {
 // MsgChannelOpenInitResponse defines the Msg/ChannelOpenInit response type.
 message MsgChannelOpenInitResponse {
   string channel_id = 1 [(gogoproto.moretags) = "yaml:\"channel_id\""];
+  string version    = 2;
 }
 
 // MsgChannelOpenInit defines a msg sent by a Relayer to try to open a channel
@@ -66,9 +79,8 @@ message MsgChannelOpenTry {
   option (gogoproto.goproto_getters) = false;
 
   string port_id = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
-  // in the case of crossing hello's, when both chains call OpenInit, we need
-  // the channel identifier of the previous channel in state INIT
-  string previous_channel_id = 2 [(gogoproto.moretags) = "yaml:\"previous_channel_id\""];
+  // Deprecated: this field is unused. Crossing hello's are no longer supported in core IBC.
+  string previous_channel_id = 2 [deprecated = true, (gogoproto.moretags) = "yaml:\"previous_channel_id\""];
   // NOTE: the version field within the channel has been deprecated. Its value will be ignored by core IBC.
   Channel                   channel              = 3 [(gogoproto.nullable) = false];
   string                    counterparty_version = 4 [(gogoproto.moretags) = "yaml:\"counterparty_version\""];
@@ -79,7 +91,9 @@ message MsgChannelOpenTry {
 }
 
 // MsgChannelOpenTryResponse defines the Msg/ChannelOpenTry response type.
-message MsgChannelOpenTryResponse {}
+message MsgChannelOpenTryResponse {
+  string version = 1;
+}
 
 // MsgChannelOpenAck defines a msg sent by a Relayer to Chain A to acknowledge
 // the change of channel state to TRYOPEN on Chain B.
@@ -163,7 +177,11 @@ message MsgRecvPacket {
 }
 
 // MsgRecvPacketResponse defines the Msg/RecvPacket response type.
-message MsgRecvPacketResponse {}
+message MsgRecvPacketResponse {
+  option (gogoproto.goproto_getters) = false;
+
+  ResponseResultType result = 1;
+}
 
 // MsgTimeout receives timed-out packet
 message MsgTimeout {
@@ -179,7 +197,11 @@ message MsgTimeout {
 }
 
 // MsgTimeoutResponse defines the Msg/Timeout response type.
-message MsgTimeoutResponse {}
+message MsgTimeoutResponse {
+  option (gogoproto.goproto_getters) = false;
+
+  ResponseResultType result = 1;
+}
 
 // MsgTimeoutOnClose timed-out packet upon counterparty channel closure.
 message MsgTimeoutOnClose {
@@ -196,7 +218,11 @@ message MsgTimeoutOnClose {
 }
 
 // MsgTimeoutOnCloseResponse defines the Msg/TimeoutOnClose response type.
-message MsgTimeoutOnCloseResponse {}
+message MsgTimeoutOnCloseResponse {
+  option (gogoproto.goproto_getters) = false;
+
+  ResponseResultType result = 1;
+}
 
 // MsgAcknowledgement receives incoming IBC acknowledgement
 message MsgAcknowledgement {
@@ -212,4 +238,8 @@ message MsgAcknowledgement {
 }
 
 // MsgAcknowledgementResponse defines the Msg/Acknowledgement response type.
-message MsgAcknowledgementResponse {}
+message MsgAcknowledgementResponse {
+  option (gogoproto.goproto_getters) = false;
+
+  ResponseResultType result = 1;
+}

--- a/proto/ibc-go-vendor/ibc/core/client/v1/client.proto
+++ b/proto/ibc-go-vendor/ibc/core/client/v1/client.proto
@@ -2,11 +2,12 @@ syntax = "proto3";
 
 package ibc.core.client.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/02-client/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/02-client/types";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 import "cosmos/upgrade/v1beta1/upgrade.proto";
+import "cosmos_proto/cosmos.proto";
 
 // IdentifiedClientState defines a client state with an additional client
 // identifier field.
@@ -41,7 +42,8 @@ message ClientConsensusStates {
 // handler may fail if the subject and the substitute do not match in client and
 // chain parameters (with exception to latest height, frozen height, and chain-id).
 message ClientUpdateProposal {
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.goproto_getters)         = false;
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
   // the title of the update proposal
   string title = 1;
   // the description of the proposal
@@ -56,9 +58,10 @@ message ClientUpdateProposal {
 // UpgradeProposal is a gov Content type for initiating an IBC breaking
 // upgrade.
 message UpgradeProposal {
-  option (gogoproto.goproto_getters)  = false;
-  option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.equal)            = true;
+  option (gogoproto.goproto_getters)         = false;
+  option (gogoproto.goproto_stringer)        = false;
+  option (gogoproto.equal)                   = true;
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
 
   string                      title       = 1;
   string                      description = 2;

--- a/proto/ibc-go-vendor/ibc/core/client/v1/genesis.proto
+++ b/proto/ibc-go-vendor/ibc/core/client/v1/genesis.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.client.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/02-client/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/02-client/types";
 
 import "ibc/core/client/v1/client.proto";
 import "gogoproto/gogo.proto";

--- a/proto/ibc-go-vendor/ibc/core/client/v1/query.proto
+++ b/proto/ibc-go-vendor/ibc/core/client/v1/query.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.client.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/02-client/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/02-client/types";
 
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "ibc/core/client/v1/client.proto";
@@ -34,6 +34,11 @@ service Query {
   // client.
   rpc ConsensusStates(QueryConsensusStatesRequest) returns (QueryConsensusStatesResponse) {
     option (google.api.http).get = "/ibc/core/client/v1/consensus_states/{client_id}";
+  }
+
+  // ConsensusStateHeights queries the height of every consensus states associated with a given client.
+  rpc ConsensusStateHeights(QueryConsensusStateHeightsRequest) returns (QueryConsensusStateHeightsResponse) {
+    option (google.api.http).get = "/ibc/core/client/v1/consensus_states/{client_id}/heights";
   }
 
   // Status queries the status of an IBC client.
@@ -133,6 +138,24 @@ message QueryConsensusStatesRequest {
 message QueryConsensusStatesResponse {
   // consensus states associated with the identifier
   repeated ConsensusStateWithHeight consensus_states = 1 [(gogoproto.nullable) = false];
+  // pagination response
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+
+// QueryConsensusStateHeightsRequest is the request type for Query/ConsensusStateHeights
+// RPC method.
+message QueryConsensusStateHeightsRequest {
+  // client identifier
+  string client_id = 1;
+  // pagination request
+  cosmos.base.query.v1beta1.PageRequest pagination = 2;
+}
+
+// QueryConsensusStateHeightsResponse is the response type for the
+// Query/ConsensusStateHeights RPC method
+message QueryConsensusStateHeightsResponse {
+  // consensus state heights
+  repeated Height consensus_state_heights = 1 [(gogoproto.nullable) = false];
   // pagination response
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }

--- a/proto/ibc-go-vendor/ibc/core/client/v1/tx.proto
+++ b/proto/ibc-go-vendor/ibc/core/client/v1/tx.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.client.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/02-client/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/02-client/types";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";

--- a/proto/ibc-go-vendor/ibc/core/commitment/v1/commitment.proto
+++ b/proto/ibc-go-vendor/ibc/core/commitment/v1/commitment.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.commitment.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/23-commitment/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/23-commitment/types";
 
 import "gogoproto/gogo.proto";
 import "proofs.proto";

--- a/proto/ibc-go-vendor/ibc/core/connection/v1/connection.proto
+++ b/proto/ibc-go-vendor/ibc/core/connection/v1/connection.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.connection.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/commitment/v1/commitment.proto";

--- a/proto/ibc-go-vendor/ibc/core/connection/v1/genesis.proto
+++ b/proto/ibc-go-vendor/ibc/core/connection/v1/genesis.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.connection.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/connection/v1/connection.proto";

--- a/proto/ibc-go-vendor/ibc/core/connection/v1/query.proto
+++ b/proto/ibc-go-vendor/ibc/core/connection/v1/query.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.connection.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types";
 
 import "gogoproto/gogo.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";

--- a/proto/ibc-go-vendor/ibc/core/connection/v1/tx.proto
+++ b/proto/ibc-go-vendor/ibc/core/connection/v1/tx.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.connection.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/03-connection/types";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
@@ -49,14 +49,13 @@ message MsgConnectionOpenTry {
   option (gogoproto.goproto_getters) = false;
 
   string client_id = 1 [(gogoproto.moretags) = "yaml:\"client_id\""];
-  // in the case of crossing hello's, when both chains call OpenInit, we need
-  // the connection identifier of the previous connection in state INIT
-  string                    previous_connection_id = 2 [(gogoproto.moretags) = "yaml:\"previous_connection_id\""];
-  google.protobuf.Any       client_state           = 3 [(gogoproto.moretags) = "yaml:\"client_state\""];
-  Counterparty              counterparty           = 4 [(gogoproto.nullable) = false];
-  uint64                    delay_period           = 5 [(gogoproto.moretags) = "yaml:\"delay_period\""];
-  repeated Version          counterparty_versions  = 6 [(gogoproto.moretags) = "yaml:\"counterparty_versions\""];
-  ibc.core.client.v1.Height proof_height           = 7
+  // Deprecated: this field is unused. Crossing hellos are no longer supported in core IBC.
+  string previous_connection_id = 2 [deprecated = true, (gogoproto.moretags) = "yaml:\"previous_connection_id\""];
+  google.protobuf.Any       client_state          = 3 [(gogoproto.moretags) = "yaml:\"client_state\""];
+  Counterparty              counterparty          = 4 [(gogoproto.nullable) = false];
+  uint64                    delay_period          = 5 [(gogoproto.moretags) = "yaml:\"delay_period\""];
+  repeated Version          counterparty_versions = 6 [(gogoproto.moretags) = "yaml:\"counterparty_versions\""];
+  ibc.core.client.v1.Height proof_height          = 7
       [(gogoproto.moretags) = "yaml:\"proof_height\"", (gogoproto.nullable) = false];
   // proof of the initialization the connection on Chain A: `UNITIALIZED ->
   // INIT`

--- a/proto/ibc-go-vendor/ibc/core/types/v1/genesis.proto
+++ b/proto/ibc-go-vendor/ibc/core/types/v1/genesis.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.core.types.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/client/v1/genesis.proto";

--- a/proto/ibc-go-vendor/ibc/lightclients/localhost/v1/localhost.proto
+++ b/proto/ibc-go-vendor/ibc/lightclients/localhost/v1/localhost.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.lightclients.localhost.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/light-clients/09-localhost/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/light-clients/09-localhost/types";
 
 import "gogoproto/gogo.proto";
 import "ibc/core/client/v1/client.proto";

--- a/proto/ibc-go-vendor/ibc/lightclients/solomachine/v1/solomachine.proto
+++ b/proto/ibc-go-vendor/ibc/lightclients/solomachine/v1/solomachine.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.lightclients.solomachine.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/core/02-client/legacy/v100";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/core/02-client/legacy/v100";
 
 import "ibc/core/connection/v1/connection.proto";
 import "ibc/core/channel/v1/channel.proto";

--- a/proto/ibc-go-vendor/ibc/lightclients/solomachine/v2/solomachine.proto
+++ b/proto/ibc-go-vendor/ibc/lightclients/solomachine/v2/solomachine.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.lightclients.solomachine.v2;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/light-clients/06-solomachine/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/light-clients/06-solomachine/types";
 
 import "ibc/core/connection/v1/connection.proto";
 import "ibc/core/channel/v1/channel.proto";

--- a/proto/ibc-go-vendor/ibc/lightclients/tendermint/v1/tendermint.proto
+++ b/proto/ibc-go-vendor/ibc/lightclients/tendermint/v1/tendermint.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ibc.lightclients.tendermint.v1;
 
-option go_package = "github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types";
+option go_package = "github.com/cosmos/ibc-go/v5/modules/light-clients/07-tendermint/types";
 
 import "tendermint/types/validator.proto";
 import "tendermint/types/types.proto";
@@ -52,12 +52,11 @@ message ClientState {
   // "upgradedIBCState"}`
   repeated string upgrade_path = 9 [(gogoproto.moretags) = "yaml:\"upgrade_path\""];
 
-  // This flag, when set to true, will allow governance to recover a client
-  // which has expired
-  bool allow_update_after_expiry = 10 [(gogoproto.moretags) = "yaml:\"allow_update_after_expiry\""];
-  // This flag, when set to true, will allow governance to unfreeze a client
-  // whose chain has experienced a misbehaviour event
-  bool allow_update_after_misbehaviour = 11 [(gogoproto.moretags) = "yaml:\"allow_update_after_misbehaviour\""];
+  // allow_update_after_expiry is deprecated
+  bool allow_update_after_expiry = 10 [deprecated = true, (gogoproto.moretags) = "yaml:\"allow_update_after_expiry\""];
+  // allow_update_after_misbehaviour is deprecated
+  bool allow_update_after_misbehaviour = 11
+      [deprecated = true, (gogoproto.moretags) = "yaml:\"allow_update_after_misbehaviour\""];
 }
 
 // ConsensusState defines the consensus state from Tendermint.


### PR DESCRIPTION
This updates our IBC protos to match their derived types provided by the `ibc-proto` crate. Ideally, we should *only* import the crate, and not vendor these protos. The challenge is that we have our own proto (the Action type) that extends the IBC protos, but the `ibc-proto` crate only exposes (from what I can tell) the derived types.