### PR TITLE
custody: allow multi-party pre-authorizations

### DIFF
--- a/custody/src/pre_auth.rs
+++ b/custody/src/pre_auth.rs
@@ -1,19 +1,32 @@
 use penumbra_proto::{custody::v1alpha1 as pb, Protobuf};
 use penumbra_transaction::plan::TransactionPlan;
+use serde::{Deserialize, Serialize};
 
-/// A pre-authorization packet, containing an Ed25519 signature over a
-/// `TransactionPlan`.  This allows a custodian to delegate (partial) signing
-/// authority to Ed25519 keys.  Details of how a custodian manages those keys
-/// are out-of-scope for the custody protocol itself and are custodian-specific.
-#[derive(Debug, Clone)]
-pub struct PreAuthorization {
+/// A pre-authorization packet.  This allows a custodian to delegate (partial)
+/// signing authority to other authorization mechanisms.  Details of how a
+/// custodian manages those keys are out-of-scope for the custody protocol and
+/// are custodian-specific.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "pb::PreAuthorization", into = "pb::PreAuthorization")]
+pub enum PreAuthorization {
+    Ed25519(Ed25519),
+}
+
+/// An Ed25519-based preauthorization, containing an Ed25519 signature over the
+/// `TransactionPlan`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(
+    try_from = "pb::pre_authorization::Ed25519",
+    into = "pb::pre_authorization::Ed25519"
+)]
+pub struct Ed25519 {
     /// The verification key used to pre-authorize the `TransactionPlan`.
     pub vk: ed25519_consensus::VerificationKey,
     /// An Ed25519 signature over the `TransactionPlan`.
     pub sig: ed25519_consensus::Signature,
 }
 
-impl PreAuthorization {
+impl Ed25519 {
     /// Verifies the provided `TransactionPlan`.
     pub fn verify_plan(&self, plan: &TransactionPlan) -> anyhow::Result<()> {
         let plan_bytes = plan.encode_to_vec();
@@ -26,6 +39,34 @@ impl Protobuf<pb::PreAuthorization> for PreAuthorization {}
 impl TryFrom<pb::PreAuthorization> for PreAuthorization {
     type Error = anyhow::Error;
     fn try_from(value: pb::PreAuthorization) -> Result<Self, Self::Error> {
+        Ok(match value.pre_authorization {
+            Some(pb::pre_authorization::PreAuthorization::Ed25519(ed)) => {
+                Self::Ed25519(ed.try_into()?)
+            }
+            None => {
+                return Err(anyhow::anyhow!("missing pre-authorization"));
+            }
+        })
+    }
+}
+
+impl From<PreAuthorization> for pb::PreAuthorization {
+    fn from(value: PreAuthorization) -> pb::PreAuthorization {
+        Self {
+            pre_authorization: Some(match value {
+                PreAuthorization::Ed25519(ed) => {
+                    pb::pre_authorization::PreAuthorization::Ed25519(ed.into())
+                }
+            }),
+        }
+    }
+}
+
+impl Protobuf<pb::pre_authorization::Ed25519> for Ed25519 {}
+
+impl TryFrom<pb::pre_authorization::Ed25519> for Ed25519 {
+    type Error = anyhow::Error;
+    fn try_from(value: pb::pre_authorization::Ed25519) -> Result<Self, Self::Error> {
         Ok(Self {
             vk: value.vk.as_slice().try_into()?,
             sig: value.sig.as_slice().try_into()?,
@@ -33,8 +74,8 @@ impl TryFrom<pb::PreAuthorization> for PreAuthorization {
     }
 }
 
-impl From<PreAuthorization> for pb::PreAuthorization {
-    fn from(value: PreAuthorization) -> pb::PreAuthorization {
+impl From<Ed25519> for pb::pre_authorization::Ed25519 {
+    fn from(value: Ed25519) -> pb::pre_authorization::Ed25519 {
         Self {
             vk: value.vk.to_bytes().into(),
             sig: value.sig.to_bytes().into(),

--- a/proto/proto/penumbra/custody/v1alpha1/custody.proto
+++ b/proto/proto/penumbra/custody/v1alpha1/custody.proto
@@ -30,20 +30,30 @@ message AuthorizeRequest {
   core.crypto.v1alpha1.AccountID account_id = 2;
 
   // Optionally, pre-authorization data, if required by the custodian.
-  PreAuthorization pre_auth = 3;
+  //
+  // Multiple `PreAuthorization` packets can be included in a single request,
+  // to support multi-party pre-authorizations.
+  repeated PreAuthorization pre_authorizations = 3;
 }
 
 message AuthorizeResponse {
   core.transaction.v1alpha1.AuthorizationData data = 1;
 }
 
-// A pre-authorization packet, containing an Ed25519 signature over a
-// `TransactionPlan`.  This allows a custodian to delegate (partial) signing
-// authority to Ed25519 keys.  Details of how a custodian manages those keys
-// are out-of-scope for the custody protocol and are custodian-specific.
+// A pre-authorization packet.  This allows a custodian to delegate (partial)
+// signing authority to other authorization mechanisms.  Details of how a
+// custodian manages those keys are out-of-scope for the custody protocol and
+// are custodian-specific.
 message PreAuthorization {
-  // The Ed25519 verification key used to verify the signature.
-  bytes vk = 1;
-  // The Ed25519 signature over the `TransactionPlan`.
-  bytes sig = 2;
+  // An Ed25519-based preauthorization, containing an Ed25519 signature over the
+  // `TransactionPlan`.
+  message Ed25519 {
+    // The Ed25519 verification key used to verify the signature.
+    bytes vk = 1;
+    // The Ed25519 signature over the `TransactionPlan`.
+    bytes sig = 2;
+  }
+  oneof pre_authorization {
+    Ed25519 ed25519 = 1;
+  }
 }

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
@@ -400,6 +400,7 @@ pub struct DelegatorVoteBody {
     pub no_with_veto_balance_commitment: ::core::option::Option<super::super::crypto::v1alpha1::BalanceCommitment>,
 }
 /// The data required to authorize a transaction plan.
+#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizationData {
     /// The computed auth hash for the approved transaction plan.

--- a/proto/src/gen/penumbra.custody.v1alpha1.rs
+++ b/proto/src/gen/penumbra.custody.v1alpha1.rs
@@ -1,3 +1,4 @@
+#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizeRequest {
     /// The transaction plan to authorize.
@@ -7,26 +8,50 @@ pub struct AuthorizeRequest {
     #[prost(message, optional, tag="2")]
     pub account_id: ::core::option::Option<super::super::core::crypto::v1alpha1::AccountId>,
     /// Optionally, pre-authorization data, if required by the custodian.
-    #[prost(message, optional, tag="3")]
-    pub pre_auth: ::core::option::Option<PreAuthorization>,
+    ///
+    /// Multiple `PreAuthorization` packets can be included in a single request,
+    /// to support multi-party pre-authorizations.
+    #[prost(message, repeated, tag="3")]
+    pub pre_authorizations: ::prost::alloc::vec::Vec<PreAuthorization>,
 }
+#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthorizeResponse {
     #[prost(message, optional, tag="1")]
     pub data: ::core::option::Option<super::super::core::transaction::v1alpha1::AuthorizationData>,
 }
-/// A pre-authorization packet, containing an Ed25519 signature over a
-/// `TransactionPlan`.  This allows a custodian to delegate (partial) signing
-/// authority to Ed25519 keys.  Details of how a custodian manages those keys
-/// are out-of-scope for the custody protocol and are custodian-specific.
+/// A pre-authorization packet.  This allows a custodian to delegate (partial)
+/// signing authority to other authorization mechanisms.  Details of how a
+/// custodian manages those keys are out-of-scope for the custody protocol and
+/// are custodian-specific.
+#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PreAuthorization {
-    /// The Ed25519 verification key used to verify the signature.
-    #[prost(bytes="vec", tag="1")]
-    pub vk: ::prost::alloc::vec::Vec<u8>,
-    /// The Ed25519 signature over the `TransactionPlan`.
-    #[prost(bytes="vec", tag="2")]
-    pub sig: ::prost::alloc::vec::Vec<u8>,
+    #[prost(oneof="pre_authorization::PreAuthorization", tags="1")]
+    pub pre_authorization: ::core::option::Option<pre_authorization::PreAuthorization>,
+}
+/// Nested message and enum types in `PreAuthorization`.
+pub mod pre_authorization {
+    /// An Ed25519-based preauthorization, containing an Ed25519 signature over the
+    /// `TransactionPlan`.
+    #[derive(::serde::Deserialize, ::serde::Serialize)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Ed25519 {
+        /// The Ed25519 verification key used to verify the signature.
+        #[prost(bytes="vec", tag="1")]
+        #[serde(with = "crate::serializers::base64str")]
+        pub vk: ::prost::alloc::vec::Vec<u8>,
+        /// The Ed25519 signature over the `TransactionPlan`.
+        #[prost(bytes="vec", tag="2")]
+        #[serde(with = "crate::serializers::base64str")]
+        pub sig: ::prost::alloc::vec::Vec<u8>,
+    }
+    #[derive(::serde::Deserialize, ::serde::Serialize)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum PreAuthorization {
+        #[prost(message, tag="1")]
+        Ed25519(Ed25519),
+    }
 }
 /// Generated client implementations.
 #[cfg(feature = "rpc")]

--- a/tools/proto-compiler/src/main.rs
+++ b/tools/proto-compiler/src/main.rs
@@ -86,8 +86,14 @@ fn main() -> Result<()> {
         .client_mod_attribute("penumbra.view.v1alpha1", "#[cfg(feature = \"rpc\")]")
         .server_mod_attribute("penumbra.custody.v1alpha1", "#[cfg(feature = \"rpc\")]")
         .client_mod_attribute("penumbra.custody.v1alpha1", "#[cfg(feature = \"rpc\")]")
-        .server_mod_attribute("cosmos.base.tendermint.v1beta1", "#[cfg(feature = \"rpc\")]")
-        .client_mod_attribute("cosmos.base.tendermint.v1beta1", "#[cfg(feature = \"rpc\")]")
+        .server_mod_attribute(
+            "cosmos.base.tendermint.v1beta1",
+            "#[cfg(feature = \"rpc\")]",
+        )
+        .client_mod_attribute(
+            "cosmos.base.tendermint.v1beta1",
+            "#[cfg(feature = \"rpc\")]",
+        )
         .compile_with_config(
             config,
             &[
@@ -275,6 +281,10 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.core.chain.v1alpha1.Ratio", SERIALIZE),
     (".penumbra.core.transaction.v1alpha1.AuthHash", SERIALIZE),
     (
+        ".penumbra.core.transaction.v1alpha1.AuthorizationData",
+        SERIALIZE,
+    ),
+    (
         ".penumbra.core.transaction.v1alpha1.TransactionPlan",
         SERIALIZE,
     ),
@@ -417,6 +427,9 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     ),
     (".penumbra.view.v1alpha1.SpendableNoteRecord", SERIALIZE),
     (".penumbra.view.v1alpha1.SwapRecord", SERIALIZE),
+    (".penumbra.custody.v1alpha1.AuthorizeRequest", SERIALIZE),
+    (".penumbra.custody.v1alpha1.AuthorizeResponse", SERIALIZE),
+    (".penumbra.custody.v1alpha1.PreAuthorization", SERIALIZE),
 ];
 
 static FIELD_ATTRIBUTES: &[(&str, &str)] = &[
@@ -605,5 +618,13 @@ static FIELD_ATTRIBUTES: &[(&str, &str)] = &[
     (
         ".penumbra.core.transaction.v1alpha1.AuthHash.inner",
         AS_HEX_FOR_BYTES,
+    ),
+    (
+        ".penumbra.custody.v1alpha1.PreAuthorization.Ed25519.vk",
+        AS_BASE64,
+    ),
+    (
+        ".penumbra.custody.v1alpha1.PreAuthorization.Ed25519.sig",
+        AS_BASE64,
     ),
 ];

--- a/wallet/src/build.rs
+++ b/wallet/src/build.rs
@@ -22,7 +22,7 @@ where
         .authorize(AuthorizeRequest {
             account_id: fvk.hash(),
             plan: plan.clone(),
-            pre_auth: None,
+            pre_authorizations: Vec::new(),
         })
         .await?
         .data


### PR DESCRIPTION
This commit changes the `PreAuthorization` modeling in the custody protocol to allow custodians to require pre-authorization from multiple parties prior to submission, by making the `PreAuthorization` field `repeated`.

It also changes the `PreAuthorization` from just being an Ed25519 signature to being a `oneof` with one message (the existing Ed25519 preauthorization message), so that in the future, more kinds of preauthorization data can be added (e.g., webauthn).