### PR TITLE
Fix usage of "effecting" vs "authorizing" data

### DIFF
--- a/component/src/action_handler/actions/proposal/withdraw.rs
+++ b/component/src/action_handler/actions/proposal/withdraw.rs
@@ -24,9 +24,9 @@ impl ActionHandler for ProposalWithdraw {
         // but not fixed because we want to change the proposal withdrawal
         // mechanism anyways.
         /*
-        let auth_hash = context.transaction_body().auth_hash();
+        let effect_hash = context.transaction_body().effect_hash();
 
-        check::stateful::proposal_withdraw(&state, &auth_hash, self).await
+        check::stateful::proposal_withdraw(&state, &effect_hash, self).await
         */
         Ok(())
     }

--- a/component/src/action_handler/actions/spend.rs
+++ b/component/src/action_handler/actions/spend.rs
@@ -16,14 +16,14 @@ impl ActionHandler for Spend {
     #[instrument(name = "spend", skip(self, context))]
     async fn check_stateless(&self, context: Arc<Transaction>) -> Result<()> {
         let spend = self;
-        let auth_hash = context.transaction_body().auth_hash();
+        let effect_hash = context.transaction_body().effect_hash();
         let anchor = context.anchor;
 
         // 2. Check spend auth signature using provided spend auth key.
         spend
             .body
             .rk
-            .verify(auth_hash.as_ref(), &spend.auth_sig)
+            .verify(effect_hash.as_ref(), &spend.auth_sig)
             .context("spend auth signature failed to verify")?;
 
         // 3. Check that the proof verifies.

--- a/component/src/action_handler/transaction/stateless.rs
+++ b/component/src/action_handler/transaction/stateless.rs
@@ -5,13 +5,13 @@ use penumbra_transaction::Transaction;
 
 #[tracing::instrument(skip(tx))]
 pub(super) fn valid_binding_signature(tx: &Transaction) -> Result<()> {
-    let auth_hash = tx.transaction_body().auth_hash();
+    let effect_hash = tx.transaction_body().effect_hash();
 
-    tracing::debug!(bvk = ?tx.binding_verification_key(), auth_hash = ?auth_hash);
+    tracing::debug!(bvk = ?tx.binding_verification_key(), effect_hash = ?effect_hash);
 
     // Check binding signature.
     tx.binding_verification_key()
-        .verify(auth_hash.as_ref(), tx.binding_sig())
+        .verify(effect_hash.as_ref(), tx.binding_sig())
         .context("binding signature failed to verify")
 }
 

--- a/component/src/governance/check.rs
+++ b/component/src/governance/check.rs
@@ -163,7 +163,7 @@ pub mod stateful {
     /*
     pub async fn proposal_withdraw(
         state: &State,
-        auth_hash: &AuthHash,
+        effect_hash: &EffectHash,
         proposal_withdraw @ ProposalWithdraw {
             body:
                 ProposalWithdrawBody {
@@ -174,7 +174,7 @@ pub mod stateful {
         }: &ProposalWithdraw,
     ) -> Result<()> {
         proposal_withdrawable(state, *proposal).await?;
-        proposal_withdraw_key_verifies(state, auth_hash, proposal_withdraw).await?;
+        proposal_withdraw_key_verifies(state, effect_hash, proposal_withdraw).await?;
         Ok(())
     }
 
@@ -201,12 +201,12 @@ pub mod stateful {
 
     async fn proposal_withdraw_key_verifies(
         state: &State,
-        auth_hash: &AuthHash,
+        effect_hash: &EffectHash,
         ProposalWithdraw { body, auth_sig }: &ProposalWithdraw,
     ) -> Result<()> {
         if let Some(withdraw_proposal_key) = state.proposal_withdrawal_key(body.proposal).await? {
             withdraw_proposal_key
-                .verify(auth_hash.as_ref(), auth_sig)
+                .verify(effect_hash.as_ref(), auth_sig)
                 .context("proposal withdraw signature failed to verify")?;
         } else {
             anyhow::bail!("proposal {} does not exist", body.proposal);

--- a/crypto/src/dex/swap.rs
+++ b/crypto/src/dex/swap.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use ark_ff::PrimeField;
-use blake2b_simd::Hash;
+
 use decaf377::Fq;
 use once_cell::sync::Lazy;
 use penumbra_proto::{
@@ -63,20 +63,6 @@ impl BatchSwapOutputData {
             // the same token type. But this is exactly the delta_j_i.
             (delta_1_i, delta_2_i)
         }
-    }
-
-    pub fn auth_hash(&self) -> Hash {
-        blake2b_simd::Params::default()
-            .personal(b"PAH:btchswp_otpt")
-            .to_state()
-            .update(&self.delta_1.to_le_bytes())
-            .update(&self.delta_2.to_le_bytes())
-            .update(&self.lambda_1.to_le_bytes())
-            .update(&self.lambda_2.to_le_bytes())
-            .update(&self.height.to_le_bytes())
-            .update(self.trading_pair.auth_hash().as_bytes())
-            .update(&(self.success as i64).to_le_bytes())
-            .finalize()
     }
 }
 

--- a/crypto/src/dex/trading_pair.rs
+++ b/crypto/src/dex/trading_pair.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use anyhow::{anyhow, Result};
-use blake2b_simd::Hash;
+
 use decaf377::FieldExt;
 use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
 
@@ -46,12 +46,6 @@ impl TradingPair {
             asset_1: pair.1,
             asset_2: pair.0,
         })
-    }
-
-    pub fn auth_hash(&self) -> Hash {
-        blake2b_simd::Params::default()
-            .personal(b"PAH:trading_pair")
-            .hash(&self.to_bytes())
     }
 
     /// Convert the trading pair to bytes.

--- a/crypto/src/encrypted_note.rs
+++ b/crypto/src/encrypted_note.rs
@@ -1,7 +1,7 @@
 use anyhow::Error;
-use blake2b_simd::Hash;
+
 use bytes::Bytes;
-use decaf377::FieldExt;
+
 use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
 use serde::{Deserialize, Serialize};
 
@@ -59,16 +59,6 @@ impl EncryptedNote {
         // See "REJECT" attack (CVE-2019-16930) for a similar attack in ZCash
         // Section 4.1 in https://crypto.stanford.edu/timings/pingreject.pdf
         Some(note)
-    }
-
-    pub fn auth_hash(&self) -> Hash {
-        blake2b_simd::Params::default()
-            .personal(b"PAH:note_payload")
-            .to_state()
-            .update(&self.note_commitment.0.to_bytes())
-            .update(&self.ephemeral_key.0)
-            .update(&self.encrypted_note)
-            .finalize()
     }
 }
 

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -1,5 +1,3 @@
-use blake2b_simd::Hash;
-
 use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
 
 use crate::{asset, balance, Balance, Fr, Value, STAKING_TOKEN_ASSET_ID};
@@ -79,16 +77,6 @@ impl TryFrom<pb::Fee> for Fee {
 }
 
 impl Fee {
-    pub fn auth_hash(&self) -> Hash {
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:fee")
-            .to_state();
-        state.update(&self.0.amount.to_le_bytes());
-        state.update(&self.0.asset_id.to_bytes());
-
-        state.finalize()
-    }
-
     pub fn value(&self) -> Value {
         self.0
     }

--- a/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
+++ b/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
@@ -10,7 +10,7 @@ import "penumbra/core/dex/v1alpha1/dex.proto";
 import "penumbra/core/governance/v1alpha1/governance.proto";
 
 // An authorization hash for a Penumbra transaction.
-message AuthHash {
+message EffectHash {
   bytes inner = 1;
 }
 
@@ -162,17 +162,17 @@ message ActionView {
 
 // Spends a shielded note.
 message Spend {
-  // The authorizing data for the spend, which is included in the authorization hash used for signing.
+  // The effecting data of the spend.
   SpendBody body = 1;
-  // The spend authorization signature is effecting data.
+  // The authorizing signature for the spend.
   crypto.v1alpha1.SpendAuthSignature auth_sig = 2;
-  // The spend proof is effecting data.
+  // The proof that the spend is well-formed is authorizing data.
   bytes proof = 3;
 }
 
-// The body of a spend description, containing only the "authorizing" data
-// included in the authorization hash used for signing, and not the "effecting"
-// data which is bound to the authorizing data by some other means.
+// The body of a spend description, containing only the effecting data
+// describing changes to the ledger, and not the authorizing data that allows
+// those changes to be performed.
 message SpendBody {
   // A commitment to the value of the input note.
   crypto.v1alpha1.BalanceCommitment balance_commitment = 1;
@@ -184,15 +184,15 @@ message SpendBody {
 
 // Creates a new shielded note.
 message Output {
-  // The authorizing data for the output.
+  // The effecting data for the output.
   OutputBody body = 1;
-  // The output proof is effecting data.
+  // The output proof is authorizing data.
   bytes proof = 2;
 }
 
-// The body of an output description, containing only the "authorizing" data
-// included in the authorization hash used for signing, and not the "effecting"
-// data which is bound to the authorizing data by some other means.
+// The body of an output description, containing only the effecting data
+// describing changes to the ledger, and not the authorizing data that allows
+// those changes to be performed.
 message OutputBody {
   // The minimal data required to scan and process the new output note.
   crypto.v1alpha1.EncryptedNote note_payload = 1;
@@ -231,9 +231,9 @@ message ProposalWithdrawBody {
 }
 
 message ValidatorVote {
-  // The authorizing data for the vote.
+  // The effecting data for the vote.
   ValidatorVoteBody body = 1;
-  // The vote authorization signature is effecting data.
+  // The vote authorization signature is authorizing data.
   crypto.v1alpha1.SpendAuthSignature auth_sig = 2;
 }
 
@@ -249,11 +249,11 @@ message ValidatorVoteBody {
 }
 
 message DelegatorVote {
-  // The authorizing data for the vote, which is included in the authorization hash used for signing.
+  // The effecting data for the vote.
   DelegatorVoteBody body = 1;
-  // The vote authorization signature is effecting data.
+  // The vote authorization signature is authorizing data.
   crypto.v1alpha1.SpendAuthSignature auth_sig = 2;
-  // The vote proof is effecting data.
+  // The vote proof is authorizing data.
   bytes proof = 3;
 }
 
@@ -285,7 +285,7 @@ message DelegatorVoteBody {
 // The data required to authorize a transaction plan.
 message AuthorizationData {
     // The computed auth hash for the approved transaction plan.
-    AuthHash auth_hash = 1;
+    EffectHash effect_hash = 1;
     // The required spend authorizations, returned in the same order as the
     // Spend actions in the original request.
     repeated crypto.v1alpha1.SpendAuthSignature spend_auths = 2;
@@ -506,7 +506,7 @@ message Proposal {
       // The height for which the transaction was scheduled.
       uint64 scheduled_at_height = 1;
       // The auth hash of the transaction to cancel.
-      AuthHash auth_hash = 2;
+      EffectHash effect_hash = 2;
     }
   }
 }

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
@@ -2,7 +2,7 @@
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[serde(transparent)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct AuthHash {
+pub struct EffectHash {
     #[prost(bytes="bytes", tag="1")]
     #[serde(with = "crate::serializers::hexstr_bytes")]
     pub inner: ::prost::bytes::Bytes,
@@ -228,20 +228,20 @@ pub mod action_view {
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Spend {
-    /// The authorizing data for the spend, which is included in the authorization hash used for signing.
+    /// The effecting data of the spend.
     #[prost(message, optional, tag="1")]
     pub body: ::core::option::Option<SpendBody>,
-    /// The spend authorization signature is effecting data.
+    /// The authorizing signature for the spend.
     #[prost(message, optional, tag="2")]
     pub auth_sig: ::core::option::Option<super::super::crypto::v1alpha1::SpendAuthSignature>,
-    /// The spend proof is effecting data.
+    /// The proof that the spend is well-formed is authorizing data.
     #[prost(bytes="bytes", tag="3")]
     #[serde(with = "crate::serializers::base64str_bytes")]
     pub proof: ::prost::bytes::Bytes,
 }
-/// The body of a spend description, containing only the "authorizing" data
-/// included in the authorization hash used for signing, and not the "effecting"
-/// data which is bound to the authorizing data by some other means.
+/// The body of a spend description, containing only the effecting data
+/// describing changes to the ledger, and not the authorizing data that allows
+/// those changes to be performed.
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SpendBody {
@@ -261,17 +261,17 @@ pub struct SpendBody {
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Output {
-    /// The authorizing data for the output.
+    /// The effecting data for the output.
     #[prost(message, optional, tag="1")]
     pub body: ::core::option::Option<OutputBody>,
-    /// The output proof is effecting data.
+    /// The output proof is authorizing data.
     #[prost(bytes="bytes", tag="2")]
     #[serde(with = "crate::serializers::base64str_bytes")]
     pub proof: ::prost::bytes::Bytes,
 }
-/// The body of an output description, containing only the "authorizing" data
-/// included in the authorization hash used for signing, and not the "effecting"
-/// data which is bound to the authorizing data by some other means.
+/// The body of an output description, containing only the effecting data
+/// describing changes to the ledger, and not the authorizing data that allows
+/// those changes to be performed.
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OutputBody {
@@ -330,10 +330,10 @@ pub struct ProposalWithdrawBody {
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidatorVote {
-    /// The authorizing data for the vote.
+    /// The effecting data for the vote.
     #[prost(message, optional, tag="1")]
     pub body: ::core::option::Option<ValidatorVoteBody>,
-    /// The vote authorization signature is effecting data.
+    /// The vote authorization signature is authorizing data.
     #[prost(message, optional, tag="2")]
     pub auth_sig: ::core::option::Option<super::super::crypto::v1alpha1::SpendAuthSignature>,
 }
@@ -356,13 +356,13 @@ pub struct ValidatorVoteBody {
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DelegatorVote {
-    /// The authorizing data for the vote, which is included in the authorization hash used for signing.
+    /// The effecting data for the vote.
     #[prost(message, optional, tag="1")]
     pub body: ::core::option::Option<DelegatorVoteBody>,
-    /// The vote authorization signature is effecting data.
+    /// The vote authorization signature is authorizing data.
     #[prost(message, optional, tag="2")]
     pub auth_sig: ::core::option::Option<super::super::crypto::v1alpha1::SpendAuthSignature>,
-    /// The vote proof is effecting data.
+    /// The vote proof is authorizing data.
     #[prost(bytes="bytes", tag="3")]
     pub proof: ::prost::bytes::Bytes,
 }
@@ -405,7 +405,7 @@ pub struct DelegatorVoteBody {
 pub struct AuthorizationData {
     /// The computed auth hash for the approved transaction plan.
     #[prost(message, optional, tag="1")]
-    pub auth_hash: ::core::option::Option<AuthHash>,
+    pub effect_hash: ::core::option::Option<EffectHash>,
     /// The required spend authorizations, returned in the same order as the
     /// Spend actions in the original request.
     #[prost(message, repeated, tag="2")]
@@ -736,7 +736,7 @@ pub mod proposal {
             pub scheduled_at_height: u64,
             /// The auth hash of the transaction to cancel.
             #[prost(message, optional, tag="2")]
-            pub auth_hash: ::core::option::Option<super::super::AuthHash>,
+            pub effect_hash: ::core::option::Option<super::super::EffectHash>,
         }
     }
 }

--- a/tools/proto-compiler/src/main.rs
+++ b/tools/proto-compiler/src/main.rs
@@ -279,7 +279,7 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
     (".penumbra.core.chain.v1alpha1.GenesisAppState", SERIALIZE),
     (".penumbra.core.chain.v1alpha1.GenesisAllocation", SERIALIZE),
     (".penumbra.core.chain.v1alpha1.Ratio", SERIALIZE),
-    (".penumbra.core.transaction.v1alpha1.AuthHash", SERIALIZE),
+    (".penumbra.core.transaction.v1alpha1.EffectHash", SERIALIZE),
     (
         ".penumbra.core.transaction.v1alpha1.AuthorizationData",
         SERIALIZE,
@@ -422,7 +422,7 @@ static TYPE_ATTRIBUTES: &[(&str, &str)] = &[
         SERDE_TAG_OUTCOME,
     ),
     (
-        ".penumbra.core.transaction.v1alpha1.AuthHash",
+        ".penumbra.core.transaction.v1alpha1.EffectHash",
         SERDE_TRANSPARENT,
     ),
     (".penumbra.view.v1alpha1.SpendableNoteRecord", SERIALIZE),
@@ -616,7 +616,7 @@ static FIELD_ATTRIBUTES: &[(&str, &str)] = &[
     // see above re: prost issue #504
     ("penumbra.core.governance.v1alpha1.Vote.vote", AS_VOTE),
     (
-        ".penumbra.core.transaction.v1alpha1.AuthHash.inner",
+        ".penumbra.core.transaction.v1alpha1.EffectHash.inner",
         AS_HEX_FOR_BYTES,
     ),
     (

--- a/transaction/src/auth_data.rs
+++ b/transaction/src/auth_data.rs
@@ -1,14 +1,14 @@
 use penumbra_crypto::rdsa::{Signature, SpendAuth};
 use penumbra_proto::{core::transaction::v1alpha1 as pb, Protobuf};
 
-use crate::AuthHash;
+use crate::EffectHash;
 
 /// Authorization data returned in response to a
 /// [`TransactionDescription`](crate::TransactionDescription).
 #[derive(Clone, Debug)]
 pub struct AuthorizationData {
     /// The computed authorization hash for the approved transaction.
-    pub auth_hash: AuthHash,
+    pub effect_hash: EffectHash,
     /// The required spend authorization signatures, returned in the same order as the Spend actions
     /// in the original request.
     pub spend_auths: Vec<Signature<SpendAuth>>,
@@ -22,7 +22,7 @@ impl Protobuf<pb::AuthorizationData> for AuthorizationData {}
 impl From<AuthorizationData> for pb::AuthorizationData {
     fn from(msg: AuthorizationData) -> Self {
         Self {
-            auth_hash: Some(msg.auth_hash.into()),
+            effect_hash: Some(msg.effect_hash.into()),
             spend_auths: msg.spend_auths.into_iter().map(Into::into).collect(),
             withdraw_proposal_auths: msg
                 .withdraw_proposal_auths
@@ -37,9 +37,9 @@ impl TryFrom<pb::AuthorizationData> for AuthorizationData {
     type Error = anyhow::Error;
     fn try_from(value: pb::AuthorizationData) -> Result<Self, Self::Error> {
         Ok(Self {
-            auth_hash: value
-                .auth_hash
-                .ok_or_else(|| anyhow::anyhow!("missing auth_hash"))?
+            effect_hash: value
+                .effect_hash
+                .ok_or_else(|| anyhow::anyhow!("missing effect_hash"))?
                 .try_into()?,
             spend_auths: value
                 .spend_auths

--- a/transaction/src/effect_hash.rs
+++ b/transaction/src/effect_hash.rs
@@ -1,7 +1,9 @@
 use blake2b_simd::{Hash, Params};
 use decaf377::FieldExt;
 use decaf377_fmd::Clue;
-use penumbra_crypto::{FullViewingKey, PayloadKey};
+use penumbra_crypto::{
+    dex::TradingPair, transaction::Fee, EncryptedNote, FullViewingKey, PayloadKey,
+};
 use penumbra_proto::{core::transaction::v1alpha1 as pb, Message, Protobuf};
 
 use crate::{
@@ -15,66 +17,72 @@ use crate::{
     Action, Transaction, TransactionBody,
 };
 
-pub trait AuthorizingData {
-    fn auth_hash(&self) -> Hash;
+pub trait EffectingData {
+    fn effect_hash(&self) -> EffectHash;
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
-pub struct AuthHash([u8; 64]);
+pub struct EffectHash([u8; 64]);
 
-impl Default for AuthHash {
+impl EffectHash {
+    pub fn as_bytes(&self) -> &[u8; 64] {
+        &self.0
+    }
+}
+
+impl Default for EffectHash {
     fn default() -> Self {
         Self([0u8; 64])
     }
 }
 
-impl std::fmt::Debug for AuthHash {
+impl std::fmt::Debug for EffectHash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("AuthHash")
+        f.debug_tuple("EffectHash")
             .field(&hex::encode(self.0))
             .finish()
     }
 }
 
-impl Protobuf<pb::AuthHash> for AuthHash {}
+impl Protobuf<pb::EffectHash> for EffectHash {}
 
-impl From<AuthHash> for pb::AuthHash {
-    fn from(msg: AuthHash) -> Self {
+impl From<EffectHash> for pb::EffectHash {
+    fn from(msg: EffectHash) -> Self {
         Self {
             inner: msg.0.to_vec().into(),
         }
     }
 }
 
-impl TryFrom<pb::AuthHash> for AuthHash {
+impl TryFrom<pb::EffectHash> for EffectHash {
     type Error = anyhow::Error;
-    fn try_from(value: pb::AuthHash) -> Result<Self, Self::Error> {
+    fn try_from(value: pb::EffectHash) -> Result<Self, Self::Error> {
         Ok(Self(value.inner.as_ref().try_into()?))
     }
 }
 
-impl AsRef<[u8]> for AuthHash {
+impl AsRef<[u8]> for EffectHash {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
 impl Transaction {
-    pub fn auth_hash(&self) -> AuthHash {
-        self.transaction_body.auth_hash()
+    pub fn effect_hash(&self) -> EffectHash {
+        self.transaction_body.effect_hash()
     }
 }
 
 impl TransactionBody {
-    pub fn auth_hash(&self) -> AuthHash {
+    pub fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:tx_body")
             .to_state();
 
         // Hash the fixed data of the transaction body.
-        state.update(chain_id_auth_hash(&self.chain_id).as_bytes());
+        state.update(chain_id_effect_hash(&self.chain_id).as_bytes());
         state.update(&self.expiry_height.to_le_bytes());
-        state.update(self.fee.auth_hash().as_bytes());
+        state.update(self.fee.effect_hash().as_bytes());
         if self.memo.is_some() {
             let memo = self.memo.clone();
             state.update(&memo.unwrap().0);
@@ -84,28 +92,28 @@ impl TransactionBody {
         let num_actions = self.actions.len() as u32;
         state.update(&num_actions.to_le_bytes());
         for action in &self.actions {
-            state.update(action.auth_hash().as_bytes());
+            state.update(action.effect_hash().as_bytes());
         }
 
         // Hash the clues.
         let num_clues = self.fmd_clues.len() as u32;
         state.update(&num_clues.to_le_bytes());
         for fmd_clue in &self.fmd_clues {
-            state.update(fmd_clue.auth_hash().as_bytes());
+            state.update(fmd_clue.effect_hash().as_bytes());
         }
 
-        AuthHash(*state.finalize().as_array())
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
 impl TransactionPlan {
-    /// Computes the [`AuthHash`] for the [`Transaction`] described by this
+    /// Computes the [`EffectHash`] for the [`Transaction`] described by this
     /// [`TransactionPlan`].
     ///
     /// This method does not require constructing the entire [`Transaction`],
     /// but it does require the associated [`FullViewingKey`] to derive
-    /// authorizing data that will be fed into the hash.
-    pub fn auth_hash(&self, fvk: &FullViewingKey) -> AuthHash {
+    /// effecting data that will be fed into the [`EffectHash`].
+    pub fn effect_hash(&self, fvk: &FullViewingKey) -> EffectHash {
         // This implementation is identical to the one above, except that we
         // don't need to actually construct the entire `TransactionBody` with
         // complete `Action`s, we just need to construct the bodies of the
@@ -116,9 +124,9 @@ impl TransactionPlan {
             .to_state();
 
         // Hash the fixed data of the transaction body.
-        state.update(chain_id_auth_hash(&self.chain_id).as_bytes());
+        state.update(chain_id_effect_hash(&self.chain_id).as_bytes());
         state.update(&self.expiry_height.to_le_bytes());
-        state.update(self.fee.auth_hash().as_bytes());
+        state.update(self.fee.effect_hash().as_bytes());
 
         // Hash the memo and save the memo key for use with outputs later.
         let mut memo_key: Option<PayloadKey> = None;
@@ -134,7 +142,7 @@ impl TransactionPlan {
         // TransactionPlan::build builds the actions sorted by type, so hash the
         // actions in the order they'll appear in the final transaction.
         for spend in self.spend_plans() {
-            state.update(spend.spend_body(fvk).auth_hash().as_bytes());
+            state.update(spend.spend_body(fvk).effect_hash().as_bytes());
         }
 
         // If the memo_key is None, then there is no memo, and we populate the memo key
@@ -147,100 +155,107 @@ impl TransactionPlan {
                         fvk.outgoing(),
                         memo_key.as_ref().unwrap_or(&dummy_payload_key),
                     )
-                    .auth_hash()
+                    .effect_hash()
                     .as_bytes(),
             );
         }
         for swap in self.swap_plans() {
-            state.update(swap.swap_body(fvk).auth_hash().as_bytes());
+            state.update(swap.swap_body(fvk).effect_hash().as_bytes());
         }
         for swap_claim in self.swap_claim_plans() {
-            state.update(swap_claim.swap_claim_body(fvk).auth_hash().as_bytes());
+            state.update(swap_claim.swap_claim_body(fvk).effect_hash().as_bytes());
         }
         for delegation in self.delegations() {
-            state.update(delegation.auth_hash().as_bytes());
+            state.update(delegation.effect_hash().as_bytes());
         }
         for undelegation in self.undelegations() {
-            state.update(undelegation.auth_hash().as_bytes());
+            state.update(undelegation.effect_hash().as_bytes());
         }
         for plan in self.undelegate_claim_plans() {
-            state.update(plan.undelegate_claim_body().auth_hash().as_bytes());
+            state.update(plan.undelegate_claim_body().effect_hash().as_bytes());
         }
         for proposal_submit in self.proposal_submits() {
-            state.update(proposal_submit.auth_hash().as_bytes());
+            state.update(proposal_submit.effect_hash().as_bytes());
         }
         for proposal_withdraw in self.proposal_withdraws() {
-            state.update(proposal_withdraw.auth_hash().as_bytes());
+            state.update(proposal_withdraw.effect_hash().as_bytes());
         }
         for validator_vote in self.validator_votes() {
-            state.update(validator_vote.auth_hash().as_bytes());
+            state.update(validator_vote.effect_hash().as_bytes());
         }
         for _delegator_vote in self.delegator_vote_plans() {
-            // TODO: get the authorization hash of the delegator vote body for each plan
+            // TODO: get the effecthash of the delegator vote body for each plan
         }
         // These are data payloads, so just hash them directly,
-        // since we consider them authorizing data.
+        // since they are effecting data.
         for payload in self.validator_definitions() {
-            let auth_hash = Params::default()
+            let effect_hash = Params::default()
                 .personal(b"PAH:valdefnition")
                 .hash(&payload.encode_to_vec());
-            state.update(auth_hash.as_bytes());
+            state.update(effect_hash.as_bytes());
         }
         for payload in self.ibc_actions() {
-            let auth_hash = Params::default()
+            let effect_hash = Params::default()
                 .personal(b"PAH:ibc_action")
                 .hash(&payload.encode_to_vec());
-            state.update(auth_hash.as_bytes());
+            state.update(effect_hash.as_bytes());
         }
         let num_clues = self.clue_plans.len() as u32;
         state.update(&num_clues.to_le_bytes());
         for clue_plan in self.clue_plans() {
-            state.update(clue_plan.clue().auth_hash().as_bytes());
+            state.update(clue_plan.clue().effect_hash().as_bytes());
         }
 
-        AuthHash(*state.finalize().as_array())
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-fn chain_id_auth_hash(chain_id: &str) -> Hash {
+fn chain_id_effect_hash(chain_id: &str) -> Hash {
     blake2b_simd::Params::default()
         .personal(b"PAH:chain_id")
         .hash(chain_id.as_bytes())
 }
 
-impl AuthorizingData for Action {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for Action {
+    fn effect_hash(&self) -> EffectHash {
         match self {
-            Action::Output(output) => output.body.auth_hash(),
-            Action::Spend(spend) => spend.body.auth_hash(),
-            Action::Delegate(delegate) => delegate.auth_hash(),
-            Action::Undelegate(undelegate) => undelegate.auth_hash(),
-            Action::UndelegateClaim(claim) => claim.body.auth_hash(),
-            Action::ProposalSubmit(submit) => submit.auth_hash(),
-            Action::ProposalWithdraw(withdraw) => withdraw.auth_hash(),
-            Action::ValidatorVote(vote) => vote.auth_hash(),
-            Action::SwapClaim(swap_claim) => swap_claim.body.auth_hash(),
-            Action::Swap(swap) => swap.body.auth_hash(),
+            Action::Output(output) => output.body.effect_hash(),
+            Action::Spend(spend) => spend.body.effect_hash(),
+            Action::Delegate(delegate) => delegate.effect_hash(),
+            Action::Undelegate(undelegate) => undelegate.effect_hash(),
+            Action::UndelegateClaim(claim) => claim.body.effect_hash(),
+            Action::ProposalSubmit(submit) => submit.effect_hash(),
+            Action::ProposalWithdraw(withdraw) => withdraw.effect_hash(),
+            Action::ValidatorVote(vote) => vote.effect_hash(),
+            Action::SwapClaim(swap_claim) => swap_claim.body.effect_hash(),
+            Action::Swap(swap) => swap.body.effect_hash(),
             // These are data payloads, so just hash them directly,
             // since we consider them authorizing data.
-            Action::ValidatorDefinition(payload) => Params::default()
-                .personal(b"PAH:valdefnition")
-                .hash(&payload.encode_to_vec()),
-            Action::IBCAction(payload) => Params::default()
-                .personal(b"PAH:ibc_action")
-                .hash(&payload.encode_to_vec()),
-
-            Action::PositionOpen(p) => p.auth_hash(),
-            Action::PositionClose(p) => p.auth_hash(),
-            Action::PositionWithdraw(p) => p.auth_hash(),
-            Action::PositionRewardClaim(p) => p.auth_hash(),
-            Action::Ics20Withdrawal(w) => w.auth_hash(),
+            Action::ValidatorDefinition(payload) => EffectHash(
+                Params::default()
+                    .personal(b"PAH:valdefnition")
+                    .hash(&payload.encode_to_vec())
+                    .as_array()
+                    .clone(),
+            ),
+            Action::IBCAction(payload) => EffectHash(
+                Params::default()
+                    .personal(b"PAH:ibc_action")
+                    .hash(&payload.encode_to_vec())
+                    .as_array()
+                    .clone(),
+            ),
+            Action::PositionOpen(p) => p.effect_hash(),
+            Action::PositionClose(p) => p.effect_hash(),
+            Action::PositionWithdraw(p) => p.effect_hash(),
+            Action::PositionRewardClaim(p) => p.effect_hash(),
+            Action::Ics20Withdrawal(w) => w.effect_hash(),
         }
     }
 }
 
-impl AuthorizingData for output::Body {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for output::Body {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:output_body")
             .to_state();
@@ -254,12 +269,12 @@ impl AuthorizingData for output::Body {
         state.update(&self.wrapped_memo_key.0);
         state.update(&self.ovk_wrapped_key.0);
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for spend::Body {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for spend::Body {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:spend_body")
             .to_state();
@@ -270,19 +285,19 @@ impl AuthorizingData for spend::Body {
         state.update(&self.nullifier.0.to_bytes());
         state.update(&self.rk.to_bytes());
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for swap::Body {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for swap::Body {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:swap_body")
             .to_state();
 
         // All of these fields are fixed-length, so we can just throw them
         // in the hash one after the other.
-        state.update(self.trading_pair.auth_hash().as_bytes());
+        state.update(self.trading_pair.effect_hash().as_bytes());
         state.update(&self.delta_1_i.to_le_bytes());
         state.update(&self.delta_2_i.to_le_bytes());
         state.update(&self.fee_commitment.to_bytes());
@@ -290,12 +305,12 @@ impl AuthorizingData for swap::Body {
         state.update(&self.payload.ephemeral_key.0);
         state.update(&self.payload.encrypted_swap.0);
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for swap_claim::Body {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for swap_claim::Body {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:swapclaimbdy")
             .to_state();
@@ -303,17 +318,16 @@ impl AuthorizingData for swap_claim::Body {
         // All of these fields are fixed-length, so we can just throw them
         // in the hash one after the other.
         state.update(&self.nullifier.0.to_bytes());
-        state.update(self.fee.auth_hash().as_bytes());
+        state.update(self.fee.effect_hash().as_bytes());
         state.update(&self.output_1_commitment.0.to_bytes());
         state.update(&self.output_2_commitment.0.to_bytes());
-        state.update(self.output_data.auth_hash().as_bytes());
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for Delegate {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for Delegate {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:delegate")
             .to_state();
@@ -325,12 +339,12 @@ impl AuthorizingData for Delegate {
         state.update(&self.unbonded_amount.to_le_bytes());
         state.update(&self.delegation_amount.to_le_bytes());
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for Undelegate {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for Undelegate {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:undelegate")
             .to_state();
@@ -343,12 +357,12 @@ impl AuthorizingData for Undelegate {
         state.update(&self.unbonded_amount.to_le_bytes());
         state.update(&self.delegation_amount.to_le_bytes());
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for UndelegateClaimBody {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for UndelegateClaimBody {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:udlgclm_body")
             .to_state();
@@ -361,22 +375,22 @@ impl AuthorizingData for UndelegateClaimBody {
         state.update(&self.penalty.0.to_le_bytes());
         state.update(&self.balance_commitment.to_bytes());
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for Proposal {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for Proposal {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:proposal")
             .to_state();
         state.update(&self.encode_to_vec());
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for ProposalSubmit {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for ProposalSubmit {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:prop_submit")
             .to_state();
@@ -388,42 +402,42 @@ impl AuthorizingData for ProposalSubmit {
         state.update(&self.withdraw_proposal_key.to_bytes());
 
         // The proposal itself is variable-length, so we hash it, and then hash its hash in
-        state.update(self.proposal.auth_hash().as_bytes());
+        state.update(self.proposal.effect_hash().as_bytes());
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for ProposalWithdraw {
-    fn auth_hash(&self) -> Hash {
-        self.body.auth_hash()
+impl EffectingData for ProposalWithdraw {
+    fn effect_hash(&self) -> EffectHash {
+        self.body.effect_hash()
     }
 }
 
-impl AuthorizingData for ProposalWithdrawPlan {
-    fn auth_hash(&self) -> Hash {
-        self.body.auth_hash()
+impl EffectingData for ProposalWithdrawPlan {
+    fn effect_hash(&self) -> EffectHash {
+        self.body.effect_hash()
     }
 }
 
-impl AuthorizingData for ProposalWithdrawBody {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for ProposalWithdrawBody {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:prop_withdrw")
             .to_state();
         state.update(&self.encode_to_vec());
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for ValidatorVote {
-    fn auth_hash(&self) -> Hash {
-        self.body.auth_hash()
+impl EffectingData for ValidatorVote {
+    fn effect_hash(&self) -> EffectHash {
+        self.body.effect_hash()
     }
 }
 
-impl AuthorizingData for Vote {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for Vote {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:vote")
             .to_state();
@@ -436,12 +450,12 @@ impl AuthorizingData for Vote {
             Vote::NoWithVeto => b"V",
         });
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for ValidatorVoteBody {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for ValidatorVoteBody {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:val_vote")
             .to_state();
@@ -449,15 +463,15 @@ impl AuthorizingData for ValidatorVoteBody {
         // All of these fields are fixed-length, so we can just throw them in the hash one after the
         // other.
         state.update(&self.proposal.to_le_bytes());
-        state.update(self.vote.auth_hash().as_bytes());
+        state.update(self.vote.effect_hash().as_bytes());
         state.update(&self.identity_key.0.to_bytes());
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for PositionOpen {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for PositionOpen {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:pos_open")
             .to_state();
@@ -468,24 +482,24 @@ impl AuthorizingData for PositionOpen {
         state.update(&self.initial_reserves.r1.to_le_bytes());
         state.update(&self.initial_reserves.r2.to_le_bytes());
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for PositionClose {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for PositionClose {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:pos_close")
             .to_state();
 
         state.update(&self.position_id.0);
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for PositionWithdraw {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for PositionWithdraw {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:pos_withdraw")
             .to_state();
@@ -493,12 +507,12 @@ impl AuthorizingData for PositionWithdraw {
         state.update(&self.position_id.0);
         state.update(&self.reserves_commitment.to_bytes());
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for PositionRewardClaim {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for PositionRewardClaim {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:pos_rewrdclm")
             .to_state();
@@ -506,12 +520,12 @@ impl AuthorizingData for PositionRewardClaim {
         state.update(&self.position_id.0);
         state.update(&self.rewards_commitment.to_bytes());
 
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for Ics20Withdrawal {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for Ics20Withdrawal {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:ics20wthdrwl")
             .to_state();
@@ -529,18 +543,61 @@ impl AuthorizingData for Ics20Withdrawal {
         state.update(&self.return_address.to_vec());
         state.update(&self.timeout_height.to_le_bytes());
         state.update(&self.timeout_time.to_le_bytes());
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
     }
 }
 
-impl AuthorizingData for Clue {
-    fn auth_hash(&self) -> Hash {
+impl EffectingData for Clue {
+    fn effect_hash(&self) -> EffectHash {
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:decaffmdclue")
             .to_state();
 
         state.update(&self.0);
-        state.finalize()
+        EffectHash(state.finalize().as_array().clone())
+    }
+}
+
+impl EffectingData for EncryptedNote {
+    fn effect_hash(&self) -> EffectHash {
+        EffectHash(
+            blake2b_simd::Params::default()
+                .personal(b"PAH:note_payload")
+                .to_state()
+                .update(&self.note_commitment.0.to_bytes())
+                .update(&self.ephemeral_key.0)
+                .update(&self.encrypted_note)
+                .finalize()
+                .as_array()
+                .clone(),
+        )
+    }
+}
+
+impl EffectingData for Fee {
+    fn effect_hash(&self) -> EffectHash {
+        let mut state = blake2b_simd::Params::default()
+            .personal(b"PAH:fee")
+            .to_state();
+        state.update(&self.0.amount.to_le_bytes());
+        state.update(&self.0.asset_id.to_bytes());
+
+        EffectHash(state.finalize().as_array().clone())
+    }
+}
+
+impl EffectingData for TradingPair {
+    fn effect_hash(&self) -> EffectHash {
+        EffectHash(
+            blake2b_simd::Params::default()
+                .personal(b"PAH:trading_pair")
+                .to_state()
+                .update(&self.asset_1().to_bytes())
+                .update(&self.asset_2().to_bytes())
+                .finalize()
+                .as_array()
+                .clone(),
+        )
     }
 }
 
@@ -567,7 +624,7 @@ mod tests {
     /// All we hope to check here is that, for a basic transaction plan,
     /// we compute the same auth hash for the plan and for the transaction.
     #[test]
-    fn plan_auth_hash_matches_transaction_auth_hash() {
+    fn plan_effect_hash_matches_transaction_effect_hash() {
         let rng = OsRng;
         let seed_phrase = SeedPhrase::generate(rng);
         let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
@@ -640,7 +697,7 @@ mod tests {
 
         println!("{}", serde_json::to_string_pretty(&plan).unwrap());
 
-        let plan_auth_hash = plan.auth_hash(fvk);
+        let plan_effect_hash = plan.effect_hash(fvk);
 
         let auth_data = plan.authorize(rng, &sk);
         let witness_data = WitnessData {
@@ -659,8 +716,8 @@ mod tests {
             .build(&mut OsRng, fvk, auth_data, witness_data)
             .unwrap();
 
-        let transaction_auth_hash = transaction.auth_hash();
+        let transaction_effect_hash = transaction.effect_hash();
 
-        assert_eq!(plan_auth_hash, transaction_auth_hash);
+        assert_eq!(plan_effect_hash, transaction_effect_hash);
     }
 }

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::clone_on_copy)]
 
 mod auth_data;
-mod auth_hash;
+mod effect_hash;
 mod error;
 mod transaction;
 mod witness_data;
@@ -26,7 +26,7 @@ pub mod view;
 
 pub use action::{Action, IsAction};
 pub use auth_data::AuthorizationData;
-pub use auth_hash::AuthHash;
+pub use effect_hash::EffectHash;
 pub use error::Error;
 pub use transaction::{Transaction, TransactionBody};
 pub use view::{ActionView, TransactionPerspective, TransactionView};

--- a/transaction/src/plan/auth.rs
+++ b/transaction/src/plan/auth.rs
@@ -12,23 +12,23 @@ impl TransactionPlan {
         mut rng: R,
         sk: &SpendKey,
     ) -> AuthorizationData {
-        let auth_hash = self.auth_hash(sk.full_viewing_key());
+        let effect_hash = self.effect_hash(sk.full_viewing_key());
         let mut spend_auths = Vec::new();
         let mut withdraw_proposal_auths = Vec::new();
         for spend_plan in self.spend_plans() {
             let rsk = sk.spend_auth_key().randomize(&spend_plan.randomizer);
-            let auth_sig = rsk.sign(&mut rng, auth_hash.as_ref());
+            let auth_sig = rsk.sign(&mut rng, effect_hash.as_ref());
             spend_auths.push(auth_sig);
         }
         for withdraw_proposal_plan in self.proposal_withdraws() {
             let rsk = sk
                 .spend_auth_key()
                 .randomize(&withdraw_proposal_plan.randomizer);
-            let auth_sig = rsk.sign(&mut rng, auth_hash.as_ref());
+            let auth_sig = rsk.sign(&mut rng, effect_hash.as_ref());
             withdraw_proposal_auths.push(auth_sig);
         }
         AuthorizationData {
-            auth_hash,
+            effect_hash,
             spend_auths,
             withdraw_proposal_auths,
         }

--- a/transaction/src/plan/build.rs
+++ b/transaction/src/plan/build.rs
@@ -48,7 +48,7 @@ impl TransactionPlan {
 
         // We build the actions sorted by type, with all spends first, then all
         // outputs, etc.  This order has to align with the ordering in
-        // TransactionPlan::auth_hash, which computes the auth hash of the
+        // TransactionPlan::effect_hash, which computes the auth hash of the
         // transaction we'll build here without actually building it.
 
         // Build the transaction's spends.
@@ -148,8 +148,8 @@ impl TransactionPlan {
 
         // Finally, compute the binding signature and assemble the transaction.
         let binding_signing_key = rdsa::SigningKey::from(synthetic_blinding_factor);
-        let binding_sig = binding_signing_key.sign(rng, auth_data.auth_hash.as_ref());
-        tracing::debug!(bvk = ?rdsa::VerificationKey::from(&binding_signing_key), auth_hash = ?auth_data.auth_hash);
+        let binding_sig = binding_signing_key.sign(rng, auth_data.effect_hash.as_ref());
+        tracing::debug!(bvk = ?rdsa::VerificationKey::from(&binding_signing_key), effect_hash = ?auth_data.effect_hash);
 
         // TODO: add consistency checks?
 


### PR DESCRIPTION
Closes #1758

We use the same words as in ZIP-244, namely "effecting" and "authorizing" data, but accidentally use them with opposite meanings, because I misunderstood which was which when originally reading the ZIP.  This is a huge source of conceptual confusion, which will surely lead to bugs.

The correct definitions are here: https://github.com/zcash/zips/issues/651

> * "Effecting data" is any data within a transaction that contributes to the effects of applying the transaction to the global state (results in previously-spendable coins or notes becoming spent, creates newly-spendable coins or notes, causes the root of a commitment tree to change, etc.). Any change to this data by definition results in a different transaction.
> * "Authorizing data" is the rest of the data within a transaction. It does not contribute to the effects of the transaction on global state, but allows those effects to take place. This data can be changed arbitrarily without resulting in a different transaction (but the changes may alter whether the transaction is allowed to be applied or not).

[The points about "results in a different transaction" don't perfectly apply to us, because unlike Zcash, where the transaction hash is defined to be a hash of structured data, using Tendermint means we don't get to control the transaction hash, it's just the hash of the bytes of the transaction encoding]