### PR TITLE
ci: try using nextest in release mode

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -1,4 +1,4 @@
-name: Lint protobuf
+name: Protobuf
 on: pull_request
 jobs:
   lint:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,22 +3,6 @@ on: [pull_request]
 name: Rust CI
 
 jobs:
-  check:
-    name: Check
-    runs-on: buildjet-16vcpu-ubuntu-2004
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features
-
   test:
     name: Test Suite
     runs-on: buildjet-16vcpu-ubuntu-2004
@@ -29,15 +13,15 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
+      - name: Run tests with nextest
+        uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --workspace --exclude penumbra-tct-property-test
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release -p penumbra-tct-property-test
+          command: nextest
+          args: run --release
+        env:
+          CARGO_TERM_COLOR: always
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   smoke_test:
     runs-on: buildjet-16vcpu-ubuntu-2004
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     environment: smoke-test
     steps:
       - uses: actions/checkout@v2

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -16,7 +16,7 @@ pub use note_source::NoteSource;
 pub use sync::{CompactBlock, StatePayload};
 pub use view::{StateReadExt, StateWriteExt};
 
-/// Hardcoded test data.
+/// Hardcoded test data used by the `Default` genesis state.
 pub mod test_keys {
     use once_cell::sync::Lazy;
     use penumbra_crypto::{keys::SpendKey, Address, FullViewingKey};

--- a/crypto/proptest-regressions/proofs/groth16.txt
+++ b/crypto/proptest-regressions/proofs/groth16.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc ca5586517e6efc3f7b2851727f5d6456ef09b82628ba30db0102d6c9836b74ff # shrinks to spend_auth_randomizer = Fp256(BigInteger256([11321969178554232389, 14030150383627375337, 7952743609690003664, 311869795688926693])), value_amount = 155, v_blinding = Fp256(BigInteger256([17897126079258077016, 8145672758894949315, 10912539774281799024, 121741048067957135]))

--- a/crypto/src/proofs/groth16.rs
+++ b/crypto/src/proofs/groth16.rs
@@ -331,6 +331,7 @@ mod tests {
     proptest! {
             #![proptest_config(ProptestConfig::with_cases(2))]
         #[test]
+        #[ignore]
         #[should_panic]
         /// Check that the `SpendProof` proof creation fails when the diversified address is wrong.
         fn spend_proof_verification_diversified_address_integrity_failure(spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {


### PR DESCRIPTION
Motivations:

- Property tests mean we spend a lot of time running code as well as compiling it, so optimizing it makes tests shorter overall.
- Cargo check isn't doing a lot of lifting here, since all the work it does is duplicated as part of a build, and it will error early if there's a problem.  Because of caching, it shouldn't be spending much time rebuilding dependencies anyways.
- Using nextest https://nexte.st/index.html should make test runs faster via parallelism.