### PR TITLE
crypto: re-enable diversified address integrity gadget test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3452,6 +3452,7 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "ark-groth16",
+ "ark-nonnative-field",
  "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -49,6 +49,7 @@ ark-groth16 = "0.3"
 ark-snark = "0.3"
 ark-r1cs-std = "0.3"
 ark-relations = "0.3"
+ark-nonnative-field = "0.3"
 
 [dev-dependencies]
 proptest = "1"

--- a/crypto/src/proofs/groth16.rs
+++ b/crypto/src/proofs/groth16.rs
@@ -41,12 +41,12 @@ mod tests {
     proptest! {
     #![proptest_config(ProptestConfig::with_cases(2))]
     #[test]
-    fn output_proof_happy_path(v_blinding in fr_strategy(), value_amount in 2..200u64, esk_inner in fr_strategy()) {
+    fn output_proof_happy_path(seed_phrase_randomness in any::<[u8; 32]>(), v_blinding in fr_strategy(), value_amount in 2..200u64, esk_inner in fr_strategy()) {
             let (pk, vk) = OutputCircuit::generate_test_parameters();
 
             let mut rng = OsRng;
 
-            let seed_phrase = SeedPhrase::generate(rng);
+            let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
             let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
             let fvk_recipient = sk_recipient.full_viewing_key();
             let ivk_recipient = fvk_recipient.incoming();
@@ -84,11 +84,11 @@ mod tests {
     proptest! {
     #![proptest_config(ProptestConfig::with_cases(2))]
     #[test]
-    fn output_proof_verification_note_commitment_integrity_failure(v_blinding in fr_strategy(), value_amount in 2..200u64, esk_inner in fr_strategy(), note_blinding in fq_strategy()) {
+    fn output_proof_verification_note_commitment_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), v_blinding in fr_strategy(), value_amount in 2..200u64, esk_inner in fr_strategy(), note_blinding in fq_strategy()) {
         let (pk, vk) = OutputCircuit::generate_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::generate(rng);
+        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
         let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
@@ -134,11 +134,11 @@ mod tests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(2))]
         #[test]
-    fn output_proof_verification_balance_commitment_integrity_failure(v_blinding in fr_strategy(), value_amount in 2..200u64, esk_inner in fr_strategy(), incorrect_v_blinding in fr_strategy()) {
+    fn output_proof_verification_balance_commitment_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), v_blinding in fr_strategy(), value_amount in 2..200u64, esk_inner in fr_strategy(), incorrect_v_blinding in fr_strategy()) {
         let (pk, vk) = OutputCircuit::generate_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::generate(rng);
+        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
         let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
@@ -178,11 +178,11 @@ mod tests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(2))]
     #[test]
-    fn output_proof_verification_ephemeral_public_key_integrity_failure(v_blinding in fr_strategy(), value_amount in 2..200u64, esk_inner in fr_strategy(), incorrect_esk_inner in fr_strategy()) {
+    fn output_proof_verification_ephemeral_public_key_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), v_blinding in fr_strategy(), value_amount in 2..200u64, esk_inner in fr_strategy(), incorrect_esk_inner in fr_strategy()) {
         let (pk, vk) = OutputCircuit::generate_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::generate(rng);
+        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
         let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
@@ -224,11 +224,11 @@ mod tests {
         #![proptest_config(ProptestConfig::with_cases(2))]
     #[test]
     /// Check that the `SpendProof` verification succeeds.
-    fn spend_proof_verification_success(spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {
+    fn spend_proof_verification_success(seed_phrase_randomness in any::<[u8; 32]>(), spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {
         let (pk, vk) = SpendCircuit::generate_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::generate(rng);
+        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
@@ -278,11 +278,11 @@ mod tests {
     #[test]
     /// Check that the `SpendProof` verification fails when using an incorrect
     /// NCT root (`anchor`).
-    fn spend_proof_verification_merkle_path_integrity_failure(spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {
+    fn spend_proof_verification_merkle_path_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {
         let (pk, vk) = SpendCircuit::generate_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::generate(rng);
+        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
@@ -331,16 +331,15 @@ mod tests {
     proptest! {
             #![proptest_config(ProptestConfig::with_cases(2))]
         #[test]
-        #[should_panic]
-        /// Check that the `SpendProof` proof creation fails when the diversified address is wrong.
-        fn spend_proof_verification_diversified_address_integrity_failure(spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {
-            let (pk, _vk) = SpendCircuit::generate_test_parameters();
+        /// Check that the `SpendProof` verification fails when the diversified address is wrong.
+        fn spend_proof_verification_diversified_address_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), incorrect_seed_phrase_randomness in any::<[u8; 32]>(), spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {
+            let (pk, vk) = SpendCircuit::generate_test_parameters();
             let mut rng = OsRng;
 
-            let seed_phrase = SeedPhrase::generate(rng);
+            let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
 
-            let wrong_seed_phrase = SeedPhrase::generate(rng);
+            let wrong_seed_phrase = SeedPhrase::from_randomness(incorrect_seed_phrase_randomness);
             let wrong_sk_sender = SpendKey::from_seed_phrase(wrong_seed_phrase, 0);
             let wrong_fvk_sender = wrong_sk_sender.full_viewing_key();
             let wrong_ivk_sender = wrong_fvk_sender.incoming();
@@ -365,9 +364,7 @@ mod tests {
             let rk: VerificationKey<SpendAuth> = rsk.into();
             let nf = nk.derive_nullifier(0.into(), &note_commitment);
 
-            // Circuit should be unsatisifiable if the diversified address integrity fails.
-            // This will cause a panic.
-            SpendProof::prove(
+            let proof = SpendProof::prove(
                 &mut rng,
                 &pk,
                 note_commitment_proof,
@@ -380,8 +377,10 @@ mod tests {
                 balance_commitment,
                 nf,
                 rk,
-            )
-            .expect("boom");
+            ).expect("can create proof");
+
+            let proof_result = proof.verify(&vk, anchor, balance_commitment, nf, rk);
+            assert!(proof_result.is_err());
         }
     }
 
@@ -390,11 +389,11 @@ mod tests {
         #[test]
         /// Check that the `SpendProof` verification fails, when using an
         /// incorrect nullifier.
-        fn spend_proof_verification_nullifier_integrity_failure(spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {
+        fn spend_proof_verification_nullifier_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {
             let (pk, vk) = SpendCircuit::generate_test_parameters();
             let mut rng = OsRng;
 
-            let seed_phrase = SeedPhrase::generate(rng);
+            let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();
@@ -446,11 +445,11 @@ mod tests {
     #[test]
     /// Check that the `SpendProof` verification fails when using balance
     /// commitments with different blinding factors.
-    fn spend_proof_verification_balance_commitment_integrity_failure(spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy(), incorrect_blinding_factor in fr_strategy()) {
+    fn spend_proof_verification_balance_commitment_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy(), incorrect_blinding_factor in fr_strategy()) {
         let (pk, vk) = SpendCircuit::generate_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::generate(rng);
+        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
@@ -501,11 +500,11 @@ mod tests {
             #![proptest_config(ProptestConfig::with_cases(2))]
         #[test]
         /// Check that the `SpendProof` verification fails when the incorrect randomizable verification key is used.
-        fn spend_proof_verification_fails_rk_integrity(spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy(), incorrect_spend_auth_randomizer in fr_strategy()) {
+        fn spend_proof_verification_fails_rk_integrity(seed_phrase_randomness in any::<[u8; 32]>(), spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy(), incorrect_spend_auth_randomizer in fr_strategy()) {
             let (pk, vk) = SpendCircuit::generate_test_parameters();
             let mut rng = OsRng;
 
-            let seed_phrase = SeedPhrase::generate(rng);
+            let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();
@@ -559,11 +558,11 @@ mod tests {
             #![proptest_config(ProptestConfig::with_cases(2))]
         #[test]
         /// Check that the `SpendProof` verification always suceeds for dummy (zero value) spends.
-        fn spend_proof_dummy_verification_suceeds(spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {
+        fn spend_proof_dummy_verification_suceeds(seed_phrase_randomness in any::<[u8; 32]>(), spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {
             let (pk, vk) = SpendCircuit::generate_test_parameters();
             let mut rng = OsRng;
 
-            let seed_phrase = SeedPhrase::generate(rng);
+            let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();

--- a/crypto/src/proofs/groth16.rs
+++ b/crypto/src/proofs/groth16.rs
@@ -331,7 +331,6 @@ mod tests {
     proptest! {
             #![proptest_config(ProptestConfig::with_cases(2))]
         #[test]
-        #[ignore]
         #[should_panic]
         /// Check that the `SpendProof` proof creation fails when the diversified address is wrong.
         fn spend_proof_verification_diversified_address_integrity_failure(spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {

--- a/crypto/src/proofs/groth16/gadgets.rs
+++ b/crypto/src/proofs/groth16/gadgets.rs
@@ -1,9 +1,11 @@
 #![allow(clippy::too_many_arguments)]
+use ark_ff::PrimeField;
+use ark_nonnative_field::NonNativeFieldVar;
 use ark_r1cs_std::{prelude::*, ToBitsGadget};
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use decaf377::{
     r1cs::{ElementVar, FqVar},
-    Element, Fq,
+    Element, FieldExt, Fq, Fr,
 };
 use once_cell::sync::Lazy;
 
@@ -139,8 +141,15 @@ pub(crate) fn diversified_address_integrity(
     diversified_generator: ElementVar,
 ) -> Result<(), SynthesisError> {
     let ivk_domain_sep = FqVar::new_constant(cs.clone(), *IVK_DOMAIN_SEP)?;
-    let ivk = poseidon377::r1cs::hash_2(cs, &ivk_domain_sep, (nk, ak))?;
-    // TODO: Reduce ivk here mod r?
+    let ivk_mod_q = poseidon377::r1cs::hash_2(cs.clone(), &ivk_domain_sep, (nk, ak))?;
+
+    // Reduce `ivk_mod_q` modulo r
+    let inner_ivk_mod_q: Fq = ivk_mod_q.value().unwrap_or_default();
+    let ivk_mod_r = Fr::from_le_bytes_mod_order(&inner_ivk_mod_q.to_bytes());
+    let ivk =
+        NonNativeFieldVar::<Fr, Fq>::new_variable(cs, || Ok(ivk_mod_r), AllocationMode::Witness)?;
+
+    // Now compute [ivk] g_d
     let ivk_vars = ivk.to_bits_le()?;
     let test_transmission_key =
         diversified_generator.scalar_mul_le(ivk_vars.to_bits_le()?.iter())?;

--- a/crypto/src/proofs/groth16/gadgets.rs
+++ b/crypto/src/proofs/groth16/gadgets.rs
@@ -149,7 +149,7 @@ pub(crate) fn diversified_address_integrity(
     let ivk =
         NonNativeFieldVar::<Fr, Fq>::new_variable(cs, || Ok(ivk_mod_r), AllocationMode::Witness)?;
 
-    // Now compute [ivk] g_d
+    // Now add constraints to demonstrate the transmission key = [ivk] g_d
     let ivk_vars = ivk.to_bits_le()?;
     let test_transmission_key =
         diversified_generator.scalar_mul_le(ivk_vars.to_bits_le()?.iter())?;


### PR DESCRIPTION
In 4afb56bb02e9377fbe571a85736f5125cd2b9fa1 a test of the diversified address integrity gadget was ignored due to a proptest failure. The gadget checks the transmission key is equal to `[ivk] g_d` where `ivk` is the incoming viewing key and `g_d` is the diversified basepoint. The ivk should be derived from the output of a rate 2 poseidon hash - i.e. an Fq - and then reduced modulo r. However, in the gadget we were not reducing mod r (there was an unimplemented inline todo about this). 