### PR TITLE
feat(crypto): switch `Amount` to 128 bits internally

### DIFF
--- a/component/src/shielded_pool/note_manager.rs
+++ b/component/src/shielded_pool/note_manager.rs
@@ -62,7 +62,7 @@ pub trait NoteManager: StateWrite {
         let encrypted_note = note.encrypt();
 
         // Now record the note and update the total supply:
-        self.update_token_supply(&value.asset_id, i64::from(value.amount))
+        self.update_token_supply(&value.asset_id, value.amount.value() as i64)
             .await?;
         self.add_state_payload(StatePayload::Note {
             note: EncryptedNote {

--- a/crypto/src/asset/amount.rs
+++ b/crypto/src/asset/amount.rs
@@ -48,7 +48,7 @@ impl TryFrom<std::string::String> for Amount {
     type Error = anyhow::Error;
 
     fn try_from(s: std::string::String) -> Result<Self, Self::Error> {
-        let inner = s.parse::<u64>()?;
+        let inner = s.parse::<u128>()?;
         Ok(Amount { inner })
     }
 }

--- a/crypto/src/asset/amount.rs
+++ b/crypto/src/asset/amount.rs
@@ -1,4 +1,5 @@
 use crate::{Fq, Fr};
+use anyhow::anyhow;
 use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, iter::Sum, num::NonZeroU128, ops};
@@ -217,6 +218,16 @@ impl From<u64> for Amount {
 impl From<Amount> for u64 {
     fn from(amount: Amount) -> u64 {
         amount.inner as u64
+    }
+}
+
+impl TryFrom<Amount> for i64 {
+    type Error = anyhow::Error;
+    fn try_from(value: Amount) -> Result<Self, Self::Error> {
+        value
+            .inner
+            .try_into()
+            .map_err(|_| anyhow!("failed conversion!"))
     }
 }
 

--- a/crypto/src/asset/amount.rs
+++ b/crypto/src/asset/amount.rs
@@ -7,7 +7,13 @@ use std::{fmt::Display, iter::Sum, num::NonZeroU128, ops};
 #[derive(Serialize, Deserialize, PartialEq, PartialOrd, Eq, Clone, Debug, Copy)]
 #[serde(try_from = "pb::Amount", into = "pb::Amount")]
 pub struct Amount {
-    pub inner: u128,
+    inner: u128,
+}
+
+impl Amount {
+    pub fn value(&self) -> u64 {
+        self.inner as u64
+    }
 }
 
 impl From<Amount> for pb::Amount {

--- a/crypto/src/asset/amount.rs
+++ b/crypto/src/asset/amount.rs
@@ -38,7 +38,7 @@ impl From<Amount> for pb::Amount {
             }
 
             let lo = u64::from_le_bytes(lo_bytes);
-            let hi = u64::from_be_bytes(hi_bytes);
+            let hi = u64::from_le_bytes(hi_bytes);
             pb::Amount { lo, hi }
         }
     }
@@ -59,17 +59,21 @@ impl TryFrom<pb::Amount> for Amount {
     fn try_from(amount: pb::Amount) -> Result<Self, Self::Error> {
         let lo = amount.lo as u128;
         let hi = amount.hi as u128;
-        // We want to encode the hi/lo bytes as follow:
+        // `hi` and `lo` represent the high/low order bytes respectively.
+        //
+        // We want to encode `hi` and `lo` into a single `u128` of the form:
+        //
         //            hi: u64                          lo: u64
         // ┌───┬───┬───┬───┬───┬───┬───┬───┐ ┌───┬───┬───┬───┬───┬───┬───┬───┐
         // │   │   │   │   │   │   │   │   │ │   │   │   │   │   │   │   │   │
         // └───┴───┴───┴───┴───┴───┴───┴───┘ └───┴───┴───┴───┴───┴───┴───┴───┘
         //   15  14  13  12  11  10  9   8     7   6   5   4   3   2   1   0
         //
-        // To achieve this, we shift hi 8 bytes to the right, and then add the
-        // lower order bytes (lo).
+        // To achieve this, we shift `hi` 8 bytes to the left:
+        let shifted = u128::from_le(hi) << 64;
+        // and then add the lower order bytes:
+        let inner = shifted + lo;
 
-        let inner = u128::from_be(hi) + lo;
         Ok(Amount { inner })
     }
 }

--- a/crypto/src/asset/amount.rs
+++ b/crypto/src/asset/amount.rs
@@ -18,6 +18,7 @@ impl Amount {
         Self { inner: 0 }
     }
 
+    // We need fixed length encoding to produce encrypted `Note`s.
     pub fn to_le_bytes(&self) -> [u8; 16] {
         self.inner.to_le_bytes()
     }

--- a/crypto/src/balance.rs
+++ b/crypto/src/balance.rs
@@ -3,7 +3,7 @@ use std::{
     fmt::{self, Debug, Formatter},
     iter::FusedIterator,
     mem,
-    num::NonZeroU64,
+    num::NonZeroU128,
     ops::{Add, AddAssign, Deref, Neg, Sub, SubAssign},
 };
 
@@ -23,7 +23,7 @@ use imbalance::Imbalance;
 #[derive(Clone, Eq, Default)]
 pub struct Balance {
     negated: bool,
-    balance: BTreeMap<asset::Id, Imbalance<NonZeroU64>>,
+    balance: BTreeMap<asset::Id, Imbalance<NonZeroU128>>,
 }
 
 impl Debug for Balance {
@@ -141,7 +141,7 @@ impl Add for Balance {
         for imbalance in other.into_iter() {
             // Convert back into an asset id key and imbalance value
             let (sign, Value { asset_id, amount }) = imbalance.into_inner();
-            let (asset_id, mut imbalance) = if let Some(amount) = NonZeroU64::new(amount.into()) {
+            let (asset_id, mut imbalance) = if let Some(amount) = NonZeroU128::new(amount.into()) {
                 (asset_id, sign.imbalance(amount))
             } else {
                 unreachable!("values stored in balance are always nonzero")
@@ -235,7 +235,7 @@ impl SubAssign<Value> for Balance {
 impl From<Value> for Balance {
     fn from(Value { amount, asset_id }: Value) -> Self {
         let mut balance = BTreeMap::new();
-        if let Some(amount) = NonZeroU64::new(amount.into()) {
+        if let Some(amount) = NonZeroU128::new(amount.into()) {
             balance.insert(asset_id, Imbalance::Provided(amount));
         }
         Balance {

--- a/crypto/src/balance/imbalance.rs
+++ b/crypto/src/balance/imbalance.rs
@@ -1,7 +1,7 @@
 use std::{
     cmp::Ordering,
     fmt::Debug,
-    num::NonZeroU64,
+    num::NonZeroU128,
     ops::{Add, Neg, Sub},
 };
 
@@ -27,7 +27,7 @@ impl<T> Neg for Imbalance<T> {
     }
 }
 
-impl Add for Imbalance<NonZeroU64> {
+impl Add for Imbalance<NonZeroU128> {
     type Output = Option<Self>;
 
     fn add(self, other: Self) -> Self::Output {
@@ -37,7 +37,7 @@ impl Add for Imbalance<NonZeroU64> {
             (Imbalance::Required(r), Imbalance::Required(s)) => {
                 if let Some(t) = r.get().checked_add(s.get()) {
                     Some(Imbalance::Required(
-                        NonZeroU64::new(t).expect("checked addition of nonzero u64 never is zero"),
+                        NonZeroU128::new(t).expect("checked addition of nonzero u64 never is zero"),
                     ))
                 } else {
                     panic!("overflow when adding imbalances")
@@ -45,12 +45,12 @@ impl Add for Imbalance<NonZeroU64> {
             }
             (Imbalance::Required(r), Imbalance::Provided(p)) => match p.cmp(&r) {
                 Ordering::Less => Some(Imbalance::Required(
-                    NonZeroU64::new(r.get() - p.get())
+                    NonZeroU128::new(r.get() - p.get())
                         .expect("subtraction of lesser from greater is never zero"),
                 )),
                 Ordering::Equal => None,
                 Ordering::Greater => Some(Imbalance::Provided(
-                    NonZeroU64::new(p.get() - r.get())
+                    NonZeroU128::new(p.get() - r.get())
                         .expect("subtraction of lesser from greater is never zero"),
                 )),
             },
@@ -59,7 +59,7 @@ impl Add for Imbalance<NonZeroU64> {
     }
 }
 
-impl Sub for Imbalance<NonZeroU64> {
+impl Sub for Imbalance<NonZeroU128> {
     type Output = <Self as Add>::Output;
 
     fn sub(self, other: Self) -> Self::Output {
@@ -152,161 +152,161 @@ mod test {
 
     #[test]
     fn add_provided_provided() {
-        let a = Imbalance::Provided(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Provided(NonZeroU64::new(2).unwrap());
+        let a = Imbalance::Provided(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Provided(NonZeroU128::new(2).unwrap());
         let c = a + b;
-        assert_eq!(c, Some(Imbalance::Provided(NonZeroU64::new(3).unwrap())));
+        assert_eq!(c, Some(Imbalance::Provided(NonZeroU128::new(3).unwrap())));
     }
 
     #[test]
     fn add_provided_required_greater() {
-        let a = Imbalance::Provided(NonZeroU64::new(2).unwrap());
-        let b = Imbalance::Required(NonZeroU64::new(1).unwrap());
+        let a = Imbalance::Provided(NonZeroU128::new(2).unwrap());
+        let b = Imbalance::Required(NonZeroU128::new(1).unwrap());
         let c = a + b;
-        assert_eq!(c, Some(Imbalance::Provided(NonZeroU64::new(1).unwrap())));
+        assert_eq!(c, Some(Imbalance::Provided(NonZeroU128::new(1).unwrap())));
     }
 
     #[test]
     fn add_provided_required_equal() {
-        let a = Imbalance::Provided(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Required(NonZeroU64::new(1).unwrap());
+        let a = Imbalance::Provided(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Required(NonZeroU128::new(1).unwrap());
         let c = a + b;
         assert_eq!(c, None);
     }
 
     #[test]
     fn add_provided_required_less() {
-        let a = Imbalance::Provided(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Required(NonZeroU64::new(2).unwrap());
+        let a = Imbalance::Provided(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Required(NonZeroU128::new(2).unwrap());
         let c = a + b;
-        assert_eq!(c, Some(Imbalance::Required(NonZeroU64::new(1).unwrap())));
+        assert_eq!(c, Some(Imbalance::Required(NonZeroU128::new(1).unwrap())));
     }
 
     #[test]
     fn add_required_required() {
-        let a = Imbalance::Required(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Required(NonZeroU64::new(2).unwrap());
+        let a = Imbalance::Required(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Required(NonZeroU128::new(2).unwrap());
         let c = a + b;
-        assert_eq!(c, Some(Imbalance::Required(NonZeroU64::new(3).unwrap())));
+        assert_eq!(c, Some(Imbalance::Required(NonZeroU128::new(3).unwrap())));
     }
 
     #[test]
     fn add_required_provided_greater() {
-        let a = Imbalance::Required(NonZeroU64::new(2).unwrap());
-        let b = Imbalance::Provided(NonZeroU64::new(1).unwrap());
+        let a = Imbalance::Required(NonZeroU128::new(2).unwrap());
+        let b = Imbalance::Provided(NonZeroU128::new(1).unwrap());
         let c = a + b;
-        assert_eq!(c, Some(Imbalance::Required(NonZeroU64::new(1).unwrap())));
+        assert_eq!(c, Some(Imbalance::Required(NonZeroU128::new(1).unwrap())));
     }
 
     #[test]
     fn add_required_provided_equal() {
-        let a = Imbalance::Required(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Provided(NonZeroU64::new(1).unwrap());
+        let a = Imbalance::Required(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Provided(NonZeroU128::new(1).unwrap());
         let c = a + b;
         assert_eq!(c, None);
     }
 
     #[test]
     fn add_required_provided_less() {
-        let a = Imbalance::Required(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Provided(NonZeroU64::new(2).unwrap());
+        let a = Imbalance::Required(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Provided(NonZeroU128::new(2).unwrap());
         let c = a + b;
-        assert_eq!(c, Some(Imbalance::Provided(NonZeroU64::new(1).unwrap())));
+        assert_eq!(c, Some(Imbalance::Provided(NonZeroU128::new(1).unwrap())));
     }
 
     #[test]
     fn sub_provided_provided_greater() {
-        let a = Imbalance::Provided(NonZeroU64::new(2).unwrap());
-        let b = Imbalance::Provided(NonZeroU64::new(1).unwrap());
+        let a = Imbalance::Provided(NonZeroU128::new(2).unwrap());
+        let b = Imbalance::Provided(NonZeroU128::new(1).unwrap());
         let c = a - b;
-        assert_eq!(c, Some(Imbalance::Provided(NonZeroU64::new(1).unwrap())));
+        assert_eq!(c, Some(Imbalance::Provided(NonZeroU128::new(1).unwrap())));
     }
 
     #[test]
     fn sub_provided_provided_equal() {
-        let a = Imbalance::Provided(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Provided(NonZeroU64::new(1).unwrap());
+        let a = Imbalance::Provided(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Provided(NonZeroU128::new(1).unwrap());
         let c = a - b;
         assert_eq!(c, None);
     }
 
     #[test]
     fn sub_provided_provided_less() {
-        let a = Imbalance::Provided(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Provided(NonZeroU64::new(2).unwrap());
+        let a = Imbalance::Provided(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Provided(NonZeroU128::new(2).unwrap());
         let c = a - b;
-        assert_eq!(c, Some(Imbalance::Required(NonZeroU64::new(1).unwrap())));
+        assert_eq!(c, Some(Imbalance::Required(NonZeroU128::new(1).unwrap())));
     }
 
     #[test]
     fn sub_provided_required_greater() {
-        let a = Imbalance::Provided(NonZeroU64::new(2).unwrap());
-        let b = Imbalance::Required(NonZeroU64::new(1).unwrap());
+        let a = Imbalance::Provided(NonZeroU128::new(2).unwrap());
+        let b = Imbalance::Required(NonZeroU128::new(1).unwrap());
         let c = a - b;
-        assert_eq!(c, Some(Imbalance::Provided(NonZeroU64::new(3).unwrap())));
+        assert_eq!(c, Some(Imbalance::Provided(NonZeroU128::new(3).unwrap())));
     }
 
     #[test]
     fn sub_provided_required_equal() {
-        let a = Imbalance::Provided(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Required(NonZeroU64::new(1).unwrap());
+        let a = Imbalance::Provided(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Required(NonZeroU128::new(1).unwrap());
         let c = a - b;
-        assert_eq!(c, Some(Imbalance::Provided(NonZeroU64::new(2).unwrap())));
+        assert_eq!(c, Some(Imbalance::Provided(NonZeroU128::new(2).unwrap())));
     }
 
     #[test]
     fn sub_provided_required_less() {
-        let a = Imbalance::Provided(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Required(NonZeroU64::new(2).unwrap());
+        let a = Imbalance::Provided(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Required(NonZeroU128::new(2).unwrap());
         let c = a - b;
-        assert_eq!(c, Some(Imbalance::Provided(NonZeroU64::new(3).unwrap())));
+        assert_eq!(c, Some(Imbalance::Provided(NonZeroU128::new(3).unwrap())));
     }
 
     #[test]
     fn sub_required_provided_greater() {
-        let a = Imbalance::Required(NonZeroU64::new(2).unwrap());
-        let b = Imbalance::Provided(NonZeroU64::new(1).unwrap());
+        let a = Imbalance::Required(NonZeroU128::new(2).unwrap());
+        let b = Imbalance::Provided(NonZeroU128::new(1).unwrap());
         let c = a - b;
-        assert_eq!(c, Some(Imbalance::Required(NonZeroU64::new(3).unwrap())));
+        assert_eq!(c, Some(Imbalance::Required(NonZeroU128::new(3).unwrap())));
     }
 
     #[test]
     fn sub_required_provided_equal() {
-        let a = Imbalance::Required(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Provided(NonZeroU64::new(1).unwrap());
+        let a = Imbalance::Required(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Provided(NonZeroU128::new(1).unwrap());
         let c = a - b;
-        assert_eq!(c, Some(Imbalance::Required(NonZeroU64::new(2).unwrap())));
+        assert_eq!(c, Some(Imbalance::Required(NonZeroU128::new(2).unwrap())));
     }
 
     #[test]
     fn sub_required_provided_less() {
-        let a = Imbalance::Required(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Provided(NonZeroU64::new(2).unwrap());
+        let a = Imbalance::Required(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Provided(NonZeroU128::new(2).unwrap());
         let c = a - b;
-        assert_eq!(c, Some(Imbalance::Required(NonZeroU64::new(3).unwrap())));
+        assert_eq!(c, Some(Imbalance::Required(NonZeroU128::new(3).unwrap())));
     }
 
     #[test]
     fn sub_required_required_greater() {
-        let a = Imbalance::Required(NonZeroU64::new(2).unwrap());
-        let b = Imbalance::Required(NonZeroU64::new(1).unwrap());
+        let a = Imbalance::Required(NonZeroU128::new(2).unwrap());
+        let b = Imbalance::Required(NonZeroU128::new(1).unwrap());
         let c = a - b;
-        assert_eq!(c, Some(Imbalance::Required(NonZeroU64::new(1).unwrap())));
+        assert_eq!(c, Some(Imbalance::Required(NonZeroU128::new(1).unwrap())));
     }
 
     #[test]
     fn sub_required_required_equal() {
-        let a = Imbalance::Required(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Required(NonZeroU64::new(1).unwrap());
+        let a = Imbalance::Required(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Required(NonZeroU128::new(1).unwrap());
         let c = a - b;
         assert_eq!(c, None);
     }
 
     #[test]
     fn sub_required_required_less() {
-        let a = Imbalance::Required(NonZeroU64::new(1).unwrap());
-        let b = Imbalance::Required(NonZeroU64::new(2).unwrap());
+        let a = Imbalance::Required(NonZeroU128::new(1).unwrap());
+        let b = Imbalance::Required(NonZeroU128::new(2).unwrap());
         let c = a - b;
-        assert_eq!(c, Some(Imbalance::Provided(NonZeroU64::new(1).unwrap())));
+        assert_eq!(c, Some(Imbalance::Provided(NonZeroU128::new(1).unwrap())));
     }
 }

--- a/crypto/src/balance/imbalance.rs
+++ b/crypto/src/balance/imbalance.rs
@@ -37,7 +37,7 @@ impl Add for Imbalance<NonZeroU128> {
             (Imbalance::Required(r), Imbalance::Required(s)) => {
                 if let Some(t) = r.get().checked_add(s.get()) {
                     Some(Imbalance::Required(
-                        NonZeroU128::new(t).expect("checked addition of nonzero u64 never is zero"),
+                        NonZeroU128::new(t).expect("checked addition of NonZeroU128 is never zero"),
                     ))
                 } else {
                     panic!("overflow when adding imbalances")

--- a/crypto/src/balance/iter.rs
+++ b/crypto/src/balance/iter.rs
@@ -2,7 +2,7 @@ use std::{
     collections::btree_map,
     fmt::{self, Debug, Formatter},
     iter::FusedIterator,
-    num::NonZeroU64,
+    num::NonZeroU128,
 };
 
 use crate::{asset, Value};
@@ -33,7 +33,7 @@ impl IntoIterator for Balance {
 #[derive(Clone)]
 pub struct Iter<'a> {
     negated: bool,
-    iter: btree_map::Iter<'a, asset::Id, Imbalance<NonZeroU64>>,
+    iter: btree_map::Iter<'a, asset::Id, Imbalance<NonZeroU128>>,
 }
 
 impl Debug for Iter<'_> {
@@ -82,7 +82,7 @@ impl FusedIterator for Iter<'_> {}
 
 pub struct IntoIter {
     negated: bool,
-    iter: btree_map::IntoIter<asset::Id, Imbalance<NonZeroU64>>,
+    iter: btree_map::IntoIter<asset::Id, Imbalance<NonZeroU128>>,
 }
 
 impl Iterator for IntoIter {

--- a/crypto/src/dex/swap.rs
+++ b/crypto/src/dex/swap.rs
@@ -17,10 +17,10 @@ pub use ciphertext::SwapCiphertext;
 pub use payload::SwapPayload;
 pub use plaintext::SwapPlaintext;
 
-// Swap ciphertext byte length
-pub const SWAP_CIPHERTEXT_BYTES: usize = 248;
-// Swap plaintext byte length
-pub const SWAP_LEN_BYTES: usize = 232;
+// Swap ciphertext byte length.
+pub const SWAP_CIPHERTEXT_BYTES: usize = 256;
+// Swap plaintext byte length.
+pub const SWAP_LEN_BYTES: usize = 256;
 
 pub static DOMAIN_SEPARATOR: Lazy<Fq> =
     Lazy::new(|| Fq::from_le_bytes_mod_order(blake2b_simd::blake2b(b"penumbra.swap").as_bytes()));

--- a/crypto/src/dex/swap.rs
+++ b/crypto/src/dex/swap.rs
@@ -18,7 +18,7 @@ pub use payload::SwapPayload;
 pub use plaintext::SwapPlaintext;
 
 // Swap ciphertext byte length.
-pub const SWAP_CIPHERTEXT_BYTES: usize = 256;
+pub const SWAP_CIPHERTEXT_BYTES: usize = 272;
 // Swap plaintext byte length.
 pub const SWAP_LEN_BYTES: usize = 256;
 

--- a/crypto/src/dex/swap/plaintext.rs
+++ b/crypto/src/dex/swap/plaintext.rs
@@ -244,25 +244,25 @@ impl TryFrom<&[u8]> for SwapPlaintext {
         let tp_bytes: [u8; 64] = bytes[0..64]
             .try_into()
             .map_err(|_| anyhow!("error fetching trading pair bytes"))?;
-        let delta_1_bytes: [u8; 8] = bytes[64..72]
+        let delta_1_bytes: [u8; 16] = bytes[64..80]
             .try_into()
             .map_err(|_| anyhow!("error fetching delta1 bytes"))?;
-        let delta_2_bytes: [u8; 8] = bytes[72..80]
+        let delta_2_bytes: [u8; 16] = bytes[80..96]
             .try_into()
             .map_err(|_| anyhow!("error fetching delta2 bytes"))?;
-        let fee_amount_bytes: [u8; 8] = bytes[80..88]
+        let fee_amount_bytes: [u8; 16] = bytes[96..112]
             .try_into()
             .map_err(|_| anyhow!("error fetching fee amount bytes"))?;
-        let fee_asset_id_bytes: [u8; 32] = bytes[88..120]
+        let fee_asset_id_bytes: [u8; 32] = bytes[112..144]
             .try_into()
             .map_err(|_| anyhow!("error fetching fee asset ID bytes"))?;
-        let address_bytes: [u8; 80] = bytes[120..200]
+        let address_bytes: [u8; 80] = bytes[144..224]
             .try_into()
             .map_err(|_| anyhow!("error fetching address bytes"))?;
         let pb_address = pb_crypto::Address {
             inner: address_bytes.to_vec(),
         };
-        let rseed: [u8; 32] = bytes[200..232]
+        let rseed: [u8; 32] = bytes[224..256]
             .try_into()
             .map_err(|_| anyhow!("error fetching rseed bytes"))?;
 

--- a/crypto/src/dex/swap/plaintext.rs
+++ b/crypto/src/dex/swap/plaintext.rs
@@ -216,13 +216,13 @@ impl From<&SwapPlaintext> for [u8; SWAP_LEN_BYTES] {
     fn from(swap: &SwapPlaintext) -> [u8; SWAP_LEN_BYTES] {
         let mut bytes = [0u8; SWAP_LEN_BYTES];
         bytes[0..64].copy_from_slice(&swap.trading_pair.to_bytes());
-        bytes[64..72].copy_from_slice(&swap.delta_1_i.to_le_bytes());
-        bytes[72..80].copy_from_slice(&swap.delta_2_i.to_le_bytes());
-        bytes[80..88].copy_from_slice(&swap.claim_fee.0.amount.to_le_bytes());
-        bytes[88..120].copy_from_slice(&swap.claim_fee.0.asset_id.to_bytes());
+        bytes[64..80].copy_from_slice(&swap.delta_1_i.to_le_bytes());
+        bytes[80..96].copy_from_slice(&swap.delta_2_i.to_le_bytes());
+        bytes[96..112].copy_from_slice(&swap.claim_fee.0.amount.to_le_bytes());
+        bytes[112..144].copy_from_slice(&swap.claim_fee.0.asset_id.to_bytes());
         let pb_address = pb_crypto::Address::from(swap.claim_address);
-        bytes[120..200].copy_from_slice(&pb_address.inner);
-        bytes[200..232].copy_from_slice(&swap.rseed.to_bytes());
+        bytes[144..224].copy_from_slice(&pb_address.inner);
+        bytes[224..256].copy_from_slice(&swap.rseed.to_bytes());
         bytes
     }
 }

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -408,7 +408,7 @@ impl TryFrom<&[u8]> for Note {
                 .try_into()
                 .map_err(|_| Error::NoteDeserializationError)?,
             Value {
-                amount: amount_bytes.into(),
+                amount: crate::asset::Amount::from_le_bytes(amount_bytes),
                 asset_id: asset::Id(
                     Fq::from_bytes(asset_id_bytes).map_err(|_| Error::NoteDeserializationError)?,
                 ),

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -18,8 +18,8 @@ use crate::{
     Address, Fq, Rseed, Value,
 };
 
-pub const NOTE_LEN_BYTES: usize = 152;
-pub const NOTE_CIPHERTEXT_BYTES: usize = 168;
+pub const NOTE_LEN_BYTES: usize = 160;
+pub const NOTE_CIPHERTEXT_BYTES: usize = 176;
 
 /// A plaintext Penumbra note.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -361,9 +361,9 @@ impl From<&Note> for [u8; NOTE_LEN_BYTES] {
     fn from(note: &Note) -> [u8; NOTE_LEN_BYTES] {
         let mut bytes = [0u8; NOTE_LEN_BYTES];
         bytes[0..80].copy_from_slice(&note.address.to_vec());
-        bytes[80..88].copy_from_slice(&note.value.amount.to_le_bytes());
-        bytes[88..120].copy_from_slice(&note.value.asset_id.0.to_bytes());
-        bytes[120..152].copy_from_slice(&note.rseed.to_bytes());
+        bytes[80..96].copy_from_slice(&note.value.amount.to_le_bytes());
+        bytes[96..128].copy_from_slice(&note.value.asset_id.0.to_bytes());
+        bytes[128..160].copy_from_slice(&note.rseed.to_bytes());
         bytes
     }
 }
@@ -393,13 +393,13 @@ impl TryFrom<&[u8]> for Note {
             return Err(Error::NoteDeserializationError);
         }
 
-        let amount_bytes: [u8; 8] = bytes[80..88]
+        let amount_bytes: [u8; 16] = bytes[80..96]
             .try_into()
             .map_err(|_| Error::NoteDeserializationError)?;
-        let asset_id_bytes: [u8; 32] = bytes[88..120]
+        let asset_id_bytes: [u8; 32] = bytes[96..128]
             .try_into()
             .map_err(|_| Error::NoteDeserializationError)?;
-        let rseed_bytes: [u8; 32] = bytes[120..152]
+        let rseed_bytes: [u8; 32] = bytes[128..160]
             .try_into()
             .map_err(|_| Error::NoteDeserializationError)?;
 

--- a/pcli/src/command/view/tx.rs
+++ b/pcli/src/command/view/tx.rs
@@ -27,13 +27,13 @@ fn format_visible_swap_row(asset_cache: &Cache, swap: &SwapPlaintext) -> String 
 
     // For the non-pathological case:
     let (from_asset, from_value, to_asset) =
-        if swap.delta_1_i.inner == 0 && swap.delta_2_i.inner > 0 {
+        if swap.delta_1_i.value() == 0 && swap.delta_2_i.value() > 0 {
             (
                 swap.trading_pair.asset_2(),
                 swap.delta_2_i,
                 swap.trading_pair.asset_1(),
             )
-        } else if swap.delta_2_i.inner == 0 && swap.delta_1_i.inner > 0 {
+        } else if swap.delta_2_i.value() == 0 && swap.delta_1_i.value() > 0 {
             (
                 swap.trading_pair.asset_1(),
                 swap.delta_1_i,
@@ -120,9 +120,9 @@ fn format_visible_swap_claim_row(
     .format(asset_cache);
 
     // For the non-pathological case:
-    let claimed_value = if note_1.amount().inner == 0 && note_2.amount().inner > 0 {
+    let claimed_value = if note_1.amount().value() == 0 && note_2.amount().value() > 0 {
         note_2.value()
-    } else if note_2.amount().inner == 0 && note_1.amount().inner > 0 {
+    } else if note_2.amount().value() == 0 && note_1.amount().value() > 0 {
         note_1.value()
     } else {
         // The pathological case (both assets have output values).


### PR DESCRIPTION
Partial implementation of https://github.com/penumbra-zone/penumbra/issues/1378, this PR:

- make Amount use a u128 internally
- provide a getter Amount::value returning a u64
- adds the necessary conversion traits
- implements encoding a u128 into two u64s, and vice-versa

Previous #1571 - reopened with a clean remote