### PR TITLE
Ensures all peers in k8s config are via external IPs

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -1,11 +1,12 @@
 # Penumbra deployments
 
 This directory contains config management logic for managing
-Penumbra networks. As of 2022Q4, prior to mainnet,
-Penumbra Labs runs two (2) discrete networks:
+Penumbra networks. As of 2023Q1, prior to mainnet,
+Penumbra Labs runs three (3) discrete networks:
 
   * "testnet", updated approximately weekly
   * "testnet-preview", updated on every push to `main` in the repo
+  * "devnet", updated ad-hoc to serve as a sandbox debugging environment
 
 Those networks each have their own genesis and knowledge of peers.
 The networks are completely separate.
@@ -45,4 +46,5 @@ cd networks/testnet
 terraform output
 ```
 
-The reserved IPv4 address will be displayed.
+The reserved IPv4 address will be displayed. The devnet network may not have a reliable
+DNS record, or any at all.

--- a/deployments/ci.sh
+++ b/deployments/ci.sh
@@ -31,6 +31,8 @@ if [[ "$HELM_RELEASE" =~ ^penumbra-testnet$ ]] ; then
     HELM_VARS_FILE="networks/testnet/helm-values-for-${HELM_RELEASE}.yml"
 elif [[ "$HELM_RELEASE" =~ ^penumbra-testnet-preview$ ]] ; then
     HELM_VARS_FILE="networks/testnet-preview/helm-values-for-${HELM_RELEASE}.yml"
+elif [[ "$HELM_RELEASE" =~ ^penumbra-devnet$ ]] ; then
+    HELM_VARS_FILE="networks/devnet/helm-values-for-${HELM_RELEASE}.yml"
 else
     >&2 echo "ERROR: helm release name '$HELM_RELEASE' not supported"
     exit 1

--- a/deployments/helm/templates/fn-tm-config.yaml
+++ b/deployments/helm/templates/fn-tm-config.yaml
@@ -19,7 +19,7 @@ data:
     max_num_inbound-peers = 50
     max_num_outbound-peers = 50
 
-    persistent_peers = "{{ $.Files.Get "pdcli/persistent_peers.txt" | trim }}"
+    persistent_peers = "{{ $.Files.Get (printf "pdcli/persistent_peers_fn_%d.txt" $i) | trim }}"
     external_address = "{{ $.Files.Get (printf "pdcli/external_address_fn_%d.txt" $i) | trim }}"
 
     [tx_index]

--- a/deployments/helm/templates/manged-certs.yaml
+++ b/deployments/helm/templates/manged-certs.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
@@ -16,3 +17,4 @@ spec:
   domains:
     - {{ .Values.ingress.hosts.rpc }}
     - {{ .Values.ingress.hosts.grpc }}
+{{- end }}

--- a/deployments/helm/templates/val-tm-configs.yaml
+++ b/deployments/helm/templates/val-tm-configs.yaml
@@ -16,7 +16,7 @@ data:
     max_num_inbound-peers = 50
     max_num_outbound-peers = 50
 
-    persistent_peers = "{{ $.Files.Get (printf "pdcli/persistent_peers_%d.txt" $i) | trim }}"
+    persistent_peers = "{{ $.Files.Get (printf "pdcli/persistent_peers_val_%d.txt" $i) | trim }}"
     external_address = "{{ $.Files.Get (printf "pdcli/external_address_val_%d.txt" $i) | trim }}"
 
     [tx_index]

--- a/deployments/networks/devnet/helm-values-for-penumbra-devnet.yml
+++ b/deployments/networks/devnet/helm-values-for-penumbra-devnet.yml
@@ -1,0 +1,4 @@
+---
+# Values file for devnet deploys.
+ingress:
+  enabled: false


### PR DESCRIPTION
Refs #1815. There are two changes here:

* adds a `devnet` deploy target, basically a sandbox environment that is not expected to be publicly consumed, for the purpose of debugging 
* updates the config-munging logic so that _all_ k8s services use external IPs to talk to peers.

The goal of the latter changes is to achieve consistency with the goals in #1815. Also hoping to improve legibility via comments for the benefit of future maintainers. The changes aren't just superficial: now fullnodes and validators alike will peer with each other. At a later date we may wish to rearchitect the peering to implement [sentry nodes](https://docs.tendermint.com/main/tendermint-core/validators.html). 

These changes are not sufficient for resolution of 1815, but upon merge, we'll see them land on preview, and then continue. 