### PR TITLE
pd: change testnet join to use peers' listen addresses

### DIFF
--- a/pd/src/testnet.rs
+++ b/pd/src/testnet.rs
@@ -56,7 +56,7 @@ pub fn generate_tm_config(node_name: &str, persistent_peers: &[(Id, String)]) ->
         // crypto package.
         // the peer addresses need to match this impl: https://github.com/tendermint/tendermint/blob/f2a8f5e054cf99ebe246818bb6d71f41f9a30faa/internal/p2p/address.go#L43
         // The ID is for the node being connected to, *not* the connecting node's ID.
-        .map(|(id, ip)| format!("{}@{}:26656", id, ip))
+        .map(|(id, ip)| format!("{}@{}", id, ip))
         .collect::<Vec<String>>()
         .join(",");
     format!(


### PR DESCRIPTION
`pd testnet join` connects to a node of a running network and pulls information from it to generate configs for a node that runs as part of that network.  It needs to do this, because Tendermint's P2P layer is authenticated, so at some point a node needs to obtain the fingerprint of at least one other peer. However, if we only add the node we're scraping as a peer, then we might not be able to join the network if that peer has too many connections open.

To prevent this, we added logic to `pd testnet join` that scrapes the node's `net_info` RPC endpoint to obtain a list of bootstrap peers.  However, in the first version of that code, we used the `remote_ip`, which might not be the externally routable address.  This commit changes the `testnet join` logic to scrape the self-reported `listen_addr` instead, and then filters out addresses that probably aren't valid, such as loopback addresses, private addresses, the unspecified address, etc.

The code is a little messy, because it aims to minimally change the existing logic; it could be cleaned up if the `testnet join` logic were cleaned up and moved out of `main.rs`.

Longer-term, an even better solution would be to configure the "bootstrap" node in testnet deployments as a seed node, but this is a bigger change, and this fix is useful anyways.