### PR TITLE
k8s: reconcile tendermint configs

### DIFF
--- a/deployments/helm/templates/fn-tm-config.yaml
+++ b/deployments/helm/templates/fn-tm-config.yaml
@@ -16,14 +16,17 @@ data:
     laddr = "tcp://0.0.0.0:26657"
 
     [p2p]
-    max_num_inbound-peers = 50
-    max_num_outbound-peers = 50
+    max_num_inbound_peers = 50
+    max_num_outbound_peers = 50
 
     persistent_peers = "{{ $.Files.Get (printf "pdcli/persistent_peers_fn_%d.txt" $i) | trim }}"
     external_address = "{{ $.Files.Get (printf "pdcli/external_address_fn_%d.txt" $i) | trim }}"
 
     [tx_index]
-    indexer = "null"
+    indexer = "kv"
+
+    [consensus]
+    timeout_commit = "5s"
 
     [instrumentation]
     prometheus = true

--- a/deployments/helm/templates/val-tm-configs.yaml
+++ b/deployments/helm/templates/val-tm-configs.yaml
@@ -13,14 +13,17 @@ data:
     proxy_app = "tcp://localhost:26658"
 
     [p2p]
-    max_num_inbound-peers = 50
-    max_num_outbound-peers = 50
+    max_num_inbound_peers = 50
+    max_num_outbound_peers = 50
 
     persistent_peers = "{{ $.Files.Get (printf "pdcli/persistent_peers_val_%d.txt" $i) | trim }}"
     external_address = "{{ $.Files.Get (printf "pdcli/external_address_val_%d.txt" $i) | trim }}"
 
     [tx_index]
-    indexer = "null"
+    indexer = "kv"
+
+    [consensus]
+    timeout_commit = "5s"
 
     [instrumentation]
     prometheus = true


### PR DESCRIPTION
Updates the k8s tendermint config to match
what we've long been shipping via the tm config
generated by `pd`. We're doing this in advance of shifting the public testnet to use the k8s deployment, so we want the closest match possible for consistency's sake. Closes #1816.