### PR TITLE
crypto: implement rseed mechanism

### DIFF
--- a/chain/src/genesis/allocation.rs
+++ b/chain/src/genesis/allocation.rs
@@ -1,6 +1,4 @@
-use ark_ff::Zero;
-use decaf377::Fq;
-use penumbra_crypto::{asset, Address, Note, Value};
+use penumbra_crypto::{asset, Address, Note, Rseed, Value};
 use penumbra_proto::{core::chain::v1alpha1 as pb, Protobuf};
 use serde::{Deserialize, Serialize};
 
@@ -56,9 +54,8 @@ impl std::fmt::Debug for Allocation {
 impl Allocation {
     /// Obtain a note corresponding to this allocation.
     ///
-    /// Note: to ensure determinism, this uses a zero blinding factor when
-    /// creating the note. This is fine, because the genesis allocations are
-    /// already public.
+    /// Note: to ensure determinism, this uses a zero rseed when
+    /// creating the note.
     pub fn note(&self) -> Result<Note, anyhow::Error> {
         Note::from_parts(
             self.address,
@@ -69,7 +66,7 @@ impl Allocation {
                     .ok_or_else(|| anyhow::anyhow!("invalid denomination"))?
                     .id(),
             },
-            Fq::zero(),
+            Rseed([0u8; 32]),
         )
         .map_err(Into::into)
     }

--- a/component/src/action_handler/actions/output.rs
+++ b/component/src/action_handler/actions/output.rs
@@ -18,7 +18,6 @@ impl ActionHandler for Output {
         output.proof.verify(
             output.body.balance_commitment,
             output.body.note_payload.note_commitment,
-            output.body.note_payload.ephemeral_key,
         )?;
 
         Ok(())

--- a/component/src/shielded_pool/note_manager.rs
+++ b/component/src/shielded_pool/note_manager.rs
@@ -3,11 +3,9 @@ use super::{
     state_key, SupplyWrite,
 };
 use anyhow::Result;
-use ark_ff::PrimeField;
 use async_trait::async_trait;
-use decaf377::{Fq, Fr};
 use penumbra_chain::{sync::StatePayload, NoteSource};
-use penumbra_crypto::{ka, Address, EncryptedNote, Note, Nullifier, One, Value};
+use penumbra_crypto::{Address, EncryptedNote, Note, Nullifier, Rseed, Value};
 use penumbra_proto::StateWriteProto;
 use penumbra_storage::StateWrite;
 use penumbra_tct as tct;
@@ -46,24 +44,25 @@ pub trait NoteManager: StateWrite {
             .expect("note commitment tree is not full")
             .into();
 
-        let blinding_factor = Fq::from_le_bytes_mod_order(
+        let rseed = Rseed(
             blake2b_simd::Params::default()
                 .personal(b"PenumbraMint")
                 .to_state()
                 .update(&position.to_le_bytes())
                 .finalize()
-                .as_bytes(),
+                .as_bytes()
+                .try_into()?,
         );
 
-        let note = Note::from_parts(*address, value, blinding_factor)?;
+        let note = Note::from_parts(*address, value, rseed)?;
         let note_commitment = note.commit();
 
         // Scanning assumes that notes are encrypted, so we need to create
-        // note ciphertexts, even if the plaintexts are known.  Use the key
-        // "1" to ensure we have contributory behaviour in note encryption.
-        let esk = ka::Secret::new_from_field(Fr::one());
+        // note ciphertexts, even if the plaintexts are known.
+        // TODO: Check "contributory" behavior is preserved/not important
+        let esk = note.ephemeral_secret_key();
         let ephemeral_key = esk.diversified_public(&note.diversified_generator());
-        let encrypted_note = note.encrypt(&esk);
+        let encrypted_note = note.encrypt();
 
         // Now record the note and update the total supply:
         self.update_token_supply(&value.asset_id, i64::from(value.amount))

--- a/crypto/src/dex/swap/plaintext.rs
+++ b/crypto/src/dex/swap/plaintext.rs
@@ -1,5 +1,5 @@
 use crate::transaction::Fee;
-use crate::{asset, ka, Address, Amount, Note, Value};
+use crate::{asset, ka, Address, Amount, Note, Rseed, Value};
 use anyhow::{anyhow, Error, Result};
 use ark_ff::{PrimeField, UniformRand};
 use decaf377::{FieldExt, Fq};
@@ -61,13 +61,16 @@ impl SwapPlaintext {
             self.delta_2_i.try_into().unwrap(),
         ));
 
+        // TODO: Use rseed for swaps also.
+        let output_1_rseed = todo!();
+        let output_2_rseed = todo!();
         let output_1_note = Note::from_parts(
             self.claim_address,
             Value {
                 amount: lambda_1_i.into(),
                 asset_id: self.trading_pair.asset_1(),
             },
-            output_1_blinding,
+            output_1_rseed,
         )
         .expect("claim address is valid");
 
@@ -77,7 +80,7 @@ impl SwapPlaintext {
                 amount: lambda_2_i.into(),
                 asset_id: self.trading_pair.asset_2(),
             },
-            output_2_blinding,
+            output_2_rseed,
         )
         .expect("claim address is valid");
 

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -35,6 +35,7 @@ pub use governance_key::GovernanceKey;
 pub use keys::FullViewingKey;
 pub use note::Note;
 pub use nullifier::Nullifier;
+pub use rseed::Rseed;
 pub use symmetric::PayloadKey;
 pub use value::Value;
 

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -19,6 +19,7 @@ pub mod note;
 mod nullifier;
 mod prf;
 pub mod proofs;
+pub mod rseed;
 pub mod stake;
 pub mod symmetric;
 pub mod transaction;

--- a/crypto/src/memo.rs
+++ b/crypto/src/memo.rs
@@ -199,7 +199,7 @@ mod tests {
 
         let value_blinding = Fr::rand(&mut rng);
         let cv = note.value().commit(value_blinding);
-        let wrapped_ovk = note.encrypt_key(&esk, ovk, cv);
+        let wrapped_ovk = note.encrypt_key(ovk, cv);
 
         // Later, still on the sender side, we decrypt the memo by using the decrypt_outgoing method.
         let epk = esk.diversified_public(dest.diversified_generator());

--- a/crypto/src/memo.rs
+++ b/crypto/src/memo.rs
@@ -176,8 +176,6 @@ mod tests {
         let ovk = fvk.outgoing();
         let (dest, _dtk_d) = ivk.payment_address(0u64.into());
 
-        let esk = ka::Secret::new(&mut rng);
-
         let value = Value {
             amount: 10u64.into(),
             asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
@@ -190,6 +188,7 @@ mod tests {
         let memo_key = PayloadKey::random_key(&mut OsRng);
         let ciphertext =
             MemoCiphertext::encrypt(memo_key.clone(), &memo).expect("can encrypt memo");
+        let esk = note.ephemeral_secret_key();
         let wrapped_memo_key = WrappedMemoKey::encrypt(
             &memo_key,
             esk.clone(),

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -121,6 +121,10 @@ impl Note {
         self.value.amount
     }
 
+    pub fn rseed(&self) -> Rseed {
+        self.rseed
+    }
+
     /// Encrypt a note, returning its ciphertext.
     pub fn encrypt(&self) -> [u8; NOTE_CIPHERTEXT_BYTES] {
         let esk = self.ephemeral_secret_key();

--- a/crypto/src/note.rs
+++ b/crypto/src/note.rs
@@ -283,6 +283,29 @@ pub fn commitment(
     Commitment(commit)
 }
 
+/// Create a note commitment from the blinding factor, value, and address.
+pub fn commitment_from_address(
+    address: Address,
+    value: Value,
+    note_blinding: Fq,
+) -> Result<Commitment, Error> {
+    let transmission_key_s =
+        Fq::from_bytes(address.transmission_key().0).map_err(|_| Error::InvalidTransmissionKey)?;
+    let commit = poseidon377::hash_6(
+        &NOTECOMMIT_DOMAIN_SEP,
+        (
+            note_blinding,
+            value.amount.into(),
+            value.asset_id.0,
+            address.diversified_generator().vartime_compress_to_field(),
+            transmission_key_s,
+            Fq::from_le_bytes_mod_order(&address.clue_key().0[..]),
+        ),
+    );
+
+    Ok(Commitment(commit))
+}
+
 impl std::fmt::Debug for Note {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Note")

--- a/crypto/src/proofs/groth16.rs
+++ b/crypto/src/proofs/groth16.rs
@@ -15,7 +15,6 @@ mod tests {
         keys::{SeedPhrase, SpendKey},
     };
     use decaf377::{Fq, Fr};
-    use decaf377_ka as ka;
     use proptest::prelude::*;
 
     use decaf377_rdsa::{SpendAuth, VerificationKey};
@@ -41,7 +40,7 @@ mod tests {
     proptest! {
     #![proptest_config(ProptestConfig::with_cases(2))]
     #[test]
-    fn output_proof_happy_path(seed_phrase_randomness in any::<[u8; 32]>(), v_blinding in fr_strategy(), value_amount in 2..200u64, esk_inner in fr_strategy()) {
+    fn output_proof_happy_path(seed_phrase_randomness in any::<[u8; 32]>(), v_blinding in fr_strategy(), value_amount in 2..200u64) {
             let (pk, vk) = OutputCircuit::generate_test_parameters();
 
             let mut rng = OsRng;
@@ -59,8 +58,6 @@ mod tests {
 
             let note = Note::generate(&mut rng, &dest, value_to_send);
             let note_commitment = note.commit();
-            let esk = ka::Secret::new_from_field(esk_inner);
-            let epk = esk.diversified_public(&note.diversified_generator());
             let balance_commitment = value_to_send.commit(v_blinding);
 
             let proof = OutputProof::prove(
@@ -68,14 +65,12 @@ mod tests {
                 &pk,
                 note,
                 v_blinding,
-                esk,
                 balance_commitment,
                 note_commitment,
-                epk,
             )
             .expect("can create proof");
 
-            let proof_result = proof.verify(&vk, balance_commitment, note_commitment, epk);
+            let proof_result = proof.verify(&vk, balance_commitment, note_commitment);
 
             assert!(proof_result.is_ok());
         }
@@ -84,7 +79,7 @@ mod tests {
     proptest! {
     #![proptest_config(ProptestConfig::with_cases(2))]
     #[test]
-    fn output_proof_verification_note_commitment_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), v_blinding in fr_strategy(), value_amount in 2..200u64, esk_inner in fr_strategy(), note_blinding in fq_strategy()) {
+    fn output_proof_verification_note_commitment_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), v_blinding in fr_strategy(), value_amount in 2..200u64, note_blinding in fq_strategy()) {
         let (pk, vk) = OutputCircuit::generate_test_parameters();
         let mut rng = OsRng;
 
@@ -101,8 +96,6 @@ mod tests {
 
         let note = Note::generate(&mut rng, &dest, value_to_send);
         let note_commitment = note.commit();
-        let esk = ka::Secret::new_from_field(esk_inner);
-        let epk = esk.diversified_public(&note.diversified_generator());
         let balance_commitment = value_to_send.commit(v_blinding);
 
         let proof = OutputProof::prove(
@@ -110,10 +103,8 @@ mod tests {
             &pk,
             note.clone(),
             v_blinding,
-            esk,
             balance_commitment,
             note_commitment,
-            epk,
         )
         .expect("can create proof");
 
@@ -125,7 +116,7 @@ mod tests {
             note.clue_key(),
         );
 
-        let proof_result = proof.verify(&vk, balance_commitment, incorrect_note_commitment, epk);
+        let proof_result = proof.verify(&vk, balance_commitment, incorrect_note_commitment);
 
         assert!(proof_result.is_err());
     }
@@ -134,7 +125,7 @@ mod tests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(2))]
         #[test]
-    fn output_proof_verification_balance_commitment_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), v_blinding in fr_strategy(), value_amount in 2..200u64, esk_inner in fr_strategy(), incorrect_v_blinding in fr_strategy()) {
+    fn output_proof_verification_balance_commitment_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), v_blinding in fr_strategy(), value_amount in 2..200u64, incorrect_v_blinding in fr_strategy()) {
         let (pk, vk) = OutputCircuit::generate_test_parameters();
         let mut rng = OsRng;
 
@@ -151,8 +142,6 @@ mod tests {
 
         let note = Note::generate(&mut rng, &dest, value_to_send);
         let note_commitment = note.commit();
-        let esk = ka::Secret::new_from_field(esk_inner);
-        let epk = esk.diversified_public(&note.diversified_generator());
         let balance_commitment = value_to_send.commit(v_blinding);
 
         let proof = OutputProof::prove(
@@ -160,65 +149,18 @@ mod tests {
             &pk,
             note,
             v_blinding,
-            esk,
             balance_commitment,
             note_commitment,
-            epk,
         )
         .expect("can create proof");
 
         let incorrect_balance_commitment = value_to_send.commit(incorrect_v_blinding);
 
-        let proof_result = proof.verify(&vk, incorrect_balance_commitment, note_commitment, epk);
+        let proof_result = proof.verify(&vk, incorrect_balance_commitment, note_commitment);
 
         assert!(proof_result.is_err());
     }
         }
-
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(2))]
-    #[test]
-    fn output_proof_verification_ephemeral_public_key_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), v_blinding in fr_strategy(), value_amount in 2..200u64, esk_inner in fr_strategy(), incorrect_esk_inner in fr_strategy()) {
-        let (pk, vk) = OutputCircuit::generate_test_parameters();
-        let mut rng = OsRng;
-
-        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
-        let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
-        let fvk_recipient = sk_recipient.full_viewing_key();
-        let ivk_recipient = fvk_recipient.incoming();
-        let (dest, _dtk_d) = ivk_recipient.payment_address(0u64.into());
-
-        let value_to_send = Value {
-            amount: value_amount.into(),
-            asset_id: asset::REGISTRY.parse_denom("upenumbra").unwrap().id(),
-        };
-
-        let note = Note::generate(&mut rng, &dest, value_to_send);
-        let note_commitment = note.commit();
-        let esk = ka::Secret::new_from_field(esk_inner);
-        let epk = esk.diversified_public(&note.diversified_generator());
-        let balance_commitment = value_to_send.commit(v_blinding);
-
-        let proof = OutputProof::prove(
-            &mut rng,
-            &pk,
-            note.clone(),
-            v_blinding,
-            esk,
-            balance_commitment,
-            note_commitment,
-            epk,
-        )
-        .expect("can create proof");
-
-        let incorrect_esk = ka::Secret::new_from_field(incorrect_esk_inner);
-        let incorrect_epk = incorrect_esk.diversified_public(&note.diversified_generator());
-
-        let proof_result = proof.verify(&vk, balance_commitment, note_commitment, incorrect_epk);
-
-        assert!(proof_result.is_err());
-    }
-    }
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(2))]

--- a/crypto/src/proofs/groth16/gadgets.rs
+++ b/crypto/src/proofs/groth16/gadgets.rs
@@ -40,19 +40,6 @@ pub(crate) fn ak_not_identity(
     Ok(())
 }
 
-/// Check the integrity of the ephemeral public key.
-pub(crate) fn ephemeral_public_key_integrity(
-    // Witnesses
-    esk: Vec<UInt8<Fq>>,
-    g_d: ElementVar,
-    // Public inputs,
-    epk: ElementVar,
-) -> Result<(), SynthesisError> {
-    let expected_epk = g_d.scalar_mul_le(esk.to_bits_le()?.iter())?;
-    expected_epk.enforce_equal(&epk)?;
-    Ok(())
-}
-
 /// Check the integrity of the value commitment.
 pub(crate) fn value_commitment_integrity(
     cs: ConstraintSystemRef<Fq>,

--- a/crypto/src/proofs/groth16/output.rs
+++ b/crypto/src/proofs/groth16/output.rs
@@ -18,7 +18,7 @@ use rand::{CryptoRng, Rng};
 use rand_core::OsRng;
 
 use crate::proofs::groth16::{gadgets, ParameterSetup};
-use crate::{balance, keys::Diversifier, note, Address, Note, Value};
+use crate::{balance, keys::Diversifier, Rseed, note, Address, Note, Value};
 
 // Public:
 // * vcm (value commitment)
@@ -117,7 +117,7 @@ impl ParameterSetup for OutputCircuit {
         let note = Note::from_parts(
             address,
             Value::from_str("1upenumbra").expect("valid value"),
-            Fq::from(1),
+            Rseed([1u8; 32]),
         )
         .expect("can make a note");
         let v_blinding = Fr::from(1);

--- a/crypto/src/proofs/groth16/output.rs
+++ b/crypto/src/proofs/groth16/output.rs
@@ -18,7 +18,7 @@ use rand::{CryptoRng, Rng};
 use rand_core::OsRng;
 
 use crate::proofs::groth16::{gadgets, ParameterSetup};
-use crate::{balance, keys::Diversifier, Rseed, note, Address, Note, Value};
+use crate::{balance, keys::Diversifier, note, Address, Note, Rseed, Value};
 
 // Public:
 // * vcm (value commitment)

--- a/crypto/src/proofs/groth16/spend.rs
+++ b/crypto/src/proofs/groth16/spend.rs
@@ -24,7 +24,7 @@ use crate::proofs::groth16::{gadgets, ParameterSetup};
 use crate::{
     balance,
     keys::{NullifierKey, SeedPhrase, SpendKey},
-    Note, Nullifier, Value,
+    Note, Nullifier, Rseed, Value,
 };
 
 /// Groth16 proof for spending existing notes.
@@ -192,7 +192,7 @@ impl ParameterSetup for SpendCircuit {
         let note = Note::from_parts(
             address,
             Value::from_str("1upenumbra").expect("valid value"),
-            Fq::from(1),
+            Rseed([1u8; 32]),
         )
         .expect("can make a note");
         let v_blinding = Fr::from(1);

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -351,24 +351,22 @@ impl SwapClaimProof {
 
         // Output note integrity
         let (output_blinding_1, output_blinding_2) = self.swap_plaintext.output_blinding_factors();
-        let output_1_commitment = Note::from_parts(
+        let output_1_commitment = note::commitment_from_address(
             self.swap_plaintext.claim_address,
             Value {
                 amount: self.lambda_1_i.into(),
                 asset_id: self.swap_plaintext.trading_pair.asset_1(),
             },
             output_blinding_1,
-        )?
-        .commit();
-        let output_2_commitment = Note::from_parts(
+        )?;
+        let output_2_commitment = note::commitment_from_address(
             self.swap_plaintext.claim_address,
             Value {
                 amount: self.lambda_2_i.into(),
                 asset_id: self.swap_plaintext.trading_pair.asset_2(),
             },
             output_blinding_2,
-        )?
-        .commit();
+        )?;
 
         ensure!(
             output_1_commitment == note_commitment_1,

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -350,14 +350,14 @@ impl SwapClaimProof {
         ensure!(self.lambda_2_i == lambda_2_i, "lambda_2_i mismatch");
 
         // Output note integrity
-        let (output_blinding_1, output_blinding_2) = self.swap_plaintext.output_blinding_factors();
+        let (output_rseed_1, output_rseed_2) = self.swap_plaintext.output_rseeds();
         let output_1_commitment = note::commitment_from_address(
             self.swap_plaintext.claim_address,
             Value {
                 amount: self.lambda_1_i.into(),
                 asset_id: self.swap_plaintext.trading_pair.asset_1(),
             },
-            output_blinding_1,
+            output_rseed_1.derive_note_blinding(),
         )?;
         let output_2_commitment = note::commitment_from_address(
             self.swap_plaintext.claim_address,
@@ -365,7 +365,7 @@ impl SwapClaimProof {
                 amount: self.lambda_2_i.into(),
                 asset_id: self.swap_plaintext.trading_pair.asset_2(),
             },
-            output_blinding_2,
+            output_rseed_2.derive_note_blinding(),
         )?;
 
         ensure!(

--- a/crypto/src/proofs/transparent_gadgets.rs
+++ b/crypto/src/proofs/transparent_gadgets.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use decaf377_rdsa::{SpendAuth, VerificationKey};
 use penumbra_tct as tct;
 
-use crate::{balance, ka, keys, note, Balance, Fr, Note, Nullifier};
+use crate::{balance, keys, note, Balance, Fr, Note, Nullifier};
 
 /// Check the integrity of the nullifier.
 pub(crate) fn nullifier_integrity(
@@ -46,19 +46,6 @@ pub(crate) fn balance_commitment_integrity(
 ) -> Result<()> {
     if balance_commitment != balance.commit(value_blinding) {
         Err(anyhow!("balance commitment mismatch"))
-    } else {
-        Ok(())
-    }
-}
-
-/// Check the integrity of an ephemeral public key.
-pub(crate) fn ephemeral_public_key_integrity(
-    public_key: ka::Public,
-    secret_key: ka::Secret,
-    diversified_generator: decaf377::Element,
-) -> Result<()> {
-    if secret_key.diversified_public(&diversified_generator) != public_key {
-        Err(anyhow!("ephemeral public key mismatch"))
     } else {
         Ok(())
     }

--- a/crypto/src/rseed.rs
+++ b/crypto/src/rseed.rs
@@ -1,4 +1,7 @@
-use crate::{ka, Fq};
+use ark_ff::PrimeField;
+use rand::{CryptoRng, RngCore};
+
+use crate::{ka, prf, Fq, Fr};
 
 /// The rseed is a uniformly random 32-byte sequence included in the note plaintext.
 #[derive(Clone, Copy, Debug)]
@@ -6,17 +9,21 @@ pub struct Rseed(pub [u8; 32]);
 
 impl Rseed {
     /// Generate a new rseed from a random source.
-    pub fn generate(&self) -> Self {
-        todo!()
+    pub fn generate<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes)
     }
 
     /// Derive the ephemeral secret key from the rseed.
     pub fn derive_esk(&self) -> ka::Secret {
-        todo!()
+        let hash_result = prf::expand(b"Penumbra_DeriEsk", &self.0, &[4u8]);
+        ka::Secret::new_from_field(Fr::from_le_bytes_mod_order(hash_result.as_bytes()))
     }
 
     /// Derive note commitment randomness from the rseed.
     pub fn derive_note_blinding(&self) -> Fq {
-        todo!()
+        let hash_result = prf::expand(b"Penumbra_DeriRcm", &self.0, &[5u8]);
+        Fq::from_le_bytes_mod_order(hash_result.as_bytes())
     }
 }

--- a/crypto/src/rseed.rs
+++ b/crypto/src/rseed.rs
@@ -4,7 +4,7 @@ use rand::{CryptoRng, RngCore};
 use crate::{ka, prf, Fq, Fr};
 
 /// The rseed is a uniformly random 32-byte sequence included in the note plaintext.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Rseed(pub [u8; 32]);
 
 impl Rseed {
@@ -25,5 +25,9 @@ impl Rseed {
     pub fn derive_note_blinding(&self) -> Fq {
         let hash_result = prf::expand(b"Penumbra_DeriRcm", &self.0, &[5u8]);
         Fq::from_le_bytes_mod_order(hash_result.as_bytes())
+    }
+
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0
     }
 }

--- a/crypto/src/rseed.rs
+++ b/crypto/src/rseed.rs
@@ -1,0 +1,22 @@
+use crate::{ka, Fq};
+
+/// The rseed is a uniformly random 32-byte sequence included in the note plaintext.
+#[derive(Clone, Copy, Debug)]
+pub struct Rseed(pub [u8; 32]);
+
+impl Rseed {
+    /// Generate a new rseed from a random source.
+    pub fn generate(&self) -> Self {
+        todo!()
+    }
+
+    /// Derive the ephemeral secret key from the rseed.
+    pub fn derive_esk(&self) -> ka::Secret {
+        todo!()
+    }
+
+    /// Derive note commitment randomness from the rseed.
+    pub fn derive_note_blinding(&self) -> Fq {
+        todo!()
+    }
+}

--- a/docs/protocol/src/protocol/notes/note_commitments.md
+++ b/docs/protocol/src/protocol/notes/note_commitments.md
@@ -16,6 +16,13 @@ hashing together the above contents along with the note blinding factor $rcm$:
 
 `note_commitment = hash_5(ds, (rcm, v, ID, B_d, pk_d))`
 
+The note blinding factor $rcm$ is derived from the `rseed` 32-byte value in the
+note. Define `prf_expand(label, key, input)` as BLAKE2b-512 with
+personalization `label`, key `key`, and input `input`. The note blinding factor
+is derived as:
+
+`rcm = from_le_bytes(prf_expand(b"Penumbra_DeriRcm", rseed, 4)) mod q`
+
 We commit to the diversified basepoint and payment address instead of the
 diversifier itself, as in the circuit `OutputProof` when we verify the integrity of
 the derived ephemeral key $epk$, we need $B_d$: 

--- a/docs/protocol/src/protocol/notes/note_plaintexts.md
+++ b/docs/protocol/src/protocol/notes/note_plaintexts.md
@@ -3,7 +3,8 @@
 Plaintext notes contain:
 
 * the value to be transmitted which consists of an integer amount $v$ along with a scalar (32 bytes) $ID$ identifying the asset.
-* the note blinding factor $rcm$, a scalar value, which will later be used when computing note commitments.
+* $rseed$, a 32-byte random value, which will later be used to derive the note blinding factor used for the
+note commitment and an ephemeral secret key.
 * the destination address, described in more detail in the [Addressses](../addresses_keys/addresses.md) section.
 
 The note can only be spent by the holder of the spend key that corresponds to the diversified transmission key $pk_d$ in the note. 

--- a/proto/proto/penumbra/core/crypto/v1alpha1/crypto.proto
+++ b/proto/proto/penumbra/core/crypto/v1alpha1/crypto.proto
@@ -91,7 +91,7 @@ message ConsensusKey {
 
 message Note {
     Value value = 1;
-    bytes note_blinding = 2;
+    bytes rseed = 2;
     Address address = 3;
 }
 

--- a/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
+++ b/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
@@ -81,8 +81,8 @@ message SwapPlaintext {
   crypto.v1alpha1.Fee claim_fee = 4;
   // Address that will claim the swap outputs via SwapClaim.
   crypto.v1alpha1.Address claim_address = 5;
-  // Swap blinding factor
-  bytes swap_blinding = 6;
+  // Swap rseed (blinding factors are derived from this)
+  bytes rseed = 6;
 }
 
 message MockFlowCiphertext {

--- a/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
+++ b/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
@@ -399,8 +399,8 @@ message OutputPlan {
     crypto.v1alpha1.Value value = 1;
     // The destination address to send it to.
     crypto.v1alpha1.Address dest_address = 2;
-    // The blinding factor to use for the new note.
-    bytes note_blinding = 3;
+    // The rseed to use for the new note.
+    bytes rseed = 3;
     // The blinding factor to use for the value commitment.
     bytes value_blinding = 4;
 }

--- a/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
+++ b/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
@@ -403,8 +403,6 @@ message OutputPlan {
     bytes note_blinding = 3;
     // The blinding factor to use for the value commitment.
     bytes value_blinding = 4;
-    // The ephemeral secret key to use for the note encryption.
-    bytes esk = 5;
 }
 
 message ProposalWithdrawPlan {

--- a/proto/proto/penumbra/core/transparent_proofs/v1alpha1/transparent_proofs.proto
+++ b/proto/proto/penumbra/core/transparent_proofs/v1alpha1/transparent_proofs.proto
@@ -28,7 +28,6 @@ message OutputProof {
   // Auxiliary inputs
   crypto.v1alpha1.Note note = 1;
   bytes v_blinding = 5;
-  bytes esk = 7;
 }
 
 // A Penumbra transparent SwapClaimProof.

--- a/proto/src/gen/penumbra.core.crypto.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.crypto.v1alpha1.rs
@@ -178,8 +178,7 @@ pub struct Note {
     #[prost(message, optional, tag = "1")]
     pub value: ::core::option::Option<Value>,
     #[prost(bytes = "vec", tag = "2")]
-    #[serde(with = "crate::serializers::hexstr")]
-    pub note_blinding: ::prost::alloc::vec::Vec<u8>,
+    pub rseed: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "3")]
     pub address: ::core::option::Option<Address>,
 }

--- a/proto/src/gen/penumbra.core.dex.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.dex.v1alpha1.rs
@@ -117,9 +117,9 @@ pub struct SwapPlaintext {
     /// Address that will claim the swap outputs via SwapClaim.
     #[prost(message, optional, tag = "5")]
     pub claim_address: ::core::option::Option<super::super::crypto::v1alpha1::Address>,
-    /// Swap blinding factor
+    /// Swap rseed (blinding factors are derived from this)
     #[prost(bytes = "vec", tag = "6")]
-    pub swap_blinding: ::prost::alloc::vec::Vec<u8>,
+    pub rseed: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[serde(transparent)]

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
@@ -691,10 +691,6 @@ pub struct OutputPlan {
     #[prost(bytes = "bytes", tag = "4")]
     #[serde(with = "crate::serializers::hexstr_bytes")]
     pub value_blinding: ::prost::bytes::Bytes,
-    /// The ephemeral secret key to use for the note encryption.
-    #[prost(bytes = "bytes", tag = "5")]
-    #[serde(with = "crate::serializers::hexstr_bytes")]
-    pub esk: ::prost::bytes::Bytes,
 }
 #[derive(::serde::Deserialize, ::serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
@@ -683,10 +683,9 @@ pub struct OutputPlan {
     /// The destination address to send it to.
     #[prost(message, optional, tag = "2")]
     pub dest_address: ::core::option::Option<super::super::crypto::v1alpha1::Address>,
-    /// The blinding factor to use for the new note.
+    /// The rseed to use for the new note.
     #[prost(bytes = "bytes", tag = "3")]
-    #[serde(with = "crate::serializers::hexstr_bytes")]
-    pub note_blinding: ::prost::bytes::Bytes,
+    pub rseed: ::prost::bytes::Bytes,
     /// The blinding factor to use for the value commitment.
     #[prost(bytes = "bytes", tag = "4")]
     #[serde(with = "crate::serializers::hexstr_bytes")]

--- a/proto/src/gen/penumbra.core.transparent_proofs.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.transparent_proofs.v1alpha1.rs
@@ -30,8 +30,6 @@ pub struct OutputProof {
     pub note: ::core::option::Option<super::super::crypto::v1alpha1::Note>,
     #[prost(bytes = "vec", tag = "5")]
     pub v_blinding: ::prost::alloc::vec::Vec<u8>,
-    #[prost(bytes = "vec", tag = "7")]
-    pub esk: ::prost::alloc::vec::Vec<u8>,
 }
 /// A Penumbra transparent SwapClaimProof.
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/transaction/src/action/output.rs
+++ b/transaction/src/action/output.rs
@@ -27,10 +27,14 @@ impl IsAction for Output {
 
     fn view_from_perspective(&self, txp: &TransactionPerspective) -> ActionView {
         let note_commitment = self.body.note_payload.note_commitment;
+        let epk = self.body.note_payload.ephemeral_key;
         // Retrieve payload key for associated note commitment
         let output_view = if let Some(payload_key) = txp.payload_keys.get(&note_commitment) {
-            let decrypted_note =
-                Note::decrypt_with_payload_key(&self.body.note_payload.encrypted_note, payload_key);
+            let decrypted_note = Note::decrypt_with_payload_key(
+                &self.body.note_payload.encrypted_note,
+                payload_key,
+                &epk,
+            );
 
             let decrypted_memo_key = self.body.wrapped_memo_key.decrypt_outgoing(payload_key);
 

--- a/transaction/src/plan/action/spend.rs
+++ b/transaction/src/plan/action/spend.rs
@@ -1,7 +1,7 @@
 use ark_ff::UniformRand;
 use decaf377_rdsa::{Signature, SpendAuth};
 use penumbra_crypto::{
-    proofs::transparent::SpendProof, Address, FieldExt, Fq, Fr, FullViewingKey, Note, Value,
+    proofs::transparent::SpendProof, Address, FieldExt, Fr, FullViewingKey, Note, Rseed, Value,
     STAKING_TOKEN_ASSET_ID,
 };
 use penumbra_proto::{core::transaction::v1alpha1 as pb, Protobuf};
@@ -39,14 +39,14 @@ impl SpendPlan {
     /// Create a dummy [`SpendPlan`].
     pub fn dummy<R: CryptoRng + RngCore>(rng: &mut R) -> SpendPlan {
         let dummy_address = Address::dummy(rng);
-        let note_blinding = Fq::rand(rng);
+        let rseed = Rseed::generate(rng);
         let dummy_note = Note::from_parts(
             dummy_address,
             Value {
                 amount: 0u64.into(),
                 asset_id: *STAKING_TOKEN_ASSET_ID,
             },
-            note_blinding,
+            rseed,
         )
         .expect("dummy note is valid");
 

--- a/view/migrations/20220908223928_notes.sql
+++ b/view/migrations/20220908223928_notes.sql
@@ -6,7 +6,7 @@ CREATE TABLE notes (
     address                 BLOB NOT NULL,
     amount                  BIGINT NOT NULL,
     asset_id                BLOB NOT NULL,
-    blinding_factor         BLOB NOT NULL
+    rseed                   BLOB NOT NULL
 );
 
 -- general purpose note queries

--- a/view/sqlx-data.json
+++ b/view/sqlx-data.json
@@ -112,16 +112,6 @@
     },
     "query": "SELECT *\n            FROM assets"
   },
-  "33a8631f81455f7c7caa0e5e3c38108a4b54b3b391912a7b0fbd9b47be891785": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 5
-      }
-    },
-    "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        address,\n                        amount,\n                        asset_id,\n                        blinding_factor\n                    )\n                    VALUES\n                    (?, ?, ?, ?, ?)"
-  },
   "3538feca20e2988f50760f66152cf14f3051d7c4d2ca3a97446754b8547b6eaf": {
     "describe": {
       "columns": [],
@@ -256,6 +246,16 @@
     },
     "query": "INSERT INTO nct_commitments (position, commitment) VALUES (?, ?) ON CONFLICT DO NOTHING"
   },
+  "741709fac6ac70295ed4ac0986ea81f230e817a57da49a0c9e2311c91594211f": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 5
+      }
+    },
+    "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        address,\n                        amount,\n                        asset_id,\n                        rseed\n                    )\n                    VALUES\n                    (?, ?, ?, ?, ?)"
+  },
   "8b1b113ce163b0c5a5c0bd64be67b36fcc64d1396953483cb6e76fbf51dff639": {
     "describe": {
       "columns": [
@@ -357,6 +357,16 @@
       }
     },
     "query": "SELECT position, commitment FROM nct_commitments"
+  },
+  "9e8c557eb9aac31f8dbd6df3e4ffaa8cc805663123aed9dda22fad05ab8e2f2e": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 5
+      }
+    },
+    "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        address,\n                        amount,\n                        asset_id,\n                        rseed\n                    )\n                VALUES (?, ?, ?, ?, ?)\n                ON CONFLICT DO NOTHING"
   },
   "a96e4094367da72f81a656389748b9bac9f1931178dfc74bcc92e8f32b581b98": {
     "describe": {
@@ -465,16 +475,6 @@
       }
     },
     "query": "SELECT position FROM nct_position LIMIT 1"
-  },
-  "ebccd7cad2e61f7ad3ae8f24e4b9a58428fd0a36805ce284f651323b232ded2e": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Right": 5
-      }
-    },
-    "query": "INSERT INTO notes\n                    (\n                        note_commitment,\n                        address,\n                        amount,\n                        asset_id,\n                        blinding_factor\n                    )\n                VALUES (?, ?, ?, ?, ?)\n                ON CONFLICT DO NOTHING"
   },
   "efb5f4932197a38ca134b63d8ea5d2fad9145fb56d03a60351f15b5302905402": {
     "describe": {

--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -5,7 +5,7 @@ use parking_lot::Mutex;
 use penumbra_chain::params::{ChainParameters, FmdParameters};
 use penumbra_crypto::{
     asset::{self, Id},
-    note, Address, Amount, Asset, FieldExt, Fq, FullViewingKey, Note, Nullifier, Value,
+    note, Address, Amount, Asset, FieldExt, Fq, FullViewingKey, Note, Nullifier, Rseed, Value,
 };
 use penumbra_proto::{
     client::v1alpha1::{
@@ -183,7 +183,7 @@ impl Storage {
                         notes.address,
                         notes.amount,
                         notes.asset_id,
-                        notes.blinding_factor,
+                        notes.rseed,
                         spendable_notes.address_index,
                         spendable_notes.source,
                         spendable_notes.height_spent,
@@ -488,7 +488,7 @@ impl Storage {
                         notes.address,
                         notes.amount,
                         notes.asset_id,
-                        notes.blinding_factor,
+                        notes.rseed,
                         spendable_notes.address_index,
                         spendable_notes.source,
                         spendable_notes.height_spent,
@@ -599,7 +599,7 @@ impl Storage {
                         notes.address,
                         notes.amount,
                         notes.asset_id,
-                        notes.blinding_factor,
+                        notes.rseed,
                         spendable_notes.address_index,
                         spendable_notes.source,
                         spendable_notes.height_spent,
@@ -704,7 +704,7 @@ impl Storage {
         let address = note.address().to_vec();
         let amount = u64::from(note.amount()) as i64;
         let asset_id = note.asset_id().to_bytes().to_vec();
-        let blinding_factor = note.note_blinding().to_bytes().to_vec();
+        let rseed = note.rseed().to_bytes().to_vec();
 
         sqlx::query!(
             "INSERT INTO notes
@@ -713,7 +713,7 @@ impl Storage {
                         address,
                         amount,
                         asset_id,
-                        blinding_factor
+                        rseed
                     )
                     VALUES
                     (?, ?, ?, ?, ?)",
@@ -721,7 +721,7 @@ impl Storage {
             address,
             amount,
             asset_id,
-            blinding_factor,
+            rseed,
         )
         .execute(&mut tx)
         .await?;
@@ -749,7 +749,7 @@ impl Storage {
                 "SELECT notes.address,
                         notes.amount,
                         notes.asset_id,
-                        notes.blinding_factor
+                        notes.rseed
                 FROM notes
                 LEFT OUTER JOIN spendable_notes ON notes.note_commitment = spendable_notes.note_commitment
                 WHERE (spendable_notes.note_commitment IS NULL) AND (notes.note_commitment IN ({}))",
@@ -773,14 +773,9 @@ impl Storage {
                     .try_into()
                     .expect("32 bytes"),
             )?);
-            let blinding_factor = Fq::from_bytes(
-                row.get::<&[u8], _>("blinding_factor")
-                    .try_into()
-                    .expect("32 bytes"),
-            )?;
+            let rseed = Rseed(row.get::<&[u8], _>("rseed").try_into().expect("32 bytes"));
 
-            let note =
-                Note::from_parts(address, Value { amount, asset_id }, blinding_factor).unwrap();
+            let note = Note::from_parts(address, Value { amount, asset_id }, rseed).unwrap();
 
             notes.insert(note.commit(), note);
         }
@@ -803,7 +798,7 @@ impl Storage {
                         notes.address,
                         notes.amount,
                         notes.asset_id,
-                        notes.blinding_factor,
+                        notes.rseed,
                         spendable_notes.address_index,
                         spendable_notes.source,
                         spendable_notes.height_spent,
@@ -864,7 +859,7 @@ impl Storage {
             let address = note_record.note.address().to_vec();
             let amount = u64::from(note_record.note.amount()) as i64;
             let asset_id = note_record.note.asset_id().to_bytes().to_vec();
-            let blinding_factor = note_record.note.note_blinding().to_bytes().to_vec();
+            let rseed = note_record.note.rseed().to_bytes().to_vec();
             let address_index = note_record.address_index.to_bytes().to_vec();
             let nullifier = note_record.nullifier.to_bytes().to_vec();
             let position = (u64::from(note_record.position)) as i64;
@@ -880,7 +875,7 @@ impl Storage {
                         address,
                         amount,
                         asset_id,
-                        blinding_factor
+                        rseed
                     )
                 VALUES (?, ?, ?, ?, ?)
                 ON CONFLICT DO NOTHING",
@@ -888,7 +883,7 @@ impl Storage {
                 address,
                 amount,
                 asset_id,
-                blinding_factor,
+                rseed,
             )
             .execute(&mut dbtx)
             .await?;


### PR DESCRIPTION
Closes #1688

This modifies our notes to use the mechanism described in [ZIP212](https://zips.z.cash/zip-0212):
* When generating notes we choose a 32-byte uniformly random value called the rseed.
* We derive using a PRF the esk from this rseed.
* We derive using a PRF the note commitment randomness from this rseed.
* The note plaintext includes the rseed instead of the note blinding factor.
* During note decryption the recipient will check epk = [esk] g_d and discard the note if this check fails.
* We no longer need to do the ephemeral pubkey integrity check (epk = [esk] g_d) check in our proofs as we do it at note decryption time. 