### PR TITLE
k8s: set externalTrafficPolicy=Local

### DIFF
--- a/deployments/ci.sh
+++ b/deployments/ci.sh
@@ -21,7 +21,7 @@ PENUMBRA_VERSION="${PENUMBRA_VERSION:-main}"
 PENUMBRA_UID_GID="${PENUMBRA_UID_GID:-1000\:1000}"
 TENDERMINT_VERSION="${TENDERMINT_VERSION:-v0.34.23}"
 NVALS="${NVALS:-2}"
-NFULLNODES="${NFULLNODES:-1}"
+NFULLNODES="${NFULLNODES:-2}"
 CONTAINERHOME="${CONTAINERHOME:-/root}"
 # Default to preview for deployments; less likely to break public testnet.
 HELM_RELEASE="${HELM_RELEASE:-penumbra-testnet-preview}"

--- a/deployments/helm/templates/fn-p2p-svcs.yaml
+++ b/deployments/helm/templates/fn-p2p-svcs.yaml
@@ -19,6 +19,7 @@ on every re-deploy.
   annotations:
     "helm.sh/resource-policy": keep
 spec:
+  externalTrafficPolicy: Local
   type: LoadBalancer
   selector:
     app: {{ $fn_name }}

--- a/deployments/helm/templates/val-p2p-svcs.yaml
+++ b/deployments/helm/templates/val-p2p-svcs.yaml
@@ -20,6 +20,7 @@ on every re-deploy.
     "helm.sh/resource-policy": keep
 spec:
   type: LoadBalancer
+  externalTrafficPolicy: Local
   selector:
     app: {{ $val_name }}
   ports:


### PR DESCRIPTION
During load-testing, we observed that the k8s setup stopped peering once its peer count surpassed the number of external IPs assigned to the deployment. Log diving showed that peers were identified by the closest hop, i.e. NAT'd, addresses. To resolve, here we update the Service spec externalTrafficPolicy from "Cluster" (the default) to "Local". See docs at [0]. After deploying this change on a devnet, each remote peer successfully peered with all nodes in the deployment. The remote peers do not peer with each other, but further config changes will be required to support that functionality, based on our generated tm configs.
    
[0] https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip