### PR TITLE
ci: make smoke tests fail fast

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -31,19 +31,7 @@ jobs:
           chmod -R 777 ~/.penumbra/testnet_data
           docker-compose build
 
-      - name: Run testnet for smoke test duration.
-        run: timeout --preserve-status $TESTNET_RUNTIME docker-compose up --exit-code-from pd-node0
+      - name: Run the smoke test suite
+        run: scripts/smoke-test.sh
         env:
           TESTNET_RUNTIME: 5m
-
-      - name: Now start testnet in the background so we can run integration tests.
-        run: |
-          docker-compose up --detach
-
-      # DOC: please update the devnet guide if you change this (see "How to run smoke-tests")
-      - name: Run integration tests against localhost.
-        run: cargo test --features nct-divergence-check --package pcli -- --ignored --test-threads 1 --nocapture
-        env:
-          PENUMBRA_NODE_HOSTNAME: 127.0.0.1
-          PCLI_UNLEASH_DANGER: yes
-          RUST_LOG: pcli=debug,penumbra=debug

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Wrapper script to bottle up logic for running "smoke tests" in CI,
+# supporting backgrounding tasks and checking on their status later.
+# The execution plan is:
+#
+#   1. Start the network
+#   2. Wait ~10s
+#   3. Run integration tests (fail here if non-zero)
+#   4. Continue running network ~5m
+#
+# The goal is to fail fast if an integration test exits, but permit
+# a slightly longer runtime for the suite to find more errors.
+set -euo pipefail
+
+
+# Duration that the network will be left running before script exits.
+TESTNET_RUNTIME="${TESTNET_RUNTIME:-5m}"
+# Duration that the network will run before integration tests are run.
+TESTNET_BOOTTIME="${TESTNET_BOOTTIME:-10s}"
+
+# Run the network via compose, and pause briefly before testing.
+# { sleep 5s; true ; } &
+echo "Starting smoketest network via compose..."
+docker-compose up --abort-on-container-exit &
+smoke_test_pid="$!"
+sleep "$TESTNET_BOOTTIME"
+
+echo "Running integration tests against network"
+PENUMBRA_NODE_HOSTNAME="127.0.0.1" \
+    PCLI_UNLEASH_DANGER="yes" \
+    RUST_LOG="pcli=debug,penumbra=debug" \
+    cargo test --features nct-divergence-check --package pcli -- --ignored --test-threads 1 --nocapture
+
+echo "Waiting another $TESTNET_RUNTIME while network runs..."
+sleep "$TESTNET_RUNTIME"
+# `kill -0` checks existence of pid, i.e. whether the process is still running.
+# It doesn't inspect errors, but the only reason the process would be stopped
+# is if it failed, so it's good enough for our needs.
+if kill -0 "$smoke_test_pid"; then
+    kill -9 "$smoke_test_pid"
+    echo "SUCCESS! Smoke test complete. Ran for $TESTNET_RUNTIME, found no errors."
+else
+    >&2 echo "ERROR: smoke test compose process exited early"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
The goal here is to get faster feedback from the smoke test suite. We now run the integration tests almost immediately after creating the network, allowing for a tighter feedback loop if errors are encountered, then continue running the network for a while longer, in an attempt to catch more subtle problems.

The wall-time here is mostly unchanged; the smoke test suite still takes >20m to complete. It will now exit much faster if errors are found, though, which is a win.

Closes #1780.