### PR TITLE
pd: use type-aware tendermint-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3327,6 +3327,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.4",
+ "toml",
  "tonic",
  "tonic-web",
  "tower",

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -38,6 +38,7 @@ tendermint-light-client-verifier = "0.26.0"
 ibc = "0.23.0"
 ibc-proto = "0.22.0"
 prost = "0.11"
+toml = "0.5"
 # We don't need this crate at all, but its upstream published a breaking change as
 # 0.7.1 (also prost-related), and depending on an exact version here will exclude
 # the bad update until it's yanked.

--- a/testnets/tm_config_template.toml
+++ b/testnets/tm_config_template.toml
@@ -15,7 +15,7 @@
 proxy_app = "tcp://127.0.0.1:26658"
 
 # A custom human readable name for this node
-moniker = "{}"
+moniker = ""
 
 # If this node is many blocks behind the tip of the chain, FastSync
 # allows them to catchup quickly by downloading blocks in parallel
@@ -197,7 +197,7 @@ tls_cert_file = ""
 tls_key_file = ""
 
 # pprof listen address (https://golang.org/pkg/net/http/pprof)
-pprof_laddr = ":6060"
+pprof_laddr = "127.0.0.1:6060"
 
 #######################################################
 ###           P2P Configuration Options             ###
@@ -215,7 +215,7 @@ laddr = "tcp://0.0.0.0:26656"
 external_address = ""
 
 # Comma separated list of seed nodes to connect to
-seeds = "{}"
+seeds = ""
 
 # Comma separated list of nodes to keep persistent connections to
 persistent_peers = ""


### PR DESCRIPTION
We now use the "tendermint-config" crate to build our TM testnet config with types. We preserve the hardcoded TOML template as a baseline config, then substitute values dynamically at runtime. There are some superficial changes:

  * final tm config has no comments
  * peer strings are formatted with "tcp://" prefix

but those are well worth the additional assurances we get from using a typed config object.

Closes #1827. Towards #1826. 