### PR TITLE
feat: use seed node in k8s deployment

### DIFF
--- a/deployments/helm/templates/fn-tm-config.yaml
+++ b/deployments/helm/templates/fn-tm-config.yaml
@@ -22,6 +22,10 @@ data:
     persistent_peers = "{{ $.Files.Get (printf "pdcli/persistent_peers_fn_%d.txt" $i) | trim }}"
     external_address = "{{ $.Files.Get (printf "pdcli/external_address_fn_%d.txt" $i) | trim }}"
 
+{{ if eq $i 0 }}
+    seed_mode = true
+{{ end }}
+
     [tx_index]
     indexer = "kv"
 


### PR DESCRIPTION
The first fullnode in the deployment will now have `p2p.seed_mode=true` set in its Terndermint config. The first fullnode already has its external IPs targeted by DNS A records like "testnet.penumbra.zone", so folks joining the testnet will still talk to the same service on the backend. The seed_mode=true change is intended to allow clients to connect and find peers, but then they'll be automatically disconnected immediately, ensuring that the max connections of 50 isn't exhausted by the first 50 peers joining.

Refs #1847.