### PR TITLE
custody: rework crate to support policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-consensus"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dd91246c940272326f665724138660a183577ffb77b384a5e10d67d2d5075a"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
 dependencies = [
  "curve25519-dalek-ng",
  "hex",
@@ -3512,6 +3512,7 @@ name = "penumbra-custody"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.13.1",
  "bincode",
  "bytes",
  "ed25519-consensus",
@@ -3527,6 +3528,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "toml",
  "tonic",
  "tracing",
  "vergen",

--- a/crypto/src/keys/spend.rs
+++ b/crypto/src/keys/spend.rs
@@ -22,7 +22,7 @@ pub const SPENDKEY_LEN_BYTES: usize = 32;
 /// TODO(hdevalence): In the future, we should hide the SpendKeyBytes
 /// and force everything to use the proto format / bech32 serialization.
 /// But we can't do this now, because we need it to support existing wallets.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SpendKeyBytes(pub [u8; SPENDKEY_LEN_BYTES]);
 
 /// A key representing a single spending authority.
@@ -33,6 +33,14 @@ pub struct SpendKey {
     ask: SigningKey<SpendAuth>,
     fvk: FullViewingKey,
 }
+
+impl PartialEq for SpendKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.seed == other.seed
+    }
+}
+
+impl Eq for SpendKey {}
 
 impl Protobuf<pb::SpendKey> for SpendKey {}
 

--- a/custody/Cargo.toml
+++ b/custody/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 # Workspace dependencies
-penumbra-proto = { path = "../proto" }
+penumbra-proto = { path = "../proto" , features = ["rpc"] }
 penumbra-chain = { path = "../chain" }
 penumbra-crypto = { path = "../crypto" }
 penumbra-transaction = { path = "../transaction" }
@@ -25,7 +25,11 @@ prost = "0.11"
 futures = "0.3"
 hex = "0.4"
 rand_core = "0.6"
-ed25519-consensus = "2"
+ed25519-consensus = "2.1"
+base64 = "0.13"
 
 [build-dependencies]
 vergen = "5"
+
+[dev-dependencies]
+toml = "0.5"

--- a/custody/src/client.rs
+++ b/custody/src/client.rs
@@ -7,6 +7,8 @@ use tonic::codegen::Bytes;
 
 use crate::AuthorizeRequest;
 
+/// A well-typed wrapper around the GRPC custody protocol that uses Rust domain types rather than proto types.
+///
 /// The custody protocol is used by a wallet client to request authorization for
 /// a transaction they’ve constructed.
 ///

--- a/custody/src/lib.rs
+++ b/custody/src/lib.rs
@@ -1,17 +1,16 @@
 //! Implementations of custody services responsible for signing transactions.
 //!
-//! Currently, this just has a stub software implementation that signs any
-//! transaction it sees, but in the future this interface could allow
-//! programmable policy (inspecting transaction plans), custom custody flows
-//! (HSMs, hardware wallets with humans-in-the-loop, threshold signer clusters,
-//! offline threshold signing, ...).
+//! This crate currently focuses on the [`soft_kms`] implementation, a basic
+//! software key management system that can perform basic policy-based
+//! authorization or blind signing.
 
 mod client;
 mod pre_auth;
 mod request;
-mod soft_kms;
+
+pub mod policy;
+pub mod soft_kms;
 
 pub use client::CustodyClient;
 pub use pre_auth::PreAuthorization;
 pub use request::AuthorizeRequest;
-pub use soft_kms::SoftKms;

--- a/custody/src/policy.rs
+++ b/custody/src/policy.rs
@@ -1,0 +1,181 @@
+//! A set of basic spend authorization policies.
+
+use std::collections::HashSet;
+
+use penumbra_crypto::Address;
+use penumbra_transaction::plan::ActionPlan;
+use serde::{Deserialize, Serialize};
+
+use crate::{AuthorizeRequest, PreAuthorization};
+
+/// A trait for checking whether a transaction plan is allowed by a policy.
+pub trait Policy {
+    /// Checks whether the proposed transaction plan is allowed by this policy.
+    fn check(&self, request: &AuthorizeRequest) -> Result<(), anyhow::Error>;
+}
+
+/// A set of basic spend authorization policies.
+///
+/// These policies are intended to be simple enough that they can be written by
+/// hand in a config file.  More complex policy logic than than should be
+/// implemented by a custom implementation of the [`Policy`] trait.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[serde(tag = "type")]
+pub enum AuthPolicy {
+    /// Only allow transactions whose outputs are controlled by one of the
+    /// allowed destination addresses.
+    DestinationAllowList {
+        allowed_destination_addresses: Vec<Address>,
+    },
+    /// Intended for relayers, only allows `Spend`, `Output`, and `IbcAction`
+    /// actions in transactions.
+    ///
+    /// This policy should be combined with an `AllowList` to prevent sending
+    /// funds outside of the relayer account.
+    OnlyIbcRelay,
+    /// Require specific pre-authorizations for submitted [`TransactionPlan`](penumbra_transaction::plan::TransactionPlan)s.
+    PreAuthorization(PreAuthorizationPolicy),
+}
+
+/// A set of pre-authorization policies.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+// We need to use a different tag name here, so we can stack it with the
+// SpendPolicy tag; in toml, for instance, this will turn into
+// [[spend_policy]]
+// type = 'PreAuthorization'
+// method = 'Ed25519'
+#[serde(tag = "method")]
+pub enum PreAuthorizationPolicy {
+    Ed25519 {
+        /// The number of distinct pre-authorizations required to authorize a transaction plan.
+        ///
+        /// Each `allowed_signer`'s contributions count only once towards this total.
+        required_signatures: u32,
+        /// A list of pre-authorization keys that can be used to authorize a transaction plan.
+        #[serde(with = "ed25519_vec_base64")]
+        allowed_signers: Vec<ed25519_consensus::VerificationKey>,
+    },
+}
+
+/// A serde helper to serialize pre-authorization keys as base64-encoded data.
+/// Because Go's encoding/json will encode byte[] as base64-encoded strings,
+/// and Go's Ed25519 keys are byte[] values, this hopefully makes it easier to
+/// copy-paste pre-authorization keys from Go programs into the Rust config.
+// TODO: remove this after <https://github.com/penumbra-zone/ed25519-consensus/issues/7>
+mod ed25519_vec_base64 {
+    pub fn serialize<S: serde::Serializer>(
+        keys: &[ed25519_consensus::VerificationKey],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        use serde::Serialize;
+        let mut base64_keys = Vec::with_capacity(keys.len());
+        for key in keys {
+            base64_keys.push(base64::encode(key.as_bytes()));
+        }
+        base64_keys.serialize(serializer)
+    }
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<Vec<ed25519_consensus::VerificationKey>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::Deserialize;
+        let base64_keys: Vec<String> = Vec::deserialize(deserializer)?;
+        let mut vks = Vec::with_capacity(base64_keys.len());
+        for base64_key in base64_keys {
+            let bytes = base64::decode(base64_key).map_err(serde::de::Error::custom)?;
+            let vk = ed25519_consensus::VerificationKey::try_from(bytes.as_slice())
+                .map_err(serde::de::Error::custom)?;
+            vks.push(vk);
+        }
+        Ok(vks)
+    }
+}
+
+impl Policy for AuthPolicy {
+    fn check(&self, request: &AuthorizeRequest) -> Result<(), anyhow::Error> {
+        let plan = &request.plan;
+        match self {
+            AuthPolicy::DestinationAllowList {
+                allowed_destination_addresses,
+            } => {
+                for output in plan.output_plans() {
+                    if !allowed_destination_addresses.contains(&output.dest_address) {
+                        return Err(anyhow::anyhow!(
+                            "output {:?} has dest_address not in allow list",
+                            output
+                        ));
+                    }
+                }
+                for swap in plan.swap_plans() {
+                    if !allowed_destination_addresses.contains(&swap.swap_plaintext.claim_address) {
+                        return Err(anyhow::anyhow!(
+                            "swap {:?} has claim_address not in allow list",
+                            swap
+                        ));
+                    }
+                }
+                Ok(())
+            }
+            AuthPolicy::OnlyIbcRelay => {
+                for action in &plan.actions {
+                    match action {
+                        ActionPlan::Spend { .. }
+                        | ActionPlan::Output { .. }
+                        | ActionPlan::IBCAction { .. } => {}
+                        _ => {
+                            return Err(anyhow::anyhow!(
+                                "action {:?} not allowed by OnlyRelay policy",
+                                action
+                            ));
+                        }
+                    }
+                }
+                Ok(())
+            }
+            AuthPolicy::PreAuthorization(policy) => policy.check(request),
+        }
+    }
+}
+
+impl Policy for PreAuthorizationPolicy {
+    fn check(&self, request: &AuthorizeRequest) -> Result<(), anyhow::Error> {
+        match self {
+            PreAuthorizationPolicy::Ed25519 {
+                required_signatures,
+                allowed_signers,
+            } => {
+                let ed25519_pre_auths =
+                    request
+                        .pre_authorizations
+                        .iter()
+                        .filter_map(|pre_auth| match pre_auth {
+                            PreAuthorization::Ed25519(pre_auth) => Some(pre_auth),
+                            // _ => None,
+                        });
+
+                let mut allowed_signers = allowed_signers.iter().cloned().collect::<HashSet<_>>();
+                let mut seen_signers = HashSet::new();
+
+                for pre_auth in ed25519_pre_auths {
+                    // Remove the signer from the allowed signers set, so that
+                    // each signer can only submit one pre-authorization.
+                    if let Some(signer) = allowed_signers.take(&pre_auth.vk) {
+                        pre_auth.verify_plan(&request.plan)?;
+                        seen_signers.insert(signer);
+                    }
+                }
+
+                if seen_signers.len() < *required_signatures as usize {
+                    return Err(anyhow::anyhow!(
+                        "required {} pre-authorization signatures but only saw {}",
+                        required_signatures,
+                        seen_signers.len(),
+                    ));
+                }
+                Ok(())
+            }
+        }
+    }
+}

--- a/custody/src/soft_kms.rs
+++ b/custody/src/soft_kms.rs
@@ -1,41 +1,39 @@
-use std::collections::BTreeMap;
+//! A basic software key management system that stores keys in memory but
+//! presents as an asynchronous signer.
 
-use penumbra_crypto::keys::{AccountID, SpendKey};
 use penumbra_proto::custody::v1alpha1::{self as pb, AuthorizeResponse};
 use penumbra_transaction::AuthorizationData;
 use rand_core::OsRng;
 use tonic::{async_trait, Request, Response, Status};
 
-use crate::AuthorizeRequest;
+use crate::{policy::Policy, AuthorizeRequest};
+
+mod config;
+
+pub use config::Config;
 
 /// A basic software key management system that stores keys in memory but
 /// presents as an asynchronous signer.
 pub struct SoftKms {
-    /// Store keys in a BTreeMap so we can identify them by account ID.
-    keys: BTreeMap<AccountID, SpendKey>,
+    config: Config,
 }
 
 impl SoftKms {
-    /// Initialize with the given keys.
-    pub fn new(keys: Vec<SpendKey>) -> Self {
-        Self {
-            keys: keys
-                .into_iter()
-                .map(|sk| (sk.full_viewing_key().hash(), sk))
-                .collect(),
-        }
+    /// Initialize with the given [`Config`].
+    pub fn new(config: Config) -> Self {
+        Self { config }
     }
 
-    /// Attempt to authorize the requested [`TransactionPlan`].
+    /// Attempt to authorize the requested [`TransactionPlan`](penumbra_transaction::plan::TransactionPlan).
     #[tracing::instrument(skip(self, request), name = "softhsm_sign")]
     pub fn sign(&self, request: &AuthorizeRequest) -> anyhow::Result<AuthorizationData> {
-        let sk = self.keys.get(&request.account_id).ok_or_else(|| {
-            anyhow::anyhow!("Missing signing key for account ID {}", request.account_id)
-        })?;
-
         tracing::debug!(?request.plan);
 
-        Ok(request.plan.authorize(OsRng, sk))
+        for policy in &self.config.auth_policy {
+            policy.check(request)?;
+        }
+
+        Ok(request.plan.authorize(OsRng, &self.config.spend_key))
     }
 }
 
@@ -52,7 +50,7 @@ impl pb::custody_protocol_service_server::CustodyProtocolService for SoftKms {
 
         let authorization_data = self
             .sign(&request)
-            .map_err(|e| Status::invalid_argument(e.to_string()))?;
+            .map_err(|e| Status::unauthenticated(format!("{:#}", e)))?;
 
         let authorization_response = AuthorizeResponse {
             data: Some(authorization_data.into()),

--- a/custody/src/soft_kms/config.rs
+++ b/custody/src/soft_kms/config.rs
@@ -1,0 +1,83 @@
+use crate::policy::AuthPolicy;
+use penumbra_crypto::keys::SpendKey;
+use serde::{Deserialize, Serialize};
+
+/// Configuration data for the [`SoftKms`](super::SoftKms).
+///
+/// Only the `spend_key` field is required; leaving the other fields
+/// empty/default provides blind signing.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct Config {
+    pub spend_key: SpendKey,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub auth_policy: Vec<AuthPolicy>,
+}
+
+impl From<SpendKey> for Config {
+    fn from(spend_key: SpendKey) -> Self {
+        Self {
+            spend_key,
+            auth_policy: Default::default(),
+        }
+    }
+}
+
+/// Helper function for Serde serialization, allowing us to skip serialization
+/// of default config values.  Rationale: if we don't skip serialization of
+/// defaults, if someone serializes a config with some default values, they're
+/// "pinning" the current defaults as their choices for all time, and we have no
+/// way to distinguish between fields they configured explicitly and ones they
+/// passed through from the defaults. If we skip serializing default values,
+/// then we know every value in the config was explicitly set.
+fn is_default<T: Default + Eq>(value: &T) -> bool {
+    *value == T::default()
+}
+
+#[cfg(test)]
+mod tests {
+    use penumbra_crypto::keys::SeedPhrase;
+
+    use crate::policy::PreAuthorizationPolicy;
+
+    use super::*;
+
+    #[test]
+    fn toml_config_round_trip() {
+        let seed_phrase = SeedPhrase::generate(rand_core::OsRng);
+        let spend_key = SpendKey::from_seed_phrase(seed_phrase, 0);
+
+        let pak = ed25519_consensus::SigningKey::new(rand_core::OsRng);
+        let pvk = pak.verification_key();
+
+        let auth_policy = vec![
+            AuthPolicy::OnlyIbcRelay,
+            AuthPolicy::DestinationAllowList {
+                allowed_destination_addresses: vec![
+                    spend_key
+                        .incoming_viewing_key()
+                        .payment_address(Default::default())
+                        .0,
+                ],
+            },
+            AuthPolicy::PreAuthorization(PreAuthorizationPolicy::Ed25519 {
+                required_signatures: 1,
+                allowed_signers: vec![pvk],
+            }),
+        ];
+
+        let example = Config {
+            spend_key: spend_key.clone(),
+            auth_policy,
+        };
+
+        let encoded = toml::to_string_pretty(&example).unwrap();
+        println!("{}", encoded);
+        let example2 = toml::from_str(&encoded).unwrap();
+        assert_eq!(example, example2);
+
+        println!("---");
+
+        let example3 = Config::from(spend_key);
+        println!("{}", toml::to_string_pretty(&example3).unwrap());
+    }
+}

--- a/pcli/src/opt.rs
+++ b/pcli/src/opt.rs
@@ -7,7 +7,7 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use directories::ProjectDirs;
 use penumbra_crypto::FullViewingKey;
-use penumbra_custody::SoftKms;
+use penumbra_custody::soft_kms::SoftKms;
 use penumbra_proto::{
     custody::v1alpha1::{
         custody_protocol_service_client::CustodyProtocolServiceClient,
@@ -76,7 +76,7 @@ impl Opt {
 
         // Build the custody service...
         let wallet = KeyStore::load(custody_path)?;
-        let soft_kms = SoftKms::new(vec![wallet.spend_key.clone()]);
+        let soft_kms = SoftKms::new(wallet.spend_key.clone().into());
         let custody_svc = CustodyProtocolServiceServer::new(soft_kms);
         let custody = CustodyProtocolServiceClient::new(box_grpc_svc::local(custody_svc));
 


### PR DESCRIPTION
This PR reworks the `custody` crate to support authorization policy, so that we can use it for online signers from other languages (e.g., the go relayer).

The behavior is defined by the `soft_kms::Config` struct, designed to be serialized using TOML:
```toml
spend_key = 'penumbraspendkey1h8z74kgcgm6azte70yehzv8tlkqwwlr4zpkt9qtr60zgkz5axesqnej2vj'

[[auth_policy]]
type = 'OnlyIbcRelay'

[[auth_policy]]
type = 'DestinationAllowList'
allowed_destination_addresses = ['penumbrav2t1zxzas63u5sy8s3ph5kh6tdd0dad6zxxgw3tr8vhhzvygwwzxvt87xfkldez8q2trm36xhnuagle9knt7lnyphcg2ap6yr0nlnsmcwzg95gn90wwhxjkc0acpd6thj2cu3qrn6n']

[[auth_policy]]
type = 'PreAuthorization'
method = 'Ed25519'
required_signatures = 1
allowed_signers = ['Ss08p+SPEk0sWRhDKDTFIkh07e6qLopQ2AFUq5toMds=']
```

In this example, three policies are applied:

* `OnlyIbcRelay` restricts transactions to only include `Spend`, `Output`, or `IbcAction`s;
* `DestinationAllowList` restricts transactions to only output funds to the specified account;
* `PreAuthorization` requires a valid Ed25519 signature over the `TransactionPlan` using the specified key.

Currently, this config file format is not used anywhere. `pcli` has a `custody.json` file that just stores the spend key. As a followup, we should think about how we want `pcli` to support multiple custody providers and consider replacing it with the TOML file, but since the TOML file is only useful for specifying policy, which isn't relevant for `pcli`, this isn't particularly urgent.