### PR TITLE
build: fix docker-compose entrypoint for pd

### DIFF
--- a/Dockerfile.old
+++ b/Dockerfile.old
@@ -25,6 +25,6 @@ FROM debian:bullseye-slim as runtime
 ARG DATABASE_URL
 ENV DATABASE_URL=$DATABASE_URL
 WORKDIR /penumbra
-COPY --from=build /out/pd /usr/bin/pd
+COPY --from=build /out/pd /bin/pd
 ENV RUST_LOG=warn,pd=info,penumbra=info
-CMD [ "/usr/bin/pd" ]
+CMD [ "/bin/pd" ]


### PR DESCRIPTION
The `pd` container in the docker-compose workflow had a mismatched command path of `/usr/bin/pd` in the Dockerfile, but `/bin/pd` in the docker-compose file referencing it. Let's use `/bin/pd` everywhere instead.