### PR TITLE
Add `SwapExecution` proto

### DIFF
--- a/crypto/src/dex/lp/trading_function.rs
+++ b/crypto/src/dex/lp/trading_function.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
 use serde::{Deserialize, Serialize};
 
@@ -28,12 +29,15 @@ impl TradingFunction {
     ) -> anyhow::Result<TradingFunction> {
         // TODO(erwan): we should fail to compose trading functions with non-overlapping assets.
         // but the logic to do this is tedious, so I'll re-insert it in the `Path` PR.
-        // TODO: overflow handling
+        // TODO: * insert scaling code here
+        //       * overflow handling
         let fee = self.component.fee * psi.component.fee;
-        // TODO: insert scaling code here
         let r1 = self.component.p * psi.component.p;
         let r2 = self.component.q * psi.component.q;
         Ok(TradingFunction::new(pair, fee, r1, r2))
+        //        Err(anyhow!(
+        //            "composing two trading functions require that their trading pairs overlap"
+        //        ))
     }
 }
 

--- a/crypto/src/dex/lp/trading_function.rs
+++ b/crypto/src/dex/lp/trading_function.rs
@@ -1,4 +1,3 @@
-use anyhow::anyhow;
 use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
 use serde::{Deserialize, Serialize};
 
@@ -28,16 +27,15 @@ impl TradingFunction {
         pair: TradingPair,
     ) -> anyhow::Result<TradingFunction> {
         // TODO(erwan): we should fail to compose trading functions with non-overlapping assets.
-        // but the logic to do this is tedious, so I'll re-insert it in the `Path` PR.
+        //  however, since we're not using `DirectedTradingPair` here, the logic to check what
         // TODO: * insert scaling code here
         //       * overflow handling
+        //  should be the resulting pair is tedious. I will re-insert it later.
         let fee = self.component.fee * psi.component.fee;
+        // TODO: insert scaling code here
         let r1 = self.component.p * psi.component.p;
         let r2 = self.component.q * psi.component.q;
         Ok(TradingFunction::new(pair, fee, r1, r2))
-        //        Err(anyhow!(
-        //            "composing two trading functions require that their trading pairs overlap"
-        //        ))
     }
 }
 

--- a/proto/proto/buf.lock
+++ b/proto/proto/buf.lock
@@ -8,16 +8,20 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: cosmos-sdk
-    commit: 8cb30a2c4de74dc9bd8d260b1e75e176
+    commit: 8c515ebc07ee4514aabcaf3a584a1d1a
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto
-    commit: bee5511075b7499da6178d9e4aaa628b
+    commit: 34d970b699f84aa382f3c29773a60836
   - remote: buf.build
     owner: cosmos
     repository: ibc
-    commit: a930cbf9d19a41b1bde5a51c78d5e4cd
+    commit: 8f001451b26147f7beb44afa3534205b
+  - remote: buf.build
+    owner: cosmos
+    repository: ics23
+    commit: 55085f7c710a45f58fa09947208eb70b
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 783e4b5374fa488ab068d08af9658438
+    commit: 8d7204855ec14631a499bd7393ce1970

--- a/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
+++ b/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
@@ -331,3 +331,18 @@ message Path {
     repeated crypto.v1alpha1.AssetId route = 2;
     TradingFunction phi = 3;
 }
+
+// A path and the amount of the assets on either side that were traded.
+message Trade {
+  // The path taken by the trade.
+  Path path = 1;
+  // The amount of the start asset being traded.
+  crypto.v1alpha1.Amount start_amount = 2;
+  // The amount of end asset being received.
+  crypto.v1alpha1.Amount end_amount = 3;
+}
+
+// Contains the entire execution of a particular swap.
+message SwapExecution {
+  repeated Trade trades = 1;
+}

--- a/proto/src/gen/penumbra.core.dex.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.dex.v1alpha1.rs
@@ -542,3 +542,24 @@ pub struct Path {
     #[prost(message, optional, tag = "3")]
     pub phi: ::core::option::Option<TradingFunction>,
 }
+/// A path and the amount of the assets on either side that were traded.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Trade {
+    /// The path taken by the trade.
+    #[prost(message, optional, tag = "1")]
+    pub path: ::core::option::Option<Path>,
+    /// The amount of the start asset being traded.
+    #[prost(message, optional, tag = "2")]
+    pub start_amount: ::core::option::Option<super::super::crypto::v1alpha1::Amount>,
+    /// The amount of end asset being received.
+    #[prost(message, optional, tag = "3")]
+    pub end_amount: ::core::option::Option<super::super::crypto::v1alpha1::Amount>,
+}
+/// Contains the entire execution of a particular swap.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SwapExecution {
+    #[prost(message, repeated, tag = "1")]
+    pub trades: ::prost::alloc::vec::Vec<Trade>,
+}


### PR DESCRIPTION
Adds a new `SwapExecution` proto that contains the execution path of a particular swap, represented as `Trade`s consisting of a `Path` and amounts.

Closes #1834

This is branched from https://github.com/penumbra-zone/penumbra/tree/1836_amm_composition_cherry and shouldn't be merged before https://github.com/penumbra-zone/penumbra/pull/1854