### PR TITLE
Discard fewer errors

### DIFF
--- a/chain/src/note_source.rs
+++ b/chain/src/note_source.rs
@@ -76,7 +76,12 @@ impl TryFrom<pb::NoteSource> for NoteSource {
     type Error = anyhow::Error;
     fn try_from(note_source: pb::NoteSource) -> Result<Self> {
         <[u8; 32]>::try_from(note_source.inner)
-            .map_err(|_| anyhow!("expected 32 bytes"))?
+            .map_err(|bytes| {
+                anyhow!(format!(
+                    "expected 32 byte note source, found {} bytes",
+                    bytes.len()
+                ))
+            })?
             .try_into()
     }
 }

--- a/component/src/ibc/component/channel/stateful/proof_verification.rs
+++ b/component/src/ibc/component/channel/stateful/proof_verification.rs
@@ -18,10 +18,10 @@ use ibc::core::ics24_host::path::ReceiptsPath;
 use ibc::core::ics24_host::path::SeqRecvsPath;
 use ibc::core::ics24_host::Path;
 
+use anyhow::Context;
 use ibc_proto::ibc::core::commitment::v1::MerkleProof as RawMerkleProof;
-use prost::Message;
-
 use penumbra_chain::StateReadExt as _;
+use prost::Message;
 use sha2::{Digest, Sha256};
 
 // NOTE: this is underspecified.
@@ -58,7 +58,7 @@ fn verify_merkle_absence_proof(
 ) -> anyhow::Result<()> {
     let merkle_path = apply_prefix(prefix, vec![path.into().to_string()]);
     let merkle_proof: MerkleProof = RawMerkleProof::try_from(proof.clone())
-        .map_err(|_| anyhow::anyhow!("invalid merkle proof"))?
+        .context("invalid merkle proof")?
         .into();
 
     merkle_proof.verify_non_membership(proof_specs, root.clone().into(), merkle_path)?;
@@ -76,7 +76,7 @@ fn verify_merkle_proof(
 ) -> anyhow::Result<()> {
     let merkle_path = apply_prefix(prefix, vec![path.into().to_string()]);
     let merkle_proof: MerkleProof = RawMerkleProof::try_from(proof.clone())
-        .map_err(|_| anyhow::anyhow!("invalid merkle proof"))?
+        .context("invalid merkle proof")?
         .into();
 
     merkle_proof.verify_membership(proof_specs, root.clone().into(), merkle_path, value, 0)?;

--- a/component/src/ibc/component/client.rs
+++ b/component/src/ibc/component/client.rs
@@ -1,6 +1,6 @@
 use crate::ibc::client::ics02_validation;
 use crate::Component;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use ibc::clients::ics07_tendermint;
 
@@ -427,7 +427,7 @@ pub trait StateReadExt: StateRead {
             .ok_or_else(|| anyhow::anyhow!("client update time not found"))?;
 
         ibc::timestamp::Timestamp::from_nanoseconds(timestamp_nanos)
-            .map_err(|_| anyhow::anyhow!("invalid client update time"))
+            .context("invalid client update time")
     }
 
     // returns the lowest verified consensus state that is higher than the given height, if it

--- a/component/src/ibc/component/client/stateful.rs
+++ b/component/src/ibc/component/client/stateful.rs
@@ -64,7 +64,7 @@ pub mod update_client {
             let trusted_height = trusted_height
                 .revision_height()
                 .try_into()
-                .map_err(|_| anyhow::anyhow!("invalid header height"))?;
+                .context("invalid header height")?;
 
             let trusted_validator_set =
                 verify_header_validator_set(&untrusted_header, &last_trusted_consensus_state)?;

--- a/crypto/src/encrypted_note.rs
+++ b/crypto/src/encrypted_note.rs
@@ -1,4 +1,4 @@
-use anyhow::Error;
+use anyhow::{Context, Error};
 
 use bytes::Bytes;
 
@@ -94,10 +94,10 @@ impl TryFrom<pb::EncryptedNote> for EncryptedNote {
                 .ok_or_else(|| anyhow::anyhow!("missing note commitment"))?
                 .try_into()?,
             ephemeral_key: ka::Public::try_from(&proto.ephemeral_key[..])
-                .map_err(|_| anyhow::anyhow!("output body malformed"))?,
+                .context("ephemeral key malformed")?,
             encrypted_note: proto.encrypted_note[..]
                 .try_into()
-                .map_err(|_| anyhow::anyhow!("output body malformed"))?,
+                .context("encrypted note malformed")?,
         })
     }
 }

--- a/pd/src/consensus/service.rs
+++ b/pd/src/consensus/service.rs
@@ -4,6 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
+use anyhow::Context as _;
 use futures::FutureExt;
 use penumbra_storage::Storage;
 use tendermint::abci::{ConsensusRequest, ConsensusResponse};

--- a/pd/src/consensus/worker.rs
+++ b/pd/src/consensus/worker.rs
@@ -142,7 +142,8 @@ impl Worker {
                 tracing::info!(?e, "deliver_tx failed");
                 abci::response::DeliverTx {
                     code: 1,
-                    log: e.to_string(),
+                    // Use the alternate format specifier to include the chain of error causes.
+                    log: format!("{:#}", e),
                     ..Default::default()
                 }
             }

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -537,21 +537,15 @@ async fn main() -> anyhow::Result<()> {
                                 .iter()
                                 .map(|fs| {
                                     Ok(FundingStream {
-                                        address: Address::from_str(&fs.address).map_err(|_| {
-                                            anyhow::anyhow!(
-                                                "invalid funding stream address in validators.json"
-                                            )
-                                        })?,
+                                        address: Address::from_str(&fs.address).context(
+                                            "invalid funding stream address in validators.json",
+                                        )?,
                                         rate_bps: fs.rate_bps,
                                     })
                                 })
                                 .collect::<Result<Vec<FundingStream>, anyhow::Error>>()?,
                         )
-                        .map_err(|_| {
-                            anyhow::anyhow!(
-                                "unable to construct funding streams from validators.json"
-                            )
-                        })?,
+                        .context("unable to construct funding streams from validators.json")?,
                         sequence_number: v.sequence_number,
                     })
                 })

--- a/pd/src/mempool/service.rs
+++ b/pd/src/mempool/service.rs
@@ -100,7 +100,8 @@ impl tower_service::Service<MempoolRequest> for Mempool {
                     );
                     Ok(MempoolResponse::CheckTx(CheckTxRsp {
                         code: 1,
-                        log: e.to_string(),
+                        // Use the alternate format specifier to include the chain of error causes.
+                        log: format!("{:#}", e),
                         ..Default::default()
                     }))
                 }

--- a/pd/src/mempool/service.rs
+++ b/pd/src/mempool/service.rs
@@ -4,6 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
+use anyhow::Context as _;
 use futures::FutureExt;
 use penumbra_storage::Storage;
 use tendermint::abci::{
@@ -80,10 +81,7 @@ impl tower_service::Service<MempoolRequest> for Mempool {
                 CheckTxKind::Recheck => "recheck",
             };
 
-            match rx
-                .await
-                .map_err(|_| anyhow::anyhow!("mempool worker terminated or panicked"))?
-            {
+            match rx.await.context("mempool worker terminated or panicked")? {
                 Ok(()) => {
                     tracing::info!("tx accepted");
                     metrics::increment_counter!(

--- a/proto/src/protobuf.rs
+++ b/proto/src/protobuf.rs
@@ -106,7 +106,7 @@ impl TryFrom<ProtoClue> for Clue {
     fn try_from(proto: ProtoClue) -> anyhow::Result<Self, Self::Error> {
         let clue: [u8; 68] = proto.inner[..]
             .try_into()
-            .map_err(|_| anyhow::anyhow!("clue malformed"))?;
+            .map_err(|_| anyhow::anyhow!("expected 68-byte clue"))?;
 
         Ok(Clue(clue))
     }

--- a/transaction/src/action/output.rs
+++ b/transaction/src/action/output.rs
@@ -1,6 +1,6 @@
 use std::convert::{TryFrom, TryInto};
 
-use anyhow::Error;
+use anyhow::{Context, Error};
 use bytes::Bytes;
 use penumbra_crypto::{
     balance,
@@ -95,7 +95,7 @@ impl TryFrom<pb::Output> for Output {
                 .try_into()?,
             proof: proto.proof[..]
                 .try_into()
-                .map_err(|_| anyhow::anyhow!("output body malformed"))?,
+                .context("output proof malformed")?,
         })
     }
 }
@@ -121,20 +121,21 @@ impl TryFrom<pb::OutputBody> for Body {
             .note_payload
             .ok_or_else(|| anyhow::anyhow!("missing note payload"))?
             .try_into()
-            .map_err(|e: Error| e.context("output body malformed"))?;
+            .context("malformed note payload")?;
 
         let wrapped_memo_key = proto.wrapped_memo_key[..]
             .try_into()
-            .map_err(|_| anyhow::anyhow!("output malformed"))?;
+            .context("malformed wrapped memo key")?;
 
         let ovk_wrapped_key: OvkWrappedKey = proto.ovk_wrapped_key[..]
             .try_into()
-            .map_err(|_| anyhow::anyhow!("output malformed"))?;
+            .context("malformed ovk wrapped key")?;
 
         let balance_commitment = proto
             .balance_commitment
             .ok_or_else(|| anyhow::anyhow!("missing value commitment"))?
-            .try_into()?;
+            .try_into()
+            .context("malformed balance commitment")?;
 
         Ok(Body {
             note_payload,

--- a/transaction/src/action/swap.rs
+++ b/transaction/src/action/swap.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use ark_ff::Zero;
 use decaf377::Fr;
 use penumbra_crypto::asset::Amount;
@@ -73,13 +74,12 @@ impl TryFrom<pb::Swap> for Swap {
     type Error = anyhow::Error;
     fn try_from(s: pb::Swap) -> Result<Self, Self::Error> {
         Ok(Self {
-            proof: s.proof[..]
-                .try_into()
-                .map_err(|_| anyhow::anyhow!("Swap proof malformed"))?,
+            proof: s.proof[..].try_into().context("swap proof malformed")?,
             body: s
                 .body
-                .ok_or_else(|| anyhow::anyhow!("missing body"))?
-                .try_into()?,
+                .ok_or_else(|| anyhow::anyhow!("missing swap body"))?
+                .try_into()
+                .context("swap body malformed")?,
         })
     }
 }

--- a/transaction/src/action/swap_claim.rs
+++ b/transaction/src/action/swap_claim.rs
@@ -1,5 +1,6 @@
 use crate::view::action_view::SwapClaimView;
 use crate::{ActionView, IsAction, TransactionPerspective};
+use anyhow::Context;
 use ark_ff::Zero;
 use penumbra_crypto::dex::BatchSwapOutputData;
 use penumbra_crypto::transaction::Fee;
@@ -70,11 +71,12 @@ impl TryFrom<pb::SwapClaim> for SwapClaim {
         Ok(Self {
             proof: sc.proof[..]
                 .try_into()
-                .map_err(|_| anyhow::anyhow!("SwapClaim proof malformed"))?,
+                .context("swap claim proof malformed")?,
             body: sc
                 .body
-                .ok_or_else(|| anyhow::anyhow!("missing nullifier"))?
-                .try_into()?,
+                .ok_or_else(|| anyhow::anyhow!("missing swap claim body"))?
+                .try_into()
+                .context("swap claim body malformed")?,
             epoch_duration: sc.epoch_duration,
         })
     }

--- a/transaction/src/plan/action/swap.rs
+++ b/transaction/src/plan/action/swap.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use ark_ff::UniformRand;
 
 use penumbra_crypto::dex::swap::SwapPlaintext;
@@ -108,15 +108,15 @@ impl TryFrom<pb::SwapPlan> for SwapPlan {
     fn try_from(msg: pb::SwapPlan) -> Result<Self, Self::Error> {
         let fee_blinding_bytes: [u8; 32] = msg.fee_blinding[..]
             .try_into()
-            .map_err(|_| anyhow!("proto malformed"))?;
+            .map_err(|_| anyhow!("expected 32 byte fee blinding"))?;
         Ok(Self {
-            fee_blinding: Fr::from_bytes(fee_blinding_bytes)
-                .map_err(|_| anyhow!("proto malformed"))?,
+            fee_blinding: Fr::from_bytes(fee_blinding_bytes).context("fee blinding malformed")?,
             swap_plaintext: msg
                 .swap_plaintext
                 .ok_or_else(|| anyhow!("missing swap_plaintext"))?
-                .try_into()?,
-            esk: msg.esk.as_slice().try_into()?,
+                .try_into()
+                .context("swap plaintext malformed")?,
+            esk: msg.esk.as_slice().try_into().context("esk malformed")?,
         })
     }
 }


### PR DESCRIPTION
Currently, we handle errors very poorly, leading to a lot of useless and unhelpful error messages, like `transaction malformed`. This PR works towards fixing that, by replacing a lot of `.map_err(|_| ...)` with `.context(...)`, and by passing full chains of error causes in `CheckTx`/`DeliverTx` messages.