### PR TITLE
feat: pcli commands are composable with pipes

### DIFF
--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -57,7 +57,7 @@ impl App {
             .transpose()?
             .ok_or_else(|| anyhow::anyhow!("view service did not report sync status"))?;
 
-        println!(
+        eprintln!(
             "Scanning blocks from last sync height {} to latest height {}",
             initial_status.sync_height, initial_status.latest_known_block_height,
         );

--- a/pcli/src/opt.rs
+++ b/pcli/src/opt.rs
@@ -60,6 +60,7 @@ impl Opt {
     pub fn init_tracing(&mut self) {
         tracing_subscriber::fmt()
             .with_env_filter(std::mem::take(&mut self.trace_filter))
+            .with_writer(std::io::stderr)
             .init();
     }
 


### PR DESCRIPTION
Ensures that diagnostic info emitted during `pcli` commands goes to stderr, so that only substantive content is written to stdout. This enables use of unix pipes, such as `| jq` to parse JSON data.

Also modified the tracing_subscriber config to ensure logged events for pcli do not pollute stdout. Tracing settings for other crates are unaffected.

Updates the pcli integration tests to read stdout in a few places, preserving the `--file` arg in others, so that both forms of invocation are exercised.

Closes #1624.