### PR TITLE
build(chain): drop tonic dep to support wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,7 +3409,6 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "tendermint",
- "tonic",
  "tracing",
 ]
 

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -29,5 +29,4 @@ sha2 = "0.9"
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1.52"
 tracing = "0.1"
-tonic = "0.8.1"
 num-rational = "0.4"

--- a/pd/src/info.rs
+++ b/pd/src/info.rs
@@ -1,3 +1,4 @@
+//! Logic for enabling `pd` to interact with chain state.
 use std::{
     future::Future,
     pin::Pin,

--- a/pd/src/info/oblivious.rs
+++ b/pd/src/info/oblivious.rs
@@ -71,7 +71,12 @@ impl ObliviousQueryService for Info {
         request: tonic::Request<ChainParametersRequest>,
     ) -> Result<tonic::Response<ChainParametersResponse>, Status> {
         let state = self.storage.latest_state();
-        state.check_chain_id(&request.get_ref().chain_id).await?;
+        // We map the error here to avoid including `tonic` as a dependency
+        // in the `chain` crate, to support its compilation to wasm.
+        state
+            .check_chain_id(&request.get_ref().chain_id)
+            .await
+            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {}", e)))?;
 
         let chain_params = state.get_chain_params().await.map_err(|e| {
             tonic::Status::unavailable(format!("error getting chain parameters: {}", e))
@@ -88,7 +93,10 @@ impl ObliviousQueryService for Info {
         request: tonic::Request<MutableParametersRequest>,
     ) -> Result<tonic::Response<Self::MutableParametersStream>, Status> {
         let state = self.storage.latest_state();
-        state.check_chain_id(&request.get_ref().chain_id).await?;
+        state
+            .check_chain_id(&request.get_ref().chain_id)
+            .await
+            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {}", e)))?;
 
         let mutable_params = MutableParam::iter();
 
@@ -119,7 +127,10 @@ impl ObliviousQueryService for Info {
         request: tonic::Request<AssetListRequest>,
     ) -> Result<tonic::Response<AssetListResponse>, Status> {
         let state = self.storage.latest_state();
-        state.check_chain_id(&request.get_ref().chain_id).await?;
+        state
+            .check_chain_id(&request.get_ref().chain_id)
+            .await
+            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {}", e)))?;
 
         let known_assets = state.known_assets().await.map_err(|e| {
             tonic::Status::unavailable(format!("error getting known assets: {}", e))
@@ -135,7 +146,10 @@ impl ObliviousQueryService for Info {
         request: tonic::Request<ValidatorInfoRequest>,
     ) -> Result<tonic::Response<Self::ValidatorInfoStream>, Status> {
         let state = self.storage.latest_state();
-        state.check_chain_id(&request.get_ref().chain_id).await?;
+        state
+            .check_chain_id(&request.get_ref().chain_id)
+            .await
+            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {}", e)))?;
 
         let validators = state
             .validator_list()
@@ -182,7 +196,10 @@ impl ObliviousQueryService for Info {
         request: tonic::Request<CompactBlockRangeRequest>,
     ) -> Result<tonic::Response<Self::CompactBlockRangeStream>, Status> {
         let state = self.storage.latest_state();
-        state.check_chain_id(&request.get_ref().chain_id).await?;
+        state
+            .check_chain_id(&request.get_ref().chain_id)
+            .await
+            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {}", e)))?;
 
         let CompactBlockRangeRequest {
             start_height,

--- a/pd/src/info/specific.rs
+++ b/pd/src/info/specific.rs
@@ -52,7 +52,12 @@ impl SpecificQueryService for Info {
         request: tonic::Request<KeyValueRequest>,
     ) -> Result<tonic::Response<KeyValueResponse>, Status> {
         let state = self.storage.latest_state();
-        state.check_chain_id(&request.get_ref().chain_id).await?;
+        // We map the error here to avoid including `tonic` as a dependency
+        // in the `chain` crate, to support its compilation to wasm.
+        state
+            .check_chain_id(&request.get_ref().chain_id)
+            .await
+            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {}", e)))?;
 
         let request = request.into_inner();
         tracing::debug!(?request);
@@ -92,8 +97,10 @@ impl SpecificQueryService for Info {
         request: tonic::Request<PrefixValueRequest>,
     ) -> Result<tonic::Response<Self::PrefixValueStream>, Status> {
         let state = self.storage.latest_state();
-        state.check_chain_id(&request.get_ref().chain_id).await?;
-
+        state
+            .check_chain_id(&request.get_ref().chain_id)
+            .await
+            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {}", e)))?;
         let request = request.into_inner();
         tracing::debug!(?request);
 
@@ -132,7 +139,10 @@ impl SpecificQueryService for Info {
         request: tonic::Request<AssetInfoRequest>,
     ) -> Result<tonic::Response<AssetInfoResponse>, Status> {
         let state = self.storage.latest_state();
-        state.check_chain_id(&request.get_ref().chain_id).await?;
+        state
+            .check_chain_id(&request.get_ref().chain_id)
+            .await
+            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {}", e)))?;
 
         let request = request.into_inner();
         let id: asset::Id = request
@@ -192,7 +202,10 @@ impl SpecificQueryService for Info {
         request: tonic::Request<ValidatorStatusRequest>,
     ) -> Result<tonic::Response<ValidatorStatusResponse>, Status> {
         let state = self.storage.latest_state();
-        state.check_chain_id(&request.get_ref().chain_id).await?;
+        state
+            .check_chain_id(&request.get_ref().chain_id)
+            .await
+            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {}", e)))?;
 
         let id = request
             .into_inner()
@@ -218,7 +231,10 @@ impl SpecificQueryService for Info {
         request: tonic::Request<ValidatorPenaltyRequest>,
     ) -> Result<tonic::Response<ValidatorPenaltyResponse>, Status> {
         let state = self.storage.latest_state();
-        state.check_chain_id(&request.get_ref().chain_id).await?;
+        state
+            .check_chain_id(&request.get_ref().chain_id)
+            .await
+            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {}", e)))?;
 
         let request = request.into_inner();
         let id = request


### PR DESCRIPTION
Removes the `tonic` dependency from the `chain` crate, in order to support compiling it to wasm. The only use of `tonic` in `chain` was for a few error return types. Here we swap those specific errors for more general anyhow versions, and re-map them back to tonic::Status::unknown in the calling crate, `pd`. The use of `map_err` is suboptimal, but in the interest of unblocking external partners, seems a reasonable choice.

Closes #1857.