### PR TITLE
Uncouple serde minimal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3308,6 +3308,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
+ "toml 0.4.10",
  "tonic",
  "tower",
  "tracing",
@@ -3377,7 +3378,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.4",
- "toml",
+ "toml 0.5.11",
  "tonic",
  "tonic-web",
  "tower",
@@ -3483,6 +3484,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_with 2.2.0",
  "sha2 0.9.9",
  "tempfile",
  "tendermint",
@@ -3563,7 +3565,7 @@ dependencies = [
  "serde_json",
  "serde_with 2.2.0",
  "tokio",
- "toml",
+ "toml 0.5.11",
  "tonic",
  "tracing",
  "vergen",
@@ -5317,7 +5319,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tendermint",
- "toml",
+ "toml 0.5.11",
  "url",
 ]
 
@@ -5626,6 +5628,15 @@ dependencies = [
  "slab",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,8 +1347,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core 0.14.2",
+ "darling_macro 0.14.2",
 ]
 
 [[package]]
@@ -1366,12 +1376,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "strsim",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core 0.14.2",
  "quote 1.0.23",
  "syn 1.0.107",
 ]
@@ -2447,6 +2482,7 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3264,7 +3300,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "sha2 0.9.9",
  "tempfile",
  "tendermint",
@@ -3330,7 +3366,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "sha2 0.9.9",
  "tempfile",
  "tendermint",
@@ -3500,7 +3536,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "sha2 0.10.6",
  "thiserror",
  "tracing",
@@ -3525,7 +3561,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 2.2.0",
  "tokio",
  "toml",
  "tonic",
@@ -3738,7 +3774,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "sha2 0.9.9",
  "thiserror",
  "tracing",
@@ -3771,7 +3807,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "sha2 0.10.6",
  "sqlx",
  "tendermint",
@@ -3809,7 +3845,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "tokio",
  "tonic",
  "tower",
@@ -4790,7 +4826,23 @@ checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "hex",
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros 2.2.0",
+ "time 0.3.16",
 ]
 
 [[package]]
@@ -4799,7 +4851,19 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
+dependencies = [
+ "darling 0.14.2",
  "proc-macro2 1.0.50",
  "quote 1.0.23",
  "syn 1.0.107",
@@ -5397,6 +5461,7 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
 dependencies = [
+ "itoa 1.0.5",
  "libc",
  "num_threads",
  "serde",

--- a/component/Cargo.toml
+++ b/component/Cargo.toml
@@ -27,6 +27,7 @@ ark-ff = "0.3"
 blake2b_simd = "0.5"
 bincode = "1.3.3"
 serde = { version = "1", features = ["derive"] }
+serde_with = "2.2"
 metrics = "0.19.0"
 sha2 = "0.9"
 serde_json = "1"

--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate serde_with;
+
 use async_trait::async_trait;
 use penumbra_chain::genesis;
 use penumbra_storage::StateTransaction;

--- a/component/src/stake/validator.rs
+++ b/component/src/stake/validator.rs
@@ -1,8 +1,9 @@
 //! Penumbra validators and related structures.
 
-use penumbra_crypto::GovernanceKey;
+use penumbra_crypto::{Address, GovernanceKey};
 use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
 use serde::{Deserialize, Serialize};
+use serde_with::DisplayFromStr;
 
 use crate::stake::{FundingStream, FundingStreams, IdentityKey};
 
@@ -63,6 +64,119 @@ pub struct Validator {
     /// third party from replaying previously valid but stale configuration data
     /// as an update.
     pub sequence_number: u32,
+}
+
+#[serde_as]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct ValidatorToml {
+    /// The sequence number determines which validator data takes priority, and
+    /// prevents replay attacks.  The chain only accepts new
+    /// [`ValidatorDefinition`]s with increasing sequence numbers, preventing a
+    /// third party from replaying previously valid but stale configuration data
+    /// as an update.
+    pub sequence_number: u32,
+
+    /// Whether the validator is enabled or not.
+    ///
+    /// Disabled validators cannot be delegated to, and immediately begin unbonding.
+    pub enabled: bool,
+
+    /// The validator's (human-readable) name.
+    pub name: String,
+
+    /// The validator's website URL.
+    pub website: String,
+
+    /// The validator's description.
+    pub description: String,
+
+    /// The validator's identity verification key.
+    #[serde_as(as = "DisplayFromStr")]
+    pub identity_key: IdentityKey,
+
+    /// The validator's governance verification key.
+    #[serde_as(as = "DisplayFromStr")]
+    pub governance_key: GovernanceKey,
+
+    /// The validator's consensus key, used by Tendermint for signing blocks and
+    /// other consensus operations.
+    pub consensus_key: tendermint::PublicKey,
+
+    /// The destinations for the validator's staking reward. The commission is implicitly defined
+    /// by the configuration of funding_streams, the sum of FundingStream.rate_bps.
+    ///
+    // NOTE: unclaimed rewards are tracked by inserting reward notes for the last epoch into the
+    // NCT at the beginning of each epoch
+    #[serde(rename = "funding_stream")]
+    pub funding_streams: Vec<FundingStreamToml>,
+}
+
+impl From<Validator> for ValidatorToml {
+    fn from(v: Validator) -> Self {
+        ValidatorToml {
+            identity_key: v.identity_key,
+            governance_key: v.governance_key,
+            consensus_key: v.consensus_key,
+            name: v.name,
+            website: v.website,
+            description: v.description,
+            enabled: v.enabled,
+            funding_streams: v.funding_streams.into_iter().map(Into::into).collect(),
+            sequence_number: v.sequence_number,
+        }
+    }
+}
+
+impl TryFrom<ValidatorToml> for Validator {
+    type Error = anyhow::Error;
+
+    fn try_from(v: ValidatorToml) -> anyhow::Result<Self> {
+        Ok(Validator {
+            identity_key: v.identity_key,
+            governance_key: v.governance_key,
+            consensus_key: v.consensus_key,
+            name: v.name,
+            website: v.website,
+            description: v.description,
+            enabled: v.enabled,
+            funding_streams: FundingStreams::try_from(
+                v.funding_streams
+                    .into_iter()
+                    .map(Into::into)
+                    .collect::<Vec<_>>(),
+            )?,
+            sequence_number: v.sequence_number,
+        })
+    }
+}
+
+/// Human-readable TOML-optimized version of a [`FundingStream`].
+#[serde_as]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct FundingStreamToml {
+    #[serde_as(as = "DisplayFromStr")]
+    /// The address of the funding stream.
+    address: Address,
+    /// The rate of the funding stream, in basis points.
+    rate_bps: u16,
+}
+
+impl From<FundingStream> for FundingStreamToml {
+    fn from(f: FundingStream) -> Self {
+        FundingStreamToml {
+            address: f.address,
+            rate_bps: f.rate_bps,
+        }
+    }
+}
+
+impl From<FundingStreamToml> for FundingStream {
+    fn from(f: FundingStreamToml) -> Self {
+        FundingStream {
+            address: f.address,
+            rate_bps: f.rate_bps,
+        }
+    }
 }
 
 impl Protobuf<pb::Validator> for Validator {}

--- a/custody/Cargo.toml
+++ b/custody/Cargo.toml
@@ -16,7 +16,7 @@ tokio = { version = "1.21.1", features = ["full"]}
 anyhow = "1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-serde_with = { version = "1.11", features = ["hex"] }
+serde_with = { version = "2.2", features = ["hex"] }
 tracing = "0.1"
 tonic = "0.8.1"
 bincode = "1.3.3"

--- a/custody/src/lib.rs
+++ b/custody/src/lib.rs
@@ -4,6 +4,9 @@
 //! software key management system that can perform basic policy-based
 //! authorization or blind signing.
 
+#[macro_use]
+extern crate serde_with;
+
 mod client;
 mod pre_auth;
 mod request;

--- a/custody/src/soft_kms/config.rs
+++ b/custody/src/soft_kms/config.rs
@@ -1,13 +1,16 @@
 use crate::policy::AuthPolicy;
 use penumbra_crypto::keys::SpendKey;
 use serde::{Deserialize, Serialize};
+use serde_with::DisplayFromStr;
 
 /// Configuration data for the [`SoftKms`](super::SoftKms).
 ///
 /// Only the `spend_key` field is required; leaving the other fields
 /// empty/default provides blind signing.
+#[serde_as]
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct Config {
+    #[serde_as(as = "DisplayFromStr")]
     pub spend_key: SpendKey,
     #[serde(default, skip_serializing_if = "is_default")]
     pub auth_policy: Vec<AuthPolicy>,

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -71,6 +71,7 @@ clap = { version = "3", features = ["derive", "env"] }
 camino = "1"
 url = "2"
 colored_json = "2.1"
+toml = "0.4"
 
 [build-dependencies]
 vergen = "5"

--- a/pcli/src/command/validator.rs
+++ b/pcli/src/command/validator.rs
@@ -228,13 +228,36 @@ impl ValidatorCmd {
                 }
                 .into();
 
+                let template_str = format!(
+                    "# This is a template for a validator definition.
+#
+# The identity_key and governance_key fields are auto-filled with values derived
+# from this wallet's account.
+#
+# The consensus_key field is random, and needs to be replaced with your
+# tendermint instance's public key, which can be found in
+# `priv_validator_key.json`.
+#
+# You should fill in the name, website, and description fields.
+#
+# By default, validators are disabled, and cannot be delegated to. To change
+# this, set `enabled = true`.
+#
+# Every time you upload a new validator config, you'll need to increment the
+# `sequence_number`.
+
+{}
+",
+                    toml::to_string_pretty(&template)?
+                );
+
                 if let Some(file) = file {
                     File::create(file)
                         .with_context(|| format!("cannot create file {:?}", file))?
-                        .write_all(toml::to_string_pretty(&template)?.as_bytes())
+                        .write_all(template_str.as_bytes())
                         .context("could not write file")?;
                 } else {
-                    println!("{}", toml::to_string_pretty(&template)?);
+                    println!("{}", &template_str);
                 }
             }
             ValidatorCmd::Definition(DefinitionCmd::Fetch { file }) => {

--- a/pcli/src/legacy.rs
+++ b/pcli/src/legacy.rs
@@ -44,8 +44,8 @@ pub struct ClientState {
 
 /// A legacy wallet file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(from = "serde_helpers::WalletHelper")] // Deserialize from legacy format
-#[serde(into = "penumbra_custody::soft_kms::Config")] // Serialize into non-legacy format
+#[serde(from = "serde_helpers::WalletHelper")]
+#[serde(into = "serde_helpers::WalletHelper")]
 pub struct LegacyWallet {
     pub spend_key: SpendKey,
 }
@@ -71,11 +71,10 @@ mod serde_helpers {
         }
     }
 
-    impl From<LegacyWallet> for penumbra_custody::soft_kms::Config {
+    impl From<LegacyWallet> for WalletHelper {
         fn from(w: LegacyWallet) -> Self {
-            penumbra_custody::soft_kms::Config {
-                spend_key: w.spend_key,
-                auth_policy: Default::default(),
+            Self {
+                spend_seed: w.spend_key.to_bytes().0,
             }
         }
     }

--- a/pcli/src/legacy.rs
+++ b/pcli/src/legacy.rs
@@ -44,8 +44,8 @@ pub struct ClientState {
 
 /// A legacy wallet file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(from = "serde_helpers::WalletHelper")]
-#[serde(into = "serde_helpers::WalletHelper")]
+#[serde(from = "serde_helpers::WalletHelper")] // Deserialize from legacy format
+#[serde(into = "penumbra_custody::soft_kms::Config")] // Serialize into non-legacy format
 pub struct LegacyWallet {
     pub spend_key: SpendKey,
 }
@@ -71,10 +71,11 @@ mod serde_helpers {
         }
     }
 
-    impl From<LegacyWallet> for WalletHelper {
+    impl From<LegacyWallet> for penumbra_custody::soft_kms::Config {
         fn from(w: LegacyWallet) -> Self {
-            Self {
-                spend_seed: w.spend_key.to_bytes().0,
+            penumbra_custody::soft_kms::Config {
+                spend_key: w.spend_key,
+                auth_policy: Default::default(),
             }
         }
     }

--- a/wallet/src/key_store.rs
+++ b/wallet/src/key_store.rs
@@ -1,9 +1,12 @@
 use penumbra_crypto::keys::{SeedPhrase, SpendKey};
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
 
 /// A wallet file storing a single spend authority.
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyStore {
+    #[serde_as(as = "DisplayFromStr")]
     pub spend_key: SpendKey,
 }
 


### PR DESCRIPTION
Resolves #1898.

This is missing updated documentation to reflect that validator definitions are toml instead of json now.