### PR TITLE
Change `Protobuf` trait to a `DomainType` trait with an associated type

### DIFF
--- a/chain/src/genesis/allocation.rs
+++ b/chain/src/genesis/allocation.rs
@@ -72,4 +72,6 @@ impl Allocation {
     }
 }
 
-impl Protobuf<pb::genesis_app_state::Allocation> for Allocation {}
+impl Protobuf for Allocation {
+    type Proto = pb::genesis_app_state::Allocation;
+}

--- a/chain/src/genesis/allocation.rs
+++ b/chain/src/genesis/allocation.rs
@@ -1,5 +1,5 @@
 use penumbra_crypto::{asset, Address, Note, Rseed, Value};
-use penumbra_proto::{core::chain::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::chain::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 /// A (transparent) genesis allocation.
@@ -72,6 +72,6 @@ impl Allocation {
     }
 }
 
-impl Protobuf for Allocation {
+impl DomainType for Allocation {
     type Proto = pb::genesis_app_state::Allocation;
 }

--- a/chain/src/genesis/app_state.rs
+++ b/chain/src/genesis/app_state.rs
@@ -74,4 +74,6 @@ impl TryFrom<pb::GenesisAppState> for AppState {
     }
 }
 
-impl Protobuf<pb::GenesisAppState> for AppState {}
+impl Protobuf for AppState {
+    type Proto = pb::GenesisAppState;
+}

--- a/chain/src/genesis/app_state.rs
+++ b/chain/src/genesis/app_state.rs
@@ -1,4 +1,4 @@
-use penumbra_proto::{core::chain::v1alpha1 as pb, core::stake::v1alpha1 as pb_stake, Protobuf};
+use penumbra_proto::{core::chain::v1alpha1 as pb, core::stake::v1alpha1 as pb_stake, DomainType};
 use serde::{Deserialize, Serialize};
 
 use super::Allocation;
@@ -74,6 +74,6 @@ impl TryFrom<pb::GenesisAppState> for AppState {
     }
 }
 
-impl Protobuf for AppState {
+impl DomainType for AppState {
     type Proto = pb::GenesisAppState;
 }

--- a/chain/src/known_assets.rs
+++ b/chain/src/known_assets.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 #[serde(try_from = "pb::KnownAssets", into = "pb::KnownAssets")]
 pub struct KnownAssets(pub Vec<Asset>);
 
-impl Protobuf<pb::KnownAssets> for KnownAssets {}
+impl Protobuf for KnownAssets {
+    type Proto = pb::KnownAssets;
+}
 
 impl TryFrom<pb::KnownAssets> for KnownAssets {
     type Error = anyhow::Error;

--- a/chain/src/known_assets.rs
+++ b/chain/src/known_assets.rs
@@ -1,12 +1,14 @@
 use penumbra_crypto::asset::Asset;
-use penumbra_proto::{client::v1alpha1::AssetListResponse, core::chain::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{
+    client::v1alpha1::AssetListResponse, core::chain::v1alpha1 as pb, DomainType,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(try_from = "pb::KnownAssets", into = "pb::KnownAssets")]
 pub struct KnownAssets(pub Vec<Asset>);
 
-impl Protobuf for KnownAssets {
+impl DomainType for KnownAssets {
     type Proto = pb::KnownAssets;
 }
 

--- a/chain/src/note_source.rs
+++ b/chain/src/note_source.rs
@@ -70,7 +70,9 @@ impl TryFrom<&[u8]> for NoteSource {
     }
 }
 
-impl Protobuf<pb::NoteSource> for NoteSource {}
+impl Protobuf for NoteSource {
+    type Proto = pb::NoteSource;
+}
 
 impl TryFrom<pb::NoteSource> for NoteSource {
     type Error = anyhow::Error;

--- a/chain/src/note_source.rs
+++ b/chain/src/note_source.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use penumbra_proto::{core::chain::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::chain::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -70,7 +70,7 @@ impl TryFrom<&[u8]> for NoteSource {
     }
 }
 
-impl Protobuf for NoteSource {
+impl DomainType for NoteSource {
     type Proto = pb::NoteSource;
 }
 

--- a/chain/src/params.rs
+++ b/chain/src/params.rs
@@ -4,7 +4,7 @@ use penumbra_proto::client::v1alpha1 as pb_client;
 use penumbra_proto::core::chain::v1alpha1 as pb_chain;
 use penumbra_proto::core::crypto::v1alpha1 as pb_crypto;
 use penumbra_proto::view::v1alpha1 as pb_view;
-use penumbra_proto::Protobuf;
+use penumbra_proto::DomainType;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug)]
@@ -15,7 +15,7 @@ pub struct AssetInfo {
     pub total_supply: u64,
 }
 
-impl Protobuf for AssetInfo {
+impl DomainType for AssetInfo {
     type Proto = pb_chain::AssetInfo;
 }
 
@@ -87,7 +87,7 @@ pub struct ChainParameters {
     pub proposal_veto_threshold: Ratio<u64>,
 }
 
-impl Protobuf for ChainParameters {
+impl DomainType for ChainParameters {
     type Proto = pb_chain::ChainParameters;
 }
 
@@ -230,7 +230,7 @@ pub struct FmdParameters {
     pub as_of_block_height: u64,
 }
 
-impl Protobuf for FmdParameters {
+impl DomainType for FmdParameters {
     type Proto = pb_chain::FmdParameters;
 }
 

--- a/chain/src/params.rs
+++ b/chain/src/params.rs
@@ -15,7 +15,9 @@ pub struct AssetInfo {
     pub total_supply: u64,
 }
 
-impl Protobuf<pb_chain::AssetInfo> for AssetInfo {}
+impl Protobuf for AssetInfo {
+    type Proto = pb_chain::AssetInfo;
+}
 
 impl TryFrom<pb_chain::AssetInfo> for AssetInfo {
     type Error = anyhow::Error;
@@ -85,7 +87,9 @@ pub struct ChainParameters {
     pub proposal_veto_threshold: Ratio<u64>,
 }
 
-impl Protobuf<pb_chain::ChainParameters> for ChainParameters {}
+impl Protobuf for ChainParameters {
+    type Proto = pb_chain::ChainParameters;
+}
 
 impl TryFrom<pb_chain::ChainParameters> for ChainParameters {
     type Error = anyhow::Error;
@@ -226,7 +230,9 @@ pub struct FmdParameters {
     pub as_of_block_height: u64,
 }
 
-impl Protobuf<pb_chain::FmdParameters> for FmdParameters {}
+impl Protobuf for FmdParameters {
+    type Proto = pb_chain::FmdParameters;
+}
 
 impl TryFrom<pb_chain::FmdParameters> for FmdParameters {
     type Error = anyhow::Error;

--- a/chain/src/sync/compact_block.rs
+++ b/chain/src/sync/compact_block.rs
@@ -6,7 +6,7 @@ use penumbra_crypto::{
     Nullifier,
 };
 use penumbra_proto::{
-    client::v1alpha1::CompactBlockRangeResponse, core::chain::v1alpha1 as pb, Protobuf,
+    client::v1alpha1::CompactBlockRangeResponse, core::chain::v1alpha1 as pb, DomainType,
 };
 use penumbra_tct::builder::{block, epoch};
 use serde::{Deserialize, Serialize};
@@ -66,7 +66,7 @@ impl CompactBlock {
     }
 }
 
-impl Protobuf for CompactBlock {
+impl DomainType for CompactBlock {
     type Proto = pb::CompactBlock;
 }
 

--- a/chain/src/sync/compact_block.rs
+++ b/chain/src/sync/compact_block.rs
@@ -66,7 +66,9 @@ impl CompactBlock {
     }
 }
 
-impl Protobuf<pb::CompactBlock> for CompactBlock {}
+impl Protobuf for CompactBlock {
+    type Proto = pb::CompactBlock;
+}
 
 impl From<CompactBlock> for pb::CompactBlock {
     fn from(cb: CompactBlock) -> Self {

--- a/component/src/action_handler/actions/validator_definition.rs
+++ b/component/src/action_handler/actions/validator_definition.rs
@@ -6,7 +6,7 @@ use penumbra_transaction::Transaction;
 use std::sync::Arc;
 use tracing::instrument;
 
-use penumbra_proto::{core::stake::v1alpha1::ValidatorDefinition, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1::ValidatorDefinition, DomainType};
 
 use crate::{
     action_handler::ActionHandler,

--- a/component/src/app/mod.rs
+++ b/component/src/app/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use penumbra_chain::params::FmdParameters;
 use penumbra_chain::{genesis, AppHash, StateWriteExt as _};
-use penumbra_proto::{Protobuf, StateWriteProto};
+use penumbra_proto::{DomainType, StateWriteProto};
 use penumbra_storage::{ArcStateExt, State, Storage};
 use penumbra_transaction::Transaction;
 use tendermint::abci::{self, types::ValidatorUpdate};

--- a/component/src/governance/check.rs
+++ b/component/src/governance/check.rs
@@ -6,7 +6,7 @@ use penumbra_transaction::action::{
 };
 
 pub mod stateless {
-    use penumbra_proto::Protobuf;
+    use penumbra_proto::DomainType;
     use penumbra_transaction::action::{Proposal, ProposalDepositClaim};
 
     use super::*;

--- a/component/src/governance/proposal/chain_params.rs
+++ b/component/src/governance/proposal/chain_params.rs
@@ -23,7 +23,9 @@ pub enum MutableParam {
     MissedBlocksMaximum,
 }
 
-impl Protobuf<pb::MutableChainParameter> for MutableParam {}
+impl Protobuf for MutableParam {
+    type Proto = pb::MutableChainParameter;
+}
 
 impl TryFrom<pb::MutableChainParameter> for MutableParam {
     type Error = anyhow::Error;

--- a/component/src/governance/proposal/chain_params.rs
+++ b/component/src/governance/proposal/chain_params.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, str::FromStr};
 use anyhow::{Context as _, Result};
 use penumbra_chain::params::ChainParameters;
 use penumbra_proto::{
-    client::v1alpha1::MutableParametersResponse, core::governance::v1alpha1 as pb, Protobuf,
+    client::v1alpha1::MutableParametersResponse, core::governance::v1alpha1 as pb, DomainType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -23,7 +23,7 @@ pub enum MutableParam {
     MissedBlocksMaximum,
 }
 
-impl Protobuf for MutableParam {
+impl DomainType for MutableParam {
     type Proto = pb::MutableChainParameter;
 }
 

--- a/component/src/governance/proposal/list.rs
+++ b/component/src/governance/proposal/list.rs
@@ -9,7 +9,9 @@ pub struct ProposalList {
     pub proposals: BTreeSet<u64>,
 }
 
-impl Protobuf<pb::ProposalList> for ProposalList {}
+impl Protobuf for ProposalList {
+    type Proto = pb::ProposalList;
+}
 
 impl From<ProposalList> for pb::ProposalList {
     fn from(list: ProposalList) -> Self {

--- a/component/src/governance/proposal/list.rs
+++ b/component/src/governance/proposal/list.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
-use penumbra_proto::{core::governance::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType};
 
 /// A protobuf-represented duplicate-free set of proposal ids.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -9,7 +9,7 @@ pub struct ProposalList {
     pub proposals: BTreeSet<u64>,
 }
 
-impl Protobuf for ProposalList {
+impl DomainType for ProposalList {
     type Proto = pb::ProposalList;
 }
 

--- a/component/src/governance/view.rs
+++ b/component/src/governance/view.rs
@@ -40,14 +40,14 @@ pub trait StateReadExt: StateRead + crate::stake::StateReadExt {
     /// Get the state of a proposal.
     async fn proposal_state(&self, proposal_id: u64) -> Result<Option<proposal::State>> {
         Ok(self
-            .get::<proposal::State, _>(&state_key::proposal_state(proposal_id))
+            .get::<proposal::State>(&state_key::proposal_state(proposal_id))
             .await?)
     }
 
     /// Get all the unfinished proposal ids.
     async fn unfinished_proposals(&self) -> Result<BTreeSet<u64>> {
         Ok(self
-            .get::<proposal::ProposalList, _>(state_key::unfinished_proposals())
+            .get::<proposal::ProposalList>(state_key::unfinished_proposals())
             .await?
             .unwrap_or_default()
             .proposals)
@@ -74,7 +74,7 @@ pub trait StateReadExt: StateRead + crate::stake::StateReadExt {
         identity_key: IdentityKey,
     ) -> Result<Option<Vote>> {
         Ok(self
-            .get::<Vote, _>(&state_key::validator_vote(proposal_id, identity_key))
+            .get::<Vote>(&state_key::validator_vote(proposal_id, identity_key))
             .await?)
     }
 
@@ -160,7 +160,7 @@ pub trait StateWriteExt: StateWrite {
 
         // Track the index
         let mut unfinished_proposals = self
-            .get::<proposal::ProposalList, _>(state_key::unfinished_proposals())
+            .get::<proposal::ProposalList>(state_key::unfinished_proposals())
             .await?
             .unwrap_or_default();
         match &state {

--- a/component/src/ibc/client.rs
+++ b/component/src/ibc/client.rs
@@ -7,12 +7,12 @@ use ibc::core::ics02_client::trust_threshold::TrustThreshold;
 use ibc::core::ics24_host::identifier::ChainId;
 use ibc::core::ics24_host::identifier::ConnectionId;
 use ibc_proto::google::protobuf::Any;
-use penumbra_proto::{core::ibc::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::ibc::v1alpha1 as pb, DomainType};
 
 #[derive(Clone, Debug)]
 pub struct ClientCounter(pub u64);
 
-impl Protobuf for ClientCounter {
+impl DomainType for ClientCounter {
     type Proto = pb::ClientCounter;
 }
 
@@ -35,7 +35,7 @@ pub struct VerifiedHeights {
     pub heights: Vec<Height>,
 }
 
-impl Protobuf for VerifiedHeights {
+impl DomainType for VerifiedHeights {
     type Proto = pb::VerifiedHeights;
 }
 
@@ -64,7 +64,7 @@ pub struct ClientConnections {
     pub connection_ids: Vec<ConnectionId>,
 }
 
-impl Protobuf for ClientConnections {
+impl DomainType for ClientConnections {
     type Proto = pb::ClientConnections;
 }
 

--- a/component/src/ibc/client.rs
+++ b/component/src/ibc/client.rs
@@ -12,7 +12,9 @@ use penumbra_proto::{core::ibc::v1alpha1 as pb, Protobuf};
 #[derive(Clone, Debug)]
 pub struct ClientCounter(pub u64);
 
-impl Protobuf<pb::ClientCounter> for ClientCounter {}
+impl Protobuf for ClientCounter {
+    type Proto = pb::ClientCounter;
+}
 
 impl TryFrom<pb::ClientCounter> for ClientCounter {
     type Error = anyhow::Error;
@@ -33,7 +35,9 @@ pub struct VerifiedHeights {
     pub heights: Vec<Height>,
 }
 
-impl Protobuf<pb::VerifiedHeights> for VerifiedHeights {}
+impl Protobuf for VerifiedHeights {
+    type Proto = pb::VerifiedHeights;
+}
 
 impl TryFrom<pb::VerifiedHeights> for VerifiedHeights {
     type Error = anyhow::Error;
@@ -60,7 +64,9 @@ pub struct ClientConnections {
     pub connection_ids: Vec<ConnectionId>,
 }
 
-impl Protobuf<pb::ClientConnections> for ClientConnections {}
+impl Protobuf for ClientConnections {
+    type Proto = pb::ClientConnections;
+}
 
 impl TryFrom<pb::ClientConnections> for ClientConnections {
     type Error = anyhow::Error;

--- a/component/src/ibc/connection.rs
+++ b/component/src/ibc/connection.rs
@@ -1,11 +1,11 @@
 use ibc::core::ics03_connection::version::Version;
 use once_cell::sync::Lazy;
-use penumbra_proto::{core::ibc::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::ibc::v1alpha1 as pb, DomainType};
 
 #[derive(Debug, Clone)]
 pub struct ConnectionCounter(pub u64);
 
-impl Protobuf for ConnectionCounter {
+impl DomainType for ConnectionCounter {
     type Proto = pb::ConnectionCounter;
 }
 

--- a/component/src/ibc/connection.rs
+++ b/component/src/ibc/connection.rs
@@ -5,7 +5,9 @@ use penumbra_proto::{core::ibc::v1alpha1 as pb, Protobuf};
 #[derive(Debug, Clone)]
 pub struct ConnectionCounter(pub u64);
 
-impl Protobuf<pb::ConnectionCounter> for ConnectionCounter {}
+impl Protobuf for ConnectionCounter {
+    type Proto = pb::ConnectionCounter;
+}
 
 impl TryFrom<pb::ConnectionCounter> for ConnectionCounter {
     type Error = anyhow::Error;

--- a/component/src/shielded_pool/component.rs
+++ b/component/src/shielded_pool/component.rs
@@ -126,7 +126,7 @@ pub trait StateReadExt: StateRead {
     // #[instrument(skip(self))]
     async fn check_nullifier_unspent(&self, nullifier: Nullifier) -> Result<()> {
         if let Some(source) = self
-            .get::<NoteSource, _>(&state_key::spent_nullifier_lookup(nullifier))
+            .get::<NoteSource>(&state_key::spent_nullifier_lookup(nullifier))
             .await?
         {
             return Err(anyhow!(

--- a/component/src/stake/changes.rs
+++ b/component/src/stake/changes.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 use penumbra_transaction::action::{Delegate, Undelegate};
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +12,7 @@ pub struct DelegationChanges {
     pub undelegations: Vec<Undelegate>,
 }
 
-impl Protobuf for DelegationChanges {
+impl DomainType for DelegationChanges {
     type Proto = pb::DelegationChanges;
 }
 

--- a/component/src/stake/changes.rs
+++ b/component/src/stake/changes.rs
@@ -12,7 +12,9 @@ pub struct DelegationChanges {
     pub undelegations: Vec<Undelegate>,
 }
 
-impl Protobuf<pb::DelegationChanges> for DelegationChanges {}
+impl Protobuf for DelegationChanges {
+    type Proto = pb::DelegationChanges;
+}
 
 impl From<DelegationChanges> for pb::DelegationChanges {
     fn from(changes: DelegationChanges) -> pb::DelegationChanges {

--- a/component/src/stake/component.rs
+++ b/component/src/stake/component.rs
@@ -942,7 +942,7 @@ pub trait StateReadExt: StateRead {
     ) -> Result<Penalty> {
         let prefix = state_key::penalty_in_epoch_prefix(id);
         let all_penalties = self
-            .prefix::<Penalty, _>(&prefix)
+            .prefix::<Penalty>(&prefix)
             .try_collect::<BTreeMap<String, Penalty>>()
             .await?;
 

--- a/component/src/stake/current_consensus_keys.rs
+++ b/component/src/stake/current_consensus_keys.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 use tendermint::PublicKey;
 
@@ -14,7 +14,7 @@ pub struct CurrentConsensusKeys {
     pub consensus_keys: Vec<PublicKey>,
 }
 
-impl Protobuf for CurrentConsensusKeys {
+impl DomainType for CurrentConsensusKeys {
     type Proto = pb::CurrentConsensusKeys;
 }
 

--- a/component/src/stake/current_consensus_keys.rs
+++ b/component/src/stake/current_consensus_keys.rs
@@ -14,7 +14,9 @@ pub struct CurrentConsensusKeys {
     pub consensus_keys: Vec<PublicKey>,
 }
 
-impl Protobuf<pb::CurrentConsensusKeys> for CurrentConsensusKeys {}
+impl Protobuf for CurrentConsensusKeys {
+    type Proto = pb::CurrentConsensusKeys;
+}
 
 impl From<CurrentConsensusKeys> for pb::CurrentConsensusKeys {
     fn from(value: CurrentConsensusKeys) -> pb::CurrentConsensusKeys {

--- a/component/src/stake/funding_stream.rs
+++ b/component/src/stake/funding_stream.rs
@@ -37,7 +37,9 @@ impl FundingStream {
     }
 }
 
-impl Protobuf<pb::FundingStream> for FundingStream {}
+impl Protobuf for FundingStream {
+    type Proto = pb::FundingStream;
+}
 
 impl From<FundingStream> for pb::FundingStream {
     fn from(fs: FundingStream) -> Self {

--- a/component/src/stake/funding_stream.rs
+++ b/component/src/stake/funding_stream.rs
@@ -1,5 +1,5 @@
 use penumbra_crypto::Address;
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::stake::rate::BaseRateData;
@@ -37,7 +37,7 @@ impl FundingStream {
     }
 }
 
-impl Protobuf for FundingStream {
+impl DomainType for FundingStream {
     type Proto = pb::FundingStream;
 }
 

--- a/component/src/stake/rate.rs
+++ b/component/src/stake/rate.rs
@@ -2,7 +2,7 @@
 
 use penumbra_crypto::{stake::Penalty, Amount};
 use penumbra_proto::{
-    client::v1alpha1::NextValidatorRateResponse, core::stake::v1alpha1 as pb, Protobuf,
+    client::v1alpha1::NextValidatorRateResponse, core::stake::v1alpha1 as pb, DomainType,
 };
 use penumbra_transaction::action::{Delegate, Undelegate};
 use serde::{Deserialize, Serialize};
@@ -194,7 +194,7 @@ impl BaseRateData {
     }
 }
 
-impl Protobuf for RateData {
+impl DomainType for RateData {
     type Proto = pb::RateData;
 }
 
@@ -224,7 +224,7 @@ impl TryFrom<pb::RateData> for RateData {
     }
 }
 
-impl Protobuf for BaseRateData {
+impl DomainType for BaseRateData {
     type Proto = pb::BaseRateData;
 }
 

--- a/component/src/stake/rate.rs
+++ b/component/src/stake/rate.rs
@@ -194,7 +194,9 @@ impl BaseRateData {
     }
 }
 
-impl Protobuf<pb::RateData> for RateData {}
+impl Protobuf for RateData {
+    type Proto = pb::RateData;
+}
 
 impl From<RateData> for pb::RateData {
     fn from(v: RateData) -> Self {
@@ -222,7 +224,9 @@ impl TryFrom<pb::RateData> for RateData {
     }
 }
 
-impl Protobuf<pb::BaseRateData> for BaseRateData {}
+impl Protobuf for BaseRateData {
+    type Proto = pb::BaseRateData;
+}
 
 impl From<BaseRateData> for pb::BaseRateData {
     fn from(v: BaseRateData) -> Self {

--- a/component/src/stake/uptime.rs
+++ b/component/src/stake/uptime.rs
@@ -1,6 +1,6 @@
 use bitvec::prelude::*;
 
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 /// Records information on a validator's uptime.
@@ -83,7 +83,7 @@ impl Uptime {
     }
 }
 
-impl Protobuf for Uptime {
+impl DomainType for Uptime {
     type Proto = pb::Uptime;
 }
 

--- a/component/src/stake/uptime.rs
+++ b/component/src/stake/uptime.rs
@@ -83,7 +83,9 @@ impl Uptime {
     }
 }
 
-impl Protobuf<pb::Uptime> for Uptime {}
+impl Protobuf for Uptime {
+    type Proto = pb::Uptime;
+}
 
 impl From<Uptime> for pb::Uptime {
     fn from(mut val: Uptime) -> pb::Uptime {

--- a/component/src/stake/validator.rs
+++ b/component/src/stake/validator.rs
@@ -179,7 +179,9 @@ impl From<FundingStreamToml> for FundingStream {
     }
 }
 
-impl Protobuf<pb::Validator> for Validator {}
+impl Protobuf for Validator {
+    type Proto = pb::Validator;
+}
 
 impl From<Validator> for pb::Validator {
     fn from(v: Validator) -> Self {

--- a/component/src/stake/validator.rs
+++ b/component/src/stake/validator.rs
@@ -1,7 +1,7 @@
 //! Penumbra validators and related structures.
 
 use penumbra_crypto::{Address, GovernanceKey};
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 use serde_with::DisplayFromStr;
 
@@ -179,7 +179,7 @@ impl From<FundingStreamToml> for FundingStream {
     }
 }
 
-impl Protobuf for Validator {
+impl DomainType for Validator {
     type Proto = pb::Validator;
 }
 

--- a/component/src/stake/validator/bonding.rs
+++ b/component/src/stake/validator/bonding.rs
@@ -1,4 +1,4 @@
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
@@ -34,7 +34,7 @@ impl std::fmt::Display for State {
     }
 }
 
-impl Protobuf for State {
+impl DomainType for State {
     type Proto = pb::BondingState;
 }
 

--- a/component/src/stake/validator/bonding.rs
+++ b/component/src/stake/validator/bonding.rs
@@ -34,7 +34,9 @@ impl std::fmt::Display for State {
     }
 }
 
-impl Protobuf<pb::BondingState> for State {}
+impl Protobuf for State {
+    type Proto = pb::BondingState;
+}
 
 impl From<State> for pb::BondingState {
     fn from(v: State) -> Self {

--- a/component/src/stake/validator/definition.rs
+++ b/component/src/stake/validator/definition.rs
@@ -12,7 +12,9 @@ pub struct Definition {
     pub auth_sig: Signature<SpendAuth>,
 }
 
-impl Protobuf<pb::ValidatorDefinition> for Definition {}
+impl Protobuf for Definition {
+    type Proto = pb::ValidatorDefinition;
+}
 
 impl From<Definition> for pb::ValidatorDefinition {
     fn from(v: Definition) -> Self {

--- a/component/src/stake/validator/definition.rs
+++ b/component/src/stake/validator/definition.rs
@@ -1,5 +1,5 @@
 use penumbra_crypto::rdsa::{Signature, SpendAuth};
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::stake::validator::Validator;
@@ -12,7 +12,7 @@ pub struct Definition {
     pub auth_sig: Signature<SpendAuth>,
 }
 
-impl Protobuf for Definition {
+impl DomainType for Definition {
     type Proto = pb::ValidatorDefinition;
 }
 

--- a/component/src/stake/validator/info.rs
+++ b/component/src/stake/validator/info.rs
@@ -14,7 +14,9 @@ pub struct Info {
     pub rate_data: RateData,
 }
 
-impl Protobuf<pb::ValidatorInfo> for Info {}
+impl Protobuf for Info {
+    type Proto = pb::ValidatorInfo;
+}
 
 impl From<Info> for pb::ValidatorInfo {
     fn from(v: Info) -> Self {

--- a/component/src/stake/validator/info.rs
+++ b/component/src/stake/validator/info.rs
@@ -1,5 +1,5 @@
 use penumbra_proto::{
-    client::v1alpha1::ValidatorInfoResponse, core::stake::v1alpha1 as pb, Protobuf,
+    client::v1alpha1::ValidatorInfoResponse, core::stake::v1alpha1 as pb, DomainType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -14,7 +14,7 @@ pub struct Info {
     pub rate_data: RateData,
 }
 
-impl Protobuf for Info {
+impl DomainType for Info {
     type Proto = pb::ValidatorInfo;
 }
 

--- a/component/src/stake/validator/state.rs
+++ b/component/src/stake/validator/state.rs
@@ -34,7 +34,9 @@ impl std::fmt::Display for State {
     }
 }
 
-impl Protobuf<pb::ValidatorState> for State {}
+impl Protobuf for State {
+    type Proto = pb::ValidatorState;
+}
 
 impl From<State> for pb::ValidatorState {
     fn from(v: State) -> Self {

--- a/component/src/stake/validator/state.rs
+++ b/component/src/stake/validator/state.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 /// The state of a validator in the validator state machine.
@@ -34,7 +34,7 @@ impl std::fmt::Display for State {
     }
 }
 
-impl Protobuf for State {
+impl DomainType for State {
     type Proto = pb::ValidatorState;
 }
 

--- a/component/src/stake/validator/status.rs
+++ b/component/src/stake/validator/status.rs
@@ -1,4 +1,4 @@
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::stake::{validator::BondingState, validator::State, IdentityKey};
@@ -22,7 +22,7 @@ pub struct Status {
     pub bonding_state: BondingState,
 }
 
-impl Protobuf for Status {
+impl DomainType for Status {
     type Proto = pb::ValidatorStatus;
 }
 

--- a/component/src/stake/validator/status.rs
+++ b/component/src/stake/validator/status.rs
@@ -22,7 +22,9 @@ pub struct Status {
     pub bonding_state: BondingState,
 }
 
-impl Protobuf<pb::ValidatorStatus> for Status {}
+impl Protobuf for Status {
+    type Proto = pb::ValidatorStatus;
+}
 
 impl From<Status> for pb::ValidatorStatus {
     fn from(v: Status) -> Self {

--- a/crypto/src/address.rs
+++ b/crypto/src/address.rs
@@ -127,7 +127,9 @@ impl Address {
     }
 }
 
-impl Protobuf<pb::Address> for Address {}
+impl Protobuf for Address {
+    type Proto = pb::Address;
+}
 
 impl From<Address> for pb::Address {
     fn from(a: Address) -> Self {

--- a/crypto/src/address.rs
+++ b/crypto/src/address.rs
@@ -3,7 +3,7 @@ use std::io::{Cursor, Read, Write};
 use anyhow::Context;
 use ark_serialize::CanonicalDeserialize;
 use f4jumble::{f4jumble, f4jumble_inv};
-use penumbra_proto::{core::crypto::v1alpha1 as pb, serializers::bech32str, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, serializers::bech32str, DomainType};
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 
@@ -127,7 +127,7 @@ impl Address {
     }
 }
 
-impl Protobuf for Address {
+impl DomainType for Address {
     type Proto = pb::Address;
 }
 

--- a/crypto/src/asset.rs
+++ b/crypto/src/asset.rs
@@ -24,7 +24,9 @@ pub struct Asset {
     pub denom: Denom,
 }
 
-impl Protobuf<pb::Asset> for Asset {}
+impl Protobuf for Asset {
+    type Proto = pb::Asset;
+}
 
 impl TryFrom<pb::Asset> for Asset {
     type Error = anyhow::Error;

--- a/crypto/src/asset.rs
+++ b/crypto/src/asset.rs
@@ -1,6 +1,6 @@
 //! Asset types and identifiers.
 
-use penumbra_proto::{core::crypto::v1alpha1 as pb, view::v1alpha1::AssetsResponse, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, view::v1alpha1::AssetsResponse, DomainType};
 use serde::{Deserialize, Serialize};
 
 mod amount;
@@ -24,7 +24,7 @@ pub struct Asset {
     pub denom: Denom,
 }
 
-impl Protobuf for Asset {
+impl DomainType for Asset {
     type Proto = pb::Asset;
 }
 

--- a/crypto/src/asset/amount.rs
+++ b/crypto/src/asset/amount.rs
@@ -103,7 +103,9 @@ impl TryFrom<std::string::String> for Amount {
     }
 }
 
-impl Protobuf<pb::Amount> for Amount {}
+impl Protobuf for Amount {
+    type Proto = pb::Amount;
+}
 
 impl From<u64> for Amount {
     fn from(amount: u64) -> Amount {

--- a/crypto/src/asset/amount.rs
+++ b/crypto/src/asset/amount.rs
@@ -1,6 +1,6 @@
 use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::SynthesisError;
-use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, iter::Sum, num::NonZeroU128, ops};
 
@@ -103,7 +103,7 @@ impl TryFrom<std::string::String> for Amount {
     }
 }
 
-impl Protobuf for Amount {
+impl DomainType for Amount {
     type Proto = pb::Amount;
 }
 

--- a/crypto/src/asset/denom.rs
+++ b/crypto/src/asset/denom.rs
@@ -20,7 +20,9 @@ pub struct Denom {
     pub(super) inner: Arc<Inner>,
 }
 
-impl Protobuf<pb::Denom> for Denom {}
+impl Protobuf for Denom {
+    type Proto = pb::Denom;
+}
 
 impl From<Denom> for pb::Denom {
     fn from(dn: Denom) -> Self {

--- a/crypto/src/asset/denom.rs
+++ b/crypto/src/asset/denom.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use ark_ff::fields::PrimeField;
-use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::{asset, Fq, Value};
@@ -20,7 +20,7 @@ pub struct Denom {
     pub(super) inner: Arc<Inner>,
 }
 
-impl Protobuf for Denom {
+impl DomainType for Denom {
     type Proto = pb::Denom;
 }
 

--- a/crypto/src/asset/id.rs
+++ b/crypto/src/asset/id.rs
@@ -49,7 +49,9 @@ impl TryFrom<pb::AssetId> for Id {
     }
 }
 
-impl Protobuf<pb::AssetId> for Id {}
+impl Protobuf for Id {
+    type Proto = pb::AssetId;
+}
 
 impl TryFrom<&[u8]> for Id {
     type Error = anyhow::Error;

--- a/crypto/src/asset/id.rs
+++ b/crypto/src/asset/id.rs
@@ -3,7 +3,7 @@ use ark_ff::fields::PrimeField;
 use ark_serialize::CanonicalDeserialize;
 use decaf377::FieldExt;
 use once_cell::sync::Lazy;
-use penumbra_proto::{core::crypto::v1alpha1 as pb, serializers::bech32str, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, serializers::bech32str, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::{Fq, Value};
@@ -49,7 +49,7 @@ impl TryFrom<pb::AssetId> for Id {
     }
 }
 
-impl Protobuf for Id {
+impl DomainType for Id {
     type Proto = pb::AssetId;
 }
 

--- a/crypto/src/balance/commitment.rs
+++ b/crypto/src/balance/commitment.rs
@@ -154,7 +154,9 @@ impl TryFrom<&[u8]> for Commitment {
     }
 }
 
-impl Protobuf<pb::BalanceCommitment> for Commitment {}
+impl Protobuf for Commitment {
+    type Proto = pb::BalanceCommitment;
+}
 
 impl From<Commitment> for pb::BalanceCommitment {
     fn from(cv: Commitment) -> Self {

--- a/crypto/src/balance/commitment.rs
+++ b/crypto/src/balance/commitment.rs
@@ -10,7 +10,7 @@ use decaf377::Fq;
 use decaf377::Fr;
 use once_cell::sync::Lazy;
 use penumbra_proto::core::crypto::v1alpha1 as pb;
-use penumbra_proto::Protobuf;
+use penumbra_proto::DomainType;
 
 use crate::asset::VALUE_GENERATOR_DOMAIN_SEP;
 use crate::value::ValueVar;
@@ -154,7 +154,7 @@ impl TryFrom<&[u8]> for Commitment {
     }
 }
 
-impl Protobuf for Commitment {
+impl DomainType for Commitment {
     type Proto = pb::BalanceCommitment;
 }
 

--- a/crypto/src/dex/execution.rs
+++ b/crypto/src/dex/execution.rs
@@ -2,7 +2,7 @@ use crate::asset;
 use crate::dex::lp::TradingFunction;
 use crate::dex::trading_pair::DirectedTradingPair;
 use anyhow::Result;
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 /// Contains a path for a trade, including the trading pair (with direction), the trading
@@ -47,7 +47,7 @@ impl Path {
     }
 }
 
-impl Protobuf for Path {
+impl DomainType for Path {
     type Proto = pb::Path;
 }
 

--- a/crypto/src/dex/execution.rs
+++ b/crypto/src/dex/execution.rs
@@ -47,7 +47,9 @@ impl Path {
     }
 }
 
-impl Protobuf<pb::Path> for Path {}
+impl Protobuf for Path {
+    type Proto = pb::Path;
+}
 
 impl TryFrom<pb::Path> for Path {
     type Error = anyhow::Error;

--- a/crypto/src/dex/lp/nft.rs
+++ b/crypto/src/dex/lp/nft.rs
@@ -1,4 +1,4 @@
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType};
 use regex::Regex;
 
 use super::position::{Id, State};
@@ -117,7 +117,7 @@ impl std::cmp::PartialEq for LpNft {
 
 impl std::cmp::Eq for LpNft {}
 
-impl Protobuf for LpNft {
+impl DomainType for LpNft {
     type Proto = pb::LpNft;
 }
 

--- a/crypto/src/dex/lp/nft.rs
+++ b/crypto/src/dex/lp/nft.rs
@@ -117,7 +117,9 @@ impl std::cmp::PartialEq for LpNft {
 
 impl std::cmp::Eq for LpNft {}
 
-impl Protobuf<pb::LpNft> for LpNft {}
+impl Protobuf for LpNft {
+    type Proto = pb::LpNft;
+}
 
 impl TryFrom<pb::LpNft> for LpNft {
     type Error = anyhow::Error;

--- a/crypto/src/dex/lp/position.rs
+++ b/crypto/src/dex/lp/position.rs
@@ -118,7 +118,9 @@ impl std::str::FromStr for State {
 
 // ==== Protobuf impls
 
-impl Protobuf<pb::Position> for Position {}
+impl Protobuf for Position {
+    type Proto = pb::Position;
+}
 
 impl TryFrom<pb::Position> for Position {
     type Error = anyhow::Error;
@@ -147,7 +149,9 @@ impl From<Position> for pb::Position {
     }
 }
 
-impl Protobuf<pb::PositionId> for Id {}
+impl Protobuf for Id {
+    type Proto = pb::PositionId;
+}
 
 impl TryFrom<pb::PositionId> for Id {
     type Error = anyhow::Error;
@@ -171,7 +175,9 @@ impl From<Id> for pb::PositionId {
     }
 }
 
-impl Protobuf<pb::PositionState> for State {}
+impl Protobuf for State {
+    type Proto = pb::PositionState;
+}
 
 impl From<State> for pb::PositionState {
     fn from(v: State) -> Self {

--- a/crypto/src/dex/lp/position.rs
+++ b/crypto/src/dex/lp/position.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context};
-use penumbra_proto::{core::dex::v1alpha1 as pb, serializers::bech32str, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pb, serializers::bech32str, DomainType};
 use serde::{Deserialize, Serialize};
 
 use super::trading_function::TradingFunction;
@@ -118,7 +118,7 @@ impl std::str::FromStr for State {
 
 // ==== Protobuf impls
 
-impl Protobuf for Position {
+impl DomainType for Position {
     type Proto = pb::Position;
 }
 
@@ -149,7 +149,7 @@ impl From<Position> for pb::Position {
     }
 }
 
-impl Protobuf for Id {
+impl DomainType for Id {
     type Proto = pb::PositionId;
 }
 
@@ -175,7 +175,7 @@ impl From<Id> for pb::PositionId {
     }
 }
 
-impl Protobuf for State {
+impl DomainType for State {
     type Proto = pb::PositionState;
 }
 

--- a/crypto/src/dex/lp/reserves.rs
+++ b/crypto/src/dex/lp/reserves.rs
@@ -1,6 +1,6 @@
 use crate::asset::Amount;
 use penumbra_proto::{
-    client::v1alpha1::StubCpmmReservesResponse, core::dex::v1alpha1 as pb, Protobuf,
+    client::v1alpha1::StubCpmmReservesResponse, core::dex::v1alpha1 as pb, DomainType,
 };
 
 /// The reserves of a position.
@@ -15,7 +15,7 @@ pub struct Reserves {
     pub r2: Amount,
 }
 
-impl Protobuf for Reserves {
+impl DomainType for Reserves {
     type Proto = pb::Reserves;
 }
 

--- a/crypto/src/dex/lp/reserves.rs
+++ b/crypto/src/dex/lp/reserves.rs
@@ -15,7 +15,9 @@ pub struct Reserves {
     pub r2: Amount,
 }
 
-impl Protobuf<pb::Reserves> for Reserves {}
+impl Protobuf for Reserves {
+    type Proto = pb::Reserves;
+}
 
 impl TryFrom<pb::Reserves> for Reserves {
     type Error = anyhow::Error;

--- a/crypto/src/dex/lp/trading_function.rs
+++ b/crypto/src/dex/lp/trading_function.rs
@@ -1,4 +1,4 @@
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::dex::{fixed_encoding::FixedEncoding, TradingPair};
@@ -65,7 +65,7 @@ impl From<TradingFunction> for pb::TradingFunction {
     }
 }
 
-impl Protobuf for TradingFunction {
+impl DomainType for TradingFunction {
     type Proto = pb::TradingFunction;
 }
 
@@ -128,7 +128,7 @@ impl BareTradingFunction {
     }
 }
 
-impl Protobuf for BareTradingFunction {
+impl DomainType for BareTradingFunction {
     type Proto = pb::BareTradingFunction;
 }
 

--- a/crypto/src/dex/lp/trading_function.rs
+++ b/crypto/src/dex/lp/trading_function.rs
@@ -65,7 +65,9 @@ impl From<TradingFunction> for pb::TradingFunction {
     }
 }
 
-impl Protobuf<pb::TradingFunction> for TradingFunction {}
+impl Protobuf for TradingFunction {
+    type Proto = pb::TradingFunction;
+}
 
 /// The data describing a trading function.
 ///
@@ -126,7 +128,9 @@ impl BareTradingFunction {
     }
 }
 
-impl Protobuf<pb::BareTradingFunction> for BareTradingFunction {}
+impl Protobuf for BareTradingFunction {
+    type Proto = pb::BareTradingFunction;
+}
 
 impl TryFrom<pb::BareTradingFunction> for BareTradingFunction {
     type Error = anyhow::Error;

--- a/crypto/src/dex/swap.rs
+++ b/crypto/src/dex/swap.rs
@@ -4,7 +4,7 @@ use ark_ff::PrimeField;
 use decaf377::Fq;
 use once_cell::sync::Lazy;
 use penumbra_proto::{
-    client::v1alpha1::BatchSwapOutputDataResponse, core::dex::v1alpha1 as pb, Protobuf,
+    client::v1alpha1::BatchSwapOutputDataResponse, core::dex::v1alpha1 as pb, DomainType,
 };
 
 use super::TradingPair;
@@ -66,7 +66,7 @@ impl BatchSwapOutputData {
     }
 }
 
-impl Protobuf for BatchSwapOutputData {
+impl DomainType for BatchSwapOutputData {
     type Proto = pb::BatchSwapOutputData;
 }
 

--- a/crypto/src/dex/swap.rs
+++ b/crypto/src/dex/swap.rs
@@ -66,7 +66,9 @@ impl BatchSwapOutputData {
     }
 }
 
-impl Protobuf<pb::BatchSwapOutputData> for BatchSwapOutputData {}
+impl Protobuf for BatchSwapOutputData {
+    type Proto = pb::BatchSwapOutputData;
+}
 
 impl From<BatchSwapOutputData> for pb::BatchSwapOutputData {
     fn from(s: BatchSwapOutputData) -> Self {

--- a/crypto/src/dex/swap/plaintext.rs
+++ b/crypto/src/dex/swap/plaintext.rs
@@ -167,7 +167,9 @@ impl SwapPlaintext {
     }
 }
 
-impl Protobuf<pb::SwapPlaintext> for SwapPlaintext {}
+impl Protobuf for SwapPlaintext {
+    type Proto = pb::SwapPlaintext;
+}
 
 impl TryFrom<pb::SwapPlaintext> for SwapPlaintext {
     type Error = anyhow::Error;

--- a/crypto/src/dex/swap/plaintext.rs
+++ b/crypto/src/dex/swap/plaintext.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Error, Result};
 use ark_ff::PrimeField;
 use decaf377::{FieldExt, Fq};
 use once_cell::sync::Lazy;
-use penumbra_proto::{core::crypto::v1alpha1 as pb_crypto, core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb_crypto, core::dex::v1alpha1 as pb, DomainType};
 use penumbra_tct::Commitment;
 use poseidon377::{hash_1, hash_4, hash_7};
 use rand::{CryptoRng, RngCore};
@@ -167,7 +167,7 @@ impl SwapPlaintext {
     }
 }
 
-impl Protobuf for SwapPlaintext {
+impl DomainType for SwapPlaintext {
     type Proto = pb::SwapPlaintext;
 }
 

--- a/crypto/src/dex/trading_pair.rs
+++ b/crypto/src/dex/trading_pair.rs
@@ -23,7 +23,9 @@ impl DirectedTradingPair {
     }
 }
 
-impl Protobuf<pb::DirectedTradingPair> for DirectedTradingPair {}
+impl Protobuf for DirectedTradingPair {
+    type Proto = pb::DirectedTradingPair;
+}
 
 impl From<DirectedTradingPair> for pb::DirectedTradingPair {
     fn from(tp: DirectedTradingPair) -> Self {
@@ -112,7 +114,9 @@ impl TryFrom<[u8; 64]> for TradingPair {
     }
 }
 
-impl Protobuf<pb::TradingPair> for TradingPair {}
+impl Protobuf for TradingPair {
+    type Proto = pb::TradingPair;
+}
 
 impl From<TradingPair> for pb::TradingPair {
     fn from(tp: TradingPair) -> Self {

--- a/crypto/src/dex/trading_pair.rs
+++ b/crypto/src/dex/trading_pair.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
 use decaf377::FieldExt;
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
@@ -23,7 +23,7 @@ impl DirectedTradingPair {
     }
 }
 
-impl Protobuf for DirectedTradingPair {
+impl DomainType for DirectedTradingPair {
     type Proto = pb::DirectedTradingPair;
 }
 
@@ -114,7 +114,7 @@ impl TryFrom<[u8; 64]> for TradingPair {
     }
 }
 
-impl Protobuf for TradingPair {
+impl DomainType for TradingPair {
     type Proto = pb::TradingPair;
 }
 

--- a/crypto/src/encrypted_note.rs
+++ b/crypto/src/encrypted_note.rs
@@ -72,7 +72,9 @@ impl std::fmt::Debug for EncryptedNote {
     }
 }
 
-impl Protobuf<pb::EncryptedNote> for EncryptedNote {}
+impl Protobuf for EncryptedNote {
+    type Proto = pb::EncryptedNote;
+}
 
 impl From<EncryptedNote> for pb::EncryptedNote {
     fn from(msg: EncryptedNote) -> Self {

--- a/crypto/src/encrypted_note.rs
+++ b/crypto/src/encrypted_note.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Error};
 
 use bytes::Bytes;
 
-use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::{asset::Amount, ka, note, FullViewingKey, Note};
@@ -72,7 +72,7 @@ impl std::fmt::Debug for EncryptedNote {
     }
 }
 
-impl Protobuf for EncryptedNote {
+impl DomainType for EncryptedNote {
     type Proto = pb::EncryptedNote;
 }
 

--- a/crypto/src/flow.rs
+++ b/crypto/src/flow.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, AddAssign, Deref, DerefMut};
 
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -41,7 +41,7 @@ impl AddAssign for MockFlowCiphertext {
     }
 }
 
-impl Protobuf for MockFlowCiphertext {
+impl DomainType for MockFlowCiphertext {
     type Proto = pb::MockFlowCiphertext;
 }
 

--- a/crypto/src/flow.rs
+++ b/crypto/src/flow.rs
@@ -41,7 +41,9 @@ impl AddAssign for MockFlowCiphertext {
     }
 }
 
-impl Protobuf<pb::MockFlowCiphertext> for MockFlowCiphertext {}
+impl Protobuf for MockFlowCiphertext {
+    type Proto = pb::MockFlowCiphertext;
+}
 
 impl From<MockFlowCiphertext> for pb::MockFlowCiphertext {
     fn from(ik: MockFlowCiphertext) -> Self {

--- a/crypto/src/governance/key.rs
+++ b/crypto/src/governance/key.rs
@@ -46,7 +46,9 @@ impl std::fmt::Debug for GovernanceKey {
     }
 }
 
-impl Protobuf<pb::GovernanceKey> for GovernanceKey {}
+impl Protobuf for GovernanceKey {
+    type Proto = pb::GovernanceKey;
+}
 
 impl From<GovernanceKey> for pb::GovernanceKey {
     fn from(gk: GovernanceKey) -> Self {

--- a/crypto/src/governance/key.rs
+++ b/crypto/src/governance/key.rs
@@ -1,7 +1,7 @@
 use penumbra_proto::{
     core::crypto::v1alpha1 as pb,
     serializers::bech32str::{self, validator_governance_key::BECH32_PREFIX},
-    Protobuf,
+    DomainType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -46,7 +46,7 @@ impl std::fmt::Debug for GovernanceKey {
     }
 }
 
-impl Protobuf for GovernanceKey {
+impl DomainType for GovernanceKey {
     type Proto = pb::GovernanceKey;
 }
 

--- a/crypto/src/keys/diversifier.rs
+++ b/crypto/src/keys/diversifier.rs
@@ -55,7 +55,9 @@ impl TryFrom<&[u8]> for Diversifier {
     }
 }
 
-impl Protobuf<pb::Diversifier> for Diversifier {}
+impl Protobuf for Diversifier {
+    type Proto = pb::Diversifier;
+}
 
 impl From<Diversifier> for pb::Diversifier {
     fn from(d: Diversifier) -> pb::Diversifier {
@@ -230,7 +232,9 @@ impl TryFrom<&[u8]> for AddressIndex {
     }
 }
 
-impl Protobuf<pb::AddressIndex> for AddressIndex {}
+impl Protobuf for AddressIndex {
+    type Proto = pb::AddressIndex;
+}
 
 impl From<AddressIndex> for pb::AddressIndex {
     fn from(d: AddressIndex) -> pb::AddressIndex {

--- a/crypto/src/keys/diversifier.rs
+++ b/crypto/src/keys/diversifier.rs
@@ -7,7 +7,7 @@ use aes::Aes128;
 use anyhow::anyhow;
 use ark_ff::PrimeField;
 use derivative::Derivative;
-use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::Fq;
@@ -55,7 +55,7 @@ impl TryFrom<&[u8]> for Diversifier {
     }
 }
 
-impl Protobuf for Diversifier {
+impl DomainType for Diversifier {
     type Proto = pb::Diversifier;
 }
 
@@ -232,7 +232,7 @@ impl TryFrom<&[u8]> for AddressIndex {
     }
 }
 
-impl Protobuf for AddressIndex {
+impl DomainType for AddressIndex {
     type Proto = pb::AddressIndex;
 }
 

--- a/crypto/src/keys/fvk.rs
+++ b/crypto/src/keys/fvk.rs
@@ -3,7 +3,7 @@ use ark_ff::PrimeField;
 use ark_serialize::CanonicalDeserialize;
 use decaf377::FieldExt;
 use once_cell::sync::Lazy;
-use penumbra_proto::{core::crypto::v1alpha1 as pb, serializers::bech32str, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, serializers::bech32str, DomainType};
 use poseidon377::hash_2;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -142,7 +142,7 @@ impl FullViewingKey {
     }
 }
 
-impl Protobuf for FullViewingKey {
+impl DomainType for FullViewingKey {
     type Proto = pb::FullViewingKey;
 }
 

--- a/crypto/src/keys/fvk.rs
+++ b/crypto/src/keys/fvk.rs
@@ -142,7 +142,9 @@ impl FullViewingKey {
     }
 }
 
-impl Protobuf<pb::FullViewingKey> for FullViewingKey {}
+impl Protobuf for FullViewingKey {
+    type Proto = pb::FullViewingKey;
+}
 
 impl TryFrom<pb::FullViewingKey> for FullViewingKey {
     type Error = anyhow::Error;

--- a/crypto/src/keys/spend.rs
+++ b/crypto/src/keys/spend.rs
@@ -42,7 +42,9 @@ impl PartialEq for SpendKey {
 
 impl Eq for SpendKey {}
 
-impl Protobuf<pb::SpendKey> for SpendKey {}
+impl Protobuf for SpendKey {
+    type Proto = pb::SpendKey;
+}
 
 impl TryFrom<pb::SpendKey> for SpendKey {
     type Error = anyhow::Error;

--- a/crypto/src/keys/spend.rs
+++ b/crypto/src/keys/spend.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use hmac::Hmac;
 use pbkdf2::pbkdf2;
-use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -42,7 +42,7 @@ impl PartialEq for SpendKey {
 
 impl Eq for SpendKey {}
 
-impl Protobuf for SpendKey {
+impl DomainType for SpendKey {
     type Proto = pb::SpendKey;
 }
 

--- a/crypto/src/nullifier.rs
+++ b/crypto/src/nullifier.rs
@@ -4,7 +4,7 @@ use ark_relations::r1cs::SynthesisError;
 use decaf377::{r1cs::FqVar, FieldExt, Fq};
 
 use once_cell::sync::Lazy;
-use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -18,7 +18,7 @@ impl Nullifier {
     }
 }
 
-impl Protobuf for Nullifier {
+impl DomainType for Nullifier {
     type Proto = pb::Nullifier;
 }
 

--- a/crypto/src/nullifier.rs
+++ b/crypto/src/nullifier.rs
@@ -18,7 +18,9 @@ impl Nullifier {
     }
 }
 
-impl Protobuf<pb::Nullifier> for Nullifier {}
+impl Protobuf for Nullifier {
+    type Proto = pb::Nullifier;
+}
 
 impl From<Nullifier> for pb::Nullifier {
     fn from(n: Nullifier) -> Self {

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -134,7 +134,9 @@ impl OutputProof {
 
 // Conversions
 
-impl Protobuf<transparent_proofs::SpendProof> for SpendProof {}
+impl Protobuf for SpendProof {
+    type Proto = transparent_proofs::SpendProof;
+}
 
 impl From<SpendProof> for transparent_proofs::SpendProof {
     fn from(msg: SpendProof) -> Self {
@@ -197,7 +199,9 @@ impl TryFrom<transparent_proofs::SpendProof> for SpendProof {
     }
 }
 
-impl Protobuf<transparent_proofs::OutputProof> for OutputProof {}
+impl Protobuf for OutputProof {
+    type Proto = transparent_proofs::OutputProof;
+}
 
 impl From<OutputProof> for transparent_proofs::OutputProof {
     fn from(msg: OutputProof) -> Self {
@@ -400,7 +404,9 @@ impl TryFrom<&[u8]> for SwapClaimProof {
     }
 }
 
-impl Protobuf<transparent_proofs::SwapClaimProof> for SwapClaimProof {}
+impl Protobuf for SwapClaimProof {
+    type Proto = transparent_proofs::SwapClaimProof;
+}
 
 impl From<SwapClaimProof> for transparent_proofs::SwapClaimProof {
     fn from(msg: SwapClaimProof) -> Self {
@@ -498,7 +504,9 @@ impl SwapProof {
     }
 }
 
-impl Protobuf<transparent_proofs::SwapProof> for SwapProof {}
+impl Protobuf for SwapProof {
+    type Proto = transparent_proofs::SwapProof;
+}
 
 impl From<SwapProof> for transparent_proofs::SwapProof {
     fn from(msg: SwapProof) -> Self {
@@ -581,7 +589,9 @@ impl UndelegateClaimProof {
     }
 }
 
-impl Protobuf<transparent_proofs::UndelegateClaimProof> for UndelegateClaimProof {}
+impl Protobuf for UndelegateClaimProof {
+    type Proto = transparent_proofs::UndelegateClaimProof;
+}
 
 impl From<UndelegateClaimProof> for transparent_proofs::UndelegateClaimProof {
     fn from(claim_proof: UndelegateClaimProof) -> Self {

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -6,7 +6,9 @@ use std::convert::{TryFrom, TryInto};
 
 use decaf377::FieldExt;
 use decaf377_rdsa::{SpendAuth, VerificationKey};
-use penumbra_proto::{core::transparent_proofs::v1alpha1 as transparent_proofs, Message, Protobuf};
+use penumbra_proto::{
+    core::transparent_proofs::v1alpha1 as transparent_proofs, DomainType, Message,
+};
 use penumbra_tct as tct;
 
 use super::transparent_gadgets as gadgets;
@@ -134,7 +136,7 @@ impl OutputProof {
 
 // Conversions
 
-impl Protobuf for SpendProof {
+impl DomainType for SpendProof {
     type Proto = transparent_proofs::SpendProof;
 }
 
@@ -199,7 +201,7 @@ impl TryFrom<transparent_proofs::SpendProof> for SpendProof {
     }
 }
 
-impl Protobuf for OutputProof {
+impl DomainType for OutputProof {
     type Proto = transparent_proofs::OutputProof;
 }
 
@@ -404,7 +406,7 @@ impl TryFrom<&[u8]> for SwapClaimProof {
     }
 }
 
-impl Protobuf for SwapClaimProof {
+impl DomainType for SwapClaimProof {
     type Proto = transparent_proofs::SwapClaimProof;
 }
 
@@ -504,7 +506,7 @@ impl SwapProof {
     }
 }
 
-impl Protobuf for SwapProof {
+impl DomainType for SwapProof {
     type Proto = transparent_proofs::SwapProof;
 }
 
@@ -589,7 +591,7 @@ impl UndelegateClaimProof {
     }
 }
 
-impl Protobuf for UndelegateClaimProof {
+impl DomainType for UndelegateClaimProof {
     type Proto = transparent_proofs::UndelegateClaimProof;
 }
 

--- a/crypto/src/stake/identity_key.rs
+++ b/crypto/src/stake/identity_key.rs
@@ -47,7 +47,9 @@ impl std::fmt::Debug for IdentityKey {
     }
 }
 
-impl Protobuf<pb::IdentityKey> for IdentityKey {}
+impl Protobuf for IdentityKey {
+    type Proto = pb::IdentityKey;
+}
 
 impl From<IdentityKey> for pb::IdentityKey {
     fn from(ik: IdentityKey) -> Self {

--- a/crypto/src/stake/identity_key.rs
+++ b/crypto/src/stake/identity_key.rs
@@ -2,7 +2,7 @@ use penumbra_proto::{
     client::v1alpha1::NextValidatorRateRequest,
     core::crypto::v1alpha1 as pb,
     serializers::bech32str::{self, validator_identity_key::BECH32_PREFIX},
-    Protobuf,
+    DomainType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -47,7 +47,7 @@ impl std::fmt::Debug for IdentityKey {
     }
 }
 
-impl Protobuf for IdentityKey {
+impl DomainType for IdentityKey {
     type Proto = pb::IdentityKey;
 }
 

--- a/crypto/src/stake/penalty.rs
+++ b/crypto/src/stake/penalty.rs
@@ -79,7 +79,9 @@ impl std::fmt::Display for Penalty {
     }
 }
 
-impl Protobuf<pbs::Penalty> for Penalty {}
+impl Protobuf for Penalty {
+    type Proto = pbs::Penalty;
+}
 
 impl From<Penalty> for pbs::Penalty {
     fn from(v: Penalty) -> Self {

--- a/crypto/src/stake/penalty.rs
+++ b/crypto/src/stake/penalty.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use penumbra_proto::{core::stake::v1alpha1 as pbs, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pbs, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::{asset, Amount, Balance, Value, STAKING_TOKEN_ASSET_ID};
@@ -79,7 +79,7 @@ impl std::fmt::Display for Penalty {
     }
 }
 
-impl Protobuf for Penalty {
+impl DomainType for Penalty {
     type Proto = pbs::Penalty;
 }
 

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -40,7 +40,9 @@ impl Fee {
     }
 }
 
-impl Protobuf<pb::Fee> for Fee {}
+impl Protobuf for Fee {
+    type Proto = pb::Fee;
+}
 
 impl From<Fee> for pb::Fee {
     fn from(fee: Fee) -> Self {

--- a/crypto/src/transaction.rs
+++ b/crypto/src/transaction.rs
@@ -1,4 +1,4 @@
-use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType};
 
 use crate::{asset, balance, Balance, Fr, Value, STAKING_TOKEN_ASSET_ID};
 
@@ -40,7 +40,7 @@ impl Fee {
     }
 }
 
-impl Protobuf for Fee {
+impl DomainType for Fee {
     type Proto = pb::Fee;
 }
 

--- a/custody/src/pre_auth.rs
+++ b/custody/src/pre_auth.rs
@@ -34,7 +34,9 @@ impl Ed25519 {
     }
 }
 
-impl Protobuf<pb::PreAuthorization> for PreAuthorization {}
+impl Protobuf for PreAuthorization {
+    type Proto = pb::PreAuthorization;
+}
 
 impl TryFrom<pb::PreAuthorization> for PreAuthorization {
     type Error = anyhow::Error;
@@ -62,7 +64,9 @@ impl From<PreAuthorization> for pb::PreAuthorization {
     }
 }
 
-impl Protobuf<pb::pre_authorization::Ed25519> for Ed25519 {}
+impl Protobuf for Ed25519 {
+    type Proto = pb::pre_authorization::Ed25519;
+}
 
 impl TryFrom<pb::pre_authorization::Ed25519> for Ed25519 {
     type Error = anyhow::Error;

--- a/custody/src/pre_auth.rs
+++ b/custody/src/pre_auth.rs
@@ -1,4 +1,4 @@
-use penumbra_proto::{custody::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{custody::v1alpha1 as pb, DomainType};
 use penumbra_transaction::plan::TransactionPlan;
 use serde::{Deserialize, Serialize};
 
@@ -34,7 +34,7 @@ impl Ed25519 {
     }
 }
 
-impl Protobuf for PreAuthorization {
+impl DomainType for PreAuthorization {
     type Proto = pb::PreAuthorization;
 }
 
@@ -64,7 +64,7 @@ impl From<PreAuthorization> for pb::PreAuthorization {
     }
 }
 
-impl Protobuf for Ed25519 {
+impl DomainType for Ed25519 {
     type Proto = pb::pre_authorization::Ed25519;
 }
 

--- a/custody/src/request.rs
+++ b/custody/src/request.rs
@@ -15,7 +15,9 @@ pub struct AuthorizeRequest {
     pub pre_authorizations: Vec<PreAuthorization>,
 }
 
-impl Protobuf<pb::AuthorizeRequest> for AuthorizeRequest {}
+impl Protobuf for AuthorizeRequest {
+    type Proto = pb::AuthorizeRequest;
+}
 
 impl TryFrom<pb::AuthorizeRequest> for AuthorizeRequest {
     type Error = anyhow::Error;

--- a/custody/src/request.rs
+++ b/custody/src/request.rs
@@ -1,5 +1,5 @@
 use penumbra_crypto::keys::AccountID;
-use penumbra_proto::{custody::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{custody::v1alpha1 as pb, DomainType};
 use penumbra_transaction::plan::TransactionPlan;
 
 use crate::PreAuthorization;
@@ -15,7 +15,7 @@ pub struct AuthorizeRequest {
     pub pre_authorizations: Vec<PreAuthorization>,
 }
 
-impl Protobuf for AuthorizeRequest {
+impl DomainType for AuthorizeRequest {
     type Proto = pb::AuthorizeRequest;
 }
 

--- a/pcli/src/command/query/governance.rs
+++ b/pcli/src/command/query/governance.rs
@@ -129,7 +129,7 @@ impl GovernanceCmd {
                 ValidatorVotes => {
                     let mut votes: BTreeMap<IdentityKey, Vote> = BTreeMap::new();
                     client
-                        .prefix_domain::<Vote, _>(voting_validators_list(*proposal_id))
+                        .prefix_domain::<Vote>(voting_validators_list(*proposal_id))
                         .await?
                         .next()
                         .await

--- a/pcli/src/command/query/shielded_pool.rs
+++ b/pcli/src/command/query/shielded_pool.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use colored_json::prelude::*;
 use penumbra_chain::{CompactBlock, NoteSource};
 use penumbra_crypto::Nullifier;
-use penumbra_proto::Protobuf;
+use penumbra_proto::DomainType;
 use penumbra_tct::Commitment;
 
 #[derive(Debug, clap::Subcommand)]

--- a/pcli/src/command/query/tx.rs
+++ b/pcli/src/command/query/tx.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use colored_json::prelude::*;
-use penumbra_proto::{client::v1alpha1::GetTxRequest, Protobuf};
+use penumbra_proto::{client::v1alpha1::GetTxRequest, DomainType};
 use penumbra_transaction::Transaction;
 
 use crate::App;

--- a/pcli/src/command/validator.rs
+++ b/pcli/src/command/validator.rs
@@ -10,7 +10,7 @@ use penumbra_component::stake::{
     FundingStream, FundingStreams,
 };
 use penumbra_crypto::{stake::IdentityKey, transaction::Fee, GovernanceKey};
-use penumbra_proto::{core::stake::v1alpha1::Validator as ProtoValidator, Message, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1::Validator as ProtoValidator, DomainType, Message};
 use penumbra_transaction::action::{ValidatorVote, ValidatorVoteBody, Vote};
 use penumbra_wallet::plan;
 use rand_core::OsRng;

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -8,7 +8,7 @@ use penumbra_proto::{
         tendermint_proxy_service_client::TendermintProxyServiceClient, BroadcastTxAsyncRequest,
         BroadcastTxSyncRequest,
     },
-    Protobuf,
+    DomainType,
 };
 use penumbra_transaction::{plan::TransactionPlan, Transaction};
 use penumbra_view::ViewClient;

--- a/pd/src/info/oblivious.rs
+++ b/pd/src/info/oblivious.rs
@@ -18,7 +18,7 @@ use penumbra_proto::{
         CompactBlockRangeResponse, MutableParametersRequest, MutableParametersResponse,
         ValidatorInfoRequest, ValidatorInfoResponse,
     },
-    Protobuf,
+    DomainType,
 };
 use tokio::sync::mpsc;
 use tonic::Status;

--- a/pd/src/tendermint_proxy.rs
+++ b/pd/src/tendermint_proxy.rs
@@ -17,7 +17,7 @@ use proto::client::v1alpha1::GetStatusRequest;
 use proto::client::v1alpha1::GetStatusResponse;
 use proto::client::v1alpha1::GetTxRequest;
 use proto::client::v1alpha1::GetTxResponse;
-use proto::Protobuf;
+use proto::DomainType;
 use tendermint::block::Height;
 use tendermint_rpc::abci;
 use tendermint_rpc::abci::Path;

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -12,7 +12,7 @@
 //! └───────┘  format  └──────────────┘   boundary    └──────────────┘
 //! ```
 //!
-//! The [`Protobuf`] marker trait can be implemented on a domain type to ensure
+//! The [`DomainType`] marker trait can be implemented on a domain type to ensure
 //! these conversions exist.
 
 // The autogen code is not clippy-clean, so we disable some clippy warnings for this crate.
@@ -24,7 +24,7 @@ pub use prost::Message;
 pub mod serializers;
 
 mod protobuf;
-pub use protobuf::Protobuf;
+pub use protobuf::DomainType;
 
 #[cfg(feature = "penumbra-storage")]
 mod state;
@@ -161,7 +161,7 @@ pub mod penumbra {
                 /// Get the typed domain value corresponding to a state key.
                 pub async fn key_domain<T>(&mut self, key: impl AsRef<str>) -> anyhow::Result<T>
                 where
-                    T: crate::Protobuf,
+                    T: crate::DomainType,
                     <T as TryFrom<T::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
                     C: tonic::client::GrpcService<BoxBody> + 'static,
                     C::ResponseBody: Send,
@@ -188,7 +188,7 @@ pub mod penumbra {
                     Pin<Box<dyn Stream<Item = anyhow::Result<(String, T)>> + Send + 'static>>,
                 >
                 where
-                    T: crate::Protobuf + Send + 'static + Unpin,
+                    T: crate::DomainType + Send + 'static + Unpin,
                     <T as TryFrom<T::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
                     C: tonic::client::GrpcService<BoxBody> + 'static,
                     C::ResponseBody: Send,

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -159,11 +159,10 @@ pub mod penumbra {
                 }
 
                 /// Get the typed domain value corresponding to a state key.
-                pub async fn key_domain<T, P>(&mut self, key: impl AsRef<str>) -> anyhow::Result<T>
+                pub async fn key_domain<T>(&mut self, key: impl AsRef<str>) -> anyhow::Result<T>
                 where
-                    T: crate::Protobuf<P> + TryFrom<P>,
-                    T::Error: Into<anyhow::Error> + Send + Sync + 'static,
-                    P: prost::Message + Default + From<T>,
+                    T: crate::Protobuf,
+                    <T as TryFrom<T::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
                     C: tonic::client::GrpcService<BoxBody> + 'static,
                     C::ResponseBody: Send,
                     <C as tonic::client::GrpcService<BoxBody>>::ResponseBody:
@@ -182,16 +181,15 @@ pub mod penumbra {
                 }
 
                 /// Get the typed domain value corresponding to prefixes of a state key.
-                pub async fn prefix_domain<T, P>(
+                pub async fn prefix_domain<T>(
                     &mut self,
                     prefix: impl AsRef<str>,
                 ) -> anyhow::Result<
                     Pin<Box<dyn Stream<Item = anyhow::Result<(String, T)>> + Send + 'static>>,
                 >
                 where
-                    T: crate::Protobuf<P> + TryFrom<P> + Send + Sync + 'static + Unpin,
-                    T::Error: Into<anyhow::Error> + Send + Sync + 'static,
-                    P: prost::Message + Default + From<T>,
+                    T: crate::Protobuf + Send + 'static + Unpin,
+                    <T as TryFrom<T::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
                     C: tonic::client::GrpcService<BoxBody> + 'static,
                     C::ResponseBody: Send,
                     <C as tonic::client::GrpcService<BoxBody>>::ResponseBody:

--- a/proto/src/protobuf.rs
+++ b/proto/src/protobuf.rs
@@ -1,7 +1,7 @@
 use std::convert::{From, TryFrom};
 
 /// A marker type that captures the relationships between a domain type (`Self`) and a protobuf type (`Self::Proto`).
-pub trait Protobuf
+pub trait DomainType
 where
     Self: Clone + Sized + TryFrom<Self::Proto>,
     Self::Proto: prost::Message + Default + From<Self> + Send + Sync + 'static,
@@ -41,13 +41,13 @@ use crate::core::ibc::v1alpha1::IbcAction;
 use decaf377_rdsa::{Binding, Signature, SpendAuth, VerificationKey};
 use ibc_rs::clients::ics07_tendermint;
 
-impl Protobuf for Signature<SpendAuth> {
+impl DomainType for Signature<SpendAuth> {
     type Proto = SpendAuthSignature;
 }
-impl Protobuf for Signature<Binding> {
+impl DomainType for Signature<Binding> {
     type Proto = BindingSignature;
 }
-impl Protobuf for VerificationKey<SpendAuth> {
+impl DomainType for VerificationKey<SpendAuth> {
     type Proto = SpendVerificationKey;
 }
 
@@ -100,7 +100,7 @@ impl TryFrom<SpendVerificationKey> for VerificationKey<SpendAuth> {
 use crate::core::crypto::v1alpha1::Clue as ProtoClue;
 use decaf377_fmd::Clue;
 
-impl Protobuf for Clue {
+impl DomainType for Clue {
     type Proto = ProtoClue;
 }
 
@@ -130,7 +130,7 @@ impl TryFrom<ProtoClue> for Clue {
 // this redefines its proto, because the encodings are consensus-critical
 // and we don't vendor all of the tendermint protos.
 
-impl Protobuf for tendermint::PublicKey {
+impl DomainType for tendermint::PublicKey {
     type Proto = crate::core::crypto::v1alpha1::ConsensusKey;
 }
 
@@ -150,7 +150,7 @@ impl TryFrom<crate::core::crypto::v1alpha1::ConsensusKey> for tendermint::Public
     }
 }
 
-impl Protobuf for num_rational::Ratio<u64> {
+impl DomainType for num_rational::Ratio<u64> {
     type Proto = crate::core::chain::v1alpha1::Ratio;
 }
 
@@ -182,21 +182,21 @@ use ibc_rs::core::ics03_connection::connection::ConnectionEnd;
 use ibc_rs::core::ics04_channel::channel::ChannelEnd;
 use ibc_rs::Height;
 
-impl Protobuf for ConnectionEnd {
+impl DomainType for ConnectionEnd {
     type Proto = RawConnectionEnd;
 }
-impl Protobuf for ChannelEnd {
+impl DomainType for ChannelEnd {
     type Proto = RawChannel;
 }
-impl Protobuf for Height {
+impl DomainType for Height {
     type Proto = RawHeight;
 }
 
 // TODO(erwan): create ticket to switch to a trait object based approach
-impl Protobuf for ics07_tendermint::client_state::ClientState {
+impl DomainType for ics07_tendermint::client_state::ClientState {
     type Proto = Any;
 }
-impl Protobuf for ics07_tendermint::consensus_state::ConsensusState {
+impl DomainType for ics07_tendermint::consensus_state::ConsensusState {
     type Proto = Any;
 }
 

--- a/proto/src/state/read.rs
+++ b/proto/src/state/read.rs
@@ -1,4 +1,4 @@
-use crate::{Message, Protobuf};
+use crate::{DomainType, Message};
 
 use anyhow::Result;
 use std::fmt::Debug;
@@ -19,7 +19,7 @@ pub trait StateReadProto: StateRead + Send + Sync {
     /// * `Err(_)` if the value is present but not parseable as a domain type `D`, or if an underlying storage error occurred.
     async fn get<D>(&self, key: &str) -> Result<Option<D>>
     where
-        D: Protobuf + std::fmt::Debug,
+        D: DomainType + std::fmt::Debug,
         <D as TryFrom<D::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
     {
         match self.get_proto(key).await {
@@ -66,7 +66,7 @@ pub trait StateReadProto: StateRead + Send + Sync {
         prefix: &'a str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, D)>> + Send + 'a>>
     where
-        D: Protobuf,
+        D: DomainType,
         <D as TryFrom<D::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
     {
         Box::pin(self.prefix_proto(prefix).map(|p| match p {

--- a/proto/src/state/write.rs
+++ b/proto/src/state/write.rs
@@ -1,4 +1,4 @@
-use crate::{Message, Protobuf};
+use crate::{DomainType, Message};
 
 use std::fmt::Debug;
 
@@ -8,7 +8,7 @@ pub trait StateWriteProto: StateWrite + Send + Sync {
     /// Puts a domain type into the verifiable key-value store with the given key.
     fn put<D>(&mut self, key: String, value: D)
     where
-        D: Protobuf,
+        D: DomainType,
         <D as TryFrom<D::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
     {
         self.put_proto(key, D::Proto::from(value));

--- a/proto/src/state/write.rs
+++ b/proto/src/state/write.rs
@@ -6,16 +6,12 @@ use penumbra_storage::StateWrite;
 
 pub trait StateWriteProto: StateWrite + Send + Sync {
     /// Puts a domain type into the verifiable key-value store with the given key.
-    fn put<D, P>(&mut self, key: String, value: D)
+    fn put<D>(&mut self, key: String, value: D)
     where
-        D: Protobuf<P>,
-        // TODO: does this get less awful if P is an associated type of D?
-        P: Message + Default,
-        P: From<D>,
-        D: TryFrom<P> + Clone + Debug,
-        <D as TryFrom<P>>::Error: Into<anyhow::Error>,
+        D: Protobuf,
+        <D as TryFrom<D::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
     {
-        self.put_proto(key, P::from(value));
+        self.put_proto(key, D::Proto::from(value));
     }
 
     /// Puts a proto type into the verifiable key-value store with the given key.

--- a/tct/src/block.rs
+++ b/tct/src/block.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use decaf377::{FieldExt, Fq};
 use hash_hasher::HashedMap;
-use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::error::block::*;
@@ -112,7 +112,7 @@ impl From<Root> for pb::MerkleRoot {
     }
 }
 
-impl Protobuf for Root {
+impl DomainType for Root {
     type Proto = pb::MerkleRoot;
 }
 

--- a/tct/src/block.rs
+++ b/tct/src/block.rs
@@ -112,7 +112,9 @@ impl From<Root> for pb::MerkleRoot {
     }
 }
 
-impl Protobuf<pb::MerkleRoot> for Root {}
+impl Protobuf for Root {
+    type Proto = pb::MerkleRoot;
+}
 
 impl Display for Root {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/tct/src/commitment.rs
+++ b/tct/src/commitment.rs
@@ -26,7 +26,9 @@ impl Commitment {
     }
 }
 
-impl Protobuf<pb::StateCommitment> for Commitment {}
+impl Protobuf for Commitment {
+    type Proto = pb::StateCommitment;
+}
 
 #[cfg(test)]
 mod test_serde {

--- a/tct/src/commitment.rs
+++ b/tct/src/commitment.rs
@@ -1,5 +1,5 @@
 use decaf377::FieldExt;
-use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType};
 use poseidon377::Fq;
 
 /// A commitment to a note or swap.
@@ -26,7 +26,7 @@ impl Commitment {
     }
 }
 
-impl Protobuf for Commitment {
+impl DomainType for Commitment {
     type Proto = pb::StateCommitment;
 }
 

--- a/tct/src/epoch.rs
+++ b/tct/src/epoch.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use decaf377::{FieldExt, Fq};
 use hash_hasher::HashedMap;
-use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::error::epoch::*;
@@ -115,7 +115,7 @@ impl From<Root> for pb::MerkleRoot {
     }
 }
 
-impl Protobuf for Root {
+impl DomainType for Root {
     type Proto = pb::MerkleRoot;
 }
 

--- a/tct/src/epoch.rs
+++ b/tct/src/epoch.rs
@@ -115,7 +115,9 @@ impl From<Root> for pb::MerkleRoot {
     }
 }
 
-impl Protobuf<pb::MerkleRoot> for Root {}
+impl Protobuf for Root {
+    type Proto = pb::MerkleRoot;
+}
 
 impl Display for Root {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/tct/src/proof.rs
+++ b/tct/src/proof.rs
@@ -130,6 +130,6 @@ impl TryFrom<pb::NoteCommitmentProof> for Proof {
     }
 }
 
-impl penumbra_proto::Protobuf for Proof {
+impl penumbra_proto::DomainType for Proof {
     type Proto = pb::NoteCommitmentProof;
 }

--- a/tct/src/proof.rs
+++ b/tct/src/proof.rs
@@ -130,4 +130,6 @@ impl TryFrom<pb::NoteCommitmentProof> for Proof {
     }
 }
 
-impl penumbra_proto::Protobuf<pb::NoteCommitmentProof> for Proof {}
+impl penumbra_proto::Protobuf for Proof {
+    type Proto = pb::NoteCommitmentProof;
+}

--- a/tct/src/tree.rs
+++ b/tct/src/tree.rs
@@ -83,7 +83,9 @@ impl From<Root> for pb::MerkleRoot {
     }
 }
 
-impl Protobuf<pb::MerkleRoot> for Root {}
+impl Protobuf for Root {
+    type Proto = pb::MerkleRoot;
+}
 
 impl Display for Root {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/tct/src/tree.rs
+++ b/tct/src/tree.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use decaf377::{FieldExt, Fq};
-use penumbra_proto::{core::crypto::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType};
 
 use crate::error::*;
 use crate::prelude::{Witness as _, *};
@@ -83,7 +83,7 @@ impl From<Root> for pb::MerkleRoot {
     }
 }
 
-impl Protobuf for Root {
+impl DomainType for Root {
     type Proto = pb::MerkleRoot;
 }
 

--- a/transaction/src/action.rs
+++ b/transaction/src/action.rs
@@ -120,7 +120,9 @@ impl IsAction for Action {
     }
 }
 
-impl Protobuf<pb::Action> for Action {}
+impl Protobuf for Action {
+    type Proto = pb::Action;
+}
 
 impl From<Action> for pb::Action {
     fn from(msg: Action) -> Self {

--- a/transaction/src/action.rs
+++ b/transaction/src/action.rs
@@ -3,7 +3,7 @@ use std::convert::{TryFrom, TryInto};
 use penumbra_crypto::balance;
 use penumbra_proto::{
     core::ibc::v1alpha1 as pb_ibc, core::stake::v1alpha1 as pbs, core::transaction::v1alpha1 as pb,
-    Protobuf,
+    DomainType,
 };
 
 mod delegate;
@@ -120,7 +120,7 @@ impl IsAction for Action {
     }
 }
 
-impl Protobuf for Action {
+impl DomainType for Action {
     type Proto = pb::Action;
 }
 

--- a/transaction/src/action/delegate.rs
+++ b/transaction/src/action/delegate.rs
@@ -60,7 +60,9 @@ impl Delegate {
     }
 }
 
-impl Protobuf<pb::Delegate> for Delegate {}
+impl Protobuf for Delegate {
+    type Proto = pb::Delegate;
+}
 
 impl From<Delegate> for pb::Delegate {
     fn from(d: Delegate) -> Self {

--- a/transaction/src/action/delegate.rs
+++ b/transaction/src/action/delegate.rs
@@ -4,7 +4,7 @@ use penumbra_crypto::{
     stake::{DelegationToken, IdentityKey},
     Balance, Fr, Value, STAKING_TOKEN_ASSET_ID,
 };
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::{ActionView, TransactionPerspective};
@@ -60,7 +60,7 @@ impl Delegate {
     }
 }
 
-impl Protobuf for Delegate {
+impl DomainType for Delegate {
     type Proto = pb::Delegate;
 }
 

--- a/transaction/src/action/ibc.rs
+++ b/transaction/src/action/ibc.rs
@@ -88,7 +88,9 @@ impl Ics20Withdrawal {
     }
 }
 
-impl Protobuf<pb::Ics20Withdrawal> for Ics20Withdrawal {}
+impl Protobuf for Ics20Withdrawal {
+    type Proto = pb::Ics20Withdrawal;
+}
 
 impl From<Ics20Withdrawal> for pb::Ics20Withdrawal {
     fn from(w: Ics20Withdrawal) -> Self {

--- a/transaction/src/action/ibc.rs
+++ b/transaction/src/action/ibc.rs
@@ -3,7 +3,7 @@ use ibc::core::ics24_host::identifier::{ChannelId, PortId};
 use penumbra_crypto::{asset, value, Address, Amount, Balance, Fr};
 use penumbra_proto::{
     core::ibc::v1alpha1::{self as pb, FungibleTokenPacketData},
-    Message, Protobuf,
+    DomainType, Message,
 };
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -88,7 +88,7 @@ impl Ics20Withdrawal {
     }
 }
 
-impl Protobuf for Ics20Withdrawal {
+impl DomainType for Ics20Withdrawal {
     type Proto = pb::Ics20Withdrawal;
 }
 

--- a/transaction/src/action/output.rs
+++ b/transaction/src/action/output.rs
@@ -8,7 +8,7 @@ use penumbra_crypto::{
     symmetric::{OvkWrappedKey, WrappedMemoKey},
     EncryptedNote, Note,
 };
-use penumbra_proto::{core::transaction::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::transaction::v1alpha1 as pb, DomainType};
 
 use crate::{view::action_view::OutputView, ActionView, TransactionPerspective};
 
@@ -72,7 +72,7 @@ pub struct Body {
     pub wrapped_memo_key: WrappedMemoKey,
 }
 
-impl Protobuf for Output {
+impl DomainType for Output {
     type Proto = pb::Output;
 }
 
@@ -102,7 +102,7 @@ impl TryFrom<pb::Output> for Output {
     }
 }
 
-impl Protobuf for Body {
+impl DomainType for Body {
     type Proto = pb::OutputBody;
 }
 

--- a/transaction/src/action/output.rs
+++ b/transaction/src/action/output.rs
@@ -72,7 +72,9 @@ pub struct Body {
     pub wrapped_memo_key: WrappedMemoKey,
 }
 
-impl Protobuf<pb::Output> for Output {}
+impl Protobuf for Output {
+    type Proto = pb::Output;
+}
 
 impl From<Output> for pb::Output {
     fn from(output: Output) -> Self {
@@ -100,7 +102,9 @@ impl TryFrom<pb::Output> for Output {
     }
 }
 
-impl Protobuf<pb::OutputBody> for Body {}
+impl Protobuf for Body {
+    type Proto = pb::OutputBody;
+}
 
 impl From<Body> for pb::OutputBody {
     fn from(output: Body) -> Self {

--- a/transaction/src/action/position.rs
+++ b/transaction/src/action/position.rs
@@ -173,7 +173,9 @@ impl IsAction for PositionRewardClaim {
     }
 }
 
-impl Protobuf<pb::PositionOpen> for PositionOpen {}
+impl Protobuf for PositionOpen {
+    type Proto = pb::PositionOpen;
+}
 
 impl From<PositionOpen> for pb::PositionOpen {
     fn from(value: PositionOpen) -> Self {
@@ -201,7 +203,9 @@ impl TryFrom<pb::PositionOpen> for PositionOpen {
     }
 }
 
-impl Protobuf<pb::PositionClose> for PositionClose {}
+impl Protobuf for PositionClose {
+    type Proto = pb::PositionClose;
+}
 
 impl From<PositionClose> for pb::PositionClose {
     fn from(value: PositionClose) -> Self {
@@ -224,7 +228,9 @@ impl TryFrom<pb::PositionClose> for PositionClose {
     }
 }
 
-impl Protobuf<pb::PositionWithdraw> for PositionWithdraw {}
+impl Protobuf for PositionWithdraw {
+    type Proto = pb::PositionWithdraw;
+}
 
 impl From<PositionWithdraw> for pb::PositionWithdraw {
     fn from(value: PositionWithdraw) -> Self {
@@ -252,7 +258,9 @@ impl TryFrom<pb::PositionWithdraw> for PositionWithdraw {
     }
 }
 
-impl Protobuf<pb::PositionRewardClaim> for PositionRewardClaim {}
+impl Protobuf for PositionRewardClaim {
+    type Proto = pb::PositionRewardClaim;
+}
 
 impl From<PositionRewardClaim> for pb::PositionRewardClaim {
     fn from(value: PositionRewardClaim) -> Self {

--- a/transaction/src/action/position.rs
+++ b/transaction/src/action/position.rs
@@ -8,7 +8,7 @@ use penumbra_crypto::{
     },
     Balance, Fr, Value, Zero,
 };
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType};
 
 use crate::{ActionView, TransactionPerspective};
 
@@ -173,7 +173,7 @@ impl IsAction for PositionRewardClaim {
     }
 }
 
-impl Protobuf for PositionOpen {
+impl DomainType for PositionOpen {
     type Proto = pb::PositionOpen;
 }
 
@@ -203,7 +203,7 @@ impl TryFrom<pb::PositionOpen> for PositionOpen {
     }
 }
 
-impl Protobuf for PositionClose {
+impl DomainType for PositionClose {
     type Proto = pb::PositionClose;
 }
 
@@ -228,7 +228,7 @@ impl TryFrom<pb::PositionClose> for PositionClose {
     }
 }
 
-impl Protobuf for PositionWithdraw {
+impl DomainType for PositionWithdraw {
     type Proto = pb::PositionWithdraw;
 }
 
@@ -258,7 +258,7 @@ impl TryFrom<pb::PositionWithdraw> for PositionWithdraw {
     }
 }
 
-impl Protobuf for PositionRewardClaim {
+impl DomainType for PositionRewardClaim {
     type Proto = pb::PositionRewardClaim;
 }
 

--- a/transaction/src/action/proposal.rs
+++ b/transaction/src/action/proposal.rs
@@ -154,7 +154,9 @@ impl TryFrom<pb::Proposal> for Proposal {
     }
 }
 
-impl Protobuf<pb::Proposal> for Proposal {}
+impl Protobuf for Proposal {
+    type Proto = pb::Proposal;
+}
 
 /// The specific kind of a proposal.
 #[derive(Debug, Clone)]
@@ -358,7 +360,9 @@ impl TryFrom<pb::ProposalSubmit> for ProposalSubmit {
     }
 }
 
-impl Protobuf<pb::ProposalSubmit> for ProposalSubmit {}
+impl Protobuf for ProposalSubmit {
+    type Proto = pb::ProposalSubmit;
+}
 
 impl IsAction for ProposalWithdraw {
     fn balance_commitment(&self) -> penumbra_crypto::balance::Commitment {
@@ -417,7 +421,9 @@ impl TryFrom<pb::ProposalWithdraw> for ProposalWithdraw {
     }
 }
 
-impl Protobuf<pb::ProposalWithdraw> for ProposalWithdraw {}
+impl Protobuf for ProposalWithdraw {
+    type Proto = pb::ProposalWithdraw;
+}
 
 /// A claim for the initial submission deposit for a proposal.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -564,7 +570,9 @@ impl State {
     }
 }
 
-impl Protobuf<pb::ProposalState> for State {}
+impl Protobuf for State {
+    type Proto = pb::ProposalState;
+}
 
 impl From<State> for pb::ProposalState {
     fn from(s: State) -> Self {
@@ -731,7 +739,9 @@ impl TryFrom<Withdrawn<String>> for Withdrawn<()> {
     }
 }
 
-impl Protobuf<pb::ProposalOutcome> for Outcome<String> {}
+impl Protobuf for Outcome<String> {
+    type Proto = pb::ProposalOutcome;
+}
 
 impl From<Outcome<String>> for pb::ProposalOutcome {
     fn from(o: Outcome<String>) -> Self {
@@ -783,7 +793,9 @@ impl TryFrom<pb::ProposalOutcome> for Outcome<String> {
     }
 }
 
-impl Protobuf<pb::ProposalOutcome> for Outcome<()> {}
+impl Protobuf for Outcome<()> {
+    type Proto = pb::ProposalOutcome;
+}
 
 impl From<Outcome<()>> for pb::ProposalOutcome {
     fn from(o: Outcome<()>) -> Self {

--- a/transaction/src/action/proposal.rs
+++ b/transaction/src/action/proposal.rs
@@ -6,7 +6,7 @@ use penumbra_crypto::{
     asset::{self, Amount, Denom},
     balance, Balance, Fr, ProposalNft, Value, STAKING_TOKEN_ASSET_ID,
 };
-use penumbra_proto::{core::governance::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType};
 
 use crate::{plan::TransactionPlan, ActionView, EffectHash, IsAction, TransactionPerspective};
 
@@ -154,7 +154,7 @@ impl TryFrom<pb::Proposal> for Proposal {
     }
 }
 
-impl Protobuf for Proposal {
+impl DomainType for Proposal {
     type Proto = pb::Proposal;
 }
 
@@ -360,7 +360,7 @@ impl TryFrom<pb::ProposalSubmit> for ProposalSubmit {
     }
 }
 
-impl Protobuf for ProposalSubmit {
+impl DomainType for ProposalSubmit {
     type Proto = pb::ProposalSubmit;
 }
 
@@ -421,7 +421,7 @@ impl TryFrom<pb::ProposalWithdraw> for ProposalWithdraw {
     }
 }
 
-impl Protobuf for ProposalWithdraw {
+impl DomainType for ProposalWithdraw {
     type Proto = pb::ProposalWithdraw;
 }
 
@@ -570,7 +570,7 @@ impl State {
     }
 }
 
-impl Protobuf for State {
+impl DomainType for State {
     type Proto = pb::ProposalState;
 }
 
@@ -739,7 +739,7 @@ impl TryFrom<Withdrawn<String>> for Withdrawn<()> {
     }
 }
 
-impl Protobuf for Outcome<String> {
+impl DomainType for Outcome<String> {
     type Proto = pb::ProposalOutcome;
 }
 
@@ -793,7 +793,7 @@ impl TryFrom<pb::ProposalOutcome> for Outcome<String> {
     }
 }
 
-impl Protobuf for Outcome<()> {
+impl DomainType for Outcome<()> {
     type Proto = pb::ProposalOutcome;
 }
 

--- a/transaction/src/action/spend.rs
+++ b/transaction/src/action/spend.rs
@@ -41,7 +41,9 @@ impl IsAction for Spend {
     }
 }
 
-impl Protobuf<transaction::Spend> for Spend {}
+impl Protobuf for Spend {
+    type Proto = transaction::Spend;
+}
 
 impl From<Spend> for transaction::Spend {
     fn from(msg: Spend) -> Self {
@@ -88,7 +90,9 @@ pub struct Body {
     pub rk: VerificationKey<SpendAuth>,
 }
 
-impl Protobuf<transaction::SpendBody> for Body {}
+impl Protobuf for Body {
+    type Proto = transaction::SpendBody;
+}
 
 impl From<Body> for transaction::SpendBody {
     fn from(msg: Body) -> Self {

--- a/transaction/src/action/spend.rs
+++ b/transaction/src/action/spend.rs
@@ -8,7 +8,7 @@ use penumbra_crypto::{
     rdsa::{Signature, SpendAuth, VerificationKey},
     Nullifier,
 };
-use penumbra_proto::{core::transaction::v1alpha1 as transaction, Protobuf};
+use penumbra_proto::{core::transaction::v1alpha1 as transaction, DomainType};
 
 use crate::{view::action_view::SpendView, ActionView, TransactionPerspective};
 
@@ -41,7 +41,7 @@ impl IsAction for Spend {
     }
 }
 
-impl Protobuf for Spend {
+impl DomainType for Spend {
     type Proto = transaction::Spend;
 }
 
@@ -90,7 +90,7 @@ pub struct Body {
     pub rk: VerificationKey<SpendAuth>,
 }
 
-impl Protobuf for Body {
+impl DomainType for Body {
     type Proto = transaction::SpendBody;
 }
 

--- a/transaction/src/action/swap.rs
+++ b/transaction/src/action/swap.rs
@@ -59,7 +59,9 @@ impl IsAction for Swap {
     }
 }
 
-impl Protobuf<pb::Swap> for Swap {}
+impl Protobuf for Swap {
+    type Proto = pb::Swap;
+}
 
 impl From<Swap> for pb::Swap {
     fn from(s: Swap) -> Self {
@@ -93,7 +95,9 @@ pub struct Body {
     pub payload: SwapPayload,
 }
 
-impl Protobuf<pb::SwapBody> for Body {}
+impl Protobuf for Body {
+    type Proto = pb::SwapBody;
+}
 
 impl From<Body> for pb::SwapBody {
     fn from(s: Body) -> Self {

--- a/transaction/src/action/swap.rs
+++ b/transaction/src/action/swap.rs
@@ -7,7 +7,7 @@ use penumbra_crypto::dex::TradingPair;
 use penumbra_crypto::proofs::transparent::SwapProof;
 use penumbra_crypto::Value;
 use penumbra_crypto::{balance, dex::swap::SwapCiphertext, Balance};
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType};
 
 use crate::view::action_view::SwapView;
 use crate::{ActionView, IsAction, TransactionPerspective};
@@ -59,7 +59,7 @@ impl IsAction for Swap {
     }
 }
 
-impl Protobuf for Swap {
+impl DomainType for Swap {
     type Proto = pb::Swap;
 }
 
@@ -95,7 +95,7 @@ pub struct Body {
     pub payload: SwapPayload,
 }
 
-impl Protobuf for Body {
+impl DomainType for Body {
     type Proto = pb::SwapBody;
 }
 

--- a/transaction/src/action/swap_claim.rs
+++ b/transaction/src/action/swap_claim.rs
@@ -6,7 +6,7 @@ use penumbra_crypto::dex::BatchSwapOutputData;
 use penumbra_crypto::transaction::Fee;
 use penumbra_crypto::{proofs::transparent::SwapClaimProof, Fr};
 use penumbra_crypto::{Balance, Nullifier};
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType};
 use penumbra_tct as tct;
 
 #[derive(Debug, Clone)]
@@ -53,7 +53,7 @@ impl SwapClaim {
     }
 }
 
-impl Protobuf for SwapClaim {
+impl DomainType for SwapClaim {
     type Proto = pb::SwapClaim;
 }
 
@@ -93,7 +93,7 @@ pub struct Body {
     pub output_data: BatchSwapOutputData,
 }
 
-impl Protobuf for Body {
+impl DomainType for Body {
     type Proto = pb::SwapClaimBody;
 }
 

--- a/transaction/src/action/swap_claim.rs
+++ b/transaction/src/action/swap_claim.rs
@@ -53,7 +53,9 @@ impl SwapClaim {
     }
 }
 
-impl Protobuf<pb::SwapClaim> for SwapClaim {}
+impl Protobuf for SwapClaim {
+    type Proto = pb::SwapClaim;
+}
 
 impl From<SwapClaim> for pb::SwapClaim {
     fn from(sc: SwapClaim) -> Self {
@@ -91,7 +93,9 @@ pub struct Body {
     pub output_data: BatchSwapOutputData,
 }
 
-impl Protobuf<pb::SwapClaimBody> for Body {}
+impl Protobuf for Body {
+    type Proto = pb::SwapClaimBody;
+}
 
 impl From<Body> for pb::SwapClaimBody {
     fn from(s: Body) -> Self {

--- a/transaction/src/action/undelegate.rs
+++ b/transaction/src/action/undelegate.rs
@@ -70,7 +70,9 @@ impl Undelegate {
     }
 }
 
-impl Protobuf<pb::Undelegate> for Undelegate {}
+impl Protobuf for Undelegate {
+    type Proto = pb::Undelegate;
+}
 
 impl From<Undelegate> for pb::Undelegate {
     fn from(d: Undelegate) -> Self {

--- a/transaction/src/action/undelegate.rs
+++ b/transaction/src/action/undelegate.rs
@@ -4,7 +4,7 @@ use penumbra_crypto::{
     stake::{DelegationToken, IdentityKey, UnbondingToken},
     Balance, Fr, Value,
 };
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::{ActionView, IsAction, TransactionPerspective};
@@ -70,7 +70,7 @@ impl Undelegate {
     }
 }
 
-impl Protobuf for Undelegate {
+impl DomainType for Undelegate {
     type Proto = pb::Undelegate;
 }
 

--- a/transaction/src/action/undelegate_claim.rs
+++ b/transaction/src/action/undelegate_claim.rs
@@ -3,7 +3,7 @@ use penumbra_crypto::{
     proofs::transparent::UndelegateClaimProof,
     stake::{IdentityKey, Penalty},
 };
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::{ActionView, IsAction, TransactionPerspective};
@@ -40,7 +40,7 @@ impl IsAction for UndelegateClaim {
     }
 }
 
-impl Protobuf for UndelegateClaimBody {
+impl DomainType for UndelegateClaimBody {
     type Proto = pb::UndelegateClaimBody;
 }
 
@@ -78,7 +78,7 @@ impl TryFrom<pb::UndelegateClaimBody> for UndelegateClaimBody {
     }
 }
 
-impl Protobuf for UndelegateClaim {
+impl DomainType for UndelegateClaim {
     type Proto = pb::UndelegateClaim;
 }
 

--- a/transaction/src/action/undelegate_claim.rs
+++ b/transaction/src/action/undelegate_claim.rs
@@ -40,7 +40,9 @@ impl IsAction for UndelegateClaim {
     }
 }
 
-impl Protobuf<pb::UndelegateClaimBody> for UndelegateClaimBody {}
+impl Protobuf for UndelegateClaimBody {
+    type Proto = pb::UndelegateClaimBody;
+}
 
 impl From<UndelegateClaimBody> for pb::UndelegateClaimBody {
     fn from(d: UndelegateClaimBody) -> Self {
@@ -76,7 +78,9 @@ impl TryFrom<pb::UndelegateClaimBody> for UndelegateClaimBody {
     }
 }
 
-impl Protobuf<pb::UndelegateClaim> for UndelegateClaim {}
+impl Protobuf for UndelegateClaim {
+    type Proto = pb::UndelegateClaim;
+}
 
 impl From<UndelegateClaim> for pb::UndelegateClaim {
     fn from(d: UndelegateClaim) -> Self {

--- a/transaction/src/action/vote.rs
+++ b/transaction/src/action/vote.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::anyhow;
 use decaf377_rdsa::{Signature, SpendAuth};
 use penumbra_crypto::{stake::IdentityKey, GovernanceKey};
-use penumbra_proto::{core::governance::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::{ActionView, IsAction, TransactionPerspective};
@@ -106,7 +106,7 @@ mod test {
     }
 }
 
-impl Protobuf for Vote {
+impl DomainType for Vote {
     type Proto = pb::Vote;
 }
 
@@ -205,7 +205,7 @@ impl TryFrom<pb::ValidatorVoteBody> for ValidatorVoteBody {
     }
 }
 
-impl Protobuf for ValidatorVoteBody {
+impl DomainType for ValidatorVoteBody {
     type Proto = pb::ValidatorVoteBody;
 }
 

--- a/transaction/src/action/vote.rs
+++ b/transaction/src/action/vote.rs
@@ -106,7 +106,9 @@ mod test {
     }
 }
 
-impl Protobuf<pb::Vote> for Vote {}
+impl Protobuf for Vote {
+    type Proto = pb::Vote;
+}
 
 /// A vote by a validator.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -203,7 +205,9 @@ impl TryFrom<pb::ValidatorVoteBody> for ValidatorVoteBody {
     }
 }
 
-impl Protobuf<pb::ValidatorVoteBody> for ValidatorVoteBody {}
+impl Protobuf for ValidatorVoteBody {
+    type Proto = pb::ValidatorVoteBody;
+}
 
 #[derive(Debug, Clone)]
 pub struct DelegatorVote {

--- a/transaction/src/auth_data.rs
+++ b/transaction/src/auth_data.rs
@@ -14,7 +14,9 @@ pub struct AuthorizationData {
     pub spend_auths: Vec<Signature<SpendAuth>>,
 }
 
-impl Protobuf<pb::AuthorizationData> for AuthorizationData {}
+impl Protobuf for AuthorizationData {
+    type Proto = pb::AuthorizationData;
+}
 
 impl From<AuthorizationData> for pb::AuthorizationData {
     fn from(msg: AuthorizationData) -> Self {

--- a/transaction/src/auth_data.rs
+++ b/transaction/src/auth_data.rs
@@ -1,5 +1,5 @@
 use penumbra_crypto::rdsa::{Signature, SpendAuth};
-use penumbra_proto::{core::transaction::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::transaction::v1alpha1 as pb, DomainType};
 
 use crate::EffectHash;
 
@@ -14,7 +14,7 @@ pub struct AuthorizationData {
     pub spend_auths: Vec<Signature<SpendAuth>>,
 }
 
-impl Protobuf for AuthorizationData {
+impl DomainType for AuthorizationData {
     type Proto = pb::AuthorizationData;
 }
 

--- a/transaction/src/effect_hash.rs
+++ b/transaction/src/effect_hash.rs
@@ -44,7 +44,9 @@ impl std::fmt::Debug for EffectHash {
     }
 }
 
-impl Protobuf<pb_crypto::EffectHash> for EffectHash {}
+impl Protobuf for EffectHash {
+    type Proto = pb_crypto::EffectHash;
+}
 
 impl From<EffectHash> for pb_crypto::EffectHash {
     fn from(msg: EffectHash) -> Self {

--- a/transaction/src/effect_hash.rs
+++ b/transaction/src/effect_hash.rs
@@ -4,7 +4,7 @@ use decaf377_fmd::Clue;
 use penumbra_crypto::{
     dex::TradingPair, transaction::Fee, EncryptedNote, FullViewingKey, PayloadKey,
 };
-use penumbra_proto::{core::crypto::v1alpha1 as pb_crypto, Message, Protobuf};
+use penumbra_proto::{core::crypto::v1alpha1 as pb_crypto, DomainType, Message};
 
 use crate::{
     action::{
@@ -44,7 +44,7 @@ impl std::fmt::Debug for EffectHash {
     }
 }
 
-impl Protobuf for EffectHash {
+impl DomainType for EffectHash {
     type Proto = pb_crypto::EffectHash;
 }
 

--- a/transaction/src/plan.rs
+++ b/transaction/src/plan.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use penumbra_crypto::{transaction::Fee, Address};
 use penumbra_proto::{
     core::ibc::v1alpha1 as pb_ibc, core::stake::v1alpha1 as pb_stake,
-    core::transaction::v1alpha1 as pb, Protobuf,
+    core::transaction::v1alpha1 as pb, DomainType,
 };
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
@@ -218,7 +218,7 @@ impl TransactionPlan {
     }
 }
 
-impl Protobuf for TransactionPlan {
+impl DomainType for TransactionPlan {
     type Proto = pb::TransactionPlan;
 }
 

--- a/transaction/src/plan.rs
+++ b/transaction/src/plan.rs
@@ -218,7 +218,9 @@ impl TransactionPlan {
     }
 }
 
-impl Protobuf<pb::TransactionPlan> for TransactionPlan {}
+impl Protobuf for TransactionPlan {
+    type Proto = pb::TransactionPlan;
+}
 
 impl From<TransactionPlan> for pb::TransactionPlan {
     fn from(msg: TransactionPlan) -> Self {

--- a/transaction/src/plan/action.rs
+++ b/transaction/src/plan/action.rs
@@ -1,7 +1,7 @@
 use penumbra_crypto::Balance;
 use penumbra_proto::{
     core::ibc::v1alpha1 as pb_ibc, core::stake::v1alpha1 as pb_stake,
-    core::transaction::v1alpha1 as pb_t, Protobuf,
+    core::transaction::v1alpha1 as pb_t, DomainType,
 };
 use serde::{Deserialize, Serialize};
 
@@ -188,7 +188,7 @@ impl From<PositionRewardClaim> for ActionPlan {
     }
 }
 
-impl Protobuf for ActionPlan {
+impl DomainType for ActionPlan {
     type Proto = pb_t::ActionPlan;
 }
 

--- a/transaction/src/plan/action.rs
+++ b/transaction/src/plan/action.rs
@@ -188,7 +188,9 @@ impl From<PositionRewardClaim> for ActionPlan {
     }
 }
 
-impl Protobuf<pb_t::ActionPlan> for ActionPlan {}
+impl Protobuf for ActionPlan {
+    type Proto = pb_t::ActionPlan;
+}
 
 impl From<ActionPlan> for pb_t::ActionPlan {
     fn from(msg: ActionPlan) -> Self {

--- a/transaction/src/plan/action/delegator_vote.rs
+++ b/transaction/src/plan/action/delegator_vote.rs
@@ -57,4 +57,6 @@ impl TryFrom<pb::DelegatorVotePlan> for DelegatorVotePlan {
     }
 }
 
-impl Protobuf<pb::DelegatorVotePlan> for DelegatorVotePlan {}
+impl Protobuf for DelegatorVotePlan {
+    type Proto = pb::DelegatorVotePlan;
+}

--- a/transaction/src/plan/action/delegator_vote.rs
+++ b/transaction/src/plan/action/delegator_vote.rs
@@ -1,6 +1,6 @@
 use decaf377::{FieldExt, Fr};
 use penumbra_crypto::Note;
-use penumbra_proto::{core::governance::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType};
 use penumbra_tct as tct;
 use serde::{Deserialize, Serialize};
 
@@ -57,6 +57,6 @@ impl TryFrom<pb::DelegatorVotePlan> for DelegatorVotePlan {
     }
 }
 
-impl Protobuf for DelegatorVotePlan {
+impl DomainType for DelegatorVotePlan {
     type Proto = pb::DelegatorVotePlan;
 }

--- a/transaction/src/plan/action/output.rs
+++ b/transaction/src/plan/action/output.rs
@@ -6,7 +6,7 @@ use penumbra_crypto::{
     symmetric::WrappedMemoKey,
     Address, EncryptedNote, FieldExt, Fr, Note, PayloadKey, Rseed, Value, STAKING_TOKEN_ASSET_ID,
 };
-use penumbra_proto::{core::transaction::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::transaction::v1alpha1 as pb, DomainType};
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
@@ -120,7 +120,7 @@ impl OutputPlan {
     }
 }
 
-impl Protobuf for OutputPlan {
+impl DomainType for OutputPlan {
     type Proto = pb::OutputPlan;
 }
 

--- a/transaction/src/plan/action/output.rs
+++ b/transaction/src/plan/action/output.rs
@@ -120,7 +120,9 @@ impl OutputPlan {
     }
 }
 
-impl Protobuf<pb::OutputPlan> for OutputPlan {}
+impl Protobuf for OutputPlan {
+    type Proto = pb::OutputPlan;
+}
 
 impl From<OutputPlan> for pb::OutputPlan {
     fn from(msg: OutputPlan) -> Self {

--- a/transaction/src/plan/action/spend.rs
+++ b/transaction/src/plan/action/spend.rs
@@ -4,7 +4,7 @@ use penumbra_crypto::{
     proofs::transparent::SpendProof, Address, FieldExt, Fr, FullViewingKey, Note, Rseed, Value,
     STAKING_TOKEN_ASSET_ID,
 };
-use penumbra_proto::{core::transaction::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::transaction::v1alpha1 as pb, DomainType};
 use penumbra_tct as tct;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -101,7 +101,7 @@ impl SpendPlan {
     }
 }
 
-impl Protobuf for SpendPlan {
+impl DomainType for SpendPlan {
     type Proto = pb::SpendPlan;
 }
 

--- a/transaction/src/plan/action/spend.rs
+++ b/transaction/src/plan/action/spend.rs
@@ -101,7 +101,9 @@ impl SpendPlan {
     }
 }
 
-impl Protobuf<pb::SpendPlan> for SpendPlan {}
+impl Protobuf for SpendPlan {
+    type Proto = pb::SpendPlan;
+}
 
 impl From<SpendPlan> for pb::SpendPlan {
     fn from(msg: SpendPlan) -> Self {

--- a/transaction/src/plan/action/swap.rs
+++ b/transaction/src/plan/action/swap.rs
@@ -91,7 +91,9 @@ impl SwapPlan {
     }
 }
 
-impl Protobuf<pb::SwapPlan> for SwapPlan {}
+impl Protobuf for SwapPlan {
+    type Proto = pb::SwapPlan;
+}
 
 impl From<SwapPlan> for pb::SwapPlan {
     fn from(msg: SwapPlan) -> Self {

--- a/transaction/src/plan/action/swap.rs
+++ b/transaction/src/plan/action/swap.rs
@@ -4,7 +4,7 @@ use ark_ff::UniformRand;
 use penumbra_crypto::dex::swap::SwapPlaintext;
 use penumbra_crypto::Balance;
 use penumbra_crypto::{ka, proofs::transparent::SwapProof, FieldExt, Fr, FullViewingKey, Value};
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType};
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
@@ -91,7 +91,7 @@ impl SwapPlan {
     }
 }
 
-impl Protobuf for SwapPlan {
+impl DomainType for SwapPlan {
     type Proto = pb::SwapPlan;
 }
 

--- a/transaction/src/plan/action/swap_claim.rs
+++ b/transaction/src/plan/action/swap_claim.rs
@@ -95,7 +95,9 @@ impl SwapClaimPlan {
     }
 }
 
-impl Protobuf<pb::SwapClaimPlan> for SwapClaimPlan {}
+impl Protobuf for SwapClaimPlan {
+    type Proto = pb::SwapClaimPlan;
+}
 
 impl From<SwapClaimPlan> for pb::SwapClaimPlan {
     fn from(msg: SwapClaimPlan) -> Self {

--- a/transaction/src/plan/action/swap_claim.rs
+++ b/transaction/src/plan/action/swap_claim.rs
@@ -4,7 +4,7 @@ use penumbra_crypto::{
     proofs::transparent::SwapClaimProof,
     FullViewingKey, Value,
 };
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType};
 use penumbra_tct as tct;
 
 use serde::{Deserialize, Serialize};
@@ -95,7 +95,7 @@ impl SwapClaimPlan {
     }
 }
 
-impl Protobuf for SwapClaimPlan {
+impl DomainType for SwapClaimPlan {
     type Proto = pb::SwapClaimPlan;
 }
 

--- a/transaction/src/plan/action/undelegate_claim.rs
+++ b/transaction/src/plan/action/undelegate_claim.rs
@@ -64,7 +64,9 @@ impl UndelegateClaimPlan {
     }
 }
 
-impl Protobuf<pb::UndelegateClaimPlan> for UndelegateClaimPlan {}
+impl Protobuf for UndelegateClaimPlan {
+    type Proto = pb::UndelegateClaimPlan;
+}
 
 impl From<UndelegateClaimPlan> for pb::UndelegateClaimPlan {
     fn from(msg: UndelegateClaimPlan) -> Self {

--- a/transaction/src/plan/action/undelegate_claim.rs
+++ b/transaction/src/plan/action/undelegate_claim.rs
@@ -3,7 +3,7 @@ use penumbra_crypto::{
     stake::{IdentityKey, Penalty, UnbondingToken},
     Amount, FieldExt, Fr,
 };
-use penumbra_proto::{core::stake::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType};
 
 use serde::{Deserialize, Serialize};
 
@@ -64,7 +64,7 @@ impl UndelegateClaimPlan {
     }
 }
 
-impl Protobuf for UndelegateClaimPlan {
+impl DomainType for UndelegateClaimPlan {
     type Proto = pb::UndelegateClaimPlan;
 }
 

--- a/transaction/src/plan/clue.rs
+++ b/transaction/src/plan/clue.rs
@@ -1,6 +1,6 @@
 use decaf377_fmd::{Clue, ExpandedClueKey};
 use penumbra_crypto::Address;
-use penumbra_proto::{core::transaction::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::transaction::v1alpha1 as pb, DomainType};
 
 use rand::{CryptoRng, RngCore};
 
@@ -37,7 +37,7 @@ impl CluePlan {
     }
 }
 
-impl Protobuf for CluePlan {
+impl DomainType for CluePlan {
     type Proto = pb::CluePlan;
 }
 

--- a/transaction/src/plan/clue.rs
+++ b/transaction/src/plan/clue.rs
@@ -37,7 +37,9 @@ impl CluePlan {
     }
 }
 
-impl Protobuf<pb::CluePlan> for CluePlan {}
+impl Protobuf for CluePlan {
+    type Proto = pb::CluePlan;
+}
 
 impl From<CluePlan> for pb::CluePlan {
     fn from(msg: CluePlan) -> Self {

--- a/transaction/src/plan/memo.rs
+++ b/transaction/src/plan/memo.rs
@@ -26,7 +26,9 @@ impl MemoPlan {
     }
 }
 
-impl Protobuf<pb::MemoPlan> for MemoPlan {}
+impl Protobuf for MemoPlan {
+    type Proto = pb::MemoPlan;
+}
 
 impl From<MemoPlan> for pb::MemoPlan {
     fn from(msg: MemoPlan) -> Self {

--- a/transaction/src/plan/memo.rs
+++ b/transaction/src/plan/memo.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use penumbra_crypto::{memo::MemoCiphertext, symmetric::PayloadKey};
-use penumbra_proto::{core::transaction::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::transaction::v1alpha1 as pb, DomainType};
 
 use rand::{CryptoRng, RngCore};
 
@@ -26,7 +26,7 @@ impl MemoPlan {
     }
 }
 
-impl Protobuf for MemoPlan {
+impl DomainType for MemoPlan {
     type Proto = pb::MemoPlan;
 }
 

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -322,7 +322,9 @@ impl From<TransactionBody> for Vec<u8> {
     }
 }
 
-impl Protobuf<pbt::TransactionBody> for TransactionBody {}
+impl Protobuf for TransactionBody {
+    type Proto = pbt::TransactionBody;
+}
 
 impl From<TransactionBody> for pbt::TransactionBody {
     fn from(msg: TransactionBody) -> Self {
@@ -388,7 +390,9 @@ impl TryFrom<pbt::TransactionBody> for TransactionBody {
         })
     }
 }
-impl Protobuf<pbt::Transaction> for Transaction {}
+impl Protobuf for Transaction {
+    type Proto = pbt::Transaction;
+}
 
 impl From<Transaction> for pbt::Transaction {
     fn from(msg: Transaction) -> Self {

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -16,7 +16,7 @@ use penumbra_crypto::{
 };
 use penumbra_proto::{
     core::ibc::v1alpha1 as pb_ibc, core::stake::v1alpha1 as pbs,
-    core::transaction::v1alpha1 as pbt, Message, Protobuf,
+    core::transaction::v1alpha1 as pbt, DomainType, Message,
 };
 use penumbra_tct as tct;
 use serde::{Deserialize, Serialize};
@@ -322,7 +322,7 @@ impl From<TransactionBody> for Vec<u8> {
     }
 }
 
-impl Protobuf for TransactionBody {
+impl DomainType for TransactionBody {
     type Proto = pbt::TransactionBody;
 }
 
@@ -390,7 +390,7 @@ impl TryFrom<pbt::TransactionBody> for TransactionBody {
         })
     }
 }
-impl Protobuf for Transaction {
+impl DomainType for Transaction {
     type Proto = pbt::Transaction;
 }
 

--- a/transaction/src/view.rs
+++ b/transaction/src/view.rs
@@ -20,7 +20,9 @@ pub struct TransactionView {
     pub memo: Option<String>,
 }
 
-impl Protobuf<pbt::TransactionView> for TransactionView {}
+impl Protobuf for TransactionView {
+    type Proto = pbt::TransactionView;
+}
 
 impl TryFrom<pbt::TransactionView> for TransactionView {
     type Error = anyhow::Error;

--- a/transaction/src/view.rs
+++ b/transaction/src/view.rs
@@ -1,6 +1,6 @@
 use decaf377_fmd::Clue;
 use penumbra_crypto::transaction::Fee;
-use penumbra_proto::{core::transaction::v1alpha1 as pbt, Protobuf};
+use penumbra_proto::{core::transaction::v1alpha1 as pbt, DomainType};
 use serde::{Deserialize, Serialize};
 
 pub mod action_view;
@@ -20,7 +20,7 @@ pub struct TransactionView {
     pub memo: Option<String>,
 }
 
-impl Protobuf for TransactionView {
+impl DomainType for TransactionView {
     type Proto = pbt::TransactionView;
 }
 

--- a/transaction/src/view/action_view.rs
+++ b/transaction/src/view/action_view.rs
@@ -44,7 +44,9 @@ pub enum ActionView {
     Ics20Withdrawal(Ics20Withdrawal),
 }
 
-impl Protobuf<pbt::ActionView> for ActionView {}
+impl Protobuf for ActionView {
+    type Proto = pbt::ActionView;
+}
 
 impl TryFrom<pbt::ActionView> for ActionView {
     type Error = anyhow::Error;

--- a/transaction/src/view/action_view.rs
+++ b/transaction/src/view/action_view.rs
@@ -1,5 +1,5 @@
 use penumbra_proto::core::{ibc::v1alpha1::IbcAction, stake::v1alpha1::ValidatorDefinition};
-use penumbra_proto::{core::transaction::v1alpha1 as pbt, Protobuf};
+use penumbra_proto::{core::transaction::v1alpha1 as pbt, DomainType};
 use serde::{Deserialize, Serialize};
 
 pub mod output_view;
@@ -44,7 +44,7 @@ pub enum ActionView {
     Ics20Withdrawal(Ics20Withdrawal),
 }
 
-impl Protobuf for ActionView {
+impl DomainType for ActionView {
     type Proto = pbt::ActionView;
 }
 

--- a/transaction/src/view/action_view/output_view.rs
+++ b/transaction/src/view/action_view/output_view.rs
@@ -1,5 +1,5 @@
 use penumbra_crypto::{Note, PayloadKey};
-use penumbra_proto::{core::transaction::v1alpha1 as pbt, Protobuf};
+use penumbra_proto::{core::transaction::v1alpha1 as pbt, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::action::Output;
@@ -18,7 +18,7 @@ pub enum OutputView {
     },
 }
 
-impl Protobuf for OutputView {
+impl DomainType for OutputView {
     type Proto = pbt::OutputView;
 }
 

--- a/transaction/src/view/action_view/output_view.rs
+++ b/transaction/src/view/action_view/output_view.rs
@@ -18,7 +18,9 @@ pub enum OutputView {
     },
 }
 
-impl Protobuf<pbt::OutputView> for OutputView {}
+impl Protobuf for OutputView {
+    type Proto = pbt::OutputView;
+}
 
 impl TryFrom<pbt::OutputView> for OutputView {
     type Error = anyhow::Error;

--- a/transaction/src/view/action_view/spend_view.rs
+++ b/transaction/src/view/action_view/spend_view.rs
@@ -12,7 +12,9 @@ pub enum SpendView {
     Opaque { spend: Spend },
 }
 
-impl Protobuf<pbt::SpendView> for SpendView {}
+impl Protobuf for SpendView {
+    type Proto = pbt::SpendView;
+}
 
 impl TryFrom<pbt::SpendView> for SpendView {
     type Error = anyhow::Error;

--- a/transaction/src/view/action_view/spend_view.rs
+++ b/transaction/src/view/action_view/spend_view.rs
@@ -1,5 +1,5 @@
 use penumbra_crypto::Note;
-use penumbra_proto::{core::transaction::v1alpha1 as pbt, Protobuf};
+use penumbra_proto::{core::transaction::v1alpha1 as pbt, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::action::Spend;
@@ -12,7 +12,7 @@ pub enum SpendView {
     Opaque { spend: Spend },
 }
 
-impl Protobuf for SpendView {
+impl DomainType for SpendView {
     type Proto = pbt::SpendView;
 }
 

--- a/transaction/src/view/action_view/swap_claim_view.rs
+++ b/transaction/src/view/action_view/swap_claim_view.rs
@@ -18,7 +18,9 @@ pub enum SwapClaimView {
     },
 }
 
-impl Protobuf<pbd::SwapClaimView> for SwapClaimView {}
+impl Protobuf for SwapClaimView {
+    type Proto = pbd::SwapClaimView;
+}
 
 impl TryFrom<pbd::SwapClaimView> for SwapClaimView {
     type Error = anyhow::Error;

--- a/transaction/src/view/action_view/swap_claim_view.rs
+++ b/transaction/src/view/action_view/swap_claim_view.rs
@@ -1,5 +1,5 @@
 use penumbra_crypto::Note;
-use penumbra_proto::{core::dex::v1alpha1 as pbd, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pbd, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::action::SwapClaim;
@@ -18,7 +18,7 @@ pub enum SwapClaimView {
     },
 }
 
-impl Protobuf for SwapClaimView {
+impl DomainType for SwapClaimView {
     type Proto = pbd::SwapClaimView;
 }
 

--- a/transaction/src/view/action_view/swap_view.rs
+++ b/transaction/src/view/action_view/swap_view.rs
@@ -17,7 +17,9 @@ pub enum SwapView {
     },
 }
 
-impl Protobuf<pb::SwapView> for SwapView {}
+impl Protobuf for SwapView {
+    type Proto = pb::SwapView;
+}
 
 impl TryFrom<pb::SwapView> for SwapView {
     type Error = anyhow::Error;

--- a/transaction/src/view/action_view/swap_view.rs
+++ b/transaction/src/view/action_view/swap_view.rs
@@ -1,5 +1,5 @@
 use penumbra_crypto::dex::swap::SwapPlaintext;
-use penumbra_proto::{core::dex::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 use crate::action::Swap;
@@ -17,7 +17,7 @@ pub enum SwapView {
     },
 }
 
-impl Protobuf for SwapView {
+impl DomainType for SwapView {
     type Proto = pb::SwapView;
 }
 

--- a/transaction/src/witness_data.rs
+++ b/transaction/src/witness_data.rs
@@ -17,7 +17,9 @@ impl WitnessData {
     }
 }
 
-impl Protobuf<pb::WitnessData> for WitnessData {}
+impl Protobuf for WitnessData {
+    type Proto = pb::WitnessData;
+}
 
 impl From<WitnessData> for pb::WitnessData {
     fn from(msg: WitnessData) -> Self {

--- a/transaction/src/witness_data.rs
+++ b/transaction/src/witness_data.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use penumbra_crypto::note;
-use penumbra_proto::{core::transaction::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{core::transaction::v1alpha1 as pb, DomainType};
 use penumbra_tct as tct;
 
 #[derive(Clone, Debug)]
@@ -17,7 +17,7 @@ impl WitnessData {
     }
 }
 
-impl Protobuf for WitnessData {
+impl DomainType for WitnessData {
     type Proto = pb::WitnessData;
 }
 

--- a/view/src/note_record.rs
+++ b/view/src/note_record.rs
@@ -2,7 +2,7 @@ use penumbra_chain::NoteSource;
 use penumbra_crypto::{
     asset, keys::AddressIndex, note, Address, FieldExt, Fq, Note, Nullifier, Rseed, Value,
 };
-use penumbra_proto::{view::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{view::v1alpha1 as pb, DomainType};
 use penumbra_tct as tct;
 
 use serde::{Deserialize, Serialize};
@@ -22,7 +22,7 @@ pub struct SpendableNoteRecord {
     pub source: NoteSource,
 }
 
-impl Protobuf for SpendableNoteRecord {
+impl DomainType for SpendableNoteRecord {
     type Proto = pb::SpendableNoteRecord;
 }
 impl From<SpendableNoteRecord> for pb::SpendableNoteRecord {

--- a/view/src/note_record.rs
+++ b/view/src/note_record.rs
@@ -22,7 +22,9 @@ pub struct SpendableNoteRecord {
     pub source: NoteSource,
 }
 
-impl Protobuf<pb::SpendableNoteRecord> for SpendableNoteRecord {}
+impl Protobuf for SpendableNoteRecord {
+    type Proto = pb::SpendableNoteRecord;
+}
 impl From<SpendableNoteRecord> for pb::SpendableNoteRecord {
     fn from(v: SpendableNoteRecord) -> Self {
         pb::SpendableNoteRecord {

--- a/view/src/status.rs
+++ b/view/src/status.rs
@@ -6,7 +6,9 @@ pub struct StatusStreamResponse {
     pub sync_height: u64,
 }
 
-impl Protobuf<pb::StatusStreamResponse> for StatusStreamResponse {}
+impl Protobuf for StatusStreamResponse {
+    type Proto = pb::StatusStreamResponse;
+}
 
 impl TryFrom<pb::StatusStreamResponse> for StatusStreamResponse {
     type Error = anyhow::Error;

--- a/view/src/status.rs
+++ b/view/src/status.rs
@@ -1,4 +1,4 @@
-use penumbra_proto::{view::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{view::v1alpha1 as pb, DomainType};
 
 #[derive(Clone, Copy, Debug)]
 pub struct StatusStreamResponse {
@@ -6,7 +6,7 @@ pub struct StatusStreamResponse {
     pub sync_height: u64,
 }
 
-impl Protobuf for StatusStreamResponse {
+impl DomainType for StatusStreamResponse {
     type Proto = pb::StatusStreamResponse;
 }
 

--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -11,7 +11,7 @@ use penumbra_proto::{
     client::v1alpha1::{
         oblivious_query_service_client::ObliviousQueryServiceClient, ChainParametersRequest,
     },
-    Protobuf,
+    DomainType,
 };
 use penumbra_tct as tct;
 use penumbra_transaction::Transaction;

--- a/view/src/swap_record.rs
+++ b/view/src/swap_record.rs
@@ -3,7 +3,7 @@ use penumbra_crypto::{
     dex::{swap::SwapPlaintext, BatchSwapOutputData},
     Nullifier,
 };
-use penumbra_proto::{view::v1alpha1 as pb, Protobuf};
+use penumbra_proto::{view::v1alpha1 as pb, DomainType};
 use penumbra_tct as tct;
 
 use serde::{Deserialize, Serialize};
@@ -21,7 +21,7 @@ pub struct SwapRecord {
     pub source: NoteSource,
 }
 
-impl Protobuf for SwapRecord {
+impl DomainType for SwapRecord {
     type Proto = pb::SwapRecord;
 }
 impl From<SwapRecord> for pb::SwapRecord {

--- a/view/src/swap_record.rs
+++ b/view/src/swap_record.rs
@@ -21,7 +21,9 @@ pub struct SwapRecord {
     pub source: NoteSource,
 }
 
-impl Protobuf<pb::SwapRecord> for SwapRecord {}
+impl Protobuf for SwapRecord {
+    type Proto = pb::SwapRecord;
+}
 impl From<SwapRecord> for pb::SwapRecord {
     fn from(msg: SwapRecord) -> Self {
         pb::SwapRecord {

--- a/view/src/worker.rs
+++ b/view/src/worker.rs
@@ -12,7 +12,7 @@ use penumbra_proto::{
         tendermint_proxy_service_client::TendermintProxyServiceClient, AssetListRequest,
         CompactBlockRangeRequest, GetBlockByHeightRequest,
     },
-    Protobuf,
+    DomainType,
 };
 use penumbra_transaction::Transaction;
 use sha2::Digest;


### PR DESCRIPTION
We should only have one proto-generated type per domain type, so we don't lose
anything by doing this, and we gain convenience and flexibility: before, we
always had to specify two types, the domain and proto type, while now, we
allow looking up the corresponding proto type from the domain type.

This will allow us to write more generic behavior.

One behavior that would be really nice to be able to write, but which I don't
think is (currently) possible, is a generic `Serialize`/`Deserialize`
implementation for any domain type, which passes through the proto type and its
proto-derived serde implementation.  The upside of doing this is that it
imposes a hard requirement that the serde behavior for any domain type *must*
be derived from the proto format.  But this is also why we can't -- we
implement the trait for certain foreign types, like the `decaf377_rdsa` types,
and those already have `Serialize` implementations.  For now, the status quo of
having it be a policy rather than an absolute and universal rule seems like the
way to go.

Finally, rename the `Protobuf` trait to `DomainType`; this is a clearer name,
since it's implemented for the domain type, not the proto type.