### PR TITLE
docs: update undelegation and validator toml defs

### DIFF
--- a/component/src/dex/component.rs
+++ b/component/src/dex/component.rs
@@ -9,14 +9,14 @@ pub struct Dex {}
 
 #[async_trait]
 impl Component for Dex {
-    #[instrument(name = "dex", skip(state, _app_state))]
-    async fn init_chain(state: &mut StateTransaction, _app_state: &genesis::AppState) {}
+    #[instrument(name = "dex", skip(_state, _app_state))]
+    async fn init_chain(_state: &mut StateTransaction, _app_state: &genesis::AppState) {}
 
     #[instrument(name = "dex", skip(_state, _begin_block))]
     async fn begin_block(_state: &mut StateTransaction, _begin_block: &abci::request::BeginBlock) {}
 
-    #[instrument(name = "dex", skip(state, end_block))]
-    async fn end_block(state: &mut StateTransaction, end_block: &abci::request::EndBlock) {}
+    #[instrument(name = "dex", skip(_state, _end_block))]
+    async fn end_block(_state: &mut StateTransaction, _end_block: &abci::request::EndBlock) {}
 }
 
 /// Extension trait providing read access to dex data.

--- a/component/src/dex/state_key.rs
+++ b/component/src/dex/state_key.rs
@@ -13,7 +13,7 @@ pub fn positions(trading_pair: &TradingPair, position_id: &str) -> String {
 pub(crate) mod internal {
     use penumbra_crypto::dex::lp::BareTradingFunction;
 
-    pub fn prices(btf: &BareTradingFunction) -> [u8; 43] {
+    pub fn _prices(btf: &BareTradingFunction) -> [u8; 43] {
         let mut result: [u8; 43] = [0; 43];
         result[0..11].copy_from_slice("dex/prices/".as_bytes());
         result[11..43].copy_from_slice(&btf.to_bytes());

--- a/docs/guide/src/pcli/transaction.md
+++ b/docs/guide/src/pcli/transaction.md
@@ -3,7 +3,7 @@
 Now, for the fun part: sending transactions. If you have someone else's testnet address, you can
 send them any amount of any asset you have.
 
-First, use balance to find the amount of assets you have.
+First, use balance to find the amount of assets you have:
 
 ```bash
 cargo run --release --bin pcli view balance
@@ -17,9 +17,7 @@ cargo run --quiet --release --bin pcli tx send 10penumbra --to penumbrav2t...
 ```
 
 Notice that asset amounts are typed amounts, specified without a space between the amount (`10`)
-and the asset name (`penumbra`).
-
-If you have the asset in your wallet to send, then so it shall be done!
+and the asset name (`penumbra`). If you have the asset in your wallet to send, then so it shall be done!
 
 ## Staking
 
@@ -38,7 +36,15 @@ cargo run --release --bin pcli tx delegate 10penumbra --to penumbravalid...
 ```
 
 To undelegate from a validator, use the `pcli tx undelegate` command, passing it the typed amount of
-delegation tokens you wish to undelegate.
+delegation tokens you wish to undelegate. Wait a moment for the network to process the undelegation,
+then reclaim your funds:
+
+```bash
+cargo run --release --bin pcli tx undelegate-claim
+```
+
+Inspect the output; a message may instruct you to wait longer, for a new epoch. Check back and rerun the command
+later to add the previously delegated funds to your wallet.
 
 ## Governance
 

--- a/docs/guide/src/pcli/update.md
+++ b/docs/guide/src/pcli/update.md
@@ -1,12 +1,12 @@
 ## Updating `pcli`
 
-Follow the [same steps](https://guide.penumbra.zone/main/pcli/install.html#cloning-the-repository) to update to the latest testnet [release](https://github.com/penumbra-zone/penumbra/releases)
+Make sure you've followed the [installation steps](https://guide.penumbra.zone/main/pcli/install.html#cloning-the-repository). Then, to update to the latest testnet [release](https://github.com/penumbra-zone/penumbra/releases):
 
 ```
 cd penumbra && git fetch && git checkout 041-callirrhoe
 ```
 
-Once again, build `pcli` with cargo
+Once again, build `pcli` with cargo:
 
 ```
 cargo build --release --bin pcli

--- a/docs/guide/src/pcli/wallet.md
+++ b/docs/guide/src/pcli/wallet.md
@@ -5,8 +5,11 @@ should see something like this:
 
 ```bash
 \$ cargo run --quiet --release --bin pcli keys generate
-Saving wallet to /home/\$USER/.local/share/pcli/penumbra_wallet.json
-Saving backup wallet to /home/\$USER/.local/share/penumbra-testnet-archive/penumbra-euporie/.../penumbra_wallet.json
+
+
+YOUR PRIVATE SEED PHRASE: [...]
+DO NOT SHARE WITH ANYONE!
+Saving backup wallet to /home/\$USER/.local/share/penumbra-testnet-archive/.../custody.json
 ```
 
 Penumbra's design automatically creates many (`u64::MAX`) publicly unlinkable addresses which all
@@ -15,8 +18,7 @@ of your wallet addresses, which you can view like this:
 
 ```bash
 \$ cargo run --quiet --release --bin pcli view address 0
- Index  Address
- 0      penumbrav2t1...
+penumbrav2t1...
 ```
 
 ### Getting testnet tokens on the [Discord] in the `#testnet-faucet` channel

--- a/docs/guide/src/pd/build.md
+++ b/docs/guide/src/pd/build.md
@@ -2,22 +2,13 @@
 
 The node software `pd` is part of the same repository as `pcli`, so follow
 [those instructions](../pcli/install.md) to clone the repo and install dependencies.
-
-You may need to install some additional packages in order to build `pd`,
-depending on your distribution. For a bare-bones Ubuntu installation, you can
-run
-
-```bash
-sudo apt-get install clang
-```
-
 To build `pd`, run
 
 ```bash
 cargo build --release --bin pd
 ```
 
-Because you are building a work-in-progress version of the node, you may see compilation warnings,
+Because you are building a work-in-progress version of the node software, you may see compilation warnings,
 which you can safely ignore.
 
 ### Installing Tendermint

--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -95,23 +95,40 @@ update the configuration for a validator.
 To create a template configuration, use `pcli validator template-definition`:
 
 ```console
-\$ cargo run --release --bin pcli -- validator definition template --file validator.json
-\$ cat validator.json
-{
-  "identity_key": "penumbravalid1g2huds8klwypzczfgx67j7zp6ntq2m5fxmctkf7ja96zn49d6s9qz72hu3",
-  "consensus_key": "Fodjg0m1kF/6uzcAZpRcLJswGf3EeNShLP2A+UCz8lw=",
-  "name": "",
-  "website": "",
-  "description": "",
-  "enabled": false,
-  "funding_streams": [
-    {
-      "address": "penumbrav1t1mw8270qtpgjy628fg97p2px45e860jtlw0nl3w5y7vq67qx697py9t8ppp3mhwfxv8kegg8wuny64nf60z966krx85cqznjpshqtngffpwnywtzqjklkg3qh7anxk368ywac9l",
-      "rate_bps": 100
-    }
-  ],
-  "sequence_number": 0
-}
+\$ cargo run --release --bin pcli -- validator definition template --file validator.toml
+\$ cat validator.toml
+# This is a template for a validator definition.
+#
+# The identity_key and governance_key fields are auto-filled with values derived
+# from this wallet's account.
+#
+# The consensus_key field is random, and needs to be replaced with your
+# tendermint instance's public key, which can be found in
+# `priv_validator_key.json`.
+#
+# You should fill in the name, website, and description fields.
+#
+# By default, validators are disabled, and cannot be delegated to. To change
+# this, set `enabled = true`.
+#
+# Every time you upload a new validator config, you'll need to increment the
+# `sequence_number`.
+
+sequence_number = 0
+enabled = false
+name = ''
+website = ''
+description = ''
+identity_key = 'penumbravalid1kqrecmvwcc75rvg9arhl0apsggtuannqphxhlzl34vfamp4ukg9q87ejej'
+governance_key = 'penumbragovern1kqrecmvwcc75rvg9arhl0apsggtuannqphxhlzl34vfamp4ukg9qus84v5'
+
+[consensus_key]
+type = 'tendermint/PubKeyEd25519'
+value = 'HDmm2FmJhLHxaKPnP5Fw3tC1DtlBx8ETgTL35UF+p6w='
+
+[[funding_stream]]
+address = 'penumbrav2t1cntf73e36y3um4zmqm4j0zar3jyxvyfqxywwg5q6fjxzhe28qttppmcww2kunetdp3q2zywcakwv6tzxdnaa3sqymll2gzq6zqhr5p0v7fnfdaghrr2ru2uw78nkeyt49uf49q'
+rate_bps = 100
 ```
 
 and adjust the data like the name, website, description, etc as desired.
@@ -140,9 +157,8 @@ By default `template-definition` will use a random consensus key that you won't 
   },
 ```
 
-Note: if you can't find `priv_validator_key.json`, assure that you have set
-`mode = "validator"` in the Tendermint `config.toml`, as described above, and
-restarted Tendermint after doing so.
+Copy the string in the `value` field and paste that into your `validator.toml`,
+as the `value` field under the `[consensus_key]` heading.
 
 #### Configuring funding streams
 
@@ -156,10 +172,10 @@ that would be sent to an address controlled by a DAO.
 ## Uploading a definition
 
 After setting up metadata, funding streams, and the correct consensus key in
-your `validator.json`, you can upload it to the chain:
+your `validator.toml`, you can upload it to the chain:
 
 ```console
-cargo run --release --bin pcli -- validator definition upload --file validator.json
+cargo run --release --bin pcli -- validator definition upload --file validator.toml
 ```
 
 And verify that it's known to the chain:
@@ -205,7 +221,7 @@ deployment.  You can find the values in use for the current chain in its
 First fetch your existing validator definition from the chain:
 
 ```console
-cargo run --release --bin pcli -- validator definition fetch --file validator.json
+cargo run --release --bin pcli -- validator definition fetch --file validator.toml
 ```
 
 Then make any changes desired and **make sure to increase by `sequence_number` by at least 1!**
@@ -214,5 +230,5 @@ The `sequence_number` is a unique, increasing identifier for the version of the 
 After updating the validator definition you can upload it again to update your validator metadata on-chain:
 
 ```console
-cargo run --release --bin pcli -- validator definition upload --file validator.json
+cargo run --release --bin pcli -- validator definition upload --file validator.toml
 ```


### PR DESCRIPTION
Went through sections 1 & 2 in the guide and updated according to the latest version of the code. There's now a two-stop process for undelegating:
    
* `undelegate <delegation>`
* `undelegate-claim`
    
Therefore closes #1755. Also includes JSON -> TOML changes resulting from #1911; there's a bit more follow-up required there, so the "Updating your validator" section still mentions JSON. That'll change soon.
