### PR TITLE
feat(pcli): use https url by default for pd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.5.0",
  "tokio",
  "tokio-rustls 0.22.0",
  "tower-service",
@@ -2283,7 +2283,7 @@ dependencies = [
  "hyper",
  "log",
  "rustls 0.19.1",
- "rustls-native-certs",
+ "rustls-native-certs 0.5.0",
  "tokio",
  "tokio-rustls 0.22.0",
  "webpki 0.21.4",
@@ -3679,7 +3679,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
- "serde_with",
+ "serde_with 1.14.0",
  "tracing",
 ]
 
@@ -3897,6 +3897,7 @@ dependencies = [
  "tonic-web",
  "tracing",
  "tracing-subscriber 0.2.25",
+ "url",
  "vergen",
 ]
 
@@ -4684,6 +4685,18 @@ checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
  "rustls 0.19.1",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
 ]
@@ -5789,7 +5802,10 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-derive",
+ "rustls-native-certs 0.6.2",
+ "rustls-pemfile",
  "tokio",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-util 0.7.4",
  "tower",

--- a/docs/guide/src/dev/devnet-quickstart.md
+++ b/docs/guide/src/dev/devnet-quickstart.md
@@ -89,5 +89,5 @@ To run the smoke tests:
 1. Make sure you have a devnet running (see previous steps)
 2. Run integration tests:
 ```shell
-PENUMBRA_NODE_HOSTNAME=127.0.0.1 PCLI_UNLEASH_DANGER=yes cargo test --package pcli -- --ignored --test-threads 1
+PENUMBRA_NODE_URL="http://127.0.0.1:8080" PCLI_UNLEASH_DANGER=yes cargo test --package pcli -- --ignored --test-threads 1
 ```

--- a/pcli/tests/network_integration.rs
+++ b/pcli/tests/network_integration.rs
@@ -3,7 +3,7 @@
 //! These tests are marked with `#[ignore]`, but can be run with:
 //! `cargo test --package pcli -- --ignored --test-threads 1`
 //!
-//! Tests against the network in the `PENUMBRA_NODE_HOSTNAME` environment variable.
+//! Tests against the network in the `PENUMBRA_NODE_URL` environment variable.
 //!
 //! Tests assume that the initial state of the test account is after genesis,
 //! where no tokens have been delegated, and the address with index 0

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -217,8 +217,6 @@ async fn main() -> anyhow::Result<()> {
                             }
                             None => tracing::error_span!("grpc"),
                         })
-                        // Allow HTTP/1, which will be used by grpc-web connections.
-                        .accept_http1(true)
                         // Wrap each of the gRPC services in a tonic-web proxy:
                         .add_service(tonic_web::enable(ObliviousQueryServiceServer::new(
                             info.clone(),

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -10,7 +10,7 @@ decaf377-fmd = { path = "../decaf377-fmd" }
 decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 bytes = { version = "1", features = ["serde"] }
 prost = "0.11"
-tonic = { version = "0.8.1", optional = true }
+tonic = { version = "0.8.1", features = ["tls", "tls-roots"], optional = true }
 serde = { version = "1", features = ["derive"] }
 hex = "0.4"
 anyhow = "1.0"

--- a/scripts/grpcurl-wrapper
+++ b/scripts/grpcurl-wrapper
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Wrapper script to use `grpcurl` to query Penumbra pd over HTTPS.
+#
+# Requires grpcurl to be installed locally. Assumes running from the
+# top-level dir of the penumbra git repo.
+set -euo pipefail
+
+
+if [[ $# -lt 1 ]] ; then
+    >&2 echo "Usage: $0 <protobuf_method> ; e.g."
+    >&2 echo "$0 penumbra.client.v1alpha1.ObliviousQueryService/ChainParameters"
+    exit 1
+fi
+
+
+# Disable linting on the clever find/xargs combo
+# shellcheck disable=SC2046
+grpcurl \
+    -import-path proto/proto/ \
+    -import-path proto/ibc-go-vendor \
+    $(find proto/proto -type f -iname '*.proto' | xargs -r -n 1 printf ' -proto %s ') \
+    grpc.testnet-preview.penumbra.zone:443 \
+    "$@"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -26,7 +26,7 @@ smoke_test_pid="$!"
 sleep "$TESTNET_BOOTTIME"
 
 echo "Running integration tests against network"
-PENUMBRA_NODE_HOSTNAME="127.0.0.1" \
+PENUMBRA_NODE_URL="http://127.0.0.1:8080" \
     PCLI_UNLEASH_DANGER="yes" \
     RUST_LOG="pcli=debug,penumbra=debug" \
     cargo test --features sct-divergence-check --package pcli -- --ignored --test-threads 1 --nocapture

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -54,6 +54,7 @@ async-trait = "0.1"
 tendermint = "0.26.0"
 tendermint-rpc = { version = "0.26.0", features = ["http-client"] }
 sha2 = "0.10.1"
+url = "2"
 
 [build-dependencies]
 vergen = "5"

--- a/view/src/worker.rs
+++ b/view/src/worker.rs
@@ -18,6 +18,7 @@ use penumbra_transaction::Transaction;
 use sha2::Digest;
 use tokio::sync::{watch, RwLock};
 use tonic::transport::Channel;
+use url::Url;
 
 #[cfg(feature = "sct-divergence-check")]
 use penumbra_proto::client::v1alpha1::specific_query_service_client::SpecificQueryServiceClient;
@@ -48,8 +49,7 @@ impl Worker {
     /// - a channel for notifying the client of sync progress.
     pub async fn new(
         storage: Storage,
-        node: String,
-        pd_port: u16,
+        node: Url,
     ) -> Result<
         (
             Self,
@@ -71,14 +71,11 @@ impl Worker {
         // Mark the current height as seen, since it's not new.
         sync_height_rx.borrow_and_update();
 
-        let client =
-            ObliviousQueryServiceClient::connect(format!("http://{}:{}", node, pd_port)).await?;
+        let client = ObliviousQueryServiceClient::connect(node.to_string()).await?;
         #[cfg(feature = "sct-divergence-check")]
-        let specific_client =
-            SpecificQueryServiceClient::connect(format!("http://{}:{}", node, pd_port)).await?;
+        let specific_client = SpecificQueryServiceClient::connect(node.to_string()).await?;
 
-        let tm_client =
-            TendermintProxyServiceClient::connect(format!("http://{}:{}", node, pd_port)).await?;
+        let tm_client = TendermintProxyServiceClient::connect(node.to_string()).await?;
 
         Ok((
             Self {


### PR DESCRIPTION
Updated the option handling for pcli so that the `--node` arg is now a URL, rather than a hostname. Defaults to
`https://grpc.testnet.penumbra.zone`, which routes connections to pd's grpc service on the testnet deployment. Because it's a URL, HTTP is still supported, e.g. `http://testnet.penumbra.zone:8080`.

Requires disabling support for HTTP1 in the pd service. Was not able to identify any breakage from this change; external services like Buf Studio were still able to speak protobuf fine to the patched pd instance.

Includes a wrapper script that was helpful to me during debugging, so I'm tossing it in the repo.