### PR TITLE
pd: improve tracing output at info level during block sync

### DIFF
--- a/component/src/app/mod.rs
+++ b/component/src/app/mod.rs
@@ -30,7 +30,7 @@ pub struct App {
 
 impl App {
     pub fn new(state: State) -> Self {
-        tracing::info!("initializing App instance");
+        tracing::debug!("initializing App instance");
         Self {
             // We perform the `Arc` wrapping of `State` here to ensure
             // there should be no unexpected copies elsewhere.

--- a/pd/src/mempool/worker.rs
+++ b/pd/src/mempool/worker.rs
@@ -49,7 +49,7 @@ impl Worker {
                 change = self.state_rx.changed() => {
                     if let Ok(()) = change {
                         let state = self.state_rx.borrow().into_state();
-                        tracing::info!(height = ?state.version(), "resetting ephemeral mempool state");
+                        tracing::debug!(height = ?state.version(), "resetting ephemeral mempool state");
                         self.app = App::new(state);
                     } else {
                         // TODO: what triggers this, now that the channel is owned by the


### PR DESCRIPTION
This commit changes the tracing output to demote the mempool maintenance tasks and instead promote information about the blocks being processed and committed. Its output now looks like:
```
2023-02-03T05:31:26.027364Z  INFO abci:BeginBlock{height=10072}:app{role="consensus"}: beginning block time=Time(2023-01-31 15:18:27.927578868)
2023-02-03T05:31:26.079132Z  INFO abci:Commit:app{role="consensus"}: committed block app_hash=AppHash("79be9ea80a3e63992423eea639c2c1c46ebae32b5a11ffaff4c228d57b0cda54")
2023-02-03T05:31:26.143461Z  INFO abci:BeginBlock{height=10073}:app{role="consensus"}: beginning block time=Time(2023-01-31 15:18:33.399157325)
2023-02-03T05:31:26.193797Z  INFO abci:Commit:app{role="consensus"}: committed block app_hash=AppHash("600178a176b6fc1ca51bf74e9a3878ccb314305ecd8019f6a2c08640f7ba9c63")
2023-02-03T05:31:26.256383Z  INFO abci:BeginBlock{height=10074}:app{role="consensus"}: beginning block time=Time(2023-01-31 15:18:38.92717541)
2023-02-03T05:31:26.307034Z  INFO abci:Commit:app{role="consensus"}: committed block app_hash=AppHash("3c474898e780e826b23254c462ede898d939204f78637f142e72342d4ddb939b")
2023-02-03T05:31:26.369357Z  INFO abci:BeginBlock{height=10075}:app{role="consensus"}: beginning block time=Time(2023-01-31 15:18:44.372293598)
2023-02-03T05:31:26.381537Z  INFO abci:DeliverTx{txid="5e644dcf1640fb4b5290e5b81731289d71e1fcad3c407dc5cd8eb279f995aa07"}:app{role="consensus"}: deliver_tx succeeded
2023-02-03T05:31:26.423087Z  INFO abci:Commit:app{role="consensus"}: committed block app_hash=AppHash("524b199f00f714a73843dffbed5f8a15cd32ac3f34690665b41a92bc2617587d")
2023-02-03T05:31:26.504495Z  INFO abci:BeginBlock{height=10076}:app{role="consensus"}: beginning block time=Time(2023-01-31 15:18:49.903502963)
2023-02-03T05:31:26.515994Z  INFO abci:DeliverTx{txid="b318d485eb19443a4f8b7e818337dc8e227227259750d223738e99d02e62b88b"}:app{role="consensus"}: deliver_tx succeeded
2023-02-03T05:31:26.518441Z  INFO abci:DeliverTx{txid="ea90bad7bd6e34a372024452023bedc94b4cdaa7ee71b26791158eeeef32576d"}:app{role="consensus"}: deliver_tx succeeded
2023-02-03T05:31:26.560370Z  INFO abci:Commit:app{role="consensus"}: committed block app_hash=AppHash("b3be8cce078c7fe9cb51a09a79c33d317f6a13210484129d78b20be3fc153d69")
2023-02-03T05:31:26.641774Z  INFO abci:BeginBlock{height=10077}:app{role="consensus"}: beginning block time=Time(2023-01-31 15:18:55.532543844)
2023-02-03T05:31:26.653187Z  INFO abci:DeliverTx{txid="460e2cf754deeb20e8d606cca67cd4ab81ba395e172b768addc834efaa303f2e"}:app{role="consensus"}: deliver_tx succeeded
2023-02-03T05:31:26.655667Z  INFO abci:DeliverTx{txid="24f9aa0ad6d26d692af3190e559b3e9f7a0f899caa24a2b19315164d1e9936d5"}:app{role="consensus"}: deliver_tx succeeded
2023-02-03T05:31:26.658141Z  INFO abci:DeliverTx{txid="4e22c37e6816610f928c283ec0eeb7f44e0f1a92b2741fbaa15bab0c1e087acb"}:app{role="consensus"}: deliver_tx succeeded
2023-02-03T05:31:26.697645Z  INFO abci:Commit:app{role="consensus"}: committed block app_hash=AppHash("a6b32ebdaf3ec37a7b280b4b4aaf7edf08914378b622e2875999e967dceccaef")
```