### PR TITLE
docs: install git-lfs from package managers

### DIFF
--- a/docs/guide/src/pcli/install.md
+++ b/docs/guide/src/pcli/install.md
@@ -26,10 +26,16 @@ run:
 sudo apt-get install build-essential pkg-config libssl-dev clang
 ```
 
-For a minimal Fedora image, you can run:
+For a minimal Fedora/Centos/Rhel image, you can run:
 
+This one to keep/update your system, this step is optional but recommended (this is important to keep system up to date)
 ```bash
-sudo dnf install openssl-dev clang
+sudo yum update -y ; sudo yum upgrade -y
+```
+
+This one to install required dependencies
+```bash
+sudo yum install openssl-devel clang git cargo rustfmt -y
 ```
 
 #### macOS

--- a/docs/guide/src/pcli/install.md
+++ b/docs/guide/src/pcli/install.md
@@ -12,8 +12,6 @@ OS/install method for Rust, you may have to install that separately.
 
 ### Installing Git LFS
 
-You'll also need to install [Git LFS following these instructions](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage).
-
 ### Installing build prerequisites
 
 #### Linux
@@ -23,19 +21,13 @@ depending on your distribution. For a bare-bones Ubuntu installation, you can
 run:
 
 ```bash
-sudo apt-get install build-essential pkg-config libssl-dev clang
+sudo apt-get install build-essential pkg-config libssl-dev clang git-lfs
 ```
 
-For a minimal Fedora/Centos/Rhel image, you can run:
+For a minimal Fedora/CentOS/RHEL image, you can run:
 
-This one to keep/update your system, this step is optional but recommended (this is important to keep system up to date)
 ```bash
-sudo yum update -y ; sudo yum upgrade -y
-```
-
-This one to install required dependencies
-```bash
-sudo yum install openssl-devel clang git cargo rustfmt -y
+sudo dnf install openssl-devel clang git cargo rustfmt git-lfs
 ```
 
 #### macOS
@@ -46,10 +38,10 @@ so:
 xcode-select --install
 ```
 
-You will need to install the Protobuf compiler, using Homebrew or [another
-method][protoc-install]:
-```
-brew install protobuf
+You'll also need to install Git LFS, which you can do [via Homebrew](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage?platform=mac):
+
+```bash
+brew install git-lfs
 ```
 
 ### Cloning the repository


### PR DESCRIPTION
Updates install instructions to avoid tarball-based git-lfs instructions. Also touches up the Fedora commands, ensuring they use `dnf` as `yum` is deprecated. Closes #1928. Supersedes and therefore closes #1919.
