### PR TITLE
governance: temporarily disable BeginBlock/EndBlock until #1938

### DIFF
--- a/component/src/app/mod.rs
+++ b/component/src/app/mod.rs
@@ -87,7 +87,9 @@ impl App {
         IBCComponent::begin_block(&mut state_tx, begin_block).await;
         StubDex::begin_block(&mut state_tx, begin_block).await;
         Dex::begin_block(&mut state_tx, begin_block).await;
-        Governance::begin_block(&mut state_tx, begin_block).await;
+        // Temporarily disabled until #1938 is resolved.
+        // Governance::begin_block(&mut state_tx, begin_block).await;
+
         // Shielded pool always executes last.
         ShieldedPool::begin_block(&mut state_tx, begin_block).await;
 
@@ -133,7 +135,9 @@ impl App {
         IBCComponent::end_block(&mut state_tx, end_block).await;
         StubDex::end_block(&mut state_tx, end_block).await;
         Dex::end_block(&mut state_tx, end_block).await;
-        Governance::end_block(&mut state_tx, end_block).await;
+        // Temporarily disabled until #1938 is resolved.
+        // Governance::end_block(&mut state_tx, end_block).await;
+
         // Shielded pool always executes last.
         ShieldedPool::end_block(&mut state_tx, end_block).await;
 

--- a/pcli/tests/network_integration.rs
+++ b/pcli/tests/network_integration.rs
@@ -287,6 +287,8 @@ fn swap() {
     thread::sleep(block_time);
 }
 
+// Temporarily disabled until #1938 is fixed.
+/*
 #[ignore]
 #[test]
 fn governance_submit_proposal() {
@@ -341,6 +343,7 @@ fn governance_submit_proposal() {
         .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS));
     proposals_cmd.assert().success();
 }
+ */
 
 #[ignore]
 #[test]


### PR DESCRIPTION
This avoids the performance hit until we resolve that issue.