### PR TITLE
Improve efficiency of validator updates

### DIFF
--- a/component/src/stake/component.rs
+++ b/component/src/stake/component.rs
@@ -1081,11 +1081,8 @@ pub trait StateReadExt: StateRead {
     }
 
     async fn validator_identity_list(&self) -> Result<Vec<IdentityKey>> {
-        self.prefix_raw(state_key::validators::list())
-            // The prefix stream returns keys and values, but we only want the keys.
-            // This is a little inefficient, since we're getting the validator definitions
-            // too, but we don't have to parse them, so we're just doing some extra byte copies.
-            .map_ok(|(key, _validator)| {
+        self.prefix_keys(state_key::validators::list())
+            .map_ok(|key| {
                 key.as_str()[state_key::validators::list().len()..]
                     .parse::<IdentityKey>()
                     .expect("state keys should only have valid identity keys")

--- a/storage/src/snapshot.rs
+++ b/storage/src/snapshot.rs
@@ -164,6 +164,47 @@ impl StateRead for Snapshot {
         Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx))
     }
 
+    // NOTE: this implementation is almost the same as the above, but without
+    // fetching the values. not totally clear if this could be combined, or if that would
+    // be better overall.
+    fn prefix_keys<'a>(
+        &'a self,
+        prefix: &'a str,
+    ) -> Pin<Box<dyn Stream<Item = Result<String>> + Sync + Send + 'a>> {
+        let span = Span::current();
+        let self2 = self.clone();
+
+        let mut options = rocksdb::ReadOptions::default();
+        options.set_iterate_range(rocksdb::PrefixRange(prefix.as_bytes()));
+        let mode = rocksdb::IteratorMode::Start;
+
+        let (tx, rx) = mpsc::channel(10);
+        tokio::task::Builder::new()
+            .name("Snapshot::prefix_keys")
+            .spawn_blocking(move || {
+                span.in_scope(|| {
+                    let keys_cf = self2
+                        .0
+                        .db
+                        .cf_handle("jmt_keys")
+                        .expect("jmt_keys column family not found");
+                    let iter = self2.0.snapshot.iterator_cf_opt(keys_cf, options, mode);
+                    for i in iter {
+                        // For each key that matches the prefix, fetch the value from the JMT column family.
+                        let (key_preimage, _key_hash) = i?;
+                        let k = std::str::from_utf8(key_preimage.as_ref())
+                            .expect("saved jmt keys are utf-8 strings")
+                            .to_string();
+                        tx.blocking_send(Ok(k))?;
+                    }
+                    Ok::<(), anyhow::Error>(())
+                })
+            })
+            .expect("should be able to spawn_blocking");
+
+        Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx))
+    }
+
     fn nonconsensus_prefix_raw<'a>(
         &'a self,
         prefix: &'a [u8],

--- a/storage/src/state.rs
+++ b/storage/src/state.rs
@@ -1,8 +1,8 @@
-use std::{any::Any, collections::BTreeMap, pin::Pin, sync::Arc};
+use std::{any::Any, collections::BTreeMap, future::Future, pin::Pin, sync::Arc};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use futures::Stream;
+use futures::{FutureExt, Stream};
 use tracing::Span;
 
 mod read;
@@ -141,14 +141,28 @@ impl State {
 
 #[async_trait]
 impl StateRead for State {
-    async fn get_raw(&self, key: &str) -> Result<Option<Vec<u8>>> {
-        // If the key is available in the unwritten_changes cache, return it.
-        if let Some(v) = self.unwritten_changes.get(key) {
-            return Ok(v.clone());
-        }
+    fn get_raw(
+        &self,
+        key: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Vec<u8>>>> + Send + 'static>> {
+        // We want to return a 'static future, so we need to get all our references
+        // to &self done upfront, before we bundle the results into a future.
 
-        // Otherwise, if the key is available in the snapshot, return it.
-        self.snapshot.get_raw(key).await
+        // If the key is available in the unwritten_changes cache, extract it now,
+        // so we can move it into the future we'll return.
+        let cached_value = self.unwritten_changes.get(key).cloned();
+        // Prepare a query to the state; this won't start executing until we poll it.
+        let snapshot_value = self.snapshot.get_raw(key);
+
+        async move {
+            match cached_value {
+                // If the key is available in the unwritten_changes cache, return it.
+                Some(v) => Ok(v),
+                // Otherwise, if the key is available in the JMT, return it.
+                None => snapshot_value.await,
+            }
+        }
+        .boxed()
     }
 
     async fn nonconsensus_get_raw(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {

--- a/storage/src/state.rs
+++ b/storage/src/state.rs
@@ -15,7 +15,9 @@ pub use write::StateWrite;
 
 use crate::snapshot::Snapshot;
 
-use self::read::{nonconsensus_prefix_raw_with_cache, prefix_raw_with_cache};
+use self::read::{
+    nonconsensus_prefix_raw_with_cache, prefix_keys_with_cache, prefix_raw_with_cache,
+};
 
 /// A lightweight snapshot of a particular version of the chain state.
 ///
@@ -164,6 +166,13 @@ impl StateRead for State {
         prefix: &'a str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, Vec<u8>)>> + Send + Sync + 'a>> {
         prefix_raw_with_cache(&self.snapshot, &self.unwritten_changes, prefix)
+    }
+
+    fn prefix_keys<'a>(
+        &'a self,
+        prefix: &'a str,
+    ) -> Pin<Box<dyn Stream<Item = Result<String>> + Send + Sync + 'a>> {
+        prefix_keys_with_cache(&self.snapshot, &self.unwritten_changes, prefix)
     }
 
     fn object_get<T: Any + Send + Sync>(&self, key: &str) -> Option<&T> {

--- a/storage/src/state/read.rs
+++ b/storage/src/state/read.rs
@@ -23,6 +23,12 @@ pub trait StateRead: Send + Sync {
         prefix: &'a str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, Vec<u8>)>> + Sync + Send + 'a>>;
 
+    /// Retrieve all keys (but not values) matching a prefix from the verifiable key-value store.
+    fn prefix_keys<'a>(
+        &'a self,
+        prefix: &'a str,
+    ) -> Pin<Box<dyn Stream<Item = Result<String>> + Sync + Send + 'a>>;
+
     /// Gets a byte value from the non-verifiable key-value store.
     ///
     /// This is intended for application-specific indexes of the verifiable
@@ -142,6 +148,41 @@ pub(crate) fn prefix_raw_with_cache<'a>(
     Box::pin(merged)
 }
 
+pub(crate) fn prefix_keys_with_cache<'a>(
+    sr: &'a impl StateRead,
+    cache: &'a BTreeMap<String, Option<Vec<u8>>>,
+    prefix: &'a str,
+) -> Pin<Box<dyn Stream<Item = Result<String>> + Send + Sync + 'a>> {
+    // The implementation is similar to prefix_raw_with_cache.  In order to
+    // reuse the merge_cache code, we use zero-size dummy values (), which lets
+    // us correctly handle uncommitted deletions (which will be represented as
+    // None rather than Some(())).
+
+    let state_stream = sr
+        .prefix_keys(prefix)
+        .map(move |r| r.map(move |k| (k, Some(()))));
+
+    // Range the unwritten_changes cache (sorted by key) starting with the keys matching the prefix,
+    // until we reach the keys that no longer match the prefix.
+    let unwritten_changes_iter = cache
+        .range(prefix.to_string()..)
+        .take_while(move |(k, _)| (**k).starts_with(prefix))
+        // Do a little dance to turn &Some(bytes) into Some(()), and &None into None,
+        // so we're only working with keys, not values, but we can reuse the merge_cache function.
+        .map(|(k, v)| (k.clone(), v.as_ref().map(|_| ())));
+
+    // Merge the unwritten_changes cache with the snapshot.
+    let merged = merge_cache(unwritten_changes_iter, state_stream);
+
+    // Filter out the keys that were deleted in the unwritten_changes cache.
+    let filtered = merged.filter_map(|r| async move {
+        r.map(|(k, v)| if v.is_some() { Some(k) } else { None })
+            .transpose()
+    });
+
+    Box::pin(filtered)
+}
+
 #[allow(clippy::type_complexity)]
 pub(crate) fn nonconsensus_prefix_raw_with_cache<'a>(
     sr: &'a impl StateRead,
@@ -183,6 +224,13 @@ impl<'a, S: StateRead + Send + Sync> StateRead for &'a S {
         (**self).prefix_raw(prefix)
     }
 
+    fn prefix_keys<'b>(
+        &'b self,
+        prefix: &'b str,
+    ) -> Pin<Box<dyn Stream<Item = Result<String>> + Sync + Send + 'b>> {
+        (**self).prefix_keys(prefix)
+    }
+
     fn nonconsensus_prefix_raw<'b>(
         &'b self,
         prefix: &'b [u8],
@@ -210,6 +258,13 @@ impl<'a, S: StateRead + Send + Sync> StateRead for &'a mut S {
         prefix: &'b str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, Vec<u8>)>> + Sync + Send + 'b>> {
         (**self).prefix_raw(prefix)
+    }
+
+    fn prefix_keys<'b>(
+        &'b self,
+        prefix: &'b str,
+    ) -> Pin<Box<dyn Stream<Item = Result<String>> + Sync + Send + 'b>> {
+        (**self).prefix_keys(prefix)
     }
 
     fn nonconsensus_prefix_raw<'b>(

--- a/storage/src/state/transaction.rs
+++ b/storage/src/state/transaction.rs
@@ -1,8 +1,8 @@
-use std::{any::Any, collections::BTreeMap, pin::Pin};
+use std::{any::Any, collections::BTreeMap, future::Future, pin::Pin};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use futures::Stream;
+use futures::{FutureExt, Stream};
 use tendermint::abci;
 
 use crate::State;
@@ -103,14 +103,28 @@ impl<'a> StateWrite for Transaction<'a> {
 
 #[async_trait]
 impl<'tx> StateRead for Transaction<'tx> {
-    async fn get_raw(&self, key: &str) -> Result<Option<Vec<u8>>> {
-        // If the key is available in the unwritten_changes cache, return it.
-        if let Some(v) = self.unwritten_changes.get(key) {
-            return Ok(v.clone());
-        }
+    fn get_raw(
+        &self,
+        key: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Vec<u8>>>> + Send + 'static>> {
+        // We want to return a 'static future, so we need to get all our references
+        // to &self done upfront, before we bundle the results into a future.
 
-        // Otherwise, if the key is available in the state, return it.
-        self.state.get_raw(key).await
+        // If the key is available in the unwritten_changes cache, extract it now,
+        // so we can move it into the future we'll return.
+        let cached_value = self.unwritten_changes.get(key).cloned();
+        // Prepare a query to the state; this won't start executing until we poll it.
+        let state_value = self.state.get_raw(key);
+
+        async move {
+            match cached_value {
+                // If the key is available in the unwritten_changes cache, return it.
+                Some(v) => Ok(v),
+                // Otherwise, if the key is available in the state, return it.
+                None => state_value.await,
+            }
+        }
+        .boxed()
     }
 
     async fn nonconsensus_get_raw(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {

--- a/storage/src/state/transaction.rs
+++ b/storage/src/state/transaction.rs
@@ -8,7 +8,7 @@ use tendermint::abci;
 use crate::State;
 
 use super::{
-    read::{nonconsensus_prefix_raw_with_cache, prefix_raw_with_cache},
+    read::{nonconsensus_prefix_raw_with_cache, prefix_keys_with_cache, prefix_raw_with_cache},
     StateRead, StateWrite,
 };
 
@@ -128,6 +128,13 @@ impl<'tx> StateRead for Transaction<'tx> {
         prefix: &'a str,
     ) -> Pin<Box<dyn Stream<Item = Result<(String, Vec<u8>)>> + Sync + Send + 'a>> {
         prefix_raw_with_cache(self.state, &self.unwritten_changes, prefix)
+    }
+
+    fn prefix_keys<'a>(
+        &'a self,
+        prefix: &'a str,
+    ) -> Pin<Box<dyn Stream<Item = Result<String>> + Sync + Send + 'a>> {
+        prefix_keys_with_cache(self.state, &self.unwritten_changes, prefix)
     }
 
     fn nonconsensus_prefix_raw<'a>(

--- a/storage/tests/basic.rs
+++ b/storage/tests/basic.rs
@@ -141,24 +141,40 @@ async fn simple_flow() -> anyhow::Result<()> {
     //    This is missing in tx01 and in state_init
     assert_eq!(tx01.get_raw("a/c").await?, None);
     let mut range = tx01.prefix_raw("a/");
+    let mut range_keys = tx01.prefix_keys("a/");
     assert_eq!(
         range.next().await.transpose()?,
         Some(("a/aa".to_owned(), b"aa".to_vec()))
+    );
+    assert_eq!(
+        range_keys.next().await.transpose()?,
+        Some("a/aa".to_owned())
     );
     assert_eq!(
         range.next().await.transpose()?,
         Some(("a/aaa".to_owned(), b"aaa".to_vec()))
     );
     assert_eq!(
+        range_keys.next().await.transpose()?,
+        Some("a/aaa".to_owned())
+    );
+    assert_eq!(
         range.next().await.transpose()?,
         Some(("a/ab".to_owned(), b"ab".to_vec()))
+    );
+    assert_eq!(
+        range_keys.next().await.transpose()?,
+        Some("a/ab".to_owned())
     );
     assert_eq!(
         range.next().await.transpose()?,
         Some(("a/z".to_owned(), b"z".to_vec()))
     );
+    assert_eq!(range_keys.next().await.transpose()?, Some("a/z".to_owned()));
     assert_eq!(range.next().await.transpose()?, None);
+    assert_eq!(range_keys.next().await.transpose()?, None);
     std::mem::drop(range);
+    std::mem::drop(range_keys);
 
     // Now apply the transaction to state_init
     tx01.apply();
@@ -173,24 +189,40 @@ async fn simple_flow() -> anyhow::Result<()> {
     //    This is missing in state_init
     assert_eq!(state_init.get_raw("a/c").await?, None);
     let mut range = state_init.prefix_raw("a/");
+    let mut range_keys = state_init.prefix_keys("a/");
     assert_eq!(
         range.next().await.transpose()?,
         Some(("a/aa".to_owned(), b"aa".to_vec()))
+    );
+    assert_eq!(
+        range_keys.next().await.transpose()?,
+        Some("a/aa".to_owned())
     );
     assert_eq!(
         range.next().await.transpose()?,
         Some(("a/aaa".to_owned(), b"aaa".to_vec()))
     );
     assert_eq!(
+        range_keys.next().await.transpose()?,
+        Some("a/aaa".to_owned())
+    );
+    assert_eq!(
         range.next().await.transpose()?,
         Some(("a/ab".to_owned(), b"ab".to_vec()))
+    );
+    assert_eq!(
+        range_keys.next().await.transpose()?,
+        Some("a/ab".to_owned())
     );
     assert_eq!(
         range.next().await.transpose()?,
         Some(("a/z".to_owned(), b"z".to_vec()))
     );
+    assert_eq!(range_keys.next().await.transpose()?, Some("a/z".to_owned()));
     assert_eq!(range.next().await.transpose()?, None);
+    assert_eq!(range_keys.next().await.transpose()?, None);
     std::mem::drop(range);
+    std::mem::drop(range_keys);
 
     // Now commit state_init to storage
     storage.commit(state_init).await?;


### PR DESCRIPTION
Profiling revealed we were spending a lot of time parsing validator definitions and their funding streams during block sync. This PR aims at streamlining that, and in the process discovering some new patterns for working with the chain state.

In particular, it:

- Adds `StateRead::prefix_keys`, which works like `prefix_raw` but doesn't look up values;
- Changes the `StateRead::get*` trait methods to return `'static` futures, so that state queries can be run concurrently by spawning them as independent tasks.
- Changes the `build_tendermint_validator_updates` method that runs at the end of every block to (1) not parse full validator definitions and (2) to run each validator's state queries in parallel.