### PR TITLE
dex: move composition into `BareTradingFunction`

### DIFF
--- a/crypto/src/dex/lp/trading_function.rs
+++ b/crypto/src/dex/lp/trading_function.rs
@@ -18,25 +18,6 @@ impl TradingFunction {
             pair,
         }
     }
-
-    /// Compose two trading functions together.
-    /// TODO(erwan): doc.
-    pub fn compose(
-        &self,
-        psi: TradingFunction,
-        pair: TradingPair,
-    ) -> anyhow::Result<TradingFunction> {
-        // TODO(erwan): we should fail to compose trading functions with non-overlapping assets.
-        //  however, since we're not using `DirectedTradingPair` here, the logic to check what
-        // TODO: * insert scaling code here
-        //       * overflow handling
-        //  should be the resulting pair is tedious. I will re-insert it later.
-        let fee = self.component.fee * psi.component.fee;
-        // TODO: insert scaling code here
-        let r1 = self.component.p * psi.component.p;
-        let r2 = self.component.q * psi.component.q;
-        Ok(TradingFunction::new(pair, fee, r1, r2))
-    }
 }
 
 impl TryFrom<pb::TradingFunction> for TradingFunction {
@@ -136,6 +117,14 @@ impl BareTradingFunction {
     /// Note: the float math is a placehodler
     pub fn gamma(&self) -> f64 {
         (10_000.0 - self.fee as f64) / 10_000.0
+    }
+
+    /// Returns the composition of two trading functions.
+    pub fn compose(&self, phi: BareTradingFunction) -> BareTradingFunction {
+        let fee = self.fee * phi.fee;
+        let r1 = self.p * phi.p;
+        let r2 = self.q * phi.q;
+        BareTradingFunction::new(fee, r1, r2)
     }
 }
 

--- a/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
+++ b/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
@@ -332,7 +332,7 @@ message PositionRewardClaim {
 message Path {
     DirectedTradingPair pair = 1;
     repeated crypto.v1alpha1.AssetId route = 2;
-    TradingFunction phi = 3;
+    BareTradingFunction phi = 3;
 }
 
 // A path and the amount of the assets on either side that were traded.

--- a/proto/src/gen/penumbra.core.dex.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.dex.v1alpha1.rs
@@ -505,7 +505,7 @@ pub struct Path {
     #[prost(message, repeated, tag = "2")]
     pub route: ::prost::alloc::vec::Vec<super::super::crypto::v1alpha1::AssetId>,
     #[prost(message, optional, tag = "3")]
-    pub phi: ::core::option::Option<TradingFunction>,
+    pub phi: ::core::option::Option<BareTradingFunction>,
 }
 /// A path and the amount of the assets on either side that were traded.
 #[allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
This is a refactor that moves `TradingFunction::compose` into `BareTradingFunction`. A follow-up PR will deal with coefficient rescaling within `BareTradingFunction` as part of #1836 