### PR TITLE
fix: fee commitment sign in swaps

### DIFF
--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -495,7 +495,6 @@ impl SwapProof {
             };
         let transparent_balance_commitment = transparent_balance.commit(Fr::zero());
 
-        // XXX sign error here
         // XXX we want to avoid having to twiddle signs for synthetic blinding factor in binding sig
         ensure!(
             balance_commitment == transparent_balance_commitment + fee_commitment,

--- a/transaction/src/plan/action/swap.rs
+++ b/transaction/src/plan/action/swap.rs
@@ -39,11 +39,7 @@ impl SwapPlan {
 
     /// Construct the [`swap::Body`] described by this [`SwapPlan`].
     pub fn swap_body(&self, fvk: &FullViewingKey) -> swap::Body {
-        let fee_commitment = self
-            .swap_plaintext
-            .claim_fee
-            .value()
-            .commit(self.fee_blinding);
+        let fee_commitment = self.swap_plaintext.claim_fee.commit(self.fee_blinding);
 
         swap::Body {
             trading_pair: self.swap_plaintext.trading_pair,


### PR DESCRIPTION
Closes #1746
The test here setting swap fees to non-zero fails on `main` due to the fee commitment integrity check failing in the corresponding swap proof. The second commit fixes the failure by ensuring the the fee commitment computation in the swap plan also uses `Balance::commit` (instead of `Value::commit` which does not first negate the fee value, resulting in the mismatch).