### PR TITLE
pd: improve tracing output at info level

### DIFF
--- a/pd/src/consensus/service.rs
+++ b/pd/src/consensus/service.rs
@@ -58,7 +58,7 @@ impl tower_service::Service<ConsensusRequest> for Consensus {
         }
 
         let span = req.create_span();
-        let span = error_span!(parent: &span, "app", role = "consensus");
+        //let span = error_span!(parent: &span, "app", role = "consensus");
         let (tx, rx) = oneshot::channel();
 
         self.queue

--- a/pd/src/consensus/worker.rs
+++ b/pd/src/consensus/worker.rs
@@ -136,6 +136,14 @@ impl Worker {
         match rsp {
             Ok(events) => {
                 tracing::info!("deliver_tx succeeded");
+                for event in &events {
+                    let span = tracing::info_span!("event", kind = ?event.kind);
+                    span.in_scope(|| {
+                        for attr in &event.attributes {
+                            tracing::info!(k = ?attr.key, v=?attr.value);
+                        }
+                    })
+                }
                 abci::response::DeliverTx {
                     events,
                     ..Default::default()

--- a/pd/src/mempool/service.rs
+++ b/pd/src/mempool/service.rs
@@ -60,7 +60,7 @@ impl tower_service::Service<MempoolRequest> for Mempool {
             .boxed();
         }
         let span = req.create_span();
-        let span = error_span!(parent: &span, "app", role = "mempool");
+        //let span = error_span!(parent: &span, "app", role = "mempool");
         let (tx, rx) = oneshot::channel();
 
         let MempoolRequest::CheckTx(CheckTxReq {


### PR DESCRIPTION
Removes some superfluous spans and records ABCI events.  At some point we might want to demote the ABCI events, but it's a useful summary for now:
```
2023-02-07T22:45:58.056113Z  INFO abci:BeginBlock{height=15531}: beginning block time=Time(2023-02-07 22:45:52.083434842)
2023-02-07T22:45:58.116424Z  INFO abci:Commit: committed block app_hash=AppHash("77ecedaf48871e9f2296f8303d3b5b9a6450f42a14981bfa65c9295cedade1ee")
2023-02-07T22:46:02.653850Z  INFO abci:CheckTx{kind=New txid="79249e76a5f90fb664703198a0624050d7882993c2ab26521b4f27367ed4081c"}: tx accepted
2023-02-07T22:46:03.937495Z  INFO abci:BeginBlock{height=15532}: beginning block time=Time(2023-02-07 22:45:57.754330666)
2023-02-07T22:46:03.966957Z  INFO abci:DeliverTx{txid="79249e76a5f90fb664703198a0624050d7882993c2ab26521b4f27367ed4081c"}: deliver_tx succeeded
2023-02-07T22:46:03.966973Z  INFO abci:DeliverTx{txid="79249e76a5f90fb664703198a0624050d7882993c2ab26521b4f27367ed4081c"}:event{kind="spend"}: k="nullifier" v="cc75440b83aa579992b5976a1e6c61c9f65dfe20442e5667fdbc595db7507708"
2023-02-07T22:46:03.966979Z  INFO abci:DeliverTx{txid="79249e76a5f90fb664703198a0624050d7882993c2ab26521b4f27367ed4081c"}:event{kind="spend"}: k="nullifier" v="16e4b3a1ffd2a58eb4caf2002f25c1454c76f92a7e3ec8ddece0f49838a1c101"
2023-02-07T22:46:04.022501Z  INFO abci:Commit: committed block app_hash=AppHash("fca2a7af9b6dd56ab6c695320254eb58a5f6b9564c53996f06faa5aa177df842")
2023-02-07T22:46:09.490770Z  INFO abci:BeginBlock{height=15533}: beginning block time=Time(2023-02-07 22:46:03.563221073)
2023-02-07T22:46:09.551227Z  INFO abci:Commit: committed block app_hash=AppHash("429f130c717ba64e58faa7c083adecf942b51732c33da76f4fbb86d93f628e66")
2023-02-07T22:46:15.073186Z  INFO abci:BeginBlock{height=15534}: beginning block time=Time(2023-02-07 22:46:09.19901774)
```
Getting visibility on ABCI events in this way seems useful for making sure they cover meaningful transaction activity.