### PR TITLE
pd: more event improvements

### DIFF
--- a/component/src/action_handler/actions/spend.rs
+++ b/component/src/action_handler/actions/spend.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use penumbra_storage::{State, StateRead, StateTransaction, StateWrite};
+use penumbra_storage::{State, StateRead, StateTransaction};
 use penumbra_transaction::{action::Spend, Transaction};
 use tracing::instrument;
 
 use crate::{
     action_handler::ActionHandler,
-    shielded_pool::{self, NoteManager, StateReadExt as _},
+    shielded_pool::{NoteManager, StateReadExt as _},
 };
 
 #[async_trait]
@@ -52,9 +52,6 @@ impl ActionHandler for Spend {
         let source = state.object_get("source").cloned().unwrap_or_default();
 
         state.spend_nullifier(self.body.nullifier, source).await;
-        // TODO: why do we manage event emission separately up at the top level
-        // instead of integrated into state machine?
-        state.record(shielded_pool::event::spend(self.body.nullifier));
 
         Ok(())
     }

--- a/component/src/action_handler/actions/swap_claim.rs
+++ b/component/src/action_handler/actions/swap_claim.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use penumbra_chain::{sync::StatePayload, StateReadExt as _};
-use penumbra_storage::{State, StateRead, StateTransaction, StateWrite};
+use penumbra_storage::{State, StateRead, StateTransaction};
 use penumbra_transaction::{action::SwapClaim, Transaction};
 use tracing::instrument;
 
 use crate::{
     action_handler::ActionHandler,
-    shielded_pool::{self, NoteManager, StateReadExt as _},
+    shielded_pool::{NoteManager, StateReadExt as _},
     stubdex::StateReadExt as _,
 };
 
@@ -87,9 +87,6 @@ impl ActionHandler for SwapClaim {
             .await;
 
         state.spend_nullifier(self.body.nullifier, source).await;
-        // TODO: why do we manage event emission separately up at the top level
-        // instead of integrated into state machine?
-        state.record(shielded_pool::event::spend(self.body.nullifier));
 
         Ok(())
     }

--- a/component/src/shielded_pool/component.rs
+++ b/component/src/shielded_pool/component.rs
@@ -126,7 +126,7 @@ pub trait StateReadExt: StateRead {
     // #[instrument(skip(self))]
     async fn check_nullifier_unspent(&self, nullifier: Nullifier) -> Result<()> {
         if let Some(source) = self
-            .get::<NoteSource>(&state_key::spent_nullifier_lookup(nullifier))
+            .get::<NoteSource>(&state_key::spent_nullifier_lookup(&nullifier))
             .await?
         {
             return Err(anyhow!(

--- a/component/src/shielded_pool/event.rs
+++ b/component/src/shielded_pool/event.rs
@@ -1,6 +1,14 @@
+use penumbra_chain::StatePayload;
 use penumbra_crypto::Nullifier;
 use tendermint::abci::{Event, EventAttributeIndexExt};
 
-pub fn spend(nullifier: Nullifier) -> Event {
-    Event::new("spend", vec![("nullifier", nullifier.to_string()).index()])
+pub fn spend(nullifier: &Nullifier) -> Event {
+    Event::new("spend", [("nullifier", nullifier.to_string()).index()])
+}
+
+pub fn state_payload(payload: &StatePayload) -> Event {
+    Event::new(
+        "state_payload",
+        [("commitment", payload.commitment().to_string()).index()],
+    )
 }

--- a/component/src/shielded_pool/state_key.rs
+++ b/component/src/shielded_pool/state_key.rs
@@ -49,7 +49,7 @@ pub fn block_anchor_lookup(anchor: block::Root) -> String {
     format!("shielded_pool/valid_block_anchors/{}", anchor)
 }
 
-pub fn spent_nullifier_lookup(nullifier: Nullifier) -> String {
+pub fn spent_nullifier_lookup(nullifier: &Nullifier) -> String {
     format!("shielded_pool/spent_nullifiers/{}", nullifier)
 }
 

--- a/component/src/stake/component.rs
+++ b/component/src/stake/component.rs
@@ -40,7 +40,7 @@ use crate::stake::{
 
 use crate::shielded_pool::{NoteManager, SupplyRead, SupplyWrite};
 
-use super::CurrentConsensusKeys;
+use super::{event, CurrentConsensusKeys};
 
 // Max validator power is 1152921504606846975 (i64::MAX / 8)
 // https://github.com/tendermint/tendermint/blob/master/types/validator_set.go#L25
@@ -1170,12 +1170,14 @@ pub trait StateWriteExt: StateWrite {
     }
 
     fn stub_push_delegation(&mut self, delegation: Delegate) {
+        self.record(event::delegate(&delegation));
         let mut changes = self.stub_delegation_changes();
         changes.delegations.push(delegation);
         self.put_stub_delegation_changes(changes);
     }
 
     fn stub_push_undelegation(&mut self, undelegation: Undelegate) {
+        self.record(event::undelegate(&undelegation));
         let mut changes = self.stub_delegation_changes();
         changes.undelegations.push(undelegation);
         self.put_stub_delegation_changes(changes);

--- a/component/src/stake/event.rs
+++ b/component/src/stake/event.rs
@@ -1,0 +1,22 @@
+use penumbra_transaction::action::{Delegate, Undelegate};
+use tendermint::abci::{Event, EventAttributeIndexExt};
+
+pub fn delegate(delegate: &Delegate) -> Event {
+    Event::new(
+        "delegate",
+        [
+            ("validator", delegate.validator_identity.to_string()).index(),
+            ("amount", delegate.unbonded_amount.to_string()).no_index(),
+        ],
+    )
+}
+
+pub fn undelegate(undelegate: &Undelegate) -> Event {
+    Event::new(
+        "undelegate",
+        [
+            ("validator", undelegate.validator_identity.to_string()).index(),
+            ("amount", undelegate.unbonded_amount.to_string()).no_index(),
+        ],
+    )
+}

--- a/component/src/stake/mod.rs
+++ b/component/src/stake/mod.rs
@@ -4,6 +4,7 @@ use penumbra_crypto::stake::IdentityKey;
 
 mod changes;
 mod current_consensus_keys;
+mod event;
 mod funding_stream;
 mod metrics;
 mod uptime;

--- a/pcli/src/command/query/shielded_pool.rs
+++ b/pcli/src/command/query/shielded_pool.rs
@@ -47,7 +47,7 @@ impl ShieldedPool {
             ShieldedPool::EpochAnchor { epoch } => state_key::epoch_anchor_by_index(*epoch),
             ShieldedPool::CompactBlock { height } => state_key::compact_block(*height),
             ShieldedPool::Commitment { commitment } => state_key::note_source(commitment),
-            ShieldedPool::Nullifier { nullifier } => state_key::spent_nullifier_lookup(*nullifier),
+            ShieldedPool::Nullifier { nullifier } => state_key::spent_nullifier_lookup(nullifier),
         }
     }
 


### PR DESCRIPTION
Per discussion on a shared slack channel, Cosmos-SDK apps use a config file to determine which events should be indexed or not; this is totally controlled by the app, and not by Tendermint. At some point we might consider giving users the option to configure indexing.