### PR TITLE
ci: build grafana container with custom dashboards

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-push-image:
+  build-and-push-penumbra:
     runs-on: buildjet-16vcpu-ubuntu-2004
     permissions:
       contents: read
@@ -51,6 +51,51 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           file: deployments/containerfiles/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-and-push-grafana:
+    runs-on: buildjet-16vcpu-ubuntu-2004
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the GitHub container registry (for pushes)
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to the Docker Hub container registry (for pulls)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/penumbra-zone/grafana
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: deployments/containerfiles/Dockerfile-grafana
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/deployments/compose/docker-compose.multinode.override.yml
+++ b/deployments/compose/docker-compose.multinode.override.yml
@@ -77,18 +77,11 @@ services:
       - monitoring
 
   grafana:
-    image: "docker.io/grafana/grafana:latest"
+    build:
+      context: ../../
+      dockerfile: deployments/containerfiles/Dockerfile-grafana
     ports:
       - '3000'
-    volumes:
-      # this grafana config is intended for local development and disables auth
-      # etc. in production, users will generally want to configure a centralized
-      # grafana instance...
-      - "../config/grafana/provisioning:/etc/grafana/provisioning:ro"
-      - "../config/grafana.ini:/etc/grafana/config.ini:ro"
-      # mount the dashboards dir as read-write so we can add new dashboards
-      # using the Grafana web UI.
-      - "../config/grafana/dashboards:/var/lib/grafana/dashboards:rw"
     networks:
       - monitoring
     depends_on:

--- a/deployments/compose/docker-compose.multinode.override.yml
+++ b/deployments/compose/docker-compose.multinode.override.yml
@@ -42,7 +42,7 @@ services:
 
   # The Tendermint node
   tendermint-node1:
-    image: "tendermint/tendermint:v0.34.23"
+    image: "docker.io/tendermint/tendermint:v0.34.23"
     container_name: tendermint-node1
     ports:
       - "27656:26656"
@@ -64,7 +64,7 @@ services:
   # in production, users will want to bring their own monitoring stack, rather
   # than running a separate prometheus and grafana instance on every node.
   prometheus:
-    image: "prom/prometheus:latest"
+    image: "docker.io/prom/prometheus:latest"
     ports:
       - '9090:9090'
     volumes:
@@ -77,7 +77,7 @@ services:
       - monitoring
 
   grafana:
-    image: "grafana/grafana:latest"
+    image: "docker.io/grafana/grafana:latest"
     ports:
       - '3000'
     volumes:

--- a/deployments/compose/docker-compose.override.yml
+++ b/deployments/compose/docker-compose.override.yml
@@ -24,7 +24,7 @@ services:
   # in production, users will want to bring their own monitoring stack, rather
   # than running a separate prometheus and grafana instance on every node.
   prometheus:
-    image: "prom/prometheus:latest"
+    image: "docker.io/prom/prometheus:latest"
     ports:
       - '9090:9090'
     volumes:
@@ -37,7 +37,7 @@ services:
       - monitoring
 
   grafana:
-    image: "grafana/grafana:latest"
+    image: "docker.io/grafana/grafana:latest"
     ports:
       - '3000'
     volumes:

--- a/deployments/compose/docker-compose.override.yml
+++ b/deployments/compose/docker-compose.override.yml
@@ -37,18 +37,13 @@ services:
       - monitoring
 
   grafana:
-    image: "docker.io/grafana/grafana:latest"
+    build:
+      # Use the dev Dockerfile which has better cacheing and doesn't use the release
+      # target
+      dockerfile: deployments/containerfiles/Dockerfile-grafana
+      context: ../../
     ports:
       - '3000'
-    volumes:
-      # this grafana config is intended for local development and disables auth
-      # etc. in production, users will generally want to configure a centralized
-      # grafana instance...
-      - "../config/grafana/provisioning:/etc/grafana/provisioning:ro"
-      - "../config/grafana.ini:/etc/grafana/config.ini:ro"
-      # mount the dashboards dir as read-write so we can add new dashboards
-      # using the Grafana web UI.
-      - "../config/grafana/dashboards:/var/lib/grafana/dashboards:rw"
     networks:
       - monitoring
     depends_on:

--- a/deployments/compose/docker-compose.prod.yml
+++ b/deployments/compose/docker-compose.prod.yml
@@ -22,7 +22,7 @@ services:
   # in production, users will want to bring their own monitoring stack, rather
   # than running a separate prometheus and grafana instance on every node.
   prometheus:
-    image: "prom/prometheus:latest"
+    image: "docker.io/prom/prometheus:latest"
     ports:
       - '9090:9090'
     volumes:
@@ -35,7 +35,7 @@ services:
       - monitoring
 
   grafana:
-    image: "grafana/grafana:latest"
+    image: "docker.io/grafana/grafana:latest"
     ports:
       - '3000'
     volumes:
@@ -49,7 +49,7 @@ services:
 
   # Caddy provides TLS termination for the Grafana web service
   caddy:
-    image: caddy:2-alpine
+    image: docker.io/caddy:2-alpine
     restart: unless-stopped
     ports:
       - "80:80"

--- a/deployments/compose/docker-compose.prod.yml
+++ b/deployments/compose/docker-compose.prod.yml
@@ -35,12 +35,11 @@ services:
       - monitoring
 
   grafana:
-    image: "docker.io/grafana/grafana:latest"
+    build:
+      context: ../../
+      dockerfile: deployments/containerfiles/Dockerfile-grafana
     ports:
       - '3000'
-    volumes:
-      - "grafana_configs:/etc/grafana"
-      - "grafana_data:/var/lib/grafana"
     networks:
       - monitoring
     depends_on:

--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -15,13 +15,15 @@ services:
     networks:
       localnet:
         ipv4_address: 192.167.10.10
+    user: "${UID:-1000}"
     ports:
       - "26658:26658"
       - "8080:8080"
 
   # The Tendermint node
   tendermint-node0:
-    image: "tendermint/tendermint:v0.34.23"
+    image: "docker.io/tendermint/tendermint:v0.34.23"
+    user: "${UID:-1000}"
     container_name: tendermint-node0
     ports:
       - "26656:26656"

--- a/deployments/config/Caddyfile
+++ b/deployments/config/Caddyfile
@@ -8,6 +8,3 @@
 {$TESTNET_HOST:localhost} {
     reverse_proxy grafana:3000
 }
-www.{$TESTNET_HOST:localhost} {
-    redir https://{$TESTNET_HOST:localhost}{uri}
-}

--- a/deployments/config/grafana/dashboards/ABCI.json
+++ b/deployments/config/grafana/dashboards/ABCI.json
@@ -544,7 +544,18 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-30m",

--- a/deployments/config/grafana/dashboards/Client Info.json
+++ b/deployments/config/grafana/dashboards/Client Info.json
@@ -252,7 +252,18 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/deployments/config/grafana/dashboards/Consensus.json
+++ b/deployments/config/grafana/dashboards/Consensus.json
@@ -338,7 +338,18 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/deployments/config/grafana/dashboards/P2P.json
+++ b/deployments/config/grafana/dashboards/P2P.json
@@ -247,7 +247,18 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/deployments/config/grafana/dashboards/Penumbra.json
+++ b/deployments/config/grafana/dashboards/Penumbra.json
@@ -729,7 +729,18 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/deployments/config/grafana/dashboards/Transactions.json
+++ b/deployments/config/grafana/dashboards/Transactions.json
@@ -153,7 +153,18 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/deployments/config/grafana/dashboards/Validators.json
+++ b/deployments/config/grafana/dashboards/Validators.json
@@ -272,7 +272,18 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/deployments/config/grafana/grafana.ini
+++ b/deployments/config/grafana/grafana.ini
@@ -7,6 +7,9 @@ provisioning = /etc/grafana/provisioning
 # this doesn't seem to work but you can just navigate to other URLs...
 disable_login_form = true
 
+[dashboards]
+default_home_dashboard_path = /var/lib/grafana/dashboards/Validators.json
+
 [auth.anonymous]
 # enable anonymous access
 enabled = true

--- a/deployments/containerfiles/Dockerfile-grafana
+++ b/deployments/containerfiles/Dockerfile-grafana
@@ -1,0 +1,4 @@
+FROM docker.io/grafana/grafana:latest
+COPY deployments/config/grafana/provisioning /etc/grafana/provisioning
+COPY deployments/config/grafana/grafana.ini /etc/grafana/grafana.ini
+COPY deployments/config/grafana/dashboards /var/lib/grafana/dashboards


### PR DESCRIPTION
Refs #1843. 

This PR includes a new container spec, and some tweaks to the compose files to consume the new container. No changes will be visible on the k8s deployments post-merge; first, I need CI to build the containers, then I'll work on wiring up some ingress and DNS for them. This work so far works just peachy on the caddy/compose setup when running a fullnode outside k8s, though. 