### PR TITLE
docs: prefer symlinks to 'cargo run' in guide

### DIFF
--- a/docs/guide/src/dev/devnet-quickstart.md
+++ b/docs/guide/src/dev/devnet-quickstart.md
@@ -10,7 +10,7 @@ To start, you'll need to [install Tendermint `v0.34`](../pd/build.md#installing-
 To generate a clean set of configs, run
 
 ```shell
-cargo run --release --bin pd -- testnet generate
+pd testnet generate
 ```
 
 This will write configs to `~/.penumbra/testnet_data/`.
@@ -26,7 +26,7 @@ export RUST_LOG="warn,pd=debug,penumbra=debug,jmt=info"
 To run `pd`, run
 
 ```shell
-cargo run --release --bin pd -- start  --home ~/.penumbra/testnet_data/node0/pd
+pd start  --home ~/.penumbra/testnet_data/node0/pd
 ```
 
 This will start but won't do anything yet, because Tendermint isn't running.
@@ -46,13 +46,13 @@ in another terminal window.
 To interact with the chain, first do
 
 ```shell
-cargo run --release --bin pcli -- view reset
+pcli view reset
 ```
 
 and then pass the `-n` flag to any commands you run to point `pcli` at your local node, e.g.,
 
 ```shell
-cargo run --bin pcli -- -n 127.0.0.1 view balance
+pcli -n 127.0.0.1 view balance
 ```
 
 By default, `pd testnet generate` uses the latest snapshot of the Discord's
@@ -66,13 +66,13 @@ If not, reset the state as below, and edit the `genesis.json` to add your addres
 After making changes, you may want to reset and restart the devnet:
 
 ```shell
-cargo run --release --bin pd -- testnet unsafe-reset-all
+pd testnet unsafe-reset-all
 ```
 
 You'll probably also want to reset your wallet state:
 
 ```shell
-cargo run --release --bin pcli -- view reset
+pcli view reset
 ```
 
 At this point you're ready to generate new configs, and restart both `pd` and

--- a/docs/guide/src/pcli/balance.md
+++ b/docs/guide/src/pcli/balance.md
@@ -4,7 +4,7 @@ Once you've received your first tokens, you can scan the chain to import them
 into your local wallet (this may take a few minutes the first time you run it):
 
 ```bash
-cargo run --quiet --release --bin pcli view sync
+pcli view sync
 ```
 
 Syncing is performed automatically, but running the `sync` subcommand will
@@ -14,12 +14,12 @@ invocations of `pcli` commands don't need to wait.
 If someone sent you testnet assets, you should be able to see them now by running:
 
 ```bash
-cargo run --quiet --release --bin pcli view balance
+pcli view balance
 ```
 
 This will print a table of assets by balance in each.  The `balance` view just
 shows asset amounts. To see more information about delegation tokens and the stake they represent, use
 
 ```bash
-cargo run --quiet --release --bin pcli view staked
+pcli view staked
 ```

--- a/docs/guide/src/pcli/install.md
+++ b/docs/guide/src/pcli/install.md
@@ -68,6 +68,12 @@ cargo build --release --bin pcli
 ```
 
 Because you are building a work-in-progress version of the client, you may see compilation warnings,
-which you can safely ignore.
+which you can safely ignore. Finally, create a symlink so that `pcli` is available system-wide:
+
+```bash
+sudo ln -s "\$PWD/target/release/pcli" /usr/local/bin/pcli
+```
+
+Doing so will enable you to use `pcli` as a command, even outside the Penumbra git repository.
 
 [protoc-install]: https://grpc.io/docs/protoc-installation/

--- a/docs/guide/src/pcli/pviewd.md
+++ b/docs/guide/src/pcli/pviewd.md
@@ -22,7 +22,7 @@ pviewd start
 to start the view server, and invoke `pcli` with
 
 ```shell
-pcli -v 127.0.0.1:8081
+pcli --view-address 127.0.0.1:8081
 ```
 
 to use it instead of an in-process view service.

--- a/docs/guide/src/pcli/transaction.md
+++ b/docs/guide/src/pcli/transaction.md
@@ -6,14 +6,14 @@ send them any amount of any asset you have.
 First, use balance to find the amount of assets you have:
 
 ```bash
-cargo run --release --bin pcli view balance
+pcli view balance
 ```
 
 Second, if I wanted to send 10 penumbra tokens
 to my friend, I could do that like this (filling in their full address at the end):
 
 ```bash
-cargo run --quiet --release --bin pcli tx send 10penumbra --to penumbrav2t...
+pcli tx send 10penumbra --to penumbrav2t...
 ```
 
 Notice that asset amounts are typed amounts, specified without a space between the amount (`10`)
@@ -26,13 +26,13 @@ In addition, to sending an asset, one may also stake penumbra tokens to validato
 Find a validator to stake to:
 
 ```bash
-cargo run --release --bin pcli query validator list
+pcli query validator list
 ```
 
 Copy and paste the identity key of one of the validators to stake to, then construct the staking tx:
 
 ```bash
-cargo run --release --bin pcli tx delegate 10penumbra --to penumbravalid...
+pcli tx delegate 10penumbra --to penumbravalid...
 ```
 
 To undelegate from a validator, use the `pcli tx undelegate` command, passing it the typed amount of
@@ -40,7 +40,7 @@ delegation tokens you wish to undelegate. Wait a moment for the network to proce
 then reclaim your funds:
 
 ```bash
-cargo run --release --bin pcli tx undelegate-claim
+pcli tx undelegate-claim
 ```
 
 Inspect the output; a message may instruct you to wait longer, for a new epoch. Check back and rerun the command
@@ -59,7 +59,7 @@ To submit a proposal, first generate a proposal template for the kind of proposa
 submit. For example, suppose we want to create a signaling proposal:
 
 ```bash
-cargo run --release --bin pcli tx proposal template --kind signaling --file proposal.json
+pcli tx proposal template --kind signaling --file proposal.json
 ```
 
 This outputs a JSON template for the proposal to the file `proposal.json`, where you can edit the
@@ -70,7 +70,7 @@ specify the proposal deposit in this action; it is determined automatically base
 parameters.
 
 ```bash
-cargo run --release --bin pcli tx proposal submit --file proposal.json
+pcli tx proposal submit --file proposal.json
 ```
 
 The proposal deposit will be immediately escrowed and the proposal voting period will start in the
@@ -85,13 +85,13 @@ proposal` subcommand.
 To list all the active proposals by their ID, use:
 
 ```bash
-cargo run --release --bin pcli query governance list-proposals
+pcli query governance list-proposals
 ```
 
 Other proposal query commands all follow the form:
 
 ```bash
-cargo run --release --bin pcli query governance proposal [PROPOSAL_ID] [QUERY]
+pcli query governance proposal [PROPOSAL_ID] [QUERY]
 ```
 
 These are the queries currently defined:
@@ -110,7 +110,7 @@ community consensus), you can do so before voting concludes. Note that this does
 to losing your deposit by veto, as withdrawn proposals can still be voted on and vetoed.
 
 ```bash
-cargo run --release --bin pcli tx proposal withdraw 0 --reason "some human-readable reason for withdrawal"
+pcli tx proposal withdraw 0 --reason "some human-readable reason for withdrawal"
 ```
 
 ### Voting On A Proposal
@@ -120,7 +120,7 @@ validator, you can vote on a proposal using the `validator vote` subcommand of `
 if you wanted to vote "yes" on proposal 1, you would do:
 
 ```bash
-cargo run --release --bin pcli validator vote yes --on 1
+pcli validator vote yes --on 1
 ```
 
 Validators, like delegators, cannot change their votes after they have voted.
@@ -140,13 +140,13 @@ on the volume of swaps occurring in each pair.
 You can check the current reserves for a trading pair using the `cpmm-reserves` dex query:
 
 ```bash
-cargo run --release --bin pcli -- q dex cpmm-reserves gm:penumbra
+pcli q dex cpmm-reserves gm:penumbra
 ```
 
 If you wanted to exchange 1 `penumbra` tokens for `gm` tokens, you could do so like so:
 
 ```bash
-cargo run --release --bin pcli -- tx swap --into gm 1penumbra
+pcli q tx swap --into gm 1penumbra
 ```
 
 This will handle generating the swap transaction and you'd soon have the market-rate equivalent of 1 `penumbra`

--- a/docs/guide/src/pcli/update.md
+++ b/docs/guide/src/pcli/update.md
@@ -9,11 +9,15 @@ cd penumbra && git fetch && git checkout 044-ananke
 Once again, build `pcli` with cargo:
 
 ```
-cargo build --release --bin pcli
+cargo build --release
 ```
 
 No wallet needs to be [generated](https://guide.penumbra.zone/main/pcli/wallet.html#generating-a-wallet). Instead, keep one's existing wallet and reset view data.
 
+
 ```
-cargo run --quiet --release --bin pcli view reset
+pcli view reset
 ```
+
+If you see an error containing `pcli: command not found`, make sure you have created a symlink for `pcli`,
+as described in the [install guide](https://guide.penumbra.zone/main/pcli/install.html).

--- a/docs/guide/src/pcli/wallet.md
+++ b/docs/guide/src/pcli/wallet.md
@@ -4,7 +4,7 @@ On first installation of `pcli`, you will need to generate a fresh wallet to use
 should see something like this:
 
 ```bash
-\$ cargo run --quiet --release --bin pcli keys generate
+\$ pcli keys generate
 
 
 YOUR PRIVATE SEED PHRASE: [...]
@@ -17,7 +17,7 @@ correspond to your own wallet. When you first created your wallet above, `pcli` 
 of your wallet addresses, which you can view like this:
 
 ```bash
-\$ cargo run --quiet --release --bin pcli view address 0
+\$ pcli view address 0
 penumbrav2t1...
 ```
 

--- a/docs/guide/src/pd/build.md
+++ b/docs/guide/src/pd/build.md
@@ -6,11 +6,23 @@ The node software `pd` is part of the same repository as `pcli`, so follow
 To build `pd`, run
 
 ```bash
-cargo build --release --bin pd
+cargo build --release
 ```
 
 Because you are building a work-in-progress version of the node software, you may see compilation warnings,
-which you can safely ignore.
+which you can safely ignore. Finally, create a symlink so that `pd` is available system-wide:
+
+```bash
+sudo ln -s "\$PWD/target/release/pd" /usr/local/bin/pd
+```
+
+Doing so will enable you to use `pd` as a command, even outside the Penumbra git repository.
+If you haven't already done so, consider creating symlinks for the other Penumbra binaries, too:
+
+```bash
+sudo ln -s "\$PWD/target/release/pcli" /usr/local/bin/pcli
+sudo ln -s "\$PWD/target/release/pviewd" /usr/local/bin/pviewd
+```
 
 ### Installing Tendermint
 
@@ -23,7 +35,6 @@ deprecated](https://interchain-io.medium.com/discontinuing-tendermint-v0-35-a-po
 by the Tendermint Council. We have now [rolled back to
 v0.34](https://github.com/penumbra-zone/penumbra/issues/1271).
 **Do not use** Tendermint `0.35`, which will no longer work with `pd`.
-that can prevent nodes from staying online.
 
 Follow [Tendermint's installation instructions](https://docs.tendermint.com/v0.34/introduction/install.html),
 but before you start compiling, make sure you are compiling version `v0.34.23`.

--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -21,7 +21,7 @@ To join a testnet as a fullnode, check out the tag for the current testnet, run
 First, reset the testnet data from any prior testnet you may have joined:
 
 ```shell
-cargo run --bin pd --release -- testnet unsafe-reset-all
+pd testnet unsafe-reset-all
 ```
 
 This will delete the entire testnet data directory.
@@ -31,7 +31,7 @@ This will delete the entire testnet data directory.
 Next, generate a set of configs for the current testnet:
 
 ```shell
-cargo run --bin pd --release -- testnet join --external-address IP_ADDRESS --moniker MY_NODE_NAME
+pd testnet join --external-address IP_ADDRESS --moniker MY_NODE_NAME
 ```
 
 where `IP_ADDRESS` (like `1.2.3.4`) is the public IP address of the node you're running,
@@ -58,7 +58,7 @@ export RUST_LOG="warn,pd=debug,penumbra=debug" # or some other logging level
 ```
 
 ```shell
-cargo run --bin pd --release -- start --home ~/.penumbra/testnet_data/node0/pd
+pd start --home ~/.penumbra/testnet_data/node0/pd
 ```
 
 Then (perhaps in another terminal), run Tendermint, also specifying `--home`:
@@ -96,7 +96,7 @@ update the configuration for a validator.
 To create a template configuration, use `pcli validator template-definition`:
 
 ```console
-\$ cargo run --release --bin pcli -- validator definition template --file validator.toml
+\$ pcli validator definition template --file validator.toml
 \$ cat validator.toml
 # This is a template for a validator definition.
 #
@@ -176,13 +176,13 @@ After setting up metadata, funding streams, and the correct consensus key in
 your `validator.toml`, you can upload it to the chain:
 
 ```console
-cargo run --release --bin pcli -- validator definition upload --file validator.toml
+pcli validator definition upload --file validator.toml
 ```
 
 And verify that it's known to the chain:
 
 ```console
-cargo run --release --bin pcli -- query validator list -i
+pcli query validator list -i
 ```
 
 However your validator doesn't have anything delegated to it and will remain in
@@ -194,19 +194,19 @@ active set of validators.
 First find your validator's identity key:
 
 ```console
-cargo run --release --bin pcli -- validator identity
+pcli validator identity
 ```
 
 And then delegate some amount of `penumbra` to it:
 
 ```console
-cargo run --release --bin pcli -- tx delegate 1penumbra --to penumbravalid1g2huds8klwypzczfgx67j7zp6ntq2m5fxmctkf7ja96zn49d6s9qz72hu3
+pcli tx delegate 1penumbra --to penumbravalid1g2huds8klwypzczfgx67j7zp6ntq2m5fxmctkf7ja96zn49d6s9qz72hu3
 ```
 
 You should then see your balance of `penumbra` decreased and that you have received some amount of delegation tokens for your validator:
 
 ```console
-cargo run --release --bin pcli view balance
+pcli view balance
 ```
 
 Voting power will be calculated on the next epoch transition after your
@@ -222,7 +222,7 @@ deployment.  You can find the values in use for the current chain in its
 First fetch your existing validator definition from the chain:
 
 ```console
-cargo run --release --bin pcli -- validator definition fetch --file validator.toml
+pcli validator definition fetch --file validator.toml
 ```
 
 Then make any changes desired and **make sure to increase by `sequence_number` by at least 1!**
@@ -231,5 +231,5 @@ The `sequence_number` is a unique, increasing identifier for the version of the 
 After updating the validator definition you can upload it again to update your validator metadata on-chain:
 
 ```console
-cargo run --release --bin pcli -- validator definition upload --file validator.toml
+pcli validator definition upload --file validator.toml
 ```


### PR DESCRIPTION
We're trying to make the guide more accessible. In practice, symlinking the compiled binaries onto a PATH location allows for less typing at the command line, and makes the documentaiton significantly easier to read.

Closes #1976.