### PR TITLE
storage: add metrics for state queries

### DIFF
--- a/storage/src/metrics.rs
+++ b/storage/src/metrics.rs
@@ -14,4 +14,21 @@
 pub use metrics::*;
 
 /// Registers all metrics used by this crate.
-pub fn register_metrics() {}
+pub fn register_metrics() {
+    register_histogram!(STORAGE_GET_RAW_DURATION);
+    describe_histogram!(
+        STORAGE_GET_RAW_DURATION,
+        Unit::Seconds,
+        "The duration of a get_raw request"
+    );
+    register_histogram!(STORAGE_NONCONSENSUS_GET_RAW_DURATION);
+    describe_histogram!(
+        STORAGE_NONCONSENSUS_GET_RAW_DURATION,
+        Unit::Seconds,
+        "The duration of a nonconsensus_get_raw request"
+    );
+}
+
+pub const STORAGE_GET_RAW_DURATION: &str = "penumbra_storage_get_raw_duration_seconds";
+pub const STORAGE_NONCONSENSUS_GET_RAW_DURATION: &str =
+    "penumbra_storage_nonconsensus_get_raw_duration_seconds";


### PR DESCRIPTION
This could hopefully give us a little bit of insight into what our storage performance is like, but also lets us exercise the workflow of using newly added metrics.