### PR TITLE
deploy: document systemd service files

### DIFF
--- a/deployments/systemd/README.md
+++ b/deployments/systemd/README.md
@@ -1,0 +1,30 @@
+# systemd unit files for Penumbra
+
+Here are example unit files for running Penumbra (and the required Tendermint instance)
+via systemd. You'll need to customize the `User` declaration, and possibly the path
+to the home directory, as well, depending on your system. The paths to the binaries,
+in the `ExecStart` lines, assume that a symlink exists to the locally compiled versions,
+as described in the [install guide](https://guide.penumbra.zone/main/pd/build.html).
+
+## Installing
+Copy the service files to a system-wide location:
+
+```bash
+# use 'envsubst' to replace `$USER` with your local username
+envsubst < penumbra.service | sudo tee /etc/systemd/system/penumbra.service
+envsubst < tendermint.service | sudo tee /etc/systemd/system/tendermint.service
+sudo systemctl daemon-reload
+sudo systemctl restart penumbra tendermint
+
+# view logs to monitor for errors
+sudo journalctl -af -u penumbra -u tendermint
+```
+
+## Uninstalling
+To remove the configs, run:
+
+```bash
+sudo systemctl disable --now penumbra tendermint
+sudo rm /etc/systemd/system/{penumbra,tendermint}.service
+sudo systemctl daemon-reload
+```

--- a/deployments/systemd/penumbra.service
+++ b/deployments/systemd/penumbra.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Penumbra pd
+Wants=tendermint.service
+
+[Service]
+ExecStart=/usr/local/bin/pd start --home /home/$USER/.penumbra/testnet_data/node0/pd
+Restart=on-failure
+RestartSec=5
+User=$USER
+
+[Install]
+WantedBy=default.target

--- a/deployments/systemd/tendermint.service
+++ b/deployments/systemd/tendermint.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Tendermint for Penumbra
+
+[Service]
+ExecStart=/usr/local/bin/tendermint start --home /home/$USER/.penumbra/testnet_data/node0/tendermint
+Restart=on-failure
+RestartSec=5
+User=$USER
+
+[Install]
+WantedBy=default.target

--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -74,6 +74,16 @@ cd deployments/compose/
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 ```
 
+or via systemd:
+
+```
+cd deployments/systemd/
+sudo cp *.service /etc/systemd/system/
+# edit service files to customize for your system
+sudo systemctl daemon-reload
+sudo systemctl restart penumbra tendermint
+```
+
 ## Joining as a validator
 
 After starting your node, as above, you should now be participating in the


### PR DESCRIPTION
Drops in some example configs for using systemd to orchestrate pd and tm. I use these configs myself in a few contexts to bottle up the start/stop logic in a predictable manner. Includes mention of the option in the setup guide.

Closes #1974.