### PR TITLE
ci: use git LFS for penumbra docker build

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
Closes #2042
Tested in docker build https://github.com/penumbra-zone/penumbra/actions/runs/4268186803/jobs/7430482760