### PR TITLE
transaction: introduce an AuthHash for use in binding signatures

### DIFF
--- a/component/src/action_handler/transaction/stateless.rs
+++ b/component/src/action_handler/transaction/stateless.rs
@@ -1,18 +1,17 @@
 use std::collections::BTreeSet;
 
 use anyhow::{Context, Result};
-use penumbra_proto::DomainType;
-use penumbra_transaction::Transaction;
+use penumbra_transaction::{AuthorizingData, Transaction};
 
 #[tracing::instrument(skip(tx))]
 pub(super) fn valid_binding_signature(tx: &Transaction) -> Result<()> {
-    let tx_body = tx.transaction_body().encode_to_vec();
+    let auth_hash = tx.auth_hash();
 
-    tracing::debug!(bvk = ?tx.binding_verification_key(), tx_body = ?base64::encode(&tx_body));
+    tracing::debug!(bvk = ?tx.binding_verification_key(), ?auth_hash);
 
     // Check binding signature.
     tx.binding_verification_key()
-        .verify(&tx_body[..], tx.binding_sig())
+        .verify(auth_hash.as_bytes(), tx.binding_sig())
         .context("binding signature failed to verify")
 }
 

--- a/transaction/src/auth_hash.rs
+++ b/transaction/src/auth_hash.rs
@@ -1,0 +1,53 @@
+use penumbra_proto::DomainType;
+
+use crate::{Transaction, TransactionBody};
+
+/// A hash of a transaction's _authorizing data_, describing both its effects on
+/// the chain state as well as the cryptographic authorization of those effects.
+///
+/// In practice this is simply a hash of the `TransactionBody`.
+///
+/// The transaction's binding signature is formed over the transaction's
+/// `AuthHash`.  Because the binding signature is formed using the randomness
+/// for the balance commitments for each action, this prevents replaying proofs
+/// from one transaction to another without knowledge of the openings of the
+/// balance commitments, binding the proofs to the transaction they were
+/// originally computed for.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct AuthHash(pub [u8; 32]);
+
+impl std::fmt::Debug for AuthHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("AuthHash")
+            .field(&hex::encode(self.0))
+            .finish()
+    }
+}
+
+impl AuthHash {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+pub trait AuthorizingData {
+    fn auth_hash(&self) -> AuthHash;
+}
+
+impl AuthorizingData for TransactionBody {
+    fn auth_hash(&self) -> AuthHash {
+        AuthHash(
+            blake2b_simd::Params::default()
+                .hash(&self.encode_to_vec())
+                .as_bytes()[0..32]
+                .try_into()
+                .unwrap(),
+        )
+    }
+}
+
+impl AuthorizingData for Transaction {
+    fn auth_hash(&self) -> AuthHash {
+        self.transaction_body.auth_hash()
+    }
+}

--- a/transaction/src/effect_hash.rs
+++ b/transaction/src/effect_hash.rs
@@ -21,6 +21,12 @@ pub trait EffectingData {
     fn effect_hash(&self) -> EffectHash;
 }
 
+/// A hash of a transaction's _effecting data_, describing its effects on the
+/// chain state.
+///
+/// This includes, e.g., the commitments to new output notes created by the
+/// transaction, or nullifiers spent by the transaction, but does not include
+/// _authorizing data_ such as signatures or zk proofs.
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub struct EffectHash([u8; 64]);
 

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -15,6 +15,7 @@
 #![allow(clippy::clone_on_copy)]
 
 mod auth_data;
+mod auth_hash;
 mod effect_hash;
 mod error;
 mod transaction;
@@ -26,7 +27,8 @@ pub mod view;
 
 pub use action::{Action, IsAction};
 pub use auth_data::AuthorizationData;
-pub use effect_hash::EffectHash;
+pub use auth_hash::{AuthHash, AuthorizingData};
+pub use effect_hash::{EffectHash, EffectingData};
 pub use error::Error;
 pub use transaction::{Transaction, TransactionBody};
 pub use view::{ActionView, TransactionPerspective, TransactionView};


### PR DESCRIPTION
This is immediately motivated by not wanting to have messy debug output for binding signature verification, but also fits with the conceptual division between "authorizing" and "effecting" data, which now both have their own hash type.

One rough edge in nomenclature this reveals (which we should sand down somehow) is the distinction between `AuthorizingData` (the trait) and `AuthorizationData` (the response from the custody protocol).  Unsure of the best thing to do there.