### PR TITLE
proof-params: use prepared verification keys

### DIFF
--- a/crypto/src/proofs/groth16.rs
+++ b/crypto/src/proofs/groth16.rs
@@ -20,7 +20,7 @@ mod tests {
         keys::{SeedPhrase, SpendKey},
         Address, Balance, Rseed,
     };
-    use ark_groth16::{Groth16, ProvingKey, VerifyingKey};
+    use ark_groth16::{Groth16, PreparedVerifyingKey, ProvingKey};
     use ark_r1cs_std::prelude::*;
     use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef};
     use ark_snark::SNARK;
@@ -610,7 +610,7 @@ mod tests {
     }
 
     impl ParameterSetup for MerkleProofCircuit {
-        fn generate_test_parameters() -> (ProvingKey<Bls12_377>, VerifyingKey<Bls12_377>) {
+        fn generate_test_parameters() -> (ProvingKey<Bls12_377>, PreparedVerifyingKey<Bls12_377>) {
             let seed_phrase = SeedPhrase::from_randomness([b'f'; 32]);
             let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
@@ -634,7 +634,7 @@ mod tests {
             };
             let (pk, vk) = Groth16::circuit_specific_setup(circuit, &mut OsRng)
                 .expect("can perform circuit specific setup");
-            (pk, vk)
+            (pk, vk.into())
         }
     }
 
@@ -674,7 +674,7 @@ mod tests {
             let proof =
                 Groth16::prove(&pk, circuit, &mut rng).expect("should be able to form proof");
 
-            let proof_result = Groth16::verify(&vk, &[Fq::from(anchor)], &proof);
+            let proof_result = Groth16::verify_with_processed_vk(&vk, &[Fq::from(anchor)], &proof);
             assert!(proof_result.is_ok());
         }
 
@@ -696,7 +696,7 @@ mod tests {
             let proof =
                 Groth16::prove(&pk, circuit, &mut rng).expect("should be able to form proof");
 
-            let proof_result = Groth16::verify(&vk, &[Fq::from(anchor)], &proof);
+            let proof_result = Groth16::verify_with_processed_vk(&vk, &[Fq::from(anchor)], &proof);
             assert!(proof_result.is_ok());
         }
 
@@ -718,7 +718,7 @@ mod tests {
             let proof =
                 Groth16::prove(&pk, circuit, &mut rng).expect("should be able to form proof");
 
-            let proof_result = Groth16::verify(&vk, &[Fq::from(anchor)], &proof);
+            let proof_result = Groth16::verify_with_processed_vk(&vk, &[Fq::from(anchor)], &proof);
             assert!(proof_result.is_ok());
         }
     }

--- a/crypto/src/proofs/groth16/spend.rs
+++ b/crypto/src/proofs/groth16/spend.rs
@@ -9,7 +9,7 @@ use decaf377::FieldExt;
 use decaf377::{r1cs::FqVar, Bls12_377, Fq, Fr};
 
 use ark_ff::ToConstraintField;
-use ark_groth16::{Groth16, Proof, ProvingKey, VerifyingKey};
+use ark_groth16::{Groth16, PreparedVerifyingKey, Proof, ProvingKey};
 use ark_r1cs_std::prelude::AllocVar;
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef};
 use ark_snark::SNARK;
@@ -139,7 +139,7 @@ impl ConstraintSynthesizer<Fq> for SpendCircuit {
 }
 
 impl ParameterSetup for SpendCircuit {
-    fn generate_test_parameters() -> (ProvingKey<Bls12_377>, VerifyingKey<Bls12_377>) {
+    fn generate_test_parameters() -> (ProvingKey<Bls12_377>, PreparedVerifyingKey<Bls12_377>) {
         let seed_phrase = SeedPhrase::from_randomness([b'f'; 32]);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
@@ -179,7 +179,7 @@ impl ParameterSetup for SpendCircuit {
         };
         let (pk, vk) = Groth16::circuit_specific_setup(circuit, &mut OsRng)
             .expect("can perform circuit specific setup");
-        (pk, vk)
+        (pk, vk.into())
     }
 }
 
@@ -225,13 +225,12 @@ impl SpendProof {
     #[tracing::instrument(skip(self, vk))]
     pub fn verify(
         &self,
-        vk: &VerifyingKey<Bls12_377>,
+        vk: &PreparedVerifyingKey<Bls12_377>,
         anchor: tct::Root,
         balance_commitment: balance::Commitment,
         nullifier: Nullifier,
         rk: VerificationKey<SpendAuth>,
     ) -> anyhow::Result<()> {
-        let processed_pvk = Groth16::process_vk(vk).map_err(|err| anyhow::anyhow!(err))?;
         let mut public_inputs = Vec::new();
         public_inputs.extend(Fq::from(anchor.0).to_field_elements().unwrap());
         public_inputs.extend(balance_commitment.0.to_field_elements().unwrap());
@@ -244,7 +243,7 @@ impl SpendProof {
         tracing::trace!(?public_inputs);
         let start = std::time::Instant::now();
         let proof_result =
-            Groth16::verify_with_processed_vk(&processed_pvk, public_inputs.as_slice(), &self.0)
+            Groth16::verify_with_processed_vk(&vk, public_inputs.as_slice(), &self.0)
                 .map_err(|err| anyhow::anyhow!(err))?;
         tracing::debug!(?proof_result, elapsed = ?start.elapsed());
         proof_result

--- a/crypto/src/proofs/groth16/traits.rs
+++ b/crypto/src/proofs/groth16/traits.rs
@@ -1,20 +1,20 @@
-use ark_groth16::{ProvingKey, VerifyingKey};
+use ark_groth16::{PreparedVerifyingKey, ProvingKey};
 use ark_serialize::CanonicalSerialize;
 use decaf377::Bls12_377;
 
 /// Must be implemented to generate proving and verification keys for a circuit.
 pub trait ParameterSetup {
-    fn generate_test_parameters() -> (ProvingKey<Bls12_377>, VerifyingKey<Bls12_377>);
+    fn generate_test_parameters() -> (ProvingKey<Bls12_377>, PreparedVerifyingKey<Bls12_377>);
 }
 
 pub trait VerifyingKeyExt {
     fn debug_id(&self) -> String;
 }
 
-impl VerifyingKeyExt for VerifyingKey<Bls12_377> {
+impl VerifyingKeyExt for PreparedVerifyingKey<Bls12_377> {
     fn debug_id(&self) -> String {
         let mut buf = Vec::new();
-        self.serialize(&mut buf).unwrap();
+        self.vk.serialize(&mut buf).unwrap();
         use sha2::Digest;
         let hash = sha2::Sha256::digest(&buf);
         use bech32::ToBase32;

--- a/proof-params/src/lib.rs
+++ b/proof-params/src/lib.rs
@@ -1,4 +1,4 @@
-use ark_groth16::{ProvingKey, VerifyingKey};
+use ark_groth16::{PreparedVerifyingKey, ProvingKey, VerifyingKey};
 use ark_serialize::CanonicalDeserialize;
 use decaf377::Bls12_377;
 use once_cell::sync::Lazy;
@@ -8,16 +8,16 @@ pub static SPEND_PROOF_PROVING_KEY: Lazy<ProvingKey<Bls12_377>> =
     Lazy::new(spend_proving_parameters);
 
 /// Verifying key for the spend proof.
-pub static SPEND_PROOF_VERIFICATION_KEY: Lazy<VerifyingKey<Bls12_377>> =
-    Lazy::new(spend_verification_parameters);
+pub static SPEND_PROOF_VERIFICATION_KEY: Lazy<PreparedVerifyingKey<Bls12_377>> =
+    Lazy::new(|| spend_verification_parameters().into());
 
 /// Proving key for the output proof.
 pub static OUTPUT_PROOF_PROVING_KEY: Lazy<ProvingKey<Bls12_377>> =
     Lazy::new(output_proving_parameters);
 
 /// Proving key for the spend proof.
-pub static OUTPUT_PROOF_VERIFICATION_KEY: Lazy<VerifyingKey<Bls12_377>> =
-    Lazy::new(output_verification_parameters);
+pub static OUTPUT_PROOF_VERIFICATION_KEY: Lazy<PreparedVerifyingKey<Bls12_377>> =
+    Lazy::new(|| output_verification_parameters().into());
 
 // Note: Here we are using `CanonicalDeserialize::deserialize_unchecked` as the
 // parameters are being loaded from a trusted source (our source code).


### PR DESCRIPTION
Not sure if this clobbers any other changes, I did it just to see if there would be a performance impact and then put it up.