### PR TITLE
ci: dummy-app for wasm support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,33 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  wasm:
+    name: WASM support
+    runs-on: buildjet-16vcpu-ubuntu-2004
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+      - uses: Swatinem/rust-cache@v1
+        with:
+          workspaces: |
+            . -> target
+            wasm-compat
+
+      # We cannot use the GH action because it doesn't working directory:
+      # support custom working dirs.
+      # - uses: actions-rs/cargo@v1
+      - name: build wasm32 target
+        run:
+          cargo build --release --target wasm32-unknown-unknown
+        working-directory: wasm-compat
+
   #clippy:
   #  name: Clippy
   #  runs-on: buildjet-16vcpu-ubuntu-2004

--- a/wasm-compat/.gitignore
+++ b/wasm-compat/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/wasm-compat/Cargo.toml
+++ b/wasm-compat/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "penumbra-wasm"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+# Penumbra dependencies, known to compile to wasm.
+penumbra-proto = { path = "../proto", default-features = false }
+penumbra-crypto = { path = "../crypto" }
+penumbra-tct = { path = "../tct" }
+
+# Penumbra dependencies, not yet known to compile to wasm
+# penumbra-chain = { path = "../chain", default-features = false }
+# penumbra-custody = { path = "../custody", default-features = false }
+# penumbra-component = { path = "../component", default-features = false }
+# penumbra-eddy = { path = "../eddy", default-features = false }
+# penumbra-transaction = { path = "../transaction" }
+# penumbra-wallet = { path = "../wallet", default-features = false }
+
+# Enabling the 'js' feature for getrandom for random support; see
+# https://docs.rs/getrandom/latest/getrandom/#webassembly-support
+getrandom = { version = "0.2", features = ["js"] }
+
+[lib]
+crate-type = ["cdylib"]
+
+# We set a blank 'workspace' block disassociate this crate
+# with the workspace at the repo root. Doing so models
+# how an external developer would use it.
+[workspace]

--- a/wasm-compat/README.md
+++ b/wasm-compat/README.md
@@ -1,0 +1,14 @@
+# penumbra-wasm
+
+This is dummy package, intended to track support for WASM
+in the Penumbra dependencies. There's no project code,
+just an empty skeleton app. The `Cargo.toml` declares
+relative imports for the Penumbra crates within the workspace
+at the top-level of the Penumbra git repository.
+
+## Building
+
+```
+rustup target add wasm32-unknown-unknown
+cargo build --release --target wasm32-unknown-unknown
+```

--- a/wasm-compat/justfile
+++ b/wasm-compat/justfile
@@ -1,5 +1,0 @@
-web:
-    wasm-pack build --target web
-
-build:
-    cargo build --target wasm32-unknown-unknown

--- a/wasm-compat/justfile
+++ b/wasm-compat/justfile
@@ -1,0 +1,5 @@
+web:
+    wasm-pack build --target web
+
+build:
+    cargo build --target wasm32-unknown-unknown

--- a/wasm-compat/src/lib.rs
+++ b/wasm-compat/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/wasm-compat/src/main.rs
+++ b/wasm-compat/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
Created a placeholder app, separate from the workspace, strictly to test coverage of building for wasm targets. Right now, only `crypto`, `proto`, and `tct` build without modifications.
    
Refs #1990.
