### PR TITLE
view,custody: fix missing Send bounds on domain-type traits

### DIFF
--- a/custody/src/client.rs
+++ b/custody/src/client.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
+use futures::FutureExt;
 use penumbra_proto::custody::v1alpha1::custody_protocol_service_client::CustodyProtocolServiceClient;
 use penumbra_proto::custody::v1alpha1::AuthorizeResponse;
+use std::{future::Future, pin::Pin};
 
-use tonic::async_trait;
 use tonic::codegen::Bytes;
 
 use crate::AuthorizeRequest;
@@ -27,30 +28,33 @@ use crate::AuthorizeRequest;
 /// 2. It's easier to write as a trait bound than the `CustodyProtocolServiceClient`,
 ///   which requires complex bounds on its inner type to enforce that it is a
 ///   tower `Service`
-#[async_trait(?Send)]
-pub trait CustodyClient: Sized {
+pub trait CustodyClient {
     /// Requests authorization of the transaction with the given description.
-    async fn authorize(&mut self, request: AuthorizeRequest) -> Result<AuthorizeResponse>;
+    fn authorize(
+        &mut self,
+        request: AuthorizeRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<AuthorizeResponse>> + Send + 'static>>;
 }
 
-// We need to tell `async_trait` not to add a `Send` bound to the boxed
-// futures it generates, because the underlying `CustodyProtocolServiceClient` isn't `Sync`,
-// but its `authorize` method takes `&mut self`. This would normally cause a huge
-// amount of problems, because non-`Send` futures don't compose well, but as long
-// as we're calling the method within an async block on a local mutable variable,
-// it should be fine.
-#[async_trait(?Send)]
 impl<T> CustodyClient for CustodyProtocolServiceClient<T>
 where
-    T: tonic::client::GrpcService<tonic::body::BoxBody>,
+    T: tonic::client::GrpcService<tonic::body::BoxBody> + Send + Clone + 'static,
     T::ResponseBody: tonic::codegen::Body<Data = Bytes> + Send + 'static,
+    T::Future: Send + 'static,
     T::Error: Into<tonic::codegen::StdError>,
     <T::ResponseBody as tonic::codegen::Body>::Error: Into<tonic::codegen::StdError> + Send,
 {
-    async fn authorize(&mut self, request: AuthorizeRequest) -> Result<AuthorizeResponse> {
-        Ok(self
-            .authorize(tonic::Request::new(request.into()))
-            .await?
-            .into_inner())
+    fn authorize(
+        &mut self,
+        request: AuthorizeRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<AuthorizeResponse>> + Send + 'static>> {
+        let mut self2 = self.clone();
+        async move {
+            Ok(self2
+                .authorize(tonic::Request::new(request.into()))
+                .await?
+                .into_inner())
+        }
+        .boxed()
     }
 }

--- a/transaction/src/plan/build.rs
+++ b/transaction/src/plan/build.rs
@@ -185,7 +185,7 @@ impl TransactionPlan {
     /// This can be used in environments that support tokio tasks.
     pub async fn build_concurrent<R: CryptoRng + RngCore>(
         self,
-        rng: &mut R,
+        rng: R,
         fvk: &FullViewingKey,
         auth_data: AuthorizationData,
         witness_data: WitnessData,


### PR DESCRIPTION
This makes it possible to use the well-typed client methods inside spawnable futures.