### PR TITLE
view: add BroadcastTransaction with confirmation detection to ViewService

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3920,6 +3920,7 @@ dependencies = [
  "metrics",
  "parking_lot 0.12.1",
  "penumbra-chain",
+ "penumbra-component",
  "penumbra-crypto",
  "penumbra-custody",
  "penumbra-proto",

--- a/component/src/action_handler/transaction.rs
+++ b/component/src/action_handler/transaction.rs
@@ -81,7 +81,7 @@ impl ActionHandler for Transaction {
     async fn execute<S: StateWrite>(&self, mut state: S) -> Result<()> {
         // While we have access to the full Transaction, hash it to
         // obtain a NoteSource we can cache for various actions.
-        let source = NoteSource::Transaction { id: self.id() };
+        let source = NoteSource::Transaction { id: self.id().0 };
         state.object_put("source", source);
 
         for (i, action) in self.actions().enumerate() {

--- a/pcli/src/command/tx.rs
+++ b/pcli/src/command/tx.rs
@@ -270,7 +270,7 @@ impl TxCmd {
                 for (i, plan) in plans.into_iter().enumerate() {
                     println!("building sweep {i} of {num_plans}");
                     let tx = app.build_transaction(plan).await?;
-                    app.submit_transaction_unconfirmed(&tx).await?;
+                    app.submit_transaction_unconfirmed(tx).await?;
                 }
                 if num_plans == 0 {
                     println!("finished sweeping");

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -1,18 +1,13 @@
-use anyhow::{Context as _, Result};
-use penumbra_component::ActionHandler;
-use penumbra_crypto::Nullifier;
 use penumbra_proto::{
     client::v1alpha1::{
         oblivious_query_service_client::ObliviousQueryServiceClient,
         specific_query_service_client::SpecificQueryServiceClient,
-        tendermint_proxy_service_client::TendermintProxyServiceClient, BroadcastTxAsyncRequest,
-        BroadcastTxSyncRequest,
+        tendermint_proxy_service_client::TendermintProxyServiceClient,
     },
     DomainType,
 };
-use penumbra_transaction::{plan::TransactionPlan, Transaction};
+use penumbra_transaction::{plan::TransactionPlan, Id as TransactionId, Transaction};
 use penumbra_view::ViewClient;
-use rand::Rng;
 use rand_core::OsRng;
 use std::future::Future;
 use tonic::transport::Channel;
@@ -24,24 +19,15 @@ impl App {
     pub async fn build_and_submit_transaction(
         &mut self,
         plan: TransactionPlan,
-    ) -> anyhow::Result<()> {
-        let await_detection_of_nullifier = plan.spend_plans().next().map(|spend_plan| {
-            // If we spend at least one note, then we should await detecting it (it doesn't matter
-            // which nullifier we wait for, since any will work)
-            self.fvk
-                .derive_nullifier(spend_plan.position, &spend_plan.note.commit())
-        });
-
-        let tx = self.build_transaction(plan).await?;
-
-        self.submit_transaction(&tx, await_detection_of_nullifier)
-            .await
+    ) -> anyhow::Result<TransactionId> {
+        let transaction = self.build_transaction(plan).await?;
+        self.submit_transaction(transaction).await
     }
 
     pub fn build_transaction(
         &mut self,
         plan: TransactionPlan,
-    ) -> impl Future<Output = Result<Transaction>> + '_ {
+    ) -> impl Future<Output = anyhow::Result<Transaction>> + '_ {
         println!("building transaction...");
         let start = std::time::Instant::now();
         let tx = penumbra_wallet::build_transaction(
@@ -67,105 +53,27 @@ impl App {
     }
 
     /// Submits a transaction to the network.
-    ///
-    /// # Returns
-    ///
-    /// - if `await_detection_of_nullifier` is `Some`, returns `Ok` after the specified note has been detected by the view service, implying transaction finality.
-    /// - if `await_detection_of_nullifier` is `None`, returns `Ok` after the transaction has been accepted by the node it was sent to.
-    #[instrument(skip(self, transaction, await_detection_of_nullifier))]
     pub async fn submit_transaction(
         &mut self,
-        transaction: &Transaction,
-        await_detection_of_nullifier: Option<Nullifier>,
-    ) -> Result<(), anyhow::Error> {
-        println!("pre-checking transaction...");
-        transaction
-            .check_stateless(std::sync::Arc::new(transaction.clone()))
-            .await
-            .context("transaction pre-submission checks failed")?;
-
-        println!("broadcasting transaction...");
-
-        let mut client = self.tendermint_proxy_client().await?;
-        let req_id: u8 = rand::thread_rng().gen();
-        let tx_encoding = &transaction.encode_to_vec();
-
-        // 499974 is the observed maximum byte size of a transaction before the "request body too large" error appears.
-        if tx_encoding.len() > 499974 {
-            return Err(anyhow::anyhow!(
-                "Transaction is too large to be broadcasted to the network. Please run `pcli tx sweep` and then re-try the transaction."
-            ));
-        }
-
-        let rsp = client
-            .broadcast_tx_sync(BroadcastTxSyncRequest {
-                params: tx_encoding.to_vec(),
-                req_id: req_id.into(),
-            })
-            .await?
-            .into_inner();
-
-        tracing::info!("{:#?}", rsp);
-
-        let code = rsp.code;
-        if code != 0 {
-            let log = rsp.log;
-
-            return Err(anyhow::anyhow!(
-                "Error submitting transaction: code {}, log: {}",
-                code,
-                log
-            ));
-        }
-
-        if await_detection_of_nullifier.is_none() {
-            println!("transaction submitted successfully");
-            return Ok(());
-        }
-
-        // We are waiting for a nullifier to be detected.
-        //
-        // putting two spaces in makes the ellipsis line up with the above
-        println!("confirming transaction  ...");
-
-        let account_id = self.fvk.hash();
-        if let Some(nullifier) = await_detection_of_nullifier {
-            tokio::time::timeout(
-                std::time::Duration::from_secs(20),
-                self.view().await_nullifier(account_id, nullifier),
-            )
-            .await
-            .context("timeout waiting to detect nullifier of submitted transaction")?
-            .context("error while waiting for detection of submitted transaction")?;
-        }
-
-        println!("transaction confirmed and detected");
-
-        Ok(())
+        transaction: Transaction,
+    ) -> Result<TransactionId, anyhow::Error> {
+        println!("broadcasting transaction and awaiting confirmation...");
+        let id = self.view().broadcast_transaction(transaction, true).await?;
+        println!("transaction confirmed and detected: {}", id);
+        Ok(id)
     }
 
     /// Submits a transaction to the network, returning `Ok` as soon as the
-    /// transaction has been submitted, rather than waiting to learn whether the
-    /// node accepted it.
+    /// transaction has been submitted, rather than waiting for confirmation.
     #[instrument(skip(self, transaction))]
     pub async fn submit_transaction_unconfirmed(
-        &self,
-        transaction: &Transaction,
+        &mut self,
+        transaction: Transaction,
     ) -> Result<(), anyhow::Error> {
-        println!("broadcasting transaction...");
-
-        let mut client = self.tendermint_proxy_client().await?;
-        let req_id: u8 = rand::thread_rng().gen();
-        let tx_encoding = &transaction.encode_to_vec();
-        let rsp = client
-            .broadcast_tx_async(BroadcastTxAsyncRequest {
-                params: tx_encoding.to_vec(),
-                req_id: req_id.into(),
-            })
-            .await?
-            .into_inner();
-
-        tracing::info!("{:#?}", rsp);
+        println!("broadcasting transaction without confirmation...");
+        self.view()
+            .broadcast_transaction(transaction, false)
+            .await?;
 
         Ok(())
     }

--- a/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
+++ b/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
@@ -18,6 +18,11 @@ message Transaction {
   crypto.v1alpha1.MerkleRoot anchor = 3;
 }
 
+// A transaction ID, the Sha256 hash of a transaction.
+message Id {
+  bytes hash = 1;
+}
+
 // The body of a transaction.
 message TransactionBody {
   // A list of actions (state changes) performed by this transaction.

--- a/proto/proto/penumbra/view/v1alpha1/view.proto
+++ b/proto/proto/penumbra/view/v1alpha1/view.proto
@@ -80,8 +80,22 @@ service ViewProtocolService {
 
   // Query for a transaction plan
   rpc TransactionPlanner(TransactionPlannerRequest) returns (TransactionPlannerResponse);
+
+  // Broadcast a transaction to the network, optionally waiting for full confirmation.
+  rpc BroadcastTransaction(BroadcastTransactionRequest) returns (BroadcastTransactionResponse);
 }
 
+message BroadcastTransactionRequest {
+  // The transaction to broadcast.
+  core.transaction.v1alpha1.Transaction transaction = 1;
+  // If true, wait for the view service to detect the transaction during sync.
+  bool await_detection = 2;
+}
+
+message BroadcastTransactionResponse {
+  // The hash of the transaction that was broadcast.
+  core.transaction.v1alpha1.Id id = 1;
+}
 
 message TransactionPlannerRequest {
     // The expiry height for the requested TransactionPlan

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
@@ -12,6 +12,13 @@ pub struct Transaction {
     #[prost(message, optional, tag = "3")]
     pub anchor: ::core::option::Option<super::super::crypto::v1alpha1::MerkleRoot>,
 }
+/// A transaction ID, the Sha256 hash of a transaction.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Id {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub hash: ::prost::bytes::Bytes,
+}
 /// The body of a transaction.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.serde.rs
@@ -2018,6 +2018,99 @@ impl<'de> serde::Deserialize<'de> for delegator_vote_view::Visible {
         deserializer.deserialize_struct("penumbra.core.transaction.v1alpha1.DelegatorVoteView.Visible", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for Id {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.hash.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.core.transaction.v1alpha1.Id", len)?;
+        if !self.hash.is_empty() {
+            struct_ser.serialize_field("hash", pbjson::private::base64::encode(&self.hash).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Id {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "hash",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Hash,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "hash" => Ok(GeneratedField::Hash),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Id;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.core.transaction.v1alpha1.Id")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<Id, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut hash__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::Hash => {
+                            if hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("hash"));
+                            }
+                            hash__ = 
+                                Some(map.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(Id {
+                    hash: hash__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.core.transaction.v1alpha1.Id", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for MemoPlan {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/proto/src/gen/penumbra.view.v1alpha1.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.rs
@@ -1,5 +1,24 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BroadcastTransactionRequest {
+    /// The transaction to broadcast.
+    #[prost(message, optional, tag = "1")]
+    pub transaction: ::core::option::Option<
+        super::super::core::transaction::v1alpha1::Transaction,
+    >,
+    /// If true, wait for the view service to detect the transaction during sync.
+    #[prost(bool, tag = "2")]
+    pub await_detection: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BroadcastTransactionResponse {
+    /// The hash of the transaction that was broadcast.
+    #[prost(message, optional, tag = "1")]
+    pub id: ::core::option::Option<super::super::core::transaction::v1alpha1::Id>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionPlannerRequest {
     /// The expiry height for the requested TransactionPlan
     #[prost(uint64, tag = "1")]
@@ -1088,6 +1107,29 @@ pub mod view_protocol_service_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        /// Broadcast a transaction to the network, optionally waiting for full confirmation.
+        pub async fn broadcast_transaction(
+            &mut self,
+            request: impl tonic::IntoRequest<super::BroadcastTransactionRequest>,
+        ) -> Result<
+            tonic::Response<super::BroadcastTransactionResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/penumbra.view.v1alpha1.ViewProtocolService/BroadcastTransaction",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 /// Generated client implementations.
@@ -1338,6 +1380,11 @@ pub mod view_protocol_service_server {
             &self,
             request: tonic::Request<super::TransactionPlannerRequest>,
         ) -> Result<tonic::Response<super::TransactionPlannerResponse>, tonic::Status>;
+        /// Broadcast a transaction to the network, optionally waiting for full confirmation.
+        async fn broadcast_transaction(
+            &self,
+            request: tonic::Request<super::BroadcastTransactionRequest>,
+        ) -> Result<tonic::Response<super::BroadcastTransactionResponse>, tonic::Status>;
     }
     /// The view protocol is used by a view client, who wants to do some
     /// transaction-related actions, to request data from a view service, which is
@@ -2197,6 +2244,46 @@ pub mod view_protocol_service_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = TransactionPlannerSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/penumbra.view.v1alpha1.ViewProtocolService/BroadcastTransaction" => {
+                    #[allow(non_camel_case_types)]
+                    struct BroadcastTransactionSvc<T: ViewProtocolService>(pub Arc<T>);
+                    impl<
+                        T: ViewProtocolService,
+                    > tonic::server::UnaryService<super::BroadcastTransactionRequest>
+                    for BroadcastTransactionSvc<T> {
+                        type Response = super::BroadcastTransactionResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::BroadcastTransactionRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).broadcast_transaction(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = BroadcastTransactionSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/proto/src/gen/penumbra.view.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.serde.rs
@@ -670,6 +670,206 @@ impl<'de> serde::Deserialize<'de> for BalanceByAddressResponse {
         deserializer.deserialize_struct("penumbra.view.v1alpha1.BalanceByAddressResponse", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for BroadcastTransactionRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.transaction.is_some() {
+            len += 1;
+        }
+        if self.await_detection {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.view.v1alpha1.BroadcastTransactionRequest", len)?;
+        if let Some(v) = self.transaction.as_ref() {
+            struct_ser.serialize_field("transaction", v)?;
+        }
+        if self.await_detection {
+            struct_ser.serialize_field("awaitDetection", &self.await_detection)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BroadcastTransactionRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "transaction",
+            "await_detection",
+            "awaitDetection",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Transaction,
+            AwaitDetection,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "transaction" => Ok(GeneratedField::Transaction),
+                            "awaitDetection" | "await_detection" => Ok(GeneratedField::AwaitDetection),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BroadcastTransactionRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.view.v1alpha1.BroadcastTransactionRequest")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<BroadcastTransactionRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut transaction__ = None;
+                let mut await_detection__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::Transaction => {
+                            if transaction__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transaction"));
+                            }
+                            transaction__ = map.next_value()?;
+                        }
+                        GeneratedField::AwaitDetection => {
+                            if await_detection__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("awaitDetection"));
+                            }
+                            await_detection__ = Some(map.next_value()?);
+                        }
+                    }
+                }
+                Ok(BroadcastTransactionRequest {
+                    transaction: transaction__,
+                    await_detection: await_detection__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.view.v1alpha1.BroadcastTransactionRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for BroadcastTransactionResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.id.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.view.v1alpha1.BroadcastTransactionResponse", len)?;
+        if let Some(v) = self.id.as_ref() {
+            struct_ser.serialize_field("id", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BroadcastTransactionResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "id",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Id,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "id" => Ok(GeneratedField::Id),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BroadcastTransactionResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.view.v1alpha1.BroadcastTransactionResponse")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<BroadcastTransactionResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut id__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::Id => {
+                            if id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("id"));
+                            }
+                            id__ = map.next_value()?;
+                        }
+                    }
+                }
+                Ok(BroadcastTransactionResponse {
+                    id: id__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.view.v1alpha1.BroadcastTransactionResponse", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for ChainParametersRequest {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/transaction/src/id.rs
+++ b/transaction/src/id.rs
@@ -1,0 +1,45 @@
+use penumbra_proto::{penumbra::core::transaction::v1alpha1 as pb, DomainType};
+use serde::{Deserialize, Serialize};
+
+/// A transaction ID (hash), the Sha256 hash used by Tendermint to identify transactions.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(try_from = "pb::Id", into = "pb::Id")]
+pub struct Id(pub [u8; 32]);
+
+impl std::fmt::Debug for Id {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
+    }
+}
+
+impl std::fmt::Display for Id {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
+    }
+}
+
+impl DomainType for Id {
+    type Proto = pb::Id;
+}
+
+impl From<Id> for pb::Id {
+    fn from(id: Id) -> pb::Id {
+        pb::Id {
+            hash: id.0.to_vec().into(),
+        }
+    }
+}
+
+impl TryFrom<pb::Id> for Id {
+    type Error = anyhow::Error;
+
+    fn try_from(proto: pb::Id) -> Result<Id, anyhow::Error> {
+        let hash = proto.hash;
+        if hash.len() != 32 {
+            return Err(anyhow::anyhow!("invalid transaction ID length"));
+        }
+        let mut id = [0u8; 32];
+        id.copy_from_slice(&hash);
+        Ok(Id(id))
+    }
+}

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -18,6 +18,7 @@ mod auth_data;
 mod auth_hash;
 mod effect_hash;
 mod error;
+mod id;
 mod transaction;
 mod witness_data;
 
@@ -32,6 +33,7 @@ pub use auth_data::AuthorizationData;
 pub use auth_hash::{AuthHash, AuthorizingData};
 pub use effect_hash::{EffectHash, EffectingData};
 pub use error::Error;
+pub use id::Id;
 pub use transaction::{Transaction, TransactionBody};
 pub use view::{ActionView, TransactionPerspective, TransactionView};
 pub use witness_data::WitnessData;

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -27,7 +27,7 @@ use crate::{
         ProposalWithdraw, Swap, Undelegate, ValidatorVote,
     },
     view::action_view::OutputView,
-    Action, ActionView, IsAction, TransactionPerspective, TransactionView,
+    Action, ActionView, Id, IsAction, TransactionPerspective, TransactionView,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -332,14 +332,14 @@ impl Transaction {
         &self.binding_sig
     }
 
-    pub fn id(&self) -> [u8; 32] {
+    pub fn id(&self) -> Id {
         use sha2::{Digest, Sha256};
 
         let tx_bytes: Vec<u8> = self.clone().try_into().expect("can serialize transaction");
         let mut id_bytes = [0; 32];
         id_bytes[..].copy_from_slice(Sha256::digest(&tx_bytes).as_slice());
 
-        id_bytes
+        Id(id_bytes)
     }
 
     /// Compute the binding verification key from the transaction data.

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -25,6 +25,8 @@ penumbra-crypto = { path = "../crypto" }
 penumbra-tct = { path = "../tct" }
 penumbra-transaction = { path = "../transaction" }
 penumbra-custody = {path = "../custody"}
+# TODO: replace by a penumbra-app
+penumbra-component = { path = "../component" }
 
 sqlx = { version = "0.6", features = [ "runtime-tokio-rustls", "offline", "sqlite" ] }
 tokio = { version = "1.22", features = ["full"]}

--- a/view/src/service.rs
+++ b/view/src/service.rs
@@ -184,7 +184,17 @@ impl ViewService {
 
         // 3. Optionally wait for the transaction to be detected by the view service.
         let nullifier = if await_detection {
-            transaction.spent_nullifiers().next()
+            // This needs to be only *spend* nullifiers because the nullifier detection
+            // is broken for swaps, https://github.com/penumbra-zone/penumbra/issues/1749
+            //
+            // in the meantime, inline the definition from `Transaction`
+            transaction
+                .actions()
+                .filter_map(|action| match action {
+                    penumbra_transaction::Action::Spend(spend) => Some(spend.body.nullifier),
+                    _ => None,
+                })
+                .next()
         } else {
             None
         };


### PR DESCRIPTION
This pulls code out of `pcli` and puts it in the view service, so that users of
the view service can submit transactions and await detection without having to
write custom code.