### PR TITLE
ci: remove unnecessary smoke test delays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,6 +3389,7 @@ dependencies = [
  "http-body",
  "indicatif",
  "jmt",
+ "once_cell",
  "penumbra-chain",
  "penumbra-component",
  "penumbra-crypto",

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -69,6 +69,7 @@ url = "2"
 colored_json = "2.1"
 toml = { version = "0.7", features = ["preserve_order"] }
 walkdir = "2"
+once_cell = "1"
 
 [build-dependencies]
 vergen = "5"

--- a/pcli/src/command/tx.rs
+++ b/pcli/src/command/tx.rs
@@ -371,8 +371,9 @@ impl TxCmd {
                     .await
                     .context("can't plan swap claim")?;
 
-                // Submit the `SwapClaim` transaction. TODO: should probably wait for the output notes
-                // of a SwapClaim to sync.
+                // Submit the `SwapClaim` transaction.
+                // BUG: this doesn't wait for confirmation, see
+                // https://github.com/penumbra-zone/penumbra/pull/2091/commits/128b24a6303c2f855a708e35f9342987f1dd34ec
                 app.build_and_submit_transaction(plan).await?;
             }
             TxCmd::Delegate {

--- a/pcli/tests/network_integration.rs
+++ b/pcli/tests/network_integration.rs
@@ -250,6 +250,9 @@ fn swap() {
         .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS));
     swap_cmd.assert().success();
 
+    // HACK: remove once #1749 is fixed
+    thread::sleep(std::time::Duration::from_secs(10));
+
     // Cleanup: Swap the gn back (will fail if we received no gn in the above swap).
     let mut swap_back_cmd = Command::cargo_bin("pcli").unwrap();
     swap_back_cmd


### PR DESCRIPTION
`pcli` waits for confirmation anyways, so it shouldn't be necessary to wait extra time.