### PR TITLE
ci: try faster block times for smoke test

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -49,4 +49,4 @@ jobs:
           export PATH=$HOME/bin:$PATH
           ./deployments/scripts/smoke-test.sh
         env:
-          TESTNET_RUNTIME: 5m
+          TESTNET_RUNTIME: 2m

--- a/pcli/tests/network_integration.rs
+++ b/pcli/tests/network_integration.rs
@@ -10,12 +10,11 @@
 //! was distributed 1cube.
 
 use std::path::PathBuf;
-use std::time::Duration;
-use std::{thread, time};
+use std::thread;
 
 use assert_cmd::Command;
 use directories::UserDirs;
-use once_cell::sync::Lazy;
+//use once_cell::sync::Lazy;
 use penumbra_component::stake::validator::ValidatorToml;
 use predicates::prelude::*;
 use regex::Regex;
@@ -29,14 +28,16 @@ const TEST_ASSET: &str = "1cube";
 // The maximum amount of time any command is allowed to take before we error.
 const TIMEOUT_COMMAND_SECONDS: u64 = 20;
 
-// The estimated epoch duration time.
-const EPOCH_DURATION: Lazy<Duration> = Lazy::new(|| {
+// The time to wait before attempting to perform an undelegation claim.
+/*
+const UNBONDING_DURATION: Lazy<Duration> = Lazy::new(|| {
     let seconds = std::env::var("EPOCH_DURATION")
         .unwrap_or("100".to_string())
         .parse()
         .unwrap();
     Duration::from_secs(seconds)
 });
+ */
 
 /// Import the wallet from seed phrase into a temporary directory.
 fn load_wallet_into_tmpdir() -> TempDir {
@@ -215,7 +216,8 @@ fn delegate_and_undelegate() {
     }
 
     // Wait for the epoch duration.
-    thread::sleep(*EPOCH_DURATION);
+    //thread::sleep(*UNBONDING_DURATION);
+    // TODO: exercise undelegation claims.
 
     // Now sync.
     let mut sync_cmd = Command::cargo_bin("pcli").unwrap();

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -83,6 +83,9 @@ enum TestnetCommand {
     /// Generates a directory structure containing necessary files to create a new
     /// testnet from genesis, based on input configuration.
     Generate {
+        /// The `timeout_commit` parameter (block interval) to configure Tendermint with.
+        #[clap(long)]
+        timeout_commit: Option<tendermint::Timeout>,
         /// Number of blocks per epoch.
         #[clap(long)]
         epoch_duration: Option<u64>,
@@ -327,6 +330,7 @@ async fn main() -> anyhow::Result<()> {
                     // peers will be useful in local setups until peer discovery via a seed
                     // works.
                     starting_ip,
+                    timeout_commit,
                     epoch_duration,
                     unbonding_epochs,
                     active_validator_limit,
@@ -363,6 +367,7 @@ async fn main() -> anyhow::Result<()> {
                 output_dir,
                 &chain_id,
                 active_validator_limit,
+                timeout_commit,
                 epoch_duration,
                 unbonding_epochs,
                 starting_ip,

--- a/pd/src/testnet.rs
+++ b/pd/src/testnet.rs
@@ -33,7 +33,7 @@ pub fn generate_tm_config(
     node_name: &str,
     peers: Vec<TendermintAddress>,
     external_address: Option<TendermintAddress>,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<TendermintConfig> {
     tracing::debug!("List of TM peers: {:?}", peers);
     let moniker: Moniker = Moniker::from_str(node_name)?;
     let mut tm_config =
@@ -43,7 +43,8 @@ pub fn generate_tm_config(
     tm_config.p2p.seeds = peers;
     tracing::debug!("External address looks like: {:?}", external_address);
     tm_config.p2p.external_address = external_address;
-    Ok(toml::to_string(&tm_config)?)
+    //Ok(toml::to_string(&tm_config)?)
+    Ok(tm_config)
 }
 
 /// Construct a [`tendermint_config::net::Address`] from an optional node [`Id`] and `node_address`.
@@ -157,7 +158,7 @@ pub fn write_configs(
     node_dir: PathBuf,
     vk: &ValidatorKeys,
     genesis: &Genesis<AppState>,
-    tm_config: String,
+    tm_config: TendermintConfig,
 ) -> anyhow::Result<()> {
     let mut pd_dir = node_dir.clone();
     let mut tm_dir = node_dir;
@@ -185,7 +186,7 @@ pub fn write_configs(
     config_file_path.push("config.toml");
     tracing::info!(config_file_path = %config_file_path.display(), "writing tendermint config.toml");
     let mut config_file = File::create(config_file_path)?;
-    config_file.write_all(tm_config.as_bytes())?;
+    config_file.write_all(toml::to_string(&tm_config)?.as_bytes())?;
 
     // Write this node's node_key.json
     // the underlying type doesn't implement Copy or Clone (for the best)

--- a/pd/src/testnet/generate.rs
+++ b/pd/src/testnet/generate.rs
@@ -31,6 +31,7 @@ pub fn testnet_generate(
     testnet_dir: PathBuf,
     chain_id: &str,
     active_validator_limit: Option<u64>,
+    timeout_commit: Option<tendermint::Timeout>,
     epoch_duration: Option<u64>,
     unbonding_epochs: Option<u64>,
     starting_ip: Ipv4Addr,
@@ -236,7 +237,10 @@ pub fn testnet_generate(
             })
             .filter_map(|(id, ip)| parse_tm_address(Some(&id), &ip).ok())
             .collect::<Vec<_>>();
-        let tm_config = generate_tm_config(&node_name, ips_minus_mine, None)?;
+        let mut tm_config = generate_tm_config(&node_name, ips_minus_mine, None)?;
+        if let Some(timeout_commit) = timeout_commit {
+            tm_config.consensus.timeout_commit = timeout_commit;
+        }
 
         write_configs(node_dir, vk, &validator_genesis, tm_config)?;
     }


### PR DESCRIPTION
This PR changes the smoke test to run with sub-second block times.

Also, I noticed that the undelegation test isn't actually exercising the undelegation claim flow.  In a future PR, it'd be good to add functionality that adds it to the test and checks that it worked.