### PR TITLE
crypto(zk): impl `R1CSVar` for our circuit variables

### DIFF
--- a/crypto/src/address/r1cs.rs
+++ b/crypto/src/address/r1cs.rs
@@ -64,3 +64,6 @@ impl AllocVar<Address, Fq> for AddressVar {
         }
     }
 }
+
+// We do not implement the R1CSVar trait for AddressVar since we do not have the
+// diversifier in-circuit in order to construct an Address.

--- a/crypto/src/asset/r1cs.rs
+++ b/crypto/src/asset/r1cs.rs
@@ -34,6 +34,19 @@ impl AllocVar<crate::asset::Id, Fq> for AssetIdVar {
     }
 }
 
+impl R1CSVar<Fq> for AssetIdVar {
+    type Value = crate::asset::Id;
+
+    fn cs(&self) -> ark_relations::r1cs::ConstraintSystemRef<Fq> {
+        self.asset_id.cs()
+    }
+
+    fn value(&self) -> Result<Self::Value, SynthesisError> {
+        let asset_id_fq = self.asset_id.value()?;
+        Ok(crate::asset::Id(asset_id_fq))
+    }
+}
+
 impl AssetIdVar {
     pub fn value_generator(&self) -> Result<ElementVar, SynthesisError> {
         let cs = self.asset_id.cs();

--- a/crypto/src/balance/commitment.rs
+++ b/crypto/src/balance/commitment.rs
@@ -84,6 +84,19 @@ impl AllocVar<Commitment, Fq> for BalanceCommitmentVar {
     }
 }
 
+impl R1CSVar<Fq> for BalanceCommitmentVar {
+    type Value = Commitment;
+
+    fn cs(&self) -> ark_relations::r1cs::ConstraintSystemRef<Fq> {
+        self.inner.cs()
+    }
+
+    fn value(&self) -> Result<Self::Value, SynthesisError> {
+        let inner = self.inner.value()?;
+        Ok(Commitment(inner))
+    }
+}
+
 impl EqGadget<Fq> for BalanceCommitmentVar {
     fn is_eq(&self, other: &Self) -> Result<Boolean<Fq>, SynthesisError> {
         self.inner.is_eq(&other.inner)

--- a/crypto/src/keys/nullifier.rs
+++ b/crypto/src/keys/nullifier.rs
@@ -14,7 +14,7 @@ use crate::{
 pub const NK_LEN_BYTES: usize = 32;
 
 /// Allows deriving the nullifier associated with a positioned piece of state.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NullifierKey(pub Fq);
 
 impl NullifierKey {
@@ -51,6 +51,19 @@ impl AllocVar<NullifierKey, Fq> for NullifierKeyVar {
                 inner: FqVar::new_witness(cs, || Ok(inner.0))?,
             }),
         }
+    }
+}
+
+impl R1CSVar<Fq> for NullifierKeyVar {
+    type Value = NullifierKey;
+
+    fn cs(&self) -> ark_relations::r1cs::ConstraintSystemRef<Fq> {
+        self.inner.cs()
+    }
+
+    fn value(&self) -> Result<Self::Value, SynthesisError> {
+        let inner_fq = self.inner.value()?;
+        Ok(NullifierKey(inner_fq))
     }
 }
 

--- a/crypto/src/note/r1cs.rs
+++ b/crypto/src/note/r1cs.rs
@@ -61,7 +61,7 @@ impl AllocVar<Note, Fq> for NoteVar {
             AllocationMode::Input => unimplemented!(),
             AllocationMode::Witness => {
                 let note1 = f()?;
-                let note = note1.borrow();
+                let note: &Note = note1.borrow();
 
                 let note_blinding =
                     FqVar::new_witness(cs.clone(), || Ok(note.note_blinding().clone()))?;
@@ -77,6 +77,10 @@ impl AllocVar<Note, Fq> for NoteVar {
         }
     }
 }
+
+// We do not implement `R1CSVar` for `NoteVar` since the associated type
+// should be `Note` which we cannot construct from the R1CS variable
+// since we do not have the rseed in-circuit.
 
 pub struct NoteCommitmentVar {
     pub inner: FqVar,
@@ -113,6 +117,19 @@ impl AllocVar<note::Commitment, Fq> for NoteCommitmentVar {
                 Ok(Self { inner })
             }
         }
+    }
+}
+
+impl R1CSVar<Fq> for NoteCommitmentVar {
+    type Value = note::Commitment;
+
+    fn cs(&self) -> ark_relations::r1cs::ConstraintSystemRef<Fq> {
+        self.inner.cs()
+    }
+
+    fn value(&self) -> Result<Self::Value, SynthesisError> {
+        let inner = self.inner.value()?;
+        Ok(note::Commitment(inner))
     }
 }
 

--- a/crypto/src/nullifier.rs
+++ b/crypto/src/nullifier.rs
@@ -109,6 +109,18 @@ impl AllocVar<Nullifier, Fq> for NullifierVar {
     }
 }
 
+impl R1CSVar<Fq> for NullifierVar {
+    type Value = Nullifier;
+
+    fn cs(&self) -> ark_relations::r1cs::ConstraintSystemRef<Fq> {
+        self.inner.cs()
+    }
+
+    fn value(&self) -> Result<Self::Value, SynthesisError> {
+        Ok(Nullifier(self.inner.value()?))
+    }
+}
+
 impl EqGadget<Fq> for NullifierVar {
     fn is_eq(&self, other: &Self) -> Result<Boolean<Fq>, SynthesisError> {
         self.inner.is_eq(&other.inner)

--- a/crypto/src/value.rs
+++ b/crypto/src/value.rs
@@ -99,6 +99,21 @@ impl AllocVar<Value, Fq> for ValueVar {
     }
 }
 
+impl R1CSVar<Fq> for ValueVar {
+    type Value = Value;
+
+    fn cs(&self) -> ark_relations::r1cs::ConstraintSystemRef<Fq> {
+        self.amount.cs()
+    }
+
+    fn value(&self) -> Result<Self::Value, SynthesisError> {
+        Ok(Value {
+            amount: self.amount.value()?,
+            asset_id: self.asset_id.value()?,
+        })
+    }
+}
+
 impl ValueVar {
     pub fn amount(&self) -> FqVar {
         self.amount.amount.clone()

--- a/tct/src/r1cs.rs
+++ b/tct/src/r1cs.rs
@@ -32,6 +32,23 @@ impl AllocVar<Position, Fq> for PositionVar {
     }
 }
 
+impl R1CSVar<Fq> for PositionVar {
+    type Value = Position;
+
+    fn cs(&self) -> ark_relations::r1cs::ConstraintSystemRef<Fq> {
+        self.inner.cs()
+    }
+
+    fn value(&self) -> Result<Self::Value, SynthesisError> {
+        let inner_fq = self.inner.value()?;
+        let inner_bytes = &inner_fq.to_bytes()[0..16];
+        let position_bytes: [u8; 8] = inner_bytes
+            .try_into()
+            .expect("should be able to fit in 16 bytes");
+        Ok(Position::from(u64::from_le_bytes(position_bytes)))
+    }
+}
+
 /// This represents the TCT's auth path in R1CS.
 pub struct MerkleAuthPathVar {
     inner: [[FqVar; 3]; 24],


### PR DESCRIPTION
The [R1CSVar](https://docs.rs/ark-r1cs-std/latest/ark_r1cs_std/trait.R1CSVar.html) trait is very useful for debugging as it lets you call `.value()` to learn what value the variable has in the constraint system. This PR implements it for most of our circuit variables, though I've noted a couple of places where it doesn't make sense, e.g. we can't reconstruct a full `Note` because we don't have the rseed in-circuit, only the derived values. 

Related to #2040