### PR TITLE
adding more logging for verification failures

### DIFF
--- a/crypto/src/proofs/groth16/output.rs
+++ b/crypto/src/proofs/groth16/output.rs
@@ -17,7 +17,9 @@ use rand::{CryptoRng, Rng};
 use rand_core::OsRng;
 
 use crate::balance::BalanceVar;
-use crate::proofs::groth16::{gadgets, ParameterSetup, GROTH16_PROOF_LENGTH_BYTES};
+use crate::proofs::groth16::{
+    gadgets, ParameterSetup, VerifyingKeyExt, GROTH16_PROOF_LENGTH_BYTES,
+};
 use crate::{
     balance, balance::commitment::BalanceCommitmentVar, keys::Diversifier, note, Address, Note,
     Rseed, Value,
@@ -138,10 +140,9 @@ impl OutputProof {
     /// The public inputs are:
     /// * balance commitment of the new note,
     /// * note commitment of the new note,
-    // Commented out, but this may be useful when debugging proof verification failures,
+    // For debugging proof verification failures:
     // to check that the proof data and verification keys are consistent.
-    //#[tracing::instrument(skip(self, vk), fields(self = ?base64::encode(&self.clone().encode_to_vec()), vk = ?vk.debug_id()))]
-    #[tracing::instrument(skip(self, vk))]
+    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?base64::encode(&self.clone().encode_to_vec()), vk = ?vk.debug_id()))]
     pub fn verify(
         &self,
         vk: &PreparedVerifyingKey<Bls12_377>,

--- a/crypto/src/proofs/groth16/spend.rs
+++ b/crypto/src/proofs/groth16/spend.rs
@@ -19,7 +19,7 @@ use penumbra_tct as tct;
 use rand::{CryptoRng, Rng};
 use rand_core::OsRng;
 
-use crate::proofs::groth16::{gadgets, ParameterSetup};
+use crate::proofs::groth16::{gadgets, ParameterSetup, VerifyingKeyExt};
 use crate::{
     balance,
     balance::commitment::BalanceCommitmentVar,
@@ -219,10 +219,9 @@ impl SpendProof {
     }
 
     /// Called to verify the proof using the provided public inputs.
-    // Commented out, but this may be useful when debugging proof verification failures,
+    // For debugging proof verification failures,
     // to check that the proof data and verification keys are consistent.
-    //#[tracing::instrument(skip(self, vk), fields(self = ?base64::encode(&self.clone().encode_to_vec()), vk = ?vk.debug_id()))]
-    #[tracing::instrument(skip(self, vk))]
+    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?base64::encode(&self.clone().encode_to_vec()), vk = ?vk.debug_id()))]
     pub fn verify(
         &self,
         vk: &PreparedVerifyingKey<Bls12_377>,


### PR DESCRIPTION
There have been a couple of folks reporting unexpected proof verification failures when trying to delegate or send on the most recent testnet: unfortunately these are a hard to debug since we don't have a reproducer. For the next testnet we should add additional logging such that we can ask folks to run their command with `RUST_LOG=debug` to get more info about what is going on. Possible causes include using out of date software/proving parameters or a bug that we only hit in a small subset of cases.
