### PR TITLE
crypto: by default do not use parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,7 +4105,7 @@ dependencies = [
 [[package]]
 name = "poseidon-parameters"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?branch=update-decaf377#f1a980eb5a71155e7a07582c3f2a2a0aa5f8993c"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=main#7c656864b993fa915e8fe5bf698ae3b52cb10e35"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4115,7 +4115,7 @@ dependencies = [
 [[package]]
 name = "poseidon-paramgen"
 version = "0.1.1"
-source = "git+https://github.com/penumbra-zone/poseidon377?branch=update-decaf377#f1a980eb5a71155e7a07582c3f2a2a0aa5f8993c"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=main#7c656864b993fa915e8fe5bf698ae3b52cb10e35"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "poseidon-permutation"
 version = "0.1.1"
-source = "git+https://github.com/penumbra-zone/poseidon377?branch=update-decaf377#f1a980eb5a71155e7a07582c3f2a2a0aa5f8993c"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=main#7c656864b993fa915e8fe5bf698ae3b52cb10e35"
 dependencies = [
  "ark-ff",
  "ark-std",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "poseidon377"
 version = "0.1.1"
-source = "git+https://github.com/penumbra-zone/poseidon377?branch=update-decaf377#f1a980eb5a71155e7a07582c3f2a2a0aa5f8993c"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=main#7c656864b993fa915e8fe5bf698ae3b52cb10e35"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,32 +1434,6 @@ dependencies = [
 
 [[package]]
 name = "decaf377"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18207ab15ce20be28688fd467db029717d1e9cd52be6fdb35c36b33f438b1e45"
-dependencies = [
- "anyhow",
- "ark-bls12-377",
- "ark-ec",
- "ark-ed-on-bls12-377",
- "ark-ff",
- "ark-groth16",
- "ark-r1cs-std",
- "ark-relations",
- "ark-serialize",
- "ark-snark",
- "ark-std",
- "hex",
- "num-bigint",
- "once_cell",
- "thiserror",
- "tracing",
- "tracing-subscriber 0.2.25",
- "zeroize",
-]
-
-[[package]]
-name = "decaf377"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eda36fea55fdf1651c30440ba57d92b2dc14dc2e23a862e640babeef6bde8f9"
@@ -1493,7 +1467,7 @@ dependencies = [
  "bitvec",
  "blake2b_simd 0.5.11",
  "criterion",
- "decaf377 0.3.0",
+ "decaf377",
  "proptest",
  "rand_core",
  "thiserror",
@@ -1504,7 +1478,7 @@ name = "decaf377-ka"
 version = "0.1.0"
 dependencies = [
  "ark-ff",
- "decaf377 0.3.0",
+ "decaf377",
  "hex",
  "proptest",
  "rand_core",
@@ -1522,7 +1496,7 @@ dependencies = [
  "ark-serialize",
  "blake2b_simd 0.5.11",
  "byteorder",
- "decaf377 0.3.0",
+ "decaf377",
  "digest 0.9.0",
  "hex",
  "rand_core",
@@ -1868,7 +1842,7 @@ dependencies = [
  "ark-ff",
  "ark-poly",
  "blake2b_simd 0.5.11",
- "decaf377 0.3.0",
+ "decaf377",
  "rand",
 ]
 
@@ -3381,7 +3355,7 @@ dependencies = [
  "clap 3.2.23",
  "colored_json",
  "comfy-table",
- "decaf377 0.3.0",
+ "decaf377",
  "directories",
  "ed25519-consensus",
  "futures",
@@ -3415,7 +3389,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.7",
- "toml 0.7.2",
+ "toml 0.7.3",
  "tonic",
  "tower",
  "tracing",
@@ -3488,7 +3462,7 @@ dependencies = [
  "clap 3.2.23",
  "console-subscriber",
  "csv",
- "decaf377 0.3.0",
+ "decaf377",
  "directories",
  "ed25519-consensus",
  "futures",
@@ -3586,7 +3560,7 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "bytes",
- "decaf377 0.3.0",
+ "decaf377",
  "hex",
  "ibc",
  "ics23",
@@ -3614,7 +3588,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake2b_simd 0.5.11",
- "decaf377 0.3.0",
+ "decaf377",
  "ed25519-consensus",
  "futures",
  "hex",
@@ -3669,7 +3643,7 @@ dependencies = [
  "blake2b_simd 0.5.11",
  "bytes",
  "chacha20poly1305",
- "decaf377 0.3.0",
+ "decaf377",
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",
@@ -3685,7 +3659,7 @@ dependencies = [
  "pbkdf2",
  "penumbra-proto",
  "penumbra-tct",
- "poseidon-paramgen 0.1.0 (git+https://github.com/penumbra-zone/poseidon377?rev=a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04)",
+ "poseidon-paramgen",
  "poseidon377",
  "proptest",
  "rand",
@@ -3730,7 +3704,7 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "ark-std",
- "decaf377 0.3.0",
+ "decaf377",
  "futures",
  "merlin",
  "parking_lot 0.12.1",
@@ -3772,7 +3746,7 @@ dependencies = [
  "ark-serialize",
  "ark-snark",
  "ark-std",
- "decaf377 0.3.0",
+ "decaf377",
  "num-bigint",
  "once_cell",
  "penumbra-crypto",
@@ -3845,7 +3819,7 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "blake2b_simd 1.0.1",
- "decaf377 0.3.0",
+ "decaf377",
  "derivative",
  "futures",
  "hash_hasher",
@@ -3887,7 +3861,7 @@ dependencies = [
  "axum-server",
  "bytes",
  "clap 3.2.23",
- "decaf377 0.3.0",
+ "decaf377",
  "futures",
  "hex",
  "include-flate",
@@ -3922,7 +3896,7 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "clap 3.2.23",
- "decaf377 0.3.0",
+ "decaf377",
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",
@@ -4129,46 +4103,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "poseidon-paramgen"
+name = "poseidon-parameters"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaee7da4206270e6530bc1ec1ff1d930f67239396412c2a1c13e200daf88eaa"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=update-decaf377#f1a980eb5a71155e7a07582c3f2a2a0aa5f8993c"
 dependencies = [
  "anyhow",
  "ark-ff",
- "merlin",
- "num",
- "num-bigint",
- "rand_core",
+ "num-integer",
 ]
 
 [[package]]
 name = "poseidon-paramgen"
-version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?rev=a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04#a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04"
+version = "0.1.1"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=update-decaf377#f1a980eb5a71155e7a07582c3f2a2a0aa5f8993c"
 dependencies = [
  "anyhow",
  "ark-ff",
+ "ark-std",
+ "getrandom",
  "merlin",
  "num",
  "num-bigint",
+ "poseidon-parameters",
  "rand_core",
 ]
 
 [[package]]
 name = "poseidon-permutation"
-version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?rev=a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04#a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04"
+version = "0.1.1"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=update-decaf377#f1a980eb5a71155e7a07582c3f2a2a0aa5f8993c"
 dependencies = [
  "ark-ff",
- "once_cell",
- "poseidon-paramgen 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-std",
+ "poseidon-parameters",
 ]
 
 [[package]]
 name = "poseidon377"
-version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/poseidon377?rev=a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04#a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04"
+version = "0.1.1"
+source = "git+https://github.com/penumbra-zone/poseidon377?branch=update-decaf377#f1a980eb5a71155e7a07582c3f2a2a0aa5f8993c"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -4177,10 +4150,11 @@ dependencies = [
  "ark-relations",
  "ark-snark",
  "ark-sponge",
- "decaf377 0.1.1",
+ "decaf377",
  "num-bigint",
  "once_cell",
- "poseidon-paramgen 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "poseidon-parameters",
+ "poseidon-paramgen",
  "poseidon-permutation",
 ]
 
@@ -5872,9 +5846,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
 dependencies = [
  "indexmap",
  "serde",
@@ -5894,9 +5868,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.5"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7082a95d48029677a28f181e5f6422d0c8339ad8396a39d3f33d62a90c1f6c30"
+checksum = "08de71aa0d6e348f070457f85af8bd566e2bc452156a423ddf22861b3a953fae"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
- "cipher 0.4.3",
+ "cipher 0.4.4",
  "cpufeatures",
 ]
 
@@ -189,7 +189,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
 dependencies = [
- "quote 1.0.23",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -201,7 +201,7 @@ checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint",
  "num-traits",
- "quote 1.0.23",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -298,8 +298,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd4e5f0bf8285d5ed538d27fab7411f3e297908fd93c62195de8bee3f199e82"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -402,8 +402,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -413,19 +413,19 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -498,12 +498,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd379e511536bad07447f899300aa526e9bae8e6f66dc5e5ca45d7587b7c1ec"
+checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
 dependencies = [
  "async-trait",
- "axum-core 0.3.2",
+ "axum-core 0.3.3",
  "bitflags",
  "bytes",
  "futures-util",
@@ -520,7 +520,6 @@ dependencies = [
  "serde",
  "sync_wrapper",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
 ]
@@ -543,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -639,8 +638,8 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "regex",
  "rustc-hash",
  "shlex",
@@ -719,7 +718,7 @@ checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq 0.2.4",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -733,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -759,7 +758,7 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.51",
+ "proc-macro2 1.0.52",
  "syn 1.0.109",
 ]
 
@@ -769,8 +768,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186b734fa1c9f6743e90c95d7233c9faab6360d1a96d4ffa19d9cfd1e9350f8a"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -780,8 +779,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99b7ff1008316626f485991b960ade129253d4034014616b94f309a15366cc49"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -837,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6031a462f977dd38968b6f23378356512feeace69cef817e1a4475108093cec3"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 
 [[package]]
 name = "cast"
@@ -898,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -923,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
@@ -978,8 +977,8 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -1083,9 +1082,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
+checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "core-foundation"
@@ -1174,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1184,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -1195,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -1218,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -1278,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af91f40b7355f82b0a891f50e70399475945bb0b0da4f1700ce60761c9d3e359"
+checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
 dependencies = [
  "csv-core",
  "itoa",
@@ -1321,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1333,33 +1332,33 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
 dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "scratch",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -1375,12 +1374,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core 0.14.3",
- "darling_macro 0.14.3",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
 ]
 
 [[package]]
@@ -1391,22 +1390,22 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "strsim",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "strsim",
  "syn 1.0.109",
 ]
@@ -1418,18 +1417,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
- "quote 1.0.23",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core 0.14.3",
- "quote 1.0.23",
+ "darling_core 0.14.4",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -1461,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "decaf377"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbd14ba1ba8a57dbfc225798212148e4385bc16f4359abab5f9b73552a7cd91"
+checksum = "5eda36fea55fdf1651c30440ba57d92b2dc14dc2e23a862e640babeef6bde8f9"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -1487,8 +1486,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377"
-version = "0.2.0"
-source = "git+https://github.com/penumbra-zone/decaf377#f26d4f215c84841ae30e651d65631a5a746ad71d"
+version = "0.3.0"
+source = "git+https://github.com/penumbra-zone/decaf377#877f9705fcc5de5613645b626d12dadce15fddcf"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -1516,7 +1515,7 @@ dependencies = [
  "bitvec",
  "blake2b_simd 0.5.11",
  "criterion",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest",
  "rand_core",
  "thiserror",
@@ -1527,7 +1526,7 @@ name = "decaf377-ka"
 version = "0.1.0"
 dependencies = [
  "ark-ff",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "proptest",
  "rand_core",
@@ -1545,7 +1544,7 @@ dependencies = [
  "ark-serialize",
  "blake2b_simd 0.5.11",
  "byteorder",
- "decaf377 0.2.0 (git+https://github.com/penumbra-zone/decaf377)",
+ "decaf377 0.3.0 (git+https://github.com/penumbra-zone/decaf377)",
  "digest 0.9.0",
  "hex",
  "rand_core",
@@ -1559,8 +1558,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -1570,8 +1569,8 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -1596,7 +1595,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -1627,8 +1626,8 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -1646,9 +1645,9 @@ checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "ed25519"
@@ -1719,16 +1718,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8958699f9359f0b04e691a13850d48b7de329138023876d07cbd024c2c820598"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "erased-serde"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ca605381c017ec7a5fef5e548f1cfaa419ed0f6df6367339300db74c92aa7d"
+checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
 dependencies = [
  "serde",
 ]
@@ -1849,7 +1848,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project",
- "spin 0.9.5",
+ "spin 0.9.6",
 ]
 
 [[package]]
@@ -1885,13 +1884,13 @@ dependencies = [
 [[package]]
 name = "frost377"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/frost377?branch=use-crates-decaf377#e7893dbec80e817060510e0911bfbeea948b5f64"
+source = "git+https://github.com/penumbra-zone/frost377#ee98104d666ee1b7858cc7f6334dd5a75b1d362e"
 dependencies = [
  "anyhow",
  "ark-ff",
  "ark-poly",
  "blake2b_simd 0.5.11",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
 ]
 
@@ -1903,9 +1902,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1918,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1928,15 +1927,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1956,38 +1955,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2031,8 +2030,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -2057,9 +2056,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -2259,9 +2258,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2498,8 +2497,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -2522,8 +2521,8 @@ checksum = "3a7d6e1419fa3129eb0802b4c99603c0d425c79fb5d76191d5a20d0ab0d664e8"
 dependencies = [
  "libflate",
  "proc-macro-hack",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -2586,9 +2585,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
  "windows-sys 0.45.0",
@@ -2611,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jmt"
@@ -2642,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
@@ -2681,9 +2680,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libflate"
@@ -2858,9 +2857,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -2911,8 +2910,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49e30813093f757be5cf21e50389a24dc7dbb22c49f23b7e8f51d69b508a5ffa"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -3036,15 +3035,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom8"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3109,8 +3099,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -3212,8 +3202,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -3277,9 +3267,9 @@ version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86b26a931f824dd4eca30b3e43bb4f31cd5f0d3a403c5f5ff27106b805bfde7b"
 dependencies = [
- "proc-macro-crate 1.3.0",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro-crate 1.3.1",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -3344,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pbjson"
@@ -3413,7 +3403,7 @@ dependencies = [
  "clap 3.2.23",
  "colored_json",
  "comfy-table",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories",
  "ed25519-consensus",
  "futures",
@@ -3520,7 +3510,7 @@ dependencies = [
  "clap 3.2.23",
  "console-subscriber",
  "csv",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories",
  "ed25519-consensus",
  "futures",
@@ -3600,8 +3590,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aa52829b8decbef693af90202711348ab001456803ba2a98eb4ec8fb70844c"
 dependencies = [
  "peg-runtime",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
 ]
 
 [[package]]
@@ -3618,7 +3608,7 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "bytes",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "ibc",
  "ics23",
@@ -3646,7 +3636,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake2b_simd 0.5.11",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-consensus",
  "futures",
  "hex",
@@ -3670,7 +3660,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_unit_struct",
- "serde_with 2.2.0",
+ "serde_with 2.3.1",
  "sha2 0.9.9",
  "tempfile",
  "tendermint",
@@ -3701,7 +3691,7 @@ dependencies = [
  "blake2b_simd 0.5.11",
  "bytes",
  "chacha20poly1305",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",
@@ -3747,7 +3737,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serde_json",
- "serde_with 2.2.0",
+ "serde_with 2.3.1",
  "tokio",
  "toml 0.5.11",
  "tonic",
@@ -3762,7 +3752,7 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "ark-std",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "merlin",
  "parking_lot 0.12.1",
@@ -3804,7 +3794,7 @@ dependencies = [
  "ark-serialize",
  "ark-snark",
  "ark-std",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint",
  "once_cell",
  "penumbra-crypto",
@@ -3877,7 +3867,7 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "blake2b_simd 1.0.1",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative",
  "futures",
  "hash_hasher",
@@ -3919,7 +3909,7 @@ dependencies = [
  "axum-server",
  "bytes",
  "clap 3.2.23",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "hex",
  "include-flate",
@@ -3954,7 +3944,7 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "clap 3.2.23",
- "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",
@@ -4065,9 +4055,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.5"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
+checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -4098,8 +4088,8 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -4254,11 +4244,11 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
+checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
 dependencies = [
- "proc-macro2 1.0.51",
+ "proc-macro2 1.0.52",
  "syn 1.0.109",
 ]
 
@@ -4285,12 +4275,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit 0.18.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4300,8 +4290,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
  "version_check",
 ]
@@ -4312,8 +4302,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "version_check",
 ]
 
@@ -4334,9 +4324,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -4428,8 +4418,8 @@ checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -4487,11 +4477,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "50686e0021c4136d1d453b2dfe059902278681512a34d4248435dc34b6b5c8ec"
 dependencies = [
- "proc-macro2 1.0.51",
+ "proc-macro2 1.0.52",
 ]
 
 [[package]]
@@ -4570,18 +4560,18 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "10.6.1"
+version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307f7aacdbab3f0adee67d52739a1d71112cc068d6fab169ddeb18e48877fad"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -4589,9 +4579,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -4749,14 +4739,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.16",
+ "semver 1.0.17",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
  "errno",
@@ -4814,9 +4804,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "rusty-fork"
@@ -4832,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safe-proc-macro2"
@@ -4910,9 +4900,9 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "303959cf613a6f6efd19ed4b4ad5bf79966a13352716299ad532cfb115f4205c"
 dependencies = [
- "proc-macro-crate 1.3.0",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro-crate 1.3.1",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -4933,9 +4923,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -4991,9 +4981,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "semver-parser"
@@ -5006,9 +4996,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
 dependencies = [
  "serde_derive",
 ]
@@ -5034,20 +5024,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "indexmap",
  "itoa",
@@ -5057,12 +5047,12 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -5090,7 +5080,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9da3c73dc33190768a0e4acf9d8e8c4ba9e4e439fb28100bf9446eb386cb8af"
 dependencies = [
- "quote 1.0.23",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -5119,9 +5109,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
+checksum = "85456ffac572dc8826334164f2fb6fb40a7c766aebe195a2a21ee69ee2885ecf"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -5129,7 +5119,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "serde_with_macros 2.2.0",
+ "serde_with_macros 2.3.1",
  "time 0.3.19",
 ]
 
@@ -5140,20 +5130,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling 0.13.4",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
+checksum = "7cbcd6104f8a4ab6af7f6be2a0da6be86b9de3c401f6e86bb856ab2af739232f"
 dependencies = [
- "darling 0.14.3",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "darling 0.14.4",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -5286,9 +5276,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -5302,9 +5292,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
+checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
 dependencies = [
  "lock_api",
 ]
@@ -5388,8 +5378,8 @@ dependencies = [
  "heck 0.4.1",
  "hex",
  "once_cell",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "serde",
  "serde_json",
  "sha2 0.10.6",
@@ -5445,8 +5435,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -5489,8 +5479,8 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "unicode-ident",
 ]
 
@@ -5506,8 +5496,8 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
 ]
@@ -5685,21 +5675,21 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -5812,8 +5802,8 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -5911,15 +5901,9 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.1",
- "toml_edit 0.19.4",
+ "toml_datetime",
+ "toml_edit",
 ]
-
-[[package]]
-name = "toml_datetime"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
 
 [[package]]
 name = "toml_datetime"
@@ -5932,25 +5916,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.18.1"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
-dependencies = [
- "indexmap",
- "nom8",
- "toml_datetime 0.5.1",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+checksum = "7082a95d48029677a28f181e5f6422d0c8339ad8396a39d3f33d62a90c1f6c30"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.1",
+ "toml_datetime",
  "winnow",
 ]
 
@@ -5962,7 +5935,7 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream 0.3.4",
  "async-trait",
- "axum 0.6.8",
+ "axum 0.6.11",
  "base64 0.13.1",
  "bytes",
  "futures-core",
@@ -6095,8 +6068,8 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
 ]
 
@@ -6219,15 +6192,15 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -6398,8 +6371,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
@@ -6422,7 +6395,7 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
- "quote 1.0.23",
+ "quote 1.0.24",
  "wasm-bindgen-macro-support",
 ]
 
@@ -6432,8 +6405,8 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -6618,9 +6591,9 @@ checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winnow"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09497b8f8b5ac5d3bb4d05c0a99be20f26fd3d5f2db7b0716e946d5103658"
+checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
 dependencies = [
  "memchr",
 ]
@@ -6658,8 +6631,8 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
- "proc-macro2 1.0.51",
- "quote 1.0.23",
+ "proc-macro2 1.0.52",
+ "quote 1.0.24",
  "syn 1.0.109",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,28 +1485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "decaf377"
-version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/decaf377#877f9705fcc5de5613645b626d12dadce15fddcf"
-dependencies = [
- "anyhow",
- "ark-bls12-377",
- "ark-ec",
- "ark-ed-on-bls12-377",
- "ark-ff",
- "ark-relations",
- "ark-serialize",
- "ark-std",
- "hex",
- "num-bigint",
- "once_cell",
- "thiserror",
- "tracing",
- "tracing-subscriber 0.2.25",
- "zeroize",
-]
-
-[[package]]
 name = "decaf377-fmd"
 version = "0.1.0"
 dependencies = [
@@ -1515,7 +1493,7 @@ dependencies = [
  "bitvec",
  "blake2b_simd 0.5.11",
  "criterion",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "proptest",
  "rand_core",
  "thiserror",
@@ -1526,7 +1504,7 @@ name = "decaf377-ka"
 version = "0.1.0"
 dependencies = [
  "ark-ff",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "hex",
  "proptest",
  "rand_core",
@@ -1538,13 +1516,13 @@ dependencies = [
 [[package]]
 name = "decaf377-rdsa"
 version = "0.5.0"
-source = "git+https://github.com/penumbra-zone/decaf377-rdsa#59db09ab8d59419e155ac2e10257360fb5109052"
+source = "git+https://github.com/penumbra-zone/decaf377-rdsa#bb66a8b16ea242a5d9015bd18b46601c37838bf7"
 dependencies = [
  "ark-ff",
  "ark-serialize",
  "blake2b_simd 0.5.11",
  "byteorder",
- "decaf377 0.3.0 (git+https://github.com/penumbra-zone/decaf377)",
+ "decaf377 0.3.0",
  "digest 0.9.0",
  "hex",
  "rand_core",
@@ -1884,13 +1862,13 @@ dependencies = [
 [[package]]
 name = "frost377"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/frost377#ee98104d666ee1b7858cc7f6334dd5a75b1d362e"
+source = "git+https://github.com/penumbra-zone/frost377#f82f57d848e814fc895947ee5741eba818027c7f"
 dependencies = [
  "anyhow",
  "ark-ff",
  "ark-poly",
  "blake2b_simd 0.5.11",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "rand",
 ]
 
@@ -3403,7 +3381,7 @@ dependencies = [
  "clap 3.2.23",
  "colored_json",
  "comfy-table",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "directories",
  "ed25519-consensus",
  "futures",
@@ -3510,7 +3488,7 @@ dependencies = [
  "clap 3.2.23",
  "console-subscriber",
  "csv",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "directories",
  "ed25519-consensus",
  "futures",
@@ -3608,7 +3586,7 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "bytes",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "hex",
  "ibc",
  "ics23",
@@ -3636,7 +3614,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake2b_simd 0.5.11",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "ed25519-consensus",
  "futures",
  "hex",
@@ -3691,7 +3669,7 @@ dependencies = [
  "blake2b_simd 0.5.11",
  "bytes",
  "chacha20poly1305",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",
@@ -3752,7 +3730,7 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "ark-std",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "futures",
  "merlin",
  "parking_lot 0.12.1",
@@ -3794,7 +3772,7 @@ dependencies = [
  "ark-serialize",
  "ark-snark",
  "ark-std",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "num-bigint",
  "once_cell",
  "penumbra-crypto",
@@ -3867,7 +3845,7 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "blake2b_simd 1.0.1",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "derivative",
  "futures",
  "hash_hasher",
@@ -3909,7 +3887,7 @@ dependencies = [
  "axum-server",
  "bytes",
  "clap 3.2.23",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "futures",
  "hex",
  "include-flate",
@@ -3944,7 +3922,7 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "clap 3.2.23",
- "decaf377 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "decaf377 0.3.0",
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",
@@ -6534,9 +6512,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -6549,45 +6527,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -12,14 +12,14 @@ penumbra-crypto = { path = "../crypto" }
 penumbra-tct = { path = "../tct" }
 
 # Penumbra dependencies
-decaf377 = "0.2"
+decaf377 = "0.3"
 
 tendermint = "0.29.0"
 ibc = "0.29"
 ics23 = "0.9.0"
 
 # Crates.io deps
-ark-ff = "0.3"
+ark-ff = { version = "0.3", default_features = false }
 anyhow = "1"
 bytes = "1"
 hex = "0.4"
@@ -29,3 +29,7 @@ serde = { version = "1", features = ["derive"] }
 async-trait = "0.1.52"
 tracing = "0.1"
 num-rational = "0.4"
+
+[features]
+default = ["std"]
+std = ["ark-ff/std"]

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -33,3 +33,4 @@ num-rational = "0.4"
 [features]
 default = ["std"]
 std = ["ark-ff/std"]
+parallel = ["ark-ff/parallel", "decaf377/parallel", "penumbra-crypto/parallel", "penumbra-tct/parallel"]

--- a/component/Cargo.toml
+++ b/component/Cargo.toml
@@ -9,14 +9,14 @@ edition = "2021"
 # Workspace dependencies
 penumbra-crypto = { path = "../crypto" }
 penumbra-proto = { path = "../proto", features = ["penumbra-storage"] }
-penumbra-transaction = { path = "../transaction", features = ["parallel"] }
+penumbra-transaction = { path = "../transaction" }
 penumbra-storage = { path = "../storage" }
 penumbra-chain = { path = "../chain" }
 penumbra-tct = { path = "../tct" }
 penumbra-proof-params = { path = "../proof-params" }
 
 # Penumbra dependencies
-decaf377 = "0.3"
+decaf377 = {version = "0.3"}
 jmt = "0.3"
 tokio = { version = "1.21.1", features = ["full", "tracing"] }
 async-trait = "0.1.52"
@@ -63,3 +63,4 @@ vergen = "5"
 [features]
 default = ["std"]
 std = ["ark-ff/std"]
+parallel = ["ark-ff/parallel", "penumbra-tct/parallel", "decaf377/parallel", "penumbra-transaction/parallel"]

--- a/component/Cargo.toml
+++ b/component/Cargo.toml
@@ -9,14 +9,14 @@ edition = "2021"
 # Workspace dependencies
 penumbra-crypto = { path = "../crypto" }
 penumbra-proto = { path = "../proto", features = ["penumbra-storage"] }
-penumbra-transaction = { path = "../transaction", features = ["fast-proofs"] }
+penumbra-transaction = { path = "../transaction", features = ["parallel"] }
 penumbra-storage = { path = "../storage" }
 penumbra-chain = { path = "../chain" }
 penumbra-tct = { path = "../tct" }
 penumbra-proof-params = { path = "../proof-params" }
 
 # Penumbra dependencies
-decaf377 = "0.2"
+decaf377 = "0.3"
 jmt = "0.3"
 tokio = { version = "1.21.1", features = ["full", "tracing"] }
 async-trait = "0.1.52"
@@ -24,7 +24,7 @@ tonic = "0.8.1"
 futures = "0.3"
 anyhow = "1"
 tracing = "0.1"
-ark-ff = "0.3"
+ark-ff = { version = "0.3", default_features = false }
 blake2b_simd = "0.5"
 bincode = "1.3.3"
 serde = { version = "1", features = ["derive"] }
@@ -59,3 +59,7 @@ rand_chacha = "0.3"
 
 [build-dependencies]
 vergen = "5"
+
+[features]
+default = ["std"]
+std = ["ark-ff/std"]

--- a/component/Cargo.toml
+++ b/component/Cargo.toml
@@ -63,4 +63,4 @@ vergen = "5"
 [features]
 default = ["std"]
 std = ["ark-ff/std"]
-parallel = ["ark-ff/parallel", "penumbra-tct/parallel", "decaf377/parallel", "penumbra-transaction/parallel"]
+parallel = ["ark-ff/parallel", "penumbra-tct/parallel", "decaf377/parallel", "penumbra-transaction/parallel", "penumbra-chain/parallel"]

--- a/component/src/action_handler/actions/proposal/submit.rs
+++ b/component/src/action_handler/actions/proposal/submit.rs
@@ -300,21 +300,19 @@ const DAO_TRANSACTION_RNG_SEED: &[u8; 32] = b"Penumbra DAO's tx build rng seed";
 
 async fn build_dao_transaction(transaction_plan: TransactionPlan) -> Result<Transaction> {
     let effect_hash = transaction_plan.effect_hash(&DAO_FULL_VIEWING_KEY);
-    transaction_plan
-        .build_concurrent(
-            &mut ChaCha20Rng::from_seed(*DAO_TRANSACTION_RNG_SEED),
-            &DAO_FULL_VIEWING_KEY,
-            AuthorizationData {
-                effect_hash,
-                spend_auths: Default::default(),
-                delegator_vote_auths: Default::default(),
-            },
-            WitnessData {
-                anchor: penumbra_tct::Tree::new().root(),
-                state_commitment_proofs: Default::default(),
-            },
-        )
-        .await
+    transaction_plan.build(
+        &mut ChaCha20Rng::from_seed(*DAO_TRANSACTION_RNG_SEED),
+        &DAO_FULL_VIEWING_KEY,
+        AuthorizationData {
+            effect_hash,
+            spend_auths: Default::default(),
+            delegator_vote_auths: Default::default(),
+        },
+        WitnessData {
+            anchor: penumbra_tct::Tree::new().root(),
+            state_commitment_proofs: Default::default(),
+        },
+    )
 }
 
 #[cfg(test)]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -51,7 +51,7 @@ ibig = "0.3"
 # only needed because ark-ff doesn't display correctly
 num-bigint = "0.4"
 tracing = "0.1"
-ark-groth16 = "0.3"
+ark-groth16 = {version = "0.3", default-features = false}
 ark-snark = "0.3"
 ark-r1cs-std = "0.3"
 ark-relations = "0.3"
@@ -61,3 +61,7 @@ ark-nonnative-field = "0.3"
 proptest = "1"
 serde_json = "1"
 frost377 = { git = "https://github.com/penumbra-zone/frost377", branch = "use-crates-decaf377" }
+
+[features]
+default = []
+fast-proofs = ["ark-groth16/parallel"]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -21,8 +21,8 @@ f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e
 
 # Crates.io deps
 base64 = "0.20"
-ark-ff = "0.3"
-ark-std = "0.3"
+ark-ff = { version = "0.3", default_features = false }
+ark-std = { version = "0.3", default_features = false }
 ark-serialize = "0.3"
 regex = "1.5"
 sha2 = "0.10.1"
@@ -53,7 +53,7 @@ num-bigint = "0.4"
 tracing = "0.1"
 ark-groth16 = {version = "0.3", default-features = false}
 ark-snark = "0.3"
-ark-r1cs-std = "0.3"
+ark-r1cs-std = {version = "0.3", default-features = false }
 ark-relations = "0.3"
 ark-nonnative-field = "0.3"
 
@@ -64,4 +64,4 @@ frost377 = { git = "https://github.com/penumbra-zone/frost377", branch = "use-cr
 
 [features]
 default = []
-fast-proofs = ["ark-groth16/parallel"]
+fast-proofs = ["ark-ff/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel"]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,8 +15,8 @@ penumbra-tct = { path = "../tct/", features = ["r1cs"] }
 # Git deps
 decaf377 = {version = "0.3", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
-poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04", features = ["r1cs"] }
-poseidon-paramgen = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04" }
+poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "update-decaf377", features = ["r1cs"] }
+poseidon-paramgen = { git = "https://github.com/penumbra-zone/poseidon377", branch = "update-decaf377" }
 f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps
@@ -64,4 +64,4 @@ frost377 = { git = "https://github.com/penumbra-zone/frost377", default-features
 
 [features]
 default = []
-parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "decaf377-rdsa/parallel", "penumbra-tct/parallel", "decaf377-fmd/parallel", "decaf377-ka/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel", "frost377/parallel"]
+parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "poseidon377/parallel", "decaf377-rdsa/parallel", "penumbra-tct/parallel", "decaf377-fmd/parallel", "decaf377-ka/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel", "frost377/parallel"]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -64,4 +64,4 @@ frost377 = { git = "https://github.com/penumbra-zone/frost377", default-features
 
 [features]
 default = []
-parallel = ["ark-ff/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel", "frost377/parallel"]
+parallel = ["ark-ff/parallel", "decaf377-rdsa/parallel", "penumbra-tct/parallel", "decaf377-fmd/parallel", "decaf377-ka/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel", "frost377/parallel"]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -15,8 +15,8 @@ penumbra-tct = { path = "../tct/", features = ["r1cs"] }
 # Git deps
 decaf377 = {version = "0.3", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
-poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "update-decaf377", features = ["r1cs"] }
-poseidon-paramgen = { git = "https://github.com/penumbra-zone/poseidon377", branch = "update-decaf377" }
+poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "main", features = ["r1cs"] }
+poseidon-paramgen = { git = "https://github.com/penumbra-zone/poseidon377", branch = "main" }
 f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,7 +13,7 @@ penumbra-proto = { path = "../proto/" }
 penumbra-tct = { path = "../tct/", features = ["r1cs"] }
 
 # Git deps
-decaf377 = {version = "0.2", features = ["r1cs"] }
+decaf377 = {version = "0.3", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04", features = ["r1cs"] }
 poseidon-paramgen = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04" }
@@ -60,8 +60,8 @@ ark-nonnative-field = "0.3"
 [dev-dependencies]
 proptest = "1"
 serde_json = "1"
-frost377 = { git = "https://github.com/penumbra-zone/frost377", branch = "use-crates-decaf377" }
+frost377 = { git = "https://github.com/penumbra-zone/frost377", default-features=false }
 
 [features]
 default = []
-fast-proofs = ["ark-ff/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel"]
+parallel = ["ark-ff/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel", "frost377/parallel"]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -64,4 +64,4 @@ frost377 = { git = "https://github.com/penumbra-zone/frost377", default-features
 
 [features]
 default = []
-parallel = ["ark-ff/parallel", "decaf377-rdsa/parallel", "penumbra-tct/parallel", "decaf377-fmd/parallel", "decaf377-ka/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel", "frost377/parallel"]
+parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "decaf377-rdsa/parallel", "penumbra-tct/parallel", "decaf377-fmd/parallel", "decaf377-ka/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel", "frost377/parallel"]

--- a/custody/Cargo.toml
+++ b/custody/Cargo.toml
@@ -31,3 +31,7 @@ vergen = "5"
 
 [dev-dependencies]
 toml = "0.5"
+
+[features]
+default = []
+parallel = ["penumbra-crypto/parallel", "penumbra-transaction/parallel"]

--- a/decaf377-fmd/Cargo.toml
+++ b/decaf377-fmd/Cargo.toml
@@ -25,3 +25,4 @@ harness = false
 [features]
 default = ["std"]
 std = ["ark-ff/std"]
+parallel = ["ark-ff/parallel", "decaf377/parallel"]

--- a/decaf377-fmd/Cargo.toml
+++ b/decaf377-fmd/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-decaf377 = "0.2"
-ark-ff = "0.3"
+decaf377 = "0.3"
+ark-ff = { version = "0.3", default_features = false }
 ark-serialize = "0.3"
 thiserror = "1"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
@@ -21,3 +21,7 @@ criterion = { version = "0.3", features = ["html_reports"] }
 [[bench]]
 name = "fmd"
 harness = false
+
+[features]
+default = ["std"]
+std = ["ark-ff/std"]

--- a/decaf377-ka/Cargo.toml
+++ b/decaf377-ka/Cargo.toml
@@ -20,3 +20,4 @@ proptest = "1"
 [features]
 default = ["std"]
 std = ["ark-ff/std"]
+parallel = ["ark-ff/parallel", "decaf377/parallel"]

--- a/decaf377-ka/Cargo.toml
+++ b/decaf377-ka/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ark-ff = "0.3"
-decaf377 = "0.2"
+ark-ff = { version = "0.3", default_features = false }
+decaf377 = "0.3"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 thiserror = "1"
 hex = "0.4"
@@ -16,3 +16,7 @@ zeroize_derive = "1.3"
 
 [dev-dependencies]
 proptest = "1"
+
+[features]
+default = ["std"]
+std = ["ark-ff/std"]

--- a/eddy/Cargo.toml
+++ b/eddy/Cargo.toml
@@ -15,7 +15,7 @@ rand_core = "0.6"
 rand = "0.8.5"
 proptest = "1"
 ark-ff = { version = "0.3", default_features = false }
-ark-std = "0.3"
+ark-std = {version = "0.3", default-features = false}
 thiserror = "1"
 
 [dev-dependencies]
@@ -23,5 +23,5 @@ tokio = { version = "1.21.1", features = ["full"]}
 
 [features]
 default = ["std"]
-std = ["ark-ff/std"]
-parallel = ["ark-ff/parallel", "decaf377/parallel"]
+std = ["ark-ff/std", "ark-std/std"]
+parallel = ["ark-ff/parallel", "decaf377/parallel", "ark-std/parallel"]

--- a/eddy/Cargo.toml
+++ b/eddy/Cargo.toml
@@ -7,16 +7,20 @@ edition = "2021"
 
 [dependencies]
 parking_lot = "0.12"
-decaf377 = "0.2"
+decaf377 = "0.3"
 anyhow = "1"
 futures = "0.3"
 merlin = "3"
 rand_core = "0.6"
 rand = "0.8.5"
 proptest = "1"
-ark-ff = "0.3"
+ark-ff = { version = "0.3", default_features = false }
 ark-std = "0.3"
 thiserror = "1"
 
 [dev-dependencies]
 tokio = { version = "1.21.1", features = ["full"]}
+
+[features]
+default = ["std"]
+std = ["ark-ff/std"]

--- a/eddy/Cargo.toml
+++ b/eddy/Cargo.toml
@@ -24,3 +24,4 @@ tokio = { version = "1.21.1", features = ["full"]}
 [features]
 default = ["std"]
 std = ["ark-ff/std"]
+parallel = ["ark-ff/parallel", "decaf377/parallel"]

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -15,15 +15,15 @@ publish = false
 default = ["std", "parallel"]
 sct-divergence-check = ["penumbra-view/sct-divergence-check"]
 std = ["ark-ff/std"]
-parallel = ["penumbra-chain/parallel", "ark-ff/parallel", "penumbra-wallet/parallel", "decaf377/parallel", "penumbra-component/parallel", "penumbra-crypto/parallel", "penumbra-custody/parallel", "penumbra-tct/parallel", "penumbra-view/parallel", "penumbra-transaction/parallel", ]
+parallel = ["penumbra-chain/parallel", "penumbra-proof-params/parallel", "ark-ff/parallel", "penumbra-wallet/parallel", "decaf377/parallel", "penumbra-component/parallel", "penumbra-crypto/parallel", "penumbra-custody/parallel", "penumbra-tct/parallel", "penumbra-view/parallel", "penumbra-transaction/parallel", ]
 
 [dependencies]
 # Workspace dependencies
 jmt = "0.3"
 penumbra-proto = { path = "../proto" }
-penumbra-chain = { path = "../chain" }
+penumbra-chain = { path = "../chain"  }
 penumbra-crypto = { path = "../crypto" }
-penumbra-transaction = { path = "../transaction", features = ["clap"] }
+penumbra-transaction = { path = "../transaction", features = ["clap"]}
 penumbra-wallet = { path = "../wallet" }
 penumbra-view = { path = "../view" }
 penumbra-custody = { path = "../custody" }
@@ -32,11 +32,11 @@ penumbra-tct = { path = "../tct" }
 penumbra-component = { path = "../component" }
 
 # Penumbra dependencies
-decaf377 = {version = "0.3"}
+decaf377 = {version = "0.3" }
 tendermint = { version = "0.29.0", features = ["rust-crypto"] }
 
 # External dependencies
-ark-ff = { version = "0.3" }
+ark-ff = { version = "0.3", default-features = false }
 ed25519-consensus = "2"
 futures = "0.3"
 async-stream = "0.2"
@@ -82,4 +82,4 @@ assert_cmd = "2.0"
 predicates = "2.1"
 tempfile = "3.3.0"
 regex = "1.6.0"
-penumbra-proof-params = { path = "../proof-params", features=["proving-keys", "parallel"] }
+penumbra-proof-params = { path = "../proof-params", features=["proving-keys"] }

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -20,7 +20,7 @@ std = ["ark-ff/std"]
 # Workspace dependencies
 jmt = "0.3"
 penumbra-proto = { path = "../proto" }
-penumbra-chain = { path = "../chain" }
+penumbra-chain = { path = "../chain", features = ["parallel"] }
 penumbra-crypto = { path = "../crypto", features = ["parallel"] }
 penumbra-transaction = { path = "../transaction", features = ["clap", "parallel"] }
 penumbra-wallet = { path = "../wallet", features = ["parallel"] }

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -12,30 +12,31 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std"]
+default = ["std", "parallel"]
 sct-divergence-check = ["penumbra-view/sct-divergence-check"]
 std = ["ark-ff/std"]
+parallel = ["penumbra-chain/parallel", "ark-ff/parallel", "penumbra-wallet/parallel", "decaf377/parallel", "penumbra-component/parallel", "penumbra-crypto/parallel", "penumbra-custody/parallel", "penumbra-tct/parallel", "penumbra-view/parallel", "penumbra-transaction/parallel", ]
 
 [dependencies]
 # Workspace dependencies
 jmt = "0.3"
 penumbra-proto = { path = "../proto" }
-penumbra-chain = { path = "../chain", features = ["parallel"] }
-penumbra-crypto = { path = "../crypto", features = ["parallel"] }
-penumbra-transaction = { path = "../transaction", features = ["clap", "parallel"] }
-penumbra-wallet = { path = "../wallet", features = ["parallel"] }
-penumbra-view = { path = "../view", features = ["parallel"] }
-penumbra-custody = { path = "../custody", features = ["parallel"] }
-penumbra-tct = { path = "../tct", features = ["parallel"] }
+penumbra-chain = { path = "../chain" }
+penumbra-crypto = { path = "../crypto" }
+penumbra-transaction = { path = "../transaction", features = ["clap"] }
+penumbra-wallet = { path = "../wallet" }
+penumbra-view = { path = "../view" }
+penumbra-custody = { path = "../custody" }
+penumbra-tct = { path = "../tct" }
 # TODO: replace by a penumbra-app
-penumbra-component = { path = "../component", features = ["parallel"] }
+penumbra-component = { path = "../component" }
 
 # Penumbra dependencies
-decaf377 = {version = "0.3", features = ["parallel"]}
+decaf377 = {version = "0.3"}
 tendermint = { version = "0.29.0", features = ["rust-crypto"] }
 
 # External dependencies
-ark-ff = { version = "0.3", features = ["parallel"] }
+ark-ff = { version = "0.3" }
 ed25519-consensus = "2"
 futures = "0.3"
 async-stream = "0.2"

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -22,20 +22,20 @@ jmt = "0.3"
 penumbra-proto = { path = "../proto" }
 penumbra-chain = { path = "../chain" }
 penumbra-crypto = { path = "../crypto", features = ["parallel"] }
-penumbra-transaction = { path = "../transaction", features = ["clap"] }
+penumbra-transaction = { path = "../transaction", features = ["clap", "parallel"] }
 penumbra-wallet = { path = "../wallet" }
 penumbra-view = { path = "../view" }
 penumbra-custody = { path = "../custody" }
-penumbra-tct = { path = "../tct" }
+penumbra-tct = { path = "../tct", features = ["parallel"] }
 # TODO: replace by a penumbra-app
-penumbra-component = { path = "../component" }
+penumbra-component = { path = "../component", features = ["parallel"] }
 
 # Penumbra dependencies
-decaf377 = "0.3"
+decaf377 = {version = "0.3", features = ["parallel"]}
 tendermint = { version = "0.29.0", features = ["rust-crypto"] }
 
 # External dependencies
-ark-ff = { version = "0.3", default_features = false }
+ark-ff = { version = "0.3", features = ["parallel"] }
 ed25519-consensus = "2"
 futures = "0.3"
 async-stream = "0.2"

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -25,7 +25,7 @@ penumbra-crypto = { path = "../crypto", features = ["parallel"] }
 penumbra-transaction = { path = "../transaction", features = ["clap", "parallel"] }
 penumbra-wallet = { path = "../wallet", features = ["parallel"] }
 penumbra-view = { path = "../view", features = ["parallel"] }
-penumbra-custody = { path = "../custody" }
+penumbra-custody = { path = "../custody", features = ["parallel"] }
 penumbra-tct = { path = "../tct", features = ["parallel"] }
 # TODO: replace by a penumbra-app
 penumbra-component = { path = "../component", features = ["parallel"] }

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -23,8 +23,8 @@ penumbra-proto = { path = "../proto" }
 penumbra-chain = { path = "../chain" }
 penumbra-crypto = { path = "../crypto", features = ["parallel"] }
 penumbra-transaction = { path = "../transaction", features = ["clap", "parallel"] }
-penumbra-wallet = { path = "../wallet" }
-penumbra-view = { path = "../view" }
+penumbra-wallet = { path = "../wallet", features = ["parallel"] }
+penumbra-view = { path = "../view", features = ["parallel"] }
 penumbra-custody = { path = "../custody" }
 penumbra-tct = { path = "../tct", features = ["parallel"] }
 # TODO: replace by a penumbra-app

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -20,7 +20,7 @@ sct-divergence-check = ["penumbra-view/sct-divergence-check"]
 jmt = "0.3"
 penumbra-proto = { path = "../proto" }
 penumbra-chain = { path = "../chain" }
-penumbra-crypto = { path = "../crypto" }
+penumbra-crypto = { path = "../crypto", features = ["fast-proofs"] }
 penumbra-transaction = { path = "../transaction", features = ["clap"] }
 penumbra-wallet = { path = "../wallet" }
 penumbra-view = { path = "../view" }
@@ -80,4 +80,4 @@ assert_cmd = "2.0"
 predicates = "2.1"
 tempfile = "3.3.0"
 regex = "1.6.0"
-penumbra-proof-params = { path = "../proof-params", features=["proving-keys"] }
+penumbra-proof-params = { path = "../proof-params", features=["proving-keys", "fast-proofs"] }

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -12,15 +12,16 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["std"]
 sct-divergence-check = ["penumbra-view/sct-divergence-check"]
+std = ["ark-ff/std"]
 
 [dependencies]
 # Workspace dependencies
 jmt = "0.3"
 penumbra-proto = { path = "../proto" }
 penumbra-chain = { path = "../chain" }
-penumbra-crypto = { path = "../crypto", features = ["fast-proofs"] }
+penumbra-crypto = { path = "../crypto", features = ["parallel"] }
 penumbra-transaction = { path = "../transaction", features = ["clap"] }
 penumbra-wallet = { path = "../wallet" }
 penumbra-view = { path = "../view" }
@@ -30,11 +31,11 @@ penumbra-tct = { path = "../tct" }
 penumbra-component = { path = "../component" }
 
 # Penumbra dependencies
-decaf377 = "0.2"
+decaf377 = "0.3"
 tendermint = { version = "0.29.0", features = ["rust-crypto"] }
 
 # External dependencies
-ark-ff = "0.3"
+ark-ff = { version = "0.3", default_features = false }
 ed25519-consensus = "2"
 futures = "0.3"
 async-stream = "0.2"
@@ -80,4 +81,4 @@ assert_cmd = "2.0"
 predicates = "2.1"
 tempfile = "3.3.0"
 regex = "1.6.0"
-penumbra-proof-params = { path = "../proof-params", features=["proving-keys", "fast-proofs"] }
+penumbra-proof-params = { path = "../proof-params", features=["proving-keys", "parallel"] }

--- a/pclientd/Cargo.toml
+++ b/pclientd/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 [features]
 default = []
 sct-divergence-check = ["penumbra-view/sct-divergence-check"]
+# Enable to use rayon parallelism for crypto operations
+parallel = ["penumbra-tct/parallel", "penumbra-transaction/parallel", "penumbra-component/parallel", "penumbra-view/parallel"]
 
 [dependencies]
 # Workspace dependencies

--- a/pclientd/Cargo.toml
+++ b/pclientd/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 default = []
 sct-divergence-check = ["penumbra-view/sct-divergence-check"]
 # Enable to use rayon parallelism for crypto operations
-parallel = ["penumbra-tct/parallel", "penumbra-chain/parallel", "penumbra-transaction/parallel", "penumbra-component/parallel", "penumbra-view/parallel"]
+parallel = ["penumbra-tct/parallel", "penumbra-custody/parallel", "penumbra-chain/parallel", "penumbra-transaction/parallel", "penumbra-component/parallel", "penumbra-view/parallel"]
 
 [dependencies]
 # Workspace dependencies

--- a/pclientd/Cargo.toml
+++ b/pclientd/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 default = []
 sct-divergence-check = ["penumbra-view/sct-divergence-check"]
 # Enable to use rayon parallelism for crypto operations
-parallel = ["penumbra-tct/parallel", "penumbra-transaction/parallel", "penumbra-component/parallel", "penumbra-view/parallel"]
+parallel = ["penumbra-tct/parallel", "penumbra-chain/parallel", "penumbra-transaction/parallel", "penumbra-component/parallel", "penumbra-view/parallel"]
 
 [dependencies]
 # Workspace dependencies

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -19,10 +19,10 @@ rust-version = "1.65"
 penumbra-proto = { path = "../proto" }
 penumbra-chain = { path = "../chain" }
 penumbra-crypto = { path = "../crypto", features = ["parallel"] }
-penumbra-transaction = { path = "../transaction" }
+penumbra-transaction = { path = "../transaction", features = ["parallel"] }
 penumbra-storage = { path = "../storage" }
-penumbra-component = { path = "../component" }
-penumbra-wallet = { path = "../wallet" }
+penumbra-component = { path = "../component", features = ["parallel"] }
+penumbra-wallet = { path = "../wallet", features = ["parallel"] }
 
 # Penumbra dependencies
 decaf377 = {version = "0.3", features = ["parallel"]}

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -25,7 +25,7 @@ penumbra-component = { path = "../component" }
 penumbra-wallet = { path = "../wallet" }
 
 # Penumbra dependencies
-decaf377 = "0.3"
+decaf377 = {version = "0.3", features = ["parallel"]}
 tower-abci = "0.5.0"
 jmt = "0.3"
 
@@ -44,7 +44,7 @@ toml = "0.5"
 # the bad update until it's yanked.
 ics23 = "0.9.0"
 
-ark-ff = { version = "0.3", default_features = false }
+ark-ff = { version = "0.3" }
 async-stream = "0.2"
 bincode = "1.3.3"
 blake2b_simd = "0.5"
@@ -98,7 +98,3 @@ clap = { version = "3", features = ["derive"] }
 [build-dependencies]
 vergen = "5"
 anyhow = "1"
-
-[features]
-default = ["std"]
-std = ["ark-ff/std"]

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -18,14 +18,14 @@ rust-version = "1.65"
 # Workspace dependencies
 penumbra-proto = { path = "../proto" }
 penumbra-chain = { path = "../chain" }
-penumbra-crypto = { path = "../crypto", features = ["fast-proofs"] }
+penumbra-crypto = { path = "../crypto", features = ["parallel"] }
 penumbra-transaction = { path = "../transaction" }
 penumbra-storage = { path = "../storage" }
 penumbra-component = { path = "../component" }
 penumbra-wallet = { path = "../wallet" }
 
 # Penumbra dependencies
-decaf377 = "0.2"
+decaf377 = "0.3"
 tower-abci = "0.5.0"
 jmt = "0.3"
 
@@ -44,7 +44,7 @@ toml = "0.5"
 # the bad update until it's yanked.
 ics23 = "0.9.0"
 
-ark-ff = "0.3"
+ark-ff = { version = "0.3", default_features = false }
 async-stream = "0.2"
 bincode = "1.3.3"
 blake2b_simd = "0.5"
@@ -98,3 +98,7 @@ clap = { version = "3", features = ["derive"] }
 [build-dependencies]
 vergen = "5"
 anyhow = "1"
+
+[features]
+default = ["std"]
+std = ["ark-ff/std"]

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65"
 [dependencies]
 # Workspace dependencies
 penumbra-proto = { path = "../proto" }
-penumbra-chain = { path = "../chain" }
+penumbra-chain = { path = "../chain", features = ["parallel"] }
 penumbra-crypto = { path = "../crypto", features = ["parallel"] }
 penumbra-transaction = { path = "../transaction", features = ["parallel"] }
 penumbra-storage = { path = "../storage" }

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.65"
 # Workspace dependencies
 penumbra-proto = { path = "../proto" }
 penumbra-chain = { path = "../chain" }
-penumbra-crypto = { path = "../crypto" }
+penumbra-crypto = { path = "../crypto", features = ["fast-proofs"] }
 penumbra-transaction = { path = "../transaction" }
 penumbra-storage = { path = "../storage" }
 penumbra-component = { path = "../component" }

--- a/proof-params/Cargo.toml
+++ b/proof-params/Cargo.toml
@@ -23,7 +23,7 @@ rand = "0.8"
 # only needed because ark-ff doesn't display correctly
 num-bigint = "0.4"
 tracing = "0.1"
-ark-groth16 = "0.3"
+ark-groth16 = {version = "0.3", default-features = false}
 ark-snark = "0.3"
 ark-r1cs-std = "0.3"
 ark-relations = "0.3"
@@ -34,3 +34,4 @@ penumbra-tct = { path = "../tct/", features = ["r1cs"] }
 
 [features]
 proving-keys = []
+fast-proofs = ["ark-groth16/parallel"]

--- a/proof-params/Cargo.toml
+++ b/proof-params/Cargo.toml
@@ -13,8 +13,8 @@ penumbra-crypto = { path = "../crypto/" }
 decaf377 = { version = "0.2", features = ["r1cs"] }
 
 # Crates.io deps
-ark-ff = "0.3"
-ark-std = "0.3"
+ark-ff = {version = "0.3", default-features = false}
+ark-std = {version = "0.3", default-features = false}
 ark-serialize = "0.3"
 serde = { version = "1", features = ["derive"] }
 once_cell = "1.8"
@@ -25,7 +25,7 @@ num-bigint = "0.4"
 tracing = "0.1"
 ark-groth16 = {version = "0.3", default-features = false}
 ark-snark = "0.3"
-ark-r1cs-std = "0.3"
+ark-r1cs-std = {version = "0.3", default-features = false}
 ark-relations = "0.3"
 ark-nonnative-field = "0.3"
 
@@ -34,4 +34,4 @@ penumbra-tct = { path = "../tct/", features = ["r1cs"] }
 
 [features]
 proving-keys = []
-fast-proofs = ["ark-groth16/parallel"]
+fast-proofs = ["ark-ff/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel"]

--- a/proof-params/Cargo.toml
+++ b/proof-params/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 penumbra-crypto = { path = "../crypto/" }
 
 # Git deps
-decaf377 = { version = "0.2", features = ["r1cs"] }
+decaf377 = { version = "0.3", features = ["r1cs"] }
 
 # Crates.io deps
 ark-ff = {version = "0.3", default-features = false}
@@ -34,4 +34,4 @@ penumbra-tct = { path = "../tct/", features = ["r1cs"] }
 
 [features]
 proving-keys = []
-fast-proofs = ["ark-ff/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel"]
+parallel = ["ark-ff/parallel", "decaf377/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel"]

--- a/tct-visualize/Cargo.toml
+++ b/tct-visualize/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 # We are visualizing the TCT, so we need to import it
 penumbra-tct = { path = "../tct", features = ["arbitrary"] }
-decaf377 = "0.2"
+decaf377 = "0.3"
 
 # Dependencies for live-view server
 tokio = { version = "1", features = ["full"] }

--- a/tct/Cargo.toml
+++ b/tct/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = "0.12"
 ark-ff = { version = "0.3", default_features = false }
 ark-serialize = "0.3"
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04" }
-decaf377 = { version = "0.3", features = ["r1cs"] }
+decaf377 = { version = "0.3" }
 tracing = { version = "0.1" }
 async-trait = { version = "0.1" }
 futures = "0.3"
@@ -27,7 +27,7 @@ ark-ed-on-bls12-377 = "0.3"
 rand = "0.8"
 im = { version = "^15.1.0", features = ["serde"] } # IMPORTANT: an OrdMap correctness bug was fixed in 15.1.0, as well as a performance improvement to `union`
 ark-relations = {version = "0.3", optional=true }
-ark-r1cs-std = {version = "0.3", optional=true }
+ark-r1cs-std = {version = "0.3", optional=true, default-features = false }
 
 # Dependencies for random testing
 proptest = { version = "1", optional = true }
@@ -36,7 +36,8 @@ proptest-derive = { version = "0.3", optional = true }
 [features]
 internal = []
 arbitrary = ["proptest", "proptest-derive"]
-r1cs = ["ark-r1cs-std", "ark-relations"]
+r1cs = ["ark-r1cs-std", "ark-relations", "decaf377/r1cs"]
+parallel = ["ark-r1cs-std/parallel", "ark-ff/parallel", "decaf377/parallel"]
 
 [dev-dependencies]
 static_assertions = "1"

--- a/tct/Cargo.toml
+++ b/tct/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 parking_lot = "0.12"
 ark-ff = { version = "0.3", default_features = false }
 ark-serialize = "0.3"
-poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04" }
+poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "update-decaf377"}
 decaf377 = { version = "0.3" }
 tracing = { version = "0.1" }
 async-trait = { version = "0.1" }
@@ -37,7 +37,7 @@ proptest-derive = { version = "0.3", optional = true }
 internal = []
 arbitrary = ["proptest", "proptest-derive"]
 r1cs = ["ark-r1cs-std", "ark-relations", "decaf377/r1cs"]
-parallel = ["ark-r1cs-std/parallel", "ark-ff/parallel", "decaf377/parallel"]
+parallel = ["ark-r1cs-std/parallel", "ark-ff/parallel", "decaf377/parallel", "poseidon377/parallel"]
 
 [dev-dependencies]
 static_assertions = "1"

--- a/tct/Cargo.toml
+++ b/tct/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 parking_lot = "0.12"
 ark-ff = { version = "0.3", default_features = false }
 ark-serialize = "0.3"
-poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "update-decaf377"}
+poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "main" }
 decaf377 = { version = "0.3" }
 tracing = { version = "0.1" }
 async-trait = { version = "0.1" }

--- a/tct/Cargo.toml
+++ b/tct/Cargo.toml
@@ -16,10 +16,10 @@ hash_hasher = "2"
 thiserror = "1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 parking_lot = "0.12"
-ark-ff = "0.3"
+ark-ff = { version = "0.3", default_features = false }
 ark-serialize = "0.3"
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04" }
-decaf377 = { version = "0.2", features = ["r1cs"] }
+decaf377 = { version = "0.3", features = ["r1cs"] }
 tracing = { version = "0.1" }
 async-trait = { version = "0.1" }
 futures = "0.3"

--- a/tools/parameter-setup/Cargo.toml
+++ b/tools/parameter-setup/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 penumbra-crypto = { path = "../../crypto/" }
 ark-groth16 = "0.3"
 ark-serialize = "0.3"
-decaf377 = { version = "0.2", features = ["r1cs"] }
+decaf377 = { version = "0.3", features = ["r1cs"] }

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -16,7 +16,7 @@ penumbra-proof-params = { path = "../proof-params/", features = ["proving-keys"]
 # Git deps
 decaf377 = "0.3"
 decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
-poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04" }
+poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "update-decaf377" }
 ibc = "0.29"
 ibc-proto = { version = "0.26", features = ["std"] }
 
@@ -55,4 +55,4 @@ serde_json = "1"
 [features]
 default = ["std"]
 std = ["ark-ff/std"]
-parallel = ["decaf377-rdsa/parallel", "penumbra-chain/parallel", "tokio", "ark-ff/parallel", "penumbra-tct/parallel", "decaf377-ka/parallel", "decaf377-fmd/parallel", "penumbra-crypto/parallel", "decaf377/parallel", "penumbra-proof-params/parallel"]
+parallel = ["decaf377-rdsa/parallel", "penumbra-chain/parallel", "poseidon377/parallel", "tokio", "ark-ff/parallel", "penumbra-tct/parallel", "decaf377-ka/parallel", "decaf377-fmd/parallel", "penumbra-crypto/parallel", "decaf377/parallel", "penumbra-proof-params/parallel"]

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -55,4 +55,4 @@ serde_json = "1"
 [features]
 default = ["std"]
 std = ["ark-ff/std"]
-parallel = ["decaf377-rdsa/parallel", "tokio", "ark-ff/parallel", "penumbra-tct/parallel", "decaf377-ka/parallel", "decaf377-fmd/parallel", "penumbra-crypto/parallel", "decaf377/parallel", "penumbra-proof-params/parallel"]
+parallel = ["decaf377-rdsa/parallel", "penumbra-chain/parallel", "tokio", "ark-ff/parallel", "penumbra-tct/parallel", "decaf377-ka/parallel", "decaf377-fmd/parallel", "penumbra-crypto/parallel", "decaf377/parallel", "penumbra-proof-params/parallel"]

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -15,11 +15,10 @@ penumbra-proof-params = { path = "../proof-params/", features = ["proving-keys"]
 
 # Git deps
 decaf377 = "0.3"
-decaf377-rdsa = { git = "https://github.com/penumbra-zone/decaf377-rdsa" }
+decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04" }
 ibc = "0.29"
 ibc-proto = { version = "0.26", features = ["std"] }
-
 
 # Crates.io deps
 base64 = "0.21"
@@ -56,4 +55,4 @@ serde_json = "1"
 [features]
 default = ["std"]
 std = ["ark-ff/std"]
-parallel = ["tokio", "ark-ff/parallel"]
+parallel = ["tokio", "ark-ff/parallel", "penumbra-tct/parallel", "decaf377-ka/parallel", "decaf377-fmd/parallel", "penumbra-crypto/parallel", "decaf377/parallel", "penumbra-proof-params/parallel"]

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -55,4 +55,4 @@ serde_json = "1"
 [features]
 default = ["std"]
 std = ["ark-ff/std"]
-parallel = ["tokio", "ark-ff/parallel", "penumbra-tct/parallel", "decaf377-ka/parallel", "decaf377-fmd/parallel", "penumbra-crypto/parallel", "decaf377/parallel", "penumbra-proof-params/parallel"]
+parallel = ["decaf377-rdsa/parallel", "tokio", "ark-ff/parallel", "penumbra-tct/parallel", "decaf377-ka/parallel", "decaf377-fmd/parallel", "penumbra-crypto/parallel", "decaf377/parallel", "penumbra-proof-params/parallel"]

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -16,7 +16,7 @@ penumbra-proof-params = { path = "../proof-params/", features = ["proving-keys"]
 # Git deps
 decaf377 = "0.3"
 decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
-poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "update-decaf377" }
+poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", branch = "main" }
 ibc = "0.29"
 ibc-proto = { version = "0.26", features = ["std"] }
 

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -14,7 +14,7 @@ penumbra-tct = { path = "../tct" }
 penumbra-proof-params = { path = "../proof-params/", features = ["proving-keys"] }
 
 # Git deps
-decaf377 = "0.2"
+decaf377 = "0.3"
 decaf377-rdsa = { git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04" }
 ibc = "0.29"
@@ -23,7 +23,7 @@ ibc-proto = { version = "0.26", features = ["std"] }
 
 # Crates.io deps
 base64 = "0.21"
-ark-ff = "0.3"
+ark-ff = { version = "0.3", default_features = false }
 ark-serialize = "0.3"
 regex = "1.5"
 sha2 = "0.9"
@@ -54,5 +54,6 @@ proptest-derive = "0.3"
 serde_json = "1"
 
 [features]
-default = []
-fast-proofs = ["tokio"]
+default = ["std"]
+std = ["ark-ff/std"]
+parallel = ["tokio", "ark-ff/parallel"]

--- a/transaction/src/plan/build.rs
+++ b/transaction/src/plan/build.rs
@@ -189,7 +189,7 @@ impl TransactionPlan {
         })
     }
 
-    #[cfg(feature = "fast-proofs")]
+    #[cfg(feature = "parallel")]
     /// Build the transaction this plan describes while proving concurrently.
     /// This can be used in environments that support tokio tasks.
     pub async fn build_concurrent<R: CryptoRng + RngCore>(

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 # When this feature is enabled, the view worker will request every single
 # SCT root, to pinpoint exactly where any SCT root divergence occurs.
 sct-divergence-check = []
-parallel = ["penumbra-crypto/parallel", "penumbra-chain/parallel", "penumbra-tct/parallel", "penumbra-component/parallel", "penumbra-transaction/parallel" ]
+parallel = ["penumbra-crypto/parallel", "penumbra-custody/parallel", "penumbra-chain/parallel", "penumbra-tct/parallel", "penumbra-component/parallel", "penumbra-transaction/parallel" ]
 
 [dependencies]
 # Workspace dependencies

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 # When this feature is enabled, the view worker will request every single
 # SCT root, to pinpoint exactly where any SCT root divergence occurs.
 sct-divergence-check = []
+parallel = ["penumbra-crypto/parallel", "penumbra-tct/parallel", "penumbra-component/parallel", "penumbra-transaction/parallel" ]
 
 [dependencies]
 # Workspace dependencies

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 # When this feature is enabled, the view worker will request every single
 # SCT root, to pinpoint exactly where any SCT root divergence occurs.
 sct-divergence-check = []
-parallel = ["penumbra-crypto/parallel", "penumbra-tct/parallel", "penumbra-component/parallel", "penumbra-transaction/parallel" ]
+parallel = ["penumbra-crypto/parallel", "penumbra-chain/parallel", "penumbra-tct/parallel", "penumbra-component/parallel", "penumbra-transaction/parallel" ]
 
 [dependencies]
 # Workspace dependencies

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 penumbra-proto = { path = "../proto" }
 penumbra-chain = { path = "../chain" }
 penumbra-crypto = { path = "../crypto" }
-penumbra-transaction = { path = "../transaction", features = ["parallel"] }
+penumbra-transaction = { path = "../transaction" }
 penumbra-component = { path = "../component" }
 penumbra-tct = { path = "../tct" }
 penumbra-view = { path = "../view" }
@@ -46,4 +46,4 @@ once_cell = "1"
 
 [features]
 default = []
-parallel = ["penumbra-crypto/parallel", "penumbra-custody/parallel", "penumbra-chain/parallel", "penumbra-tct/parallel", "penumbra-component/parallel", "penumbra-view/parallel" ]
+parallel = ["penumbra-crypto/parallel", "penumbra-transaction/parallel", "penumbra-custody/parallel", "penumbra-chain/parallel", "penumbra-tct/parallel", "penumbra-component/parallel", "penumbra-view/parallel" ]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 penumbra-proto = { path = "../proto" }
 penumbra-chain = { path = "../chain" }
 penumbra-crypto = { path = "../crypto" }
-penumbra-transaction = { path = "../transaction", features = ["fast-proofs"] }
+penumbra-transaction = { path = "../transaction", features = ["parallel"] }
 penumbra-component = { path = "../component" }
 penumbra-tct = { path = "../tct" }
 penumbra-view = { path = "../view" }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -46,4 +46,4 @@ once_cell = "1"
 
 [features]
 default = []
-parallel = ["penumbra-crypto/parallel", "penumbra-tct/parallel", "penumbra-component/parallel", "penumbra-view/parallel" ]
+parallel = ["penumbra-crypto/parallel", "penumbra-chain/parallel", "penumbra-tct/parallel", "penumbra-component/parallel", "penumbra-view/parallel" ]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -43,3 +43,7 @@ rand = "0.8"
 proptest = "1"
 proptest-derive = "0.3"
 once_cell = "1"
+
+[features]
+default = []
+parallel = ["penumbra-crypto/parallel", "penumbra-tct/parallel", "penumbra-component/parallel", "penumbra-view/parallel" ]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -46,4 +46,4 @@ once_cell = "1"
 
 [features]
 default = []
-parallel = ["penumbra-crypto/parallel", "penumbra-chain/parallel", "penumbra-tct/parallel", "penumbra-component/parallel", "penumbra-view/parallel" ]
+parallel = ["penumbra-crypto/parallel", "penumbra-custody/parallel", "penumbra-chain/parallel", "penumbra-tct/parallel", "penumbra-component/parallel", "penumbra-view/parallel" ]

--- a/wallet/src/build.rs
+++ b/wallet/src/build.rs
@@ -33,6 +33,13 @@ where
     let witness_data = view.witness(fvk.account_group_id(), &plan).await?;
 
     // ... and then build the transaction:
-    plan.build_concurrent(&mut rng, fvk, auth_data, witness_data)
-        .await
+    #[cfg(not(feature = "parallel"))]
+    let tx = plan.build(&mut rng, fvk, auth_data, witness_data)?;
+
+    #[cfg(feature = "parallel")]
+    let tx = plan
+        .build_concurrent(&mut rng, fvk, auth_data, witness_data)
+        .await?;
+
+    Ok(tx)
 }


### PR DESCRIPTION
Closes #2124 

This first needs:
- [x] Merge of https://github.com/penumbra-zone/decaf377/pull/50
- [x] Release decaf377 0.2.1
- [x] `cargo update` here
- [x] Enable `parallel` feature for pcli, pd

This was tested by running `cargo tree -p pcli -e features`:
* With the `pcli` `parallel` feature enabled: confirming rayon was in the output
* With the `pcli` `parallel` feature disabled: confirming rayon was _not_ in the output