### PR TITLE
use decaf377 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,13 +1885,13 @@ dependencies = [
 [[package]]
 name = "frost377"
 version = "0.1.0"
-source = "git+https://github.com/penumbra-zone/frost377#c439a41f6a0c4b6b3a9b766ffa5a456ec3208434"
+source = "git+https://github.com/penumbra-zone/frost377?branch=use-crates-decaf377#e7893dbec80e817060510e0911bfbeea948b5f64"
 dependencies = [
  "anyhow",
  "ark-ff",
  "ark-poly",
  "blake2b_simd 0.5.11",
- "decaf377 0.2.0 (git+https://github.com/penumbra-zone/decaf377)",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,8 @@ dependencies = [
 [[package]]
 name = "decaf377"
 version = "0.2.0"
-source = "git+https://github.com/penumbra-zone/decaf377#f26d4f215c84841ae30e651d65631a5a746ad71d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cbd14ba1ba8a57dbfc225798212148e4385bc16f4359abab5f9b73552a7cd91"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -1485,6 +1486,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "decaf377"
+version = "0.2.0"
+source = "git+https://github.com/penumbra-zone/decaf377#f26d4f215c84841ae30e651d65631a5a746ad71d"
+dependencies = [
+ "anyhow",
+ "ark-bls12-377",
+ "ark-ec",
+ "ark-ed-on-bls12-377",
+ "ark-ff",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
+ "hex",
+ "num-bigint",
+ "once_cell",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+ "zeroize",
+]
+
+[[package]]
 name = "decaf377-fmd"
 version = "0.1.0"
 dependencies = [
@@ -1493,7 +1516,7 @@ dependencies = [
  "bitvec",
  "blake2b_simd 0.5.11",
  "criterion",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest",
  "rand_core",
  "thiserror",
@@ -1504,7 +1527,7 @@ name = "decaf377-ka"
 version = "0.1.0"
 dependencies = [
  "ark-ff",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "proptest",
  "rand_core",
@@ -1522,7 +1545,7 @@ dependencies = [
  "ark-serialize",
  "blake2b_simd 0.5.11",
  "byteorder",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (git+https://github.com/penumbra-zone/decaf377)",
  "digest 0.9.0",
  "hex",
  "rand_core",
@@ -1868,7 +1891,7 @@ dependencies = [
  "ark-ff",
  "ark-poly",
  "blake2b_simd 0.5.11",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (git+https://github.com/penumbra-zone/decaf377)",
  "rand",
 ]
 
@@ -3390,7 +3413,7 @@ dependencies = [
  "clap 3.2.23",
  "colored_json",
  "comfy-table",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories",
  "ed25519-consensus",
  "futures",
@@ -3450,7 +3473,7 @@ dependencies = [
  "clap 3.2.23",
  "console-subscriber",
  "csv",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories",
  "ed25519-consensus",
  "futures",
@@ -3548,7 +3571,7 @@ dependencies = [
  "ark-ff",
  "async-trait",
  "bytes",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "ibc",
  "ics23",
@@ -3576,7 +3599,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake2b_simd 0.5.11",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-consensus",
  "futures",
  "hex",
@@ -3631,7 +3654,7 @@ dependencies = [
  "blake2b_simd 0.5.11",
  "bytes",
  "chacha20poly1305",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",
@@ -3692,7 +3715,7 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "ark-std",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "merlin",
  "parking_lot 0.12.1",
@@ -3734,7 +3757,7 @@ dependencies = [
  "ark-serialize",
  "ark-snark",
  "ark-std",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint",
  "once_cell",
  "penumbra-crypto",
@@ -3807,7 +3830,7 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "blake2b_simd 1.0.1",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative",
  "futures",
  "hash_hasher",
@@ -3849,7 +3872,7 @@ dependencies = [
  "axum-server",
  "bytes",
  "clap 3.2.23",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "hex",
  "include-flate",
@@ -3884,7 +3907,7 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "clap 3.2.23",
- "decaf377 0.2.0",
+ "decaf377 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "decaf377-fmd",
  "decaf377-ka",
  "decaf377-rdsa",

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -12,7 +12,7 @@ penumbra-crypto = { path = "../crypto" }
 penumbra-tct = { path = "../tct" }
 
 # Penumbra dependencies
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
+decaf377 = "0.2"
 
 tendermint = "0.29.0"
 ibc = "0.29"

--- a/component/Cargo.toml
+++ b/component/Cargo.toml
@@ -16,7 +16,7 @@ penumbra-tct = { path = "../tct" }
 penumbra-proof-params = { path = "../proof-params" }
 
 # Penumbra dependencies
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
+decaf377 = "0.2"
 jmt = "0.3"
 tokio = { version = "1.21.1", features = ["full", "tracing"] }
 async-trait = "0.1.52"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,7 +13,7 @@ penumbra-proto = { path = "../proto/" }
 penumbra-tct = { path = "../tct/", features = ["r1cs"] }
 
 # Git deps
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377", features = ["r1cs"] }
+decaf377 = {version = "0.2", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.5", git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04", features = ["r1cs"] }
 poseidon-paramgen = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04" }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -60,4 +60,4 @@ ark-nonnative-field = "0.3"
 [dev-dependencies]
 proptest = "1"
 serde_json = "1"
-frost377 = { git = "https://github.com/penumbra-zone/frost377" }
+frost377 = { git = "https://github.com/penumbra-zone/frost377", branch = "use-crates-decaf377" }

--- a/decaf377-fmd/Cargo.toml
+++ b/decaf377-fmd/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
+decaf377 = "0.2"
 ark-ff = "0.3"
 ark-serialize = "0.3"
 thiserror = "1"

--- a/decaf377-ka/Cargo.toml
+++ b/decaf377-ka/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ark-ff = "0.3"
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
+decaf377 = "0.2"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 thiserror = "1"
 hex = "0.4"

--- a/eddy/Cargo.toml
+++ b/eddy/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 parking_lot = "0.12"
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
+decaf377 = "0.2"
 anyhow = "1"
 futures = "0.3"
 merlin = "3"

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -30,7 +30,7 @@ penumbra-tct = { path = "../tct" }
 penumbra-component = { path = "../component" }
 
 # Penumbra dependencies
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
+decaf377 = "0.2"
 tendermint = { version = "0.29.0", features = ["rust-crypto"] }
 
 # External dependencies

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -25,7 +25,7 @@ penumbra-component = { path = "../component" }
 penumbra-wallet = { path = "../wallet" }
 
 # Penumbra dependencies
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
+decaf377 = "0.2"
 tower-abci = "0.5.0"
 jmt = "0.3"
 

--- a/proof-params/Cargo.toml
+++ b/proof-params/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 penumbra-crypto = { path = "../crypto/" }
 
 # Git deps
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377", features = ["r1cs"] }
+decaf377 = { version = "0.2", features = ["r1cs"] }
 
 # Crates.io deps
 ark-ff = "0.3"

--- a/tct-visualize/Cargo.toml
+++ b/tct-visualize/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 # We are visualizing the TCT, so we need to import it
 penumbra-tct = { path = "../tct", features = ["arbitrary"] }
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
+decaf377 = "0.2"
 
 # Dependencies for live-view server
 tokio = { version = "1", features = ["full"] }

--- a/tct/Cargo.toml
+++ b/tct/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = "0.12"
 ark-ff = "0.3"
 ark-serialize = "0.3"
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04" }
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377", features = ["r1cs"] }
+decaf377 = { version = "0.2", features = ["r1cs"] }
 tracing = { version = "0.1" }
 async-trait = { version = "0.1" }
 futures = "0.3"

--- a/tools/parameter-setup/Cargo.toml
+++ b/tools/parameter-setup/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 penumbra-crypto = { path = "../../crypto/" }
 ark-groth16 = "0.3"
 ark-serialize = "0.3"
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377", features = ["r1cs"] }
+decaf377 = { version = "0.2", features = ["r1cs"] }

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -14,7 +14,7 @@ penumbra-tct = { path = "../tct" }
 penumbra-proof-params = { path = "../proof-params/", features = ["proving-keys"] }
 
 # Git deps
-decaf377 = { git = "https://github.com/penumbra-zone/decaf377" }
+decaf377 = "0.2"
 decaf377-rdsa = { git = "https://github.com/penumbra-zone/decaf377-rdsa" }
 poseidon377 = { git = "https://github.com/penumbra-zone/poseidon377", rev = "a2d8c7a3288e2e877ac88a4d8fd3cc4ff2b52c04" }
 ibc = "0.29"


### PR DESCRIPTION
This PR switches our decaf377 git dependency to the published [version (0.2.0)](https://github.com/penumbra-zone/decaf377/releases/tag/0.2.0) on crates.io. 

Towards https://github.com/penumbra-zone/penumbra/issues/2004

Note only the last two commits are relevant here as this is a PR stacked on #2083. Before this PR is merged:
- [x] #2083 should be merged - I stack this PR on #2083 as the 0.2.0 version of decaf377 modifies the R1CS gadgets, and the #2083 proving and verification keys were generated with these new R1CS gadgets. After #2083 is merged, this PR can be rebased on `main`.

This PR switches us from `frost377` main branch to one using `decaf377` 0.2: https://github.com/penumbra-zone/frost377/pull/3

Once this is merged, I will merge https://github.com/penumbra-zone/frost377/pull/3 and then switch us back to the `main` branch of frost377. This is done to minimize disruption to folks that are building on `main` of this repo.