### PR TITLE
proto: make our implicit dependency on the cosmos-sdk protos explicit

### DIFF
--- a/proto/proto/buf.lock
+++ b/proto/proto/buf.lock
@@ -8,7 +8,7 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: cosmos-sdk
-    commit: 2aa7ff2b23df473a85b7a7fe1884105d
+    commit: b6ed173251f6401f8f521ddaab67faaa
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto
@@ -24,4 +24,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 8d7204855ec14631a499bd7393ce1970
+    commit: 75b4300737fb4efca0831636be94e517

--- a/proto/proto/buf.yaml
+++ b/proto/proto/buf.yaml
@@ -2,6 +2,7 @@ version: v1
 name: buf.build/penumbra-zone/penumbra
 deps: 
   - buf.build/cosmos/ibc
+  - buf.build/cosmos/cosmos-sdk
 breaking:
   use:
     - FILE


### PR DESCRIPTION
We use the tendermint-related proto files for the tendermint proxy service. However, because the ibc-go protos depended on them, Buf didn't complain about the implicit dependency.