### PR TITLE
wip: Add valid_before and valid_after fields to transaction

### DIFF
--- a/component/src/action_handler/actions/spend.rs
+++ b/component/src/action_handler/actions/spend.rs
@@ -60,6 +60,7 @@ mod tests {
     use std::sync::Arc;
 
     use anyhow::Result;
+    use ibc::timestamp::Timestamp;
     use penumbra_chain::test_keys;
     use penumbra_crypto::{transaction::Fee, Note, Value, STAKING_TOKEN_ASSET_ID};
     use penumbra_tct as tct;
@@ -103,6 +104,8 @@ mod tests {
         // transaction balances.
         let plan = TransactionPlan {
             expiry_height: 0,
+            valid_after: Timestamp::none(),
+            valid_before: Timestamp::none(),
             fee: Fee::default(),
             chain_id: "".into(),
             actions: vec![
@@ -166,6 +169,8 @@ mod tests {
         // transaction balances.
         let plan = TransactionPlan {
             expiry_height: 0,
+            valid_after: Timestamp::none(),
+            valid_before: Timestamp::none(),
             fee: Fee::default(),
             chain_id: "".into(),
             actions: vec![

--- a/component/src/action_handler/actions/spend.rs
+++ b/component/src/action_handler/actions/spend.rs
@@ -103,7 +103,6 @@ mod tests {
         // Add a single spend and output to the transaction plan such that the
         // transaction balances.
         let plan = TransactionPlan {
-            expiry_height: 0,
             valid_after: Timestamp::none(),
             valid_before: Timestamp::none(),
             fee: Fee::default(),
@@ -168,7 +167,6 @@ mod tests {
         // Add a single spend and output to the transaction plan such that the
         // transaction balances.
         let plan = TransactionPlan {
-            expiry_height: 0,
             valid_after: Timestamp::none(),
             valid_before: Timestamp::none(),
             fee: Fee::default(),

--- a/component/src/action_handler/transaction.rs
+++ b/component/src/action_handler/transaction.rs
@@ -17,6 +17,9 @@ use super::ActionHandler;
 mod stateful;
 mod stateless;
 
+#[cfg(test)]
+mod tests;
+
 use stateless::{no_duplicate_nullifiers, valid_binding_signature};
 
 #[async_trait]

--- a/component/src/action_handler/transaction.rs
+++ b/component/src/action_handler/transaction.rs
@@ -10,7 +10,7 @@ use tracing::{instrument, Instrument};
 
 use crate::shielded_pool::consensus_rules;
 
-use self::stateful::{claimed_anchor_is_valid, fmd_parameters_valid};
+use self::stateful::{claimed_anchor_is_valid, fmd_parameters_valid, timestamps_are_valid};
 
 use super::ActionHandler;
 
@@ -56,6 +56,7 @@ impl ActionHandler for Transaction {
     async fn check_stateful<S: StateRead + 'static>(&self, state: Arc<S>) -> Result<()> {
         claimed_anchor_is_valid(state.clone(), self).await?;
         fmd_parameters_valid(state.clone(), self).await?;
+        timestamps_are_valid(state.clone(), self).await?;
 
         // Currently, we need to clone the component actions so that the spawned
         // futures can have 'static lifetimes. In the future, we could try to

--- a/component/src/action_handler/transaction/stateful.rs
+++ b/component/src/action_handler/transaction/stateful.rs
@@ -41,22 +41,13 @@ pub(super) async fn timestamps_are_valid<S: StateRead>(
     let current_time: Timestamp = state.get_block_timestamp().await?.into();
 
     let after = transaction.transaction_body().valid_after;
-
-    let before = transaction.transaction_body().valid_before;
-
-    if current_time.check_expiry(&after) == ibc::timestamp::Expiry::Expired {
+    if after.check_expiry(&current_time) == ibc::timestamp::Expiry::Expired {
         anyhow::bail!("Too late!");
     }
 
-    if before.check_expiry(&current_time) == ibc::timestamp::Expiry::Expired {
+    let before = transaction.transaction_body().valid_before;
+    if current_time.check_expiry(&before) == ibc::timestamp::Expiry::Expired {
         anyhow::bail!("Too early!");
-    }
-
-    if transaction.transaction_body().expiry_height != 0 {
-        let current_block = state.get_block_height().await?;
-        if current_block > transaction.transaction_body().expiry_height {
-            anyhow::bail!("Too late!");
-        }
     }
 
     Ok(())

--- a/component/src/action_handler/transaction/stateful.rs
+++ b/component/src/action_handler/transaction/stateful.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use ibc::timestamp::Timestamp;
 use penumbra_chain::StateReadExt as _;
 use penumbra_storage::StateRead;
 use penumbra_transaction::Transaction;
@@ -31,4 +32,32 @@ pub(super) async fn fmd_parameters_valid<S: StateRead>(
         current_fmd_parameters,
         height,
     )
+}
+
+pub(super) async fn timestamps_are_valid<S: StateRead>(
+    state: S,
+    transaction: &Transaction,
+) -> Result<()> {
+    let current_time: Timestamp = state.get_block_timestamp().await?.into();
+
+    let after = transaction.transaction_body().valid_after;
+
+    let before = transaction.transaction_body().valid_before;
+
+    if current_time.check_expiry(&after) == ibc::timestamp::Expiry::Expired {
+        anyhow::bail!("Too late!");
+    }
+
+    if before.check_expiry(&current_time) == ibc::timestamp::Expiry::Expired {
+        anyhow::bail!("Too early!");
+    }
+
+    if transaction.transaction_body().expiry_height != 0 {
+        let current_block = state.get_block_height().await?;
+        if current_block > transaction.transaction_body().expiry_height {
+            anyhow::bail!("Too late!");
+        }
+    }
+
+    Ok(())
 }

--- a/component/src/action_handler/transaction/tests.rs
+++ b/component/src/action_handler/transaction/tests.rs
@@ -31,6 +31,7 @@ async fn test_valid_before_and_after() -> anyhow::Result<()> {
     assert!(exactly_after.check_stateful(state.clone()).await.is_ok());
 
     let five_minutes_ahead = (now + Duration::from_secs(5 * 60)).unwrap();
+    let five_minutes_ago = (now - Duration::from_secs(5 * 60)).unwrap();
 
     let mut too_early = Transaction::default();
     too_early.transaction_body.valid_after = five_minutes_ahead.into();
@@ -39,8 +40,6 @@ async fn test_valid_before_and_after() -> anyhow::Result<()> {
     let mut early_enough = Transaction::default();
     early_enough.transaction_body.valid_before = five_minutes_ahead.into();
     assert!(early_enough.check_stateful(state.clone()).await.is_ok());
-
-    let five_minutes_ago = (now - Duration::from_secs(5 * 60)).unwrap();
 
     let mut late_enough = Transaction::default();
     late_enough.transaction_body.valid_after = five_minutes_ago.into();

--- a/component/src/action_handler/transaction/tests.rs
+++ b/component/src/action_handler/transaction/tests.rs
@@ -1,0 +1,64 @@
+use penumbra_chain::StateWriteExt;
+use penumbra_storage::{ArcStateDeltaExt, StateDelta, TempStorage};
+
+use penumbra_transaction::Transaction;
+use tendermint::Time;
+
+use std::{sync::Arc, time::Duration};
+
+use crate::{ActionHandler, TempStorageExt};
+
+#[tokio::test]
+async fn test_valid_before_and_after() -> anyhow::Result<()> {
+    let storage = TempStorage::new().await?.apply_default_genesis().await?;
+    let mut state = Arc::new(StateDelta::new(storage.latest_snapshot()));
+
+    let now = Time::now();
+
+    let mut state_tx = state.try_begin_transaction().unwrap();
+    state_tx.put_block_timestamp(now);
+    state_tx.apply();
+
+    let no_timestamp = Transaction::default();
+    assert!(no_timestamp.check_stateful(state.clone()).await.is_ok());
+
+    let mut exactly_before = Transaction::default();
+    exactly_before.transaction_body.valid_before = now.into();
+    assert!(exactly_before.check_stateful(state.clone()).await.is_ok());
+
+    let mut exactly_after = Transaction::default();
+    exactly_after.transaction_body.valid_after = now.into();
+    assert!(exactly_after.check_stateful(state.clone()).await.is_ok());
+
+    let five_minutes_ahead = (now + Duration::from_secs(5 * 60)).unwrap();
+
+    let mut too_early = Transaction::default();
+    too_early.transaction_body.valid_after = five_minutes_ahead.into();
+    assert!(too_early.check_stateful(state.clone()).await.is_err());
+
+    let mut early_enough = Transaction::default();
+    early_enough.transaction_body.valid_before = five_minutes_ahead.into();
+    assert!(early_enough.check_stateful(state.clone()).await.is_ok());
+
+    let five_minutes_ago = (now - Duration::from_secs(5 * 60)).unwrap();
+
+    let mut late_enough = Transaction::default();
+    late_enough.transaction_body.valid_after = five_minutes_ago.into();
+    assert!(late_enough.check_stateful(state.clone()).await.is_ok());
+
+    let mut too_late = Transaction::default();
+    too_late.transaction_body.valid_before = five_minutes_ago.into();
+    assert!(too_late.check_stateful(state.clone()).await.is_err());
+
+    let mut just_right = Transaction::default();
+    just_right.transaction_body.valid_after = five_minutes_ago.into();
+    just_right.transaction_body.valid_before = five_minutes_ahead.into();
+    assert!(just_right.check_stateful(state.clone()).await.is_ok());
+
+    let mut just_wrong = Transaction::default();
+    just_wrong.transaction_body.valid_after = five_minutes_ahead.into();
+    just_wrong.transaction_body.valid_before = five_minutes_ago.into();
+    assert!(just_wrong.check_stateful(state.clone()).await.is_err());
+
+    Ok(())
+}

--- a/pcli/src/command/view/tx.rs
+++ b/pcli/src/command/view/tx.rs
@@ -337,10 +337,6 @@ impl TxCmd {
                 metadata_table.add_row(vec!["Transaction Memo Text", &memo.text]);
             }
             metadata_table.add_row(vec![
-                "Transaction Expiration Height",
-                &format!("{}", txv.expiry_height),
-            ]);
-            metadata_table.add_row(vec![
                 "Transaction Valid Before",
                 &format!("{}", txv.valid_before),
             ]);

--- a/pcli/src/command/view/tx.rs
+++ b/pcli/src/command/view/tx.rs
@@ -340,6 +340,14 @@ impl TxCmd {
                 "Transaction Expiration Height",
                 &format!("{}", txv.expiry_height),
             ]);
+            metadata_table.add_row(vec![
+                "Transaction Valid Before",
+                &format!("{}", txv.valid_before),
+            ]);
+            metadata_table.add_row(vec![
+                "Transaction Valid After",
+                &format!("{}", txv.valid_after),
+            ]);
 
             // Print table of actions and their descriptions
             println!("{actions_table}");

--- a/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
+++ b/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
@@ -42,18 +42,12 @@ message TransactionBody {
   // timestamp is < this value.
   //
   // If the value is zero, this value is considered unset.
-  // [TODO: Double check that this actually does behave like google's protobufs]
-  // The behavior of this time stamp should match google's protobuf specification:
-  // [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
   uint64 valid_before = 7;
   // A unix timestamp, in nanoseconds.
   // If this value is set, the transaction is valid iff the most recent block header
   // timestamp is > this value.
   //
   // If the value is zero, this value is considered unset.
-  // [TODO: Double check that this actually does behave like google's protobufs]
-  // The behavior of this time stamp should match google's protobuf specification:
-  // [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
   uint64 valid_after = 8;
 }
 
@@ -138,19 +132,13 @@ message TransactionView {
   // If this value is set, the transaction is valid iff the most recent block header
   // timestamp is < this value.
   //
-  // If the value is zero, this value is considered unset.
-  // [TODO: Double check that this actually does behave like google's protobufs]
-  // The behavior of this time stamp should match google's protobuf specification:
-  // [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
+  // If the value is zero, this field is considered unset.
   uint64 valid_before = 7;
   // A unix timestamp, in nanoseconds.
   // If this value is set, the transaction is valid iff the most recent block header
   // timestamp is > this value.
   //
-  // If the value is zero, this value is considered unset.
-  // [TODO: Double check that this actually does behave like google's protobufs]
-  // The behavior of this time stamp should match google's protobuf specification:
-  // [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
+  // If the value is zero, this field is considered unset.
   uint64 valid_after = 8;
 }
 

--- a/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
+++ b/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
@@ -41,6 +41,24 @@ message TransactionBody {
   // An optional encrypted memo. It will only be populated if there are
   // outputs in the actions of this transaction. 528 bytes.
   optional bytes encrypted_memo = 6;
+  // A unix timestamp, in nanoseconds.
+  // If this value is set, the transaction is valid iff the most recent block header
+  // timestamp is < this value.
+  //
+  // If the value is zero, this value is considered unset.
+  // [TODO: Double check that this actually does behave like google's protobufs]
+  // The behavior of this time stamp should match google's protobuf specification:
+  // [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
+  uint64 valid_before = 7;
+  // A unix timestamp, in nanoseconds.
+  // If this value is set, the transaction is valid iff the most recent block header
+  // timestamp is > this value.
+  //
+  // If the value is zero, this value is considered unset.
+  // [TODO: Double check that this actually does behave like google's protobufs]
+  // The behavior of this time stamp should match google's protobuf specification:
+  // [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
+  uint64 valid_after = 8;
 }
 
 // A state change performed by a transaction.
@@ -122,9 +140,26 @@ message TransactionView {
   // An optional plaintext memo. It will only be populated if there are
   // outputs in the actions of this transaction.
   optional bytes memo = 6;
-  
   // Any relevant address views.
   repeated crypto.v1alpha1.AddressView address_views = 400;
+  // A unix timestamp, in nanoseconds.
+  // If this value is set, the transaction is valid iff the most recent block header
+  // timestamp is < this value.
+  //
+  // If the value is zero, this value is considered unset.
+  // [TODO: Double check that this actually does behave like google's protobufs]
+  // The behavior of this time stamp should match google's protobuf specification:
+  // [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
+  uint64 valid_before = 7;
+  // A unix timestamp, in nanoseconds.
+  // If this value is set, the transaction is valid iff the most recent block header
+  // timestamp is > this value.
+  //
+  // If the value is zero, this value is considered unset.
+  // [TODO: Double check that this actually does behave like google's protobufs]
+  // The behavior of this time stamp should match google's protobuf specification:
+  // [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
+  uint64 valid_after = 8;
 }
 
 // A view of a specific state change action performed by a transaction.
@@ -281,6 +316,8 @@ message TransactionPlan {
     crypto.v1alpha1.Fee fee = 4;
     repeated CluePlan clue_plans = 5;
     MemoPlan memo_plan = 6;
+    uint64 valid_before = 7;
+    uint64 valid_after = 8;
 }
 
 // Describes a planned transaction action.

--- a/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
+++ b/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
@@ -27,10 +27,6 @@ message Id {
 message TransactionBody {
   // A list of actions (state changes) performed by this transaction.
   repeated Action actions = 1;
-  // The maximum height that this transaction can be included in the chain.
-  //
-  // If zero, there is no maximum.
-  uint64 expiry_height = 2;
   // The chain this transaction is intended for.  Including this prevents
   // replaying a transaction on one chain onto a different chain.
   string chain_id = 3;
@@ -126,10 +122,6 @@ message NullifierWithNote {
 message TransactionView {
   // A list views into of actions (state changes) performed by this transaction.
   repeated ActionView action_views = 1;
-  // The maximum height that this transaction can be included in the chain.
-  //
-  // If zero, there is no maximum.
-  uint64 expiry_height = 2;
   // The chain this transaction is intended for.  Including this prevents
   // replaying a transaction on one chain onto a different chain.
   string chain_id = 3;
@@ -311,7 +303,6 @@ message WitnessData {
 // Describes a planned transaction.
 message TransactionPlan {
     repeated ActionPlan actions = 1;
-    uint64 expiry_height = 2;
     string chain_id = 3;
     crypto.v1alpha1.Fee fee = 4;
     repeated CluePlan clue_plans = 5;

--- a/proto/proto/penumbra/view/v1alpha1/view.proto
+++ b/proto/proto/penumbra/view/v1alpha1/view.proto
@@ -107,6 +107,10 @@ message TransactionPlannerRequest {
     core.crypto.v1alpha1.Fee fee = 2;
     // The memo for the requested TransactionPlan
     string memo = 3;
+    // The valid_before timestamp for the requested TransactionPlan, formatted as an RFC 3339 timestamp
+    optional string valid_before = 4;
+    // The valid_after timestamp for the requested TransactionPlan, formatted as an RFC 3339 timestamp
+    optional string valid_after = 5;
     // Identifies the FVK for the notes to query.
     optional core.crypto.v1alpha1.AccountGroupId account_group_id = 14;
     // Authorizes the request.

--- a/proto/proto/penumbra/view/v1alpha1/view.proto
+++ b/proto/proto/penumbra/view/v1alpha1/view.proto
@@ -101,8 +101,6 @@ message BroadcastTransactionResponse {
 }
 
 message TransactionPlannerRequest {
-    // The expiry height for the requested TransactionPlan
-    uint64 expiry_height = 1;
     // The fee for the requested TransactionPlan, if any.
     core.crypto.v1alpha1.Fee fee = 2;
     // The memo for the requested TransactionPlan

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
@@ -26,11 +26,6 @@ pub struct TransactionBody {
     /// A list of actions (state changes) performed by this transaction.
     #[prost(message, repeated, tag = "1")]
     pub actions: ::prost::alloc::vec::Vec<Action>,
-    /// The maximum height that this transaction can be included in the chain.
-    ///
-    /// If zero, there is no maximum.
-    #[prost(uint64, tag = "2")]
-    pub expiry_height: u64,
     /// The chain this transaction is intended for.  Including this prevents
     /// replaying a transaction on one chain onto a different chain.
     #[prost(string, tag = "3")]
@@ -176,11 +171,6 @@ pub struct TransactionView {
     /// A list views into of actions (state changes) performed by this transaction.
     #[prost(message, repeated, tag = "1")]
     pub action_views: ::prost::alloc::vec::Vec<ActionView>,
-    /// The maximum height that this transaction can be included in the chain.
-    ///
-    /// If zero, there is no maximum.
-    #[prost(uint64, tag = "2")]
-    pub expiry_height: u64,
     /// The chain this transaction is intended for.  Including this prevents
     /// replaying a transaction on one chain onto a different chain.
     #[prost(string, tag = "3")]
@@ -499,8 +489,6 @@ pub struct WitnessData {
 pub struct TransactionPlan {
     #[prost(message, repeated, tag = "1")]
     pub actions: ::prost::alloc::vec::Vec<ActionPlan>,
-    #[prost(uint64, tag = "2")]
-    pub expiry_height: u64,
     #[prost(string, tag = "3")]
     pub chain_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "4")]

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
@@ -45,9 +45,6 @@ pub struct TransactionBody {
     /// timestamp is < this value.
     ///
     /// If the value is zero, this value is considered unset.
-    /// [TODO: Double check that this actually does behave like google's protobufs]
-    /// The behavior of this time stamp should match google's protobuf specification:
-    /// \[specification\]: <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp>
     #[prost(uint64, tag = "7")]
     pub valid_before: u64,
     /// A unix timestamp, in nanoseconds.
@@ -55,9 +52,6 @@ pub struct TransactionBody {
     /// timestamp is > this value.
     ///
     /// If the value is zero, this value is considered unset.
-    /// [TODO: Double check that this actually does behave like google's protobufs]
-    /// The behavior of this time stamp should match google's protobuf specification:
-    /// \[specification\]: <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp>
     #[prost(uint64, tag = "8")]
     pub valid_after: u64,
 }
@@ -194,20 +188,14 @@ pub struct TransactionView {
     /// If this value is set, the transaction is valid iff the most recent block header
     /// timestamp is < this value.
     ///
-    /// If the value is zero, this value is considered unset.
-    /// [TODO: Double check that this actually does behave like google's protobufs]
-    /// The behavior of this time stamp should match google's protobuf specification:
-    /// \[specification\]: <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp>
+    /// If the value is zero, this field is considered unset.
     #[prost(uint64, tag = "7")]
     pub valid_before: u64,
     /// A unix timestamp, in nanoseconds.
     /// If this value is set, the transaction is valid iff the most recent block header
     /// timestamp is > this value.
     ///
-    /// If the value is zero, this value is considered unset.
-    /// [TODO: Double check that this actually does behave like google's protobufs]
-    /// The behavior of this time stamp should match google's protobuf specification:
-    /// \[specification\]: <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp>
+    /// If the value is zero, this field is considered unset.
     #[prost(uint64, tag = "8")]
     pub valid_after: u64,
 }

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
@@ -45,6 +45,26 @@ pub struct TransactionBody {
     /// outputs in the actions of this transaction. 528 bytes.
     #[prost(bytes = "bytes", optional, tag = "6")]
     pub encrypted_memo: ::core::option::Option<::prost::bytes::Bytes>,
+    /// A unix timestamp, in nanoseconds.
+    /// If this value is set, the transaction is valid iff the most recent block header
+    /// timestamp is < this value.
+    ///
+    /// If the value is zero, this value is considered unset.
+    /// [TODO: Double check that this actually does behave like google's protobufs]
+    /// The behavior of this time stamp should match google's protobuf specification:
+    /// \[specification\]: <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp>
+    #[prost(uint64, tag = "7")]
+    pub valid_before: u64,
+    /// A unix timestamp, in nanoseconds.
+    /// If this value is set, the transaction is valid iff the most recent block header
+    /// timestamp is > this value.
+    ///
+    /// If the value is zero, this value is considered unset.
+    /// [TODO: Double check that this actually does behave like google's protobufs]
+    /// The behavior of this time stamp should match google's protobuf specification:
+    /// \[specification\]: <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp>
+    #[prost(uint64, tag = "8")]
+    pub valid_after: u64,
 }
 /// A state change performed by a transaction.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -180,6 +200,26 @@ pub struct TransactionView {
     pub address_views: ::prost::alloc::vec::Vec<
         super::super::crypto::v1alpha1::AddressView,
     >,
+    /// A unix timestamp, in nanoseconds.
+    /// If this value is set, the transaction is valid iff the most recent block header
+    /// timestamp is < this value.
+    ///
+    /// If the value is zero, this value is considered unset.
+    /// [TODO: Double check that this actually does behave like google's protobufs]
+    /// The behavior of this time stamp should match google's protobuf specification:
+    /// \[specification\]: <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp>
+    #[prost(uint64, tag = "7")]
+    pub valid_before: u64,
+    /// A unix timestamp, in nanoseconds.
+    /// If this value is set, the transaction is valid iff the most recent block header
+    /// timestamp is > this value.
+    ///
+    /// If the value is zero, this value is considered unset.
+    /// [TODO: Double check that this actually does behave like google's protobufs]
+    /// The behavior of this time stamp should match google's protobuf specification:
+    /// \[specification\]: <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp>
+    #[prost(uint64, tag = "8")]
+    pub valid_after: u64,
 }
 /// A view of a specific state change action performed by a transaction.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -469,6 +509,10 @@ pub struct TransactionPlan {
     pub clue_plans: ::prost::alloc::vec::Vec<CluePlan>,
     #[prost(message, optional, tag = "6")]
     pub memo_plan: ::core::option::Option<MemoPlan>,
+    #[prost(uint64, tag = "7")]
+    pub valid_before: u64,
+    #[prost(uint64, tag = "8")]
+    pub valid_after: u64,
 }
 /// Describes a planned transaction action.
 ///

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.serde.rs
@@ -3735,6 +3735,12 @@ impl serde::Serialize for TransactionBody {
         if self.encrypted_memo.is_some() {
             len += 1;
         }
+        if self.valid_before != 0 {
+            len += 1;
+        }
+        if self.valid_after != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("penumbra.core.transaction.v1alpha1.TransactionBody", len)?;
         if !self.actions.is_empty() {
             struct_ser.serialize_field("actions", &self.actions)?;
@@ -3753,6 +3759,12 @@ impl serde::Serialize for TransactionBody {
         }
         if let Some(v) = self.encrypted_memo.as_ref() {
             struct_ser.serialize_field("encryptedMemo", pbjson::private::base64::encode(&v).as_str())?;
+        }
+        if self.valid_before != 0 {
+            struct_ser.serialize_field("validBefore", ToString::to_string(&self.valid_before).as_str())?;
+        }
+        if self.valid_after != 0 {
+            struct_ser.serialize_field("validAfter", ToString::to_string(&self.valid_after).as_str())?;
         }
         struct_ser.end()
     }
@@ -3774,6 +3786,10 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
             "fmdClues",
             "encrypted_memo",
             "encryptedMemo",
+            "valid_before",
+            "validBefore",
+            "valid_after",
+            "validAfter",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -3784,6 +3800,8 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
             Fee,
             FmdClues,
             EncryptedMemo,
+            ValidBefore,
+            ValidAfter,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3811,6 +3829,8 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
                             "fee" => Ok(GeneratedField::Fee),
                             "fmdClues" | "fmd_clues" => Ok(GeneratedField::FmdClues),
                             "encryptedMemo" | "encrypted_memo" => Ok(GeneratedField::EncryptedMemo),
+                            "validBefore" | "valid_before" => Ok(GeneratedField::ValidBefore),
+                            "validAfter" | "valid_after" => Ok(GeneratedField::ValidAfter),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -3836,6 +3856,8 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
                 let mut fee__ = None;
                 let mut fmd_clues__ = None;
                 let mut encrypted_memo__ = None;
+                let mut valid_before__ = None;
+                let mut valid_after__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::Actions => {
@@ -3878,6 +3900,22 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
                                 map.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| x.0)
                             ;
                         }
+                        GeneratedField::ValidBefore => {
+                            if valid_before__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validBefore"));
+                            }
+                            valid_before__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::ValidAfter => {
+                            if valid_after__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validAfter"));
+                            }
+                            valid_after__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                     }
                 }
                 Ok(TransactionBody {
@@ -3887,6 +3925,8 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
                     fee: fee__,
                     fmd_clues: fmd_clues__.unwrap_or_default(),
                     encrypted_memo: encrypted_memo__,
+                    valid_before: valid_before__.unwrap_or_default(),
+                    valid_after: valid_after__.unwrap_or_default(),
                 })
             }
         }
@@ -4065,6 +4105,12 @@ impl serde::Serialize for TransactionPlan {
         if self.memo_plan.is_some() {
             len += 1;
         }
+        if self.valid_before != 0 {
+            len += 1;
+        }
+        if self.valid_after != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("penumbra.core.transaction.v1alpha1.TransactionPlan", len)?;
         if !self.actions.is_empty() {
             struct_ser.serialize_field("actions", &self.actions)?;
@@ -4083,6 +4129,12 @@ impl serde::Serialize for TransactionPlan {
         }
         if let Some(v) = self.memo_plan.as_ref() {
             struct_ser.serialize_field("memoPlan", v)?;
+        }
+        if self.valid_before != 0 {
+            struct_ser.serialize_field("validBefore", ToString::to_string(&self.valid_before).as_str())?;
+        }
+        if self.valid_after != 0 {
+            struct_ser.serialize_field("validAfter", ToString::to_string(&self.valid_after).as_str())?;
         }
         struct_ser.end()
     }
@@ -4104,6 +4156,10 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
             "cluePlans",
             "memo_plan",
             "memoPlan",
+            "valid_before",
+            "validBefore",
+            "valid_after",
+            "validAfter",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -4114,6 +4170,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
             Fee,
             CluePlans,
             MemoPlan,
+            ValidBefore,
+            ValidAfter,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4141,6 +4199,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
                             "fee" => Ok(GeneratedField::Fee),
                             "cluePlans" | "clue_plans" => Ok(GeneratedField::CluePlans),
                             "memoPlan" | "memo_plan" => Ok(GeneratedField::MemoPlan),
+                            "validBefore" | "valid_before" => Ok(GeneratedField::ValidBefore),
+                            "validAfter" | "valid_after" => Ok(GeneratedField::ValidAfter),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -4166,6 +4226,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
                 let mut fee__ = None;
                 let mut clue_plans__ = None;
                 let mut memo_plan__ = None;
+                let mut valid_before__ = None;
+                let mut valid_after__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::Actions => {
@@ -4206,6 +4268,22 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
                             }
                             memo_plan__ = map.next_value()?;
                         }
+                        GeneratedField::ValidBefore => {
+                            if valid_before__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validBefore"));
+                            }
+                            valid_before__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::ValidAfter => {
+                            if valid_after__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validAfter"));
+                            }
+                            valid_after__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                     }
                 }
                 Ok(TransactionPlan {
@@ -4215,6 +4293,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
                     fee: fee__,
                     clue_plans: clue_plans__.unwrap_or_default(),
                     memo_plan: memo_plan__,
+                    valid_before: valid_before__.unwrap_or_default(),
+                    valid_after: valid_after__.unwrap_or_default(),
                 })
             }
         }
@@ -4250,6 +4330,12 @@ impl serde::Serialize for TransactionView {
         if !self.address_views.is_empty() {
             len += 1;
         }
+        if self.valid_before != 0 {
+            len += 1;
+        }
+        if self.valid_after != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("penumbra.core.transaction.v1alpha1.TransactionView", len)?;
         if !self.action_views.is_empty() {
             struct_ser.serialize_field("actionViews", &self.action_views)?;
@@ -4271,6 +4357,12 @@ impl serde::Serialize for TransactionView {
         }
         if !self.address_views.is_empty() {
             struct_ser.serialize_field("addressViews", &self.address_views)?;
+        }
+        if self.valid_before != 0 {
+            struct_ser.serialize_field("validBefore", ToString::to_string(&self.valid_before).as_str())?;
+        }
+        if self.valid_after != 0 {
+            struct_ser.serialize_field("validAfter", ToString::to_string(&self.valid_after).as_str())?;
         }
         struct_ser.end()
     }
@@ -4294,6 +4386,10 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
             "memo",
             "address_views",
             "addressViews",
+            "valid_before",
+            "validBefore",
+            "valid_after",
+            "validAfter",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -4305,6 +4401,8 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
             FmdClues,
             Memo,
             AddressViews,
+            ValidBefore,
+            ValidAfter,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4333,6 +4431,8 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
                             "fmdClues" | "fmd_clues" => Ok(GeneratedField::FmdClues),
                             "memo" => Ok(GeneratedField::Memo),
                             "addressViews" | "address_views" => Ok(GeneratedField::AddressViews),
+                            "validBefore" | "valid_before" => Ok(GeneratedField::ValidBefore),
+                            "validAfter" | "valid_after" => Ok(GeneratedField::ValidAfter),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -4359,6 +4459,8 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
                 let mut fmd_clues__ = None;
                 let mut memo__ = None;
                 let mut address_views__ = None;
+                let mut valid_before__ = None;
+                let mut valid_after__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::ActionViews => {
@@ -4407,6 +4509,22 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
                             }
                             address_views__ = Some(map.next_value()?);
                         }
+                        GeneratedField::ValidBefore => {
+                            if valid_before__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validBefore"));
+                            }
+                            valid_before__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::ValidAfter => {
+                            if valid_after__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validAfter"));
+                            }
+                            valid_after__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                     }
                 }
                 Ok(TransactionView {
@@ -4417,6 +4535,8 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
                     fmd_clues: fmd_clues__.unwrap_or_default(),
                     memo: memo__,
                     address_views: address_views__.unwrap_or_default(),
+                    valid_before: valid_before__.unwrap_or_default(),
+                    valid_after: valid_after__.unwrap_or_default(),
                 })
             }
         }

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.serde.rs
@@ -3720,9 +3720,6 @@ impl serde::Serialize for TransactionBody {
         if !self.actions.is_empty() {
             len += 1;
         }
-        if self.expiry_height != 0 {
-            len += 1;
-        }
         if !self.chain_id.is_empty() {
             len += 1;
         }
@@ -3744,9 +3741,6 @@ impl serde::Serialize for TransactionBody {
         let mut struct_ser = serializer.serialize_struct("penumbra.core.transaction.v1alpha1.TransactionBody", len)?;
         if !self.actions.is_empty() {
             struct_ser.serialize_field("actions", &self.actions)?;
-        }
-        if self.expiry_height != 0 {
-            struct_ser.serialize_field("expiryHeight", ToString::to_string(&self.expiry_height).as_str())?;
         }
         if !self.chain_id.is_empty() {
             struct_ser.serialize_field("chainId", &self.chain_id)?;
@@ -3777,8 +3771,6 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
     {
         const FIELDS: &[&str] = &[
             "actions",
-            "expiry_height",
-            "expiryHeight",
             "chain_id",
             "chainId",
             "fee",
@@ -3795,7 +3787,6 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Actions,
-            ExpiryHeight,
             ChainId,
             Fee,
             FmdClues,
@@ -3824,7 +3815,6 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
                     {
                         match value {
                             "actions" => Ok(GeneratedField::Actions),
-                            "expiryHeight" | "expiry_height" => Ok(GeneratedField::ExpiryHeight),
                             "chainId" | "chain_id" => Ok(GeneratedField::ChainId),
                             "fee" => Ok(GeneratedField::Fee),
                             "fmdClues" | "fmd_clues" => Ok(GeneratedField::FmdClues),
@@ -3851,7 +3841,6 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut actions__ = None;
-                let mut expiry_height__ = None;
                 let mut chain_id__ = None;
                 let mut fee__ = None;
                 let mut fmd_clues__ = None;
@@ -3865,14 +3854,6 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
                                 return Err(serde::de::Error::duplicate_field("actions"));
                             }
                             actions__ = Some(map.next_value()?);
-                        }
-                        GeneratedField::ExpiryHeight => {
-                            if expiry_height__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("expiryHeight"));
-                            }
-                            expiry_height__ = 
-                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
-                            ;
                         }
                         GeneratedField::ChainId => {
                             if chain_id__.is_some() {
@@ -3920,7 +3901,6 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
                 }
                 Ok(TransactionBody {
                     actions: actions__.unwrap_or_default(),
-                    expiry_height: expiry_height__.unwrap_or_default(),
                     chain_id: chain_id__.unwrap_or_default(),
                     fee: fee__,
                     fmd_clues: fmd_clues__.unwrap_or_default(),
@@ -4090,9 +4070,6 @@ impl serde::Serialize for TransactionPlan {
         if !self.actions.is_empty() {
             len += 1;
         }
-        if self.expiry_height != 0 {
-            len += 1;
-        }
         if !self.chain_id.is_empty() {
             len += 1;
         }
@@ -4114,9 +4091,6 @@ impl serde::Serialize for TransactionPlan {
         let mut struct_ser = serializer.serialize_struct("penumbra.core.transaction.v1alpha1.TransactionPlan", len)?;
         if !self.actions.is_empty() {
             struct_ser.serialize_field("actions", &self.actions)?;
-        }
-        if self.expiry_height != 0 {
-            struct_ser.serialize_field("expiryHeight", ToString::to_string(&self.expiry_height).as_str())?;
         }
         if !self.chain_id.is_empty() {
             struct_ser.serialize_field("chainId", &self.chain_id)?;
@@ -4147,8 +4121,6 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
     {
         const FIELDS: &[&str] = &[
             "actions",
-            "expiry_height",
-            "expiryHeight",
             "chain_id",
             "chainId",
             "fee",
@@ -4165,7 +4137,6 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Actions,
-            ExpiryHeight,
             ChainId,
             Fee,
             CluePlans,
@@ -4194,7 +4165,6 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
                     {
                         match value {
                             "actions" => Ok(GeneratedField::Actions),
-                            "expiryHeight" | "expiry_height" => Ok(GeneratedField::ExpiryHeight),
                             "chainId" | "chain_id" => Ok(GeneratedField::ChainId),
                             "fee" => Ok(GeneratedField::Fee),
                             "cluePlans" | "clue_plans" => Ok(GeneratedField::CluePlans),
@@ -4221,7 +4191,6 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut actions__ = None;
-                let mut expiry_height__ = None;
                 let mut chain_id__ = None;
                 let mut fee__ = None;
                 let mut clue_plans__ = None;
@@ -4235,14 +4204,6 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
                                 return Err(serde::de::Error::duplicate_field("actions"));
                             }
                             actions__ = Some(map.next_value()?);
-                        }
-                        GeneratedField::ExpiryHeight => {
-                            if expiry_height__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("expiryHeight"));
-                            }
-                            expiry_height__ = 
-                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
-                            ;
                         }
                         GeneratedField::ChainId => {
                             if chain_id__.is_some() {
@@ -4288,7 +4249,6 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
                 }
                 Ok(TransactionPlan {
                     actions: actions__.unwrap_or_default(),
-                    expiry_height: expiry_height__.unwrap_or_default(),
                     chain_id: chain_id__.unwrap_or_default(),
                     fee: fee__,
                     clue_plans: clue_plans__.unwrap_or_default(),
@@ -4310,9 +4270,6 @@ impl serde::Serialize for TransactionView {
         use serde::ser::SerializeStruct;
         let mut len = 0;
         if !self.action_views.is_empty() {
-            len += 1;
-        }
-        if self.expiry_height != 0 {
             len += 1;
         }
         if !self.chain_id.is_empty() {
@@ -4339,9 +4296,6 @@ impl serde::Serialize for TransactionView {
         let mut struct_ser = serializer.serialize_struct("penumbra.core.transaction.v1alpha1.TransactionView", len)?;
         if !self.action_views.is_empty() {
             struct_ser.serialize_field("actionViews", &self.action_views)?;
-        }
-        if self.expiry_height != 0 {
-            struct_ser.serialize_field("expiryHeight", ToString::to_string(&self.expiry_height).as_str())?;
         }
         if !self.chain_id.is_empty() {
             struct_ser.serialize_field("chainId", &self.chain_id)?;
@@ -4376,8 +4330,6 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
         const FIELDS: &[&str] = &[
             "action_views",
             "actionViews",
-            "expiry_height",
-            "expiryHeight",
             "chain_id",
             "chainId",
             "fee",
@@ -4395,7 +4347,6 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             ActionViews,
-            ExpiryHeight,
             ChainId,
             Fee,
             FmdClues,
@@ -4425,7 +4376,6 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
                     {
                         match value {
                             "actionViews" | "action_views" => Ok(GeneratedField::ActionViews),
-                            "expiryHeight" | "expiry_height" => Ok(GeneratedField::ExpiryHeight),
                             "chainId" | "chain_id" => Ok(GeneratedField::ChainId),
                             "fee" => Ok(GeneratedField::Fee),
                             "fmdClues" | "fmd_clues" => Ok(GeneratedField::FmdClues),
@@ -4453,7 +4403,6 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut action_views__ = None;
-                let mut expiry_height__ = None;
                 let mut chain_id__ = None;
                 let mut fee__ = None;
                 let mut fmd_clues__ = None;
@@ -4468,14 +4417,6 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
                                 return Err(serde::de::Error::duplicate_field("actionViews"));
                             }
                             action_views__ = Some(map.next_value()?);
-                        }
-                        GeneratedField::ExpiryHeight => {
-                            if expiry_height__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("expiryHeight"));
-                            }
-                            expiry_height__ = 
-                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
-                            ;
                         }
                         GeneratedField::ChainId => {
                             if chain_id__.is_some() {
@@ -4529,7 +4470,6 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
                 }
                 Ok(TransactionView {
                     action_views: action_views__.unwrap_or_default(),
-                    expiry_height: expiry_height__.unwrap_or_default(),
                     chain_id: chain_id__.unwrap_or_default(),
                     fee: fee__,
                     fmd_clues: fmd_clues__.unwrap_or_default(),

--- a/proto/src/gen/penumbra.view.v1alpha1.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.rs
@@ -29,6 +29,12 @@ pub struct TransactionPlannerRequest {
     /// The memo for the requested TransactionPlan
     #[prost(string, tag = "3")]
     pub memo: ::prost::alloc::string::String,
+    /// The valid_before timestamp for the requested TransactionPlan, formatted as an RFC 3339 timestamp
+    #[prost(string, optional, tag = "4")]
+    pub valid_before: ::core::option::Option<::prost::alloc::string::String>,
+    /// The valid_after timestamp for the requested TransactionPlan, formatted as an RFC 3339 timestamp
+    #[prost(string, optional, tag = "5")]
+    pub valid_after: ::core::option::Option<::prost::alloc::string::String>,
     /// Identifies the FVK for the notes to query.
     #[prost(message, optional, tag = "14")]
     pub account_group_id: ::core::option::Option<

--- a/proto/src/gen/penumbra.view.v1alpha1.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.rs
@@ -20,9 +20,6 @@ pub struct BroadcastTransactionResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionPlannerRequest {
-    /// The expiry height for the requested TransactionPlan
-    #[prost(uint64, tag = "1")]
-    pub expiry_height: u64,
     /// The fee for the requested TransactionPlan, if any.
     #[prost(message, optional, tag = "2")]
     pub fee: ::core::option::Option<super::super::core::crypto::v1alpha1::Fee>,

--- a/proto/src/gen/penumbra.view.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.serde.rs
@@ -4287,9 +4287,6 @@ impl serde::Serialize for TransactionPlannerRequest {
     {
         use serde::ser::SerializeStruct;
         let mut len = 0;
-        if self.expiry_height != 0 {
-            len += 1;
-        }
         if self.fee.is_some() {
             len += 1;
         }
@@ -4324,9 +4321,6 @@ impl serde::Serialize for TransactionPlannerRequest {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("penumbra.view.v1alpha1.TransactionPlannerRequest", len)?;
-        if self.expiry_height != 0 {
-            struct_ser.serialize_field("expiryHeight", ToString::to_string(&self.expiry_height).as_str())?;
-        }
         if let Some(v) = self.fee.as_ref() {
             struct_ser.serialize_field("fee", v)?;
         }
@@ -4370,8 +4364,6 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
         D: serde::Deserializer<'de>,
     {
         const FIELDS: &[&str] = &[
-            "expiry_height",
-            "expiryHeight",
             "fee",
             "memo",
             "valid_before",
@@ -4391,7 +4383,6 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
-            ExpiryHeight,
             Fee,
             Memo,
             ValidBefore,
@@ -4424,7 +4415,6 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
                         E: serde::de::Error,
                     {
                         match value {
-                            "expiryHeight" | "expiry_height" => Ok(GeneratedField::ExpiryHeight),
                             "fee" => Ok(GeneratedField::Fee),
                             "memo" => Ok(GeneratedField::Memo),
                             "validBefore" | "valid_before" => Ok(GeneratedField::ValidBefore),
@@ -4455,7 +4445,6 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
                 where
                     V: serde::de::MapAccess<'de>,
             {
-                let mut expiry_height__ = None;
                 let mut fee__ = None;
                 let mut memo__ = None;
                 let mut valid_before__ = None;
@@ -4469,14 +4458,6 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
                 let mut ibc_actions__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
-                        GeneratedField::ExpiryHeight => {
-                            if expiry_height__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("expiryHeight"));
-                            }
-                            expiry_height__ = 
-                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
-                            ;
-                        }
                         GeneratedField::Fee => {
                             if fee__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("fee"));
@@ -4546,7 +4527,6 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
                     }
                 }
                 Ok(TransactionPlannerRequest {
-                    expiry_height: expiry_height__.unwrap_or_default(),
                     fee: fee__,
                     memo: memo__.unwrap_or_default(),
                     valid_before: valid_before__,

--- a/proto/src/gen/penumbra.view.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.serde.rs
@@ -4296,6 +4296,12 @@ impl serde::Serialize for TransactionPlannerRequest {
         if !self.memo.is_empty() {
             len += 1;
         }
+        if self.valid_before.is_some() {
+            len += 1;
+        }
+        if self.valid_after.is_some() {
+            len += 1;
+        }
         if self.account_group_id.is_some() {
             len += 1;
         }
@@ -4326,6 +4332,12 @@ impl serde::Serialize for TransactionPlannerRequest {
         }
         if !self.memo.is_empty() {
             struct_ser.serialize_field("memo", &self.memo)?;
+        }
+        if let Some(v) = self.valid_before.as_ref() {
+            struct_ser.serialize_field("validBefore", v)?;
+        }
+        if let Some(v) = self.valid_after.as_ref() {
+            struct_ser.serialize_field("validAfter", v)?;
         }
         if let Some(v) = self.account_group_id.as_ref() {
             struct_ser.serialize_field("accountGroupId", v)?;
@@ -4362,6 +4374,10 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
             "expiryHeight",
             "fee",
             "memo",
+            "valid_before",
+            "validBefore",
+            "valid_after",
+            "validAfter",
             "account_group_id",
             "accountGroupId",
             "token",
@@ -4378,6 +4394,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
             ExpiryHeight,
             Fee,
             Memo,
+            ValidBefore,
+            ValidAfter,
             AccountGroupId,
             Token,
             Outputs,
@@ -4409,6 +4427,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
                             "expiryHeight" | "expiry_height" => Ok(GeneratedField::ExpiryHeight),
                             "fee" => Ok(GeneratedField::Fee),
                             "memo" => Ok(GeneratedField::Memo),
+                            "validBefore" | "valid_before" => Ok(GeneratedField::ValidBefore),
+                            "validAfter" | "valid_after" => Ok(GeneratedField::ValidAfter),
                             "accountGroupId" | "account_group_id" => Ok(GeneratedField::AccountGroupId),
                             "token" => Ok(GeneratedField::Token),
                             "outputs" => Ok(GeneratedField::Outputs),
@@ -4438,6 +4458,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
                 let mut expiry_height__ = None;
                 let mut fee__ = None;
                 let mut memo__ = None;
+                let mut valid_before__ = None;
+                let mut valid_after__ = None;
                 let mut account_group_id__ = None;
                 let mut token__ = None;
                 let mut outputs__ = None;
@@ -4466,6 +4488,18 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
                                 return Err(serde::de::Error::duplicate_field("memo"));
                             }
                             memo__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::ValidBefore => {
+                            if valid_before__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validBefore"));
+                            }
+                            valid_before__ = map.next_value()?;
+                        }
+                        GeneratedField::ValidAfter => {
+                            if valid_after__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validAfter"));
+                            }
+                            valid_after__ = map.next_value()?;
                         }
                         GeneratedField::AccountGroupId => {
                             if account_group_id__.is_some() {
@@ -4515,6 +4549,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
                     expiry_height: expiry_height__.unwrap_or_default(),
                     fee: fee__,
                     memo: memo__.unwrap_or_default(),
+                    valid_before: valid_before__,
+                    valid_after: valid_after__,
                     account_group_id: account_group_id__,
                     token: token__,
                     outputs: outputs__.unwrap_or_default(),

--- a/transaction/src/effect_hash.rs
+++ b/transaction/src/effect_hash.rs
@@ -92,6 +92,8 @@ impl TransactionBody {
         // Hash the fixed data of the transaction body.
         state.update(chain_id_effect_hash(&self.chain_id).as_bytes());
         state.update(&self.expiry_height.to_le_bytes());
+        state.update(&self.valid_after.nanoseconds().to_le_bytes());
+        state.update(&self.valid_before.nanoseconds().to_le_bytes());
         state.update(self.fee.effect_hash().as_bytes());
         if self.memo.is_some() {
             let memo = self.memo.clone();
@@ -136,6 +138,8 @@ impl TransactionPlan {
         // Hash the fixed data of the transaction body.
         state.update(chain_id_effect_hash(&self.chain_id).as_bytes());
         state.update(&self.expiry_height.to_le_bytes());
+        state.update(&self.valid_after.nanoseconds().to_le_bytes());
+        state.update(&self.valid_before.nanoseconds().to_le_bytes());
         state.update(self.fee.effect_hash().as_bytes());
 
         // Hash the memo and save the memo key for use with outputs later.
@@ -886,6 +890,8 @@ mod tests {
                 )
                 .unwrap(),
             ),
+            valid_after: ibc::timestamp::Timestamp::none(),
+            valid_before: ibc::timestamp::Timestamp::none(),
         };
 
         println!("{}", serde_json::to_string_pretty(&plan).unwrap());

--- a/transaction/src/effect_hash.rs
+++ b/transaction/src/effect_hash.rs
@@ -91,7 +91,6 @@ impl TransactionBody {
 
         // Hash the fixed data of the transaction body.
         state.update(chain_id_effect_hash(&self.chain_id).as_bytes());
-        state.update(&self.expiry_height.to_le_bytes());
         state.update(&self.valid_after.nanoseconds().to_le_bytes());
         state.update(&self.valid_before.nanoseconds().to_le_bytes());
         state.update(self.fee.effect_hash().as_bytes());
@@ -137,7 +136,6 @@ impl TransactionPlan {
 
         // Hash the fixed data of the transaction body.
         state.update(chain_id_effect_hash(&self.chain_id).as_bytes());
-        state.update(&self.expiry_height.to_le_bytes());
         state.update(&self.valid_after.nanoseconds().to_le_bytes());
         state.update(&self.valid_before.nanoseconds().to_le_bytes());
         state.update(self.fee.effect_hash().as_bytes());
@@ -860,7 +858,6 @@ mod tests {
         let mut rng = OsRng;
 
         let plan = TransactionPlan {
-            expiry_height: 0,
             fee: Fee::default(),
             chain_id: "penumbra-test".to_string(),
             // Put outputs first to check that the auth hash

--- a/transaction/src/plan.rs
+++ b/transaction/src/plan.rs
@@ -2,6 +2,7 @@
 //! creation.
 
 use anyhow::Result;
+use ibc::timestamp::Timestamp;
 use penumbra_crypto::{transaction::Fee, Address};
 use penumbra_proto::{
     core::ibc::v1alpha1 as pb_ibc, core::stake::v1alpha1 as pb_stake,
@@ -40,6 +41,8 @@ pub struct TransactionPlan {
     pub fee: Fee,
     pub clue_plans: Vec<CluePlan>,
     pub memo_plan: Option<MemoPlan>,
+    pub valid_before: Timestamp,
+    pub valid_after: Timestamp,
 }
 
 impl TransactionPlan {
@@ -268,6 +271,8 @@ impl From<TransactionPlan> for pb::TransactionPlan {
         Self {
             actions: msg.actions.into_iter().map(Into::into).collect(),
             expiry_height: msg.expiry_height,
+            valid_after: msg.valid_after.nanoseconds(),
+            valid_before: msg.valid_before.nanoseconds(),
             chain_id: msg.chain_id,
             fee: Some(msg.fee.into()),
             clue_plans: msg.clue_plans.into_iter().map(Into::into).collect(),
@@ -291,6 +296,8 @@ impl TryFrom<pb::TransactionPlan> for TransactionPlan {
                 .map(TryInto::try_into)
                 .collect::<Result<_, _>>()?,
             expiry_height: value.expiry_height,
+            valid_after: Timestamp::from_nanoseconds(value.valid_after)?,
+            valid_before: Timestamp::from_nanoseconds(value.valid_before)?,
             chain_id: value.chain_id,
             fee: value
                 .fee

--- a/transaction/src/plan.rs
+++ b/transaction/src/plan.rs
@@ -36,7 +36,6 @@ pub use memo::MemoPlan;
 pub struct TransactionPlan {
     /// A list of this transaction's actions.
     pub actions: Vec<ActionPlan>,
-    pub expiry_height: u64,
     pub chain_id: String,
     pub fee: Fee,
     pub clue_plans: Vec<CluePlan>,
@@ -270,7 +269,6 @@ impl From<TransactionPlan> for pb::TransactionPlan {
     fn from(msg: TransactionPlan) -> Self {
         Self {
             actions: msg.actions.into_iter().map(Into::into).collect(),
-            expiry_height: msg.expiry_height,
             valid_after: msg.valid_after.nanoseconds(),
             valid_before: msg.valid_before.nanoseconds(),
             chain_id: msg.chain_id,
@@ -295,7 +293,6 @@ impl TryFrom<pb::TransactionPlan> for TransactionPlan {
                 .into_iter()
                 .map(TryInto::try_into)
                 .collect::<Result<_, _>>()?,
-            expiry_height: value.expiry_height,
             valid_after: Timestamp::from_nanoseconds(value.valid_after)?,
             valid_before: Timestamp::from_nanoseconds(value.valid_before)?,
             chain_id: value.chain_id,

--- a/transaction/src/plan/build.rs
+++ b/transaction/src/plan/build.rs
@@ -171,6 +171,8 @@ impl TransactionPlan {
         let transaction_body = TransactionBody {
             actions,
             expiry_height: self.expiry_height,
+            valid_after: self.valid_after,
+            valid_before: self.valid_before,
             chain_id: self.chain_id,
             fee: self.fee,
             fmd_clues,
@@ -393,6 +395,8 @@ impl TransactionPlan {
         let transaction_body = TransactionBody {
             actions,
             expiry_height: self.expiry_height,
+            valid_after: self.valid_after,
+            valid_before: self.valid_before,
             chain_id: self.chain_id,
             fee: self.fee,
             fmd_clues,

--- a/transaction/src/plan/build.rs
+++ b/transaction/src/plan/build.rs
@@ -170,7 +170,6 @@ impl TransactionPlan {
 
         let transaction_body = TransactionBody {
             actions,
-            expiry_height: self.expiry_height,
             valid_after: self.valid_after,
             valid_before: self.valid_before,
             chain_id: self.chain_id,
@@ -394,7 +393,6 @@ impl TransactionPlan {
 
         let transaction_body = TransactionBody {
             actions,
-            expiry_height: self.expiry_height,
             valid_after: self.valid_after,
             valid_before: self.valid_before,
             chain_id: self.chain_id,

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -34,7 +34,6 @@ use ibc::timestamp::Timestamp;
 #[derive(Clone, Debug, Default)]
 pub struct TransactionBody {
     pub actions: Vec<Action>,
-    pub expiry_height: u64,
     pub chain_id: String,
     pub fee: Fee,
     pub fmd_clues: Vec<Clue>,
@@ -173,7 +172,6 @@ impl Transaction {
 
         TransactionView {
             action_views,
-            expiry_height: self.transaction_body().expiry_height,
             valid_after: self.transaction_body().valid_after,
             valid_before: self.transaction_body().valid_before,
             chain_id: self.transaction_body().chain_id,
@@ -394,7 +392,6 @@ impl From<TransactionBody> for pbt::TransactionBody {
     fn from(msg: TransactionBody) -> Self {
         pbt::TransactionBody {
             actions: msg.actions.into_iter().map(|x| x.into()).collect(),
-            expiry_height: msg.expiry_height,
             valid_after: msg.valid_after.nanoseconds(),
             valid_before: msg.valid_before.nanoseconds(),
             chain_id: msg.chain_id,
@@ -418,7 +415,6 @@ impl TryFrom<pbt::TransactionBody> for TransactionBody {
             );
         }
 
-        let expiry_height = proto.expiry_height;
         let valid_before = Timestamp::from_nanoseconds(proto.valid_before)?;
         let valid_after = Timestamp::from_nanoseconds(proto.valid_after)?;
 
@@ -450,7 +446,6 @@ impl TryFrom<pbt::TransactionBody> for TransactionBody {
 
         Ok(TransactionBody {
             actions,
-            expiry_height,
             valid_before,
             valid_after,
             chain_id,

--- a/transaction/src/view.rs
+++ b/transaction/src/view.rs
@@ -1,4 +1,5 @@
 use decaf377_fmd::Clue;
+use ibc::timestamp::Timestamp;
 use penumbra_crypto::{memo::MemoPlaintext, transaction::Fee, AddressView};
 use penumbra_proto::{core::transaction::v1alpha1 as pbt, DomainType};
 use serde::{Deserialize, Serialize};
@@ -14,6 +15,8 @@ pub use transaction_perspective::TransactionPerspective;
 pub struct TransactionView {
     pub action_views: Vec<ActionView>,
     pub expiry_height: u64,
+    pub valid_after: Timestamp,
+    pub valid_before: Timestamp,
     pub chain_id: String,
     pub fee: Fee,
     pub fmd_clues: Vec<Clue>,
@@ -36,6 +39,8 @@ impl TryFrom<pbt::TransactionView> for TransactionView {
                 .map(TryInto::try_into)
                 .collect::<Result<Vec<_>, _>>()?,
             expiry_height: v.expiry_height,
+            valid_after: Timestamp::from_nanoseconds(v.valid_after)?,
+            valid_before: Timestamp::from_nanoseconds(v.valid_before)?,
             chain_id: v.chain_id,
             fee: v
                 .fee
@@ -64,6 +69,8 @@ impl From<TransactionView> for pbt::TransactionView {
         Self {
             action_views: v.action_views.into_iter().map(Into::into).collect(),
             expiry_height: v.expiry_height,
+            valid_after: v.valid_after.nanoseconds(),
+            valid_before: v.valid_before.nanoseconds(),
             chain_id: v.chain_id,
             fee: Some(v.fee.into()),
             fmd_clues: v.fmd_clues.into_iter().map(Into::into).collect(),

--- a/transaction/src/view.rs
+++ b/transaction/src/view.rs
@@ -14,7 +14,6 @@ pub use transaction_perspective::TransactionPerspective;
 #[serde(try_from = "pbt::TransactionView", into = "pbt::TransactionView")]
 pub struct TransactionView {
     pub action_views: Vec<ActionView>,
-    pub expiry_height: u64,
     pub valid_after: Timestamp,
     pub valid_before: Timestamp,
     pub chain_id: String,
@@ -38,7 +37,6 @@ impl TryFrom<pbt::TransactionView> for TransactionView {
                 .into_iter()
                 .map(TryInto::try_into)
                 .collect::<Result<Vec<_>, _>>()?,
-            expiry_height: v.expiry_height,
             valid_after: Timestamp::from_nanoseconds(v.valid_after)?,
             valid_before: Timestamp::from_nanoseconds(v.valid_before)?,
             chain_id: v.chain_id,
@@ -68,7 +66,6 @@ impl From<TransactionView> for pbt::TransactionView {
     fn from(v: TransactionView) -> Self {
         Self {
             action_views: v.action_views.into_iter().map(Into::into).collect(),
-            expiry_height: v.expiry_height,
             valid_after: v.valid_after.nanoseconds(),
             valid_before: v.valid_before.nanoseconds(),
             chain_id: v.chain_id,

--- a/view/src/planner.rs
+++ b/view/src/planner.rs
@@ -33,6 +33,7 @@ use penumbra_transaction::{
     proposal,
 };
 use rand::{CryptoRng, RngCore};
+use tendermint::Time;
 use tracing::instrument;
 
 use crate::{SpendableNoteRecord, ViewClient};
@@ -121,6 +122,20 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     #[instrument(skip(self))]
     pub fn expiry_height(&mut self, expiry_height: u64) -> &mut Self {
         self.plan.expiry_height = expiry_height;
+        self
+    }
+
+    /// Set the timestamp after which this transaction is valid
+    #[instrument(skip(self))]
+    pub fn valid_after(&mut self, valid_after: Time) -> &mut Self {
+        self.plan.valid_after = valid_after.into();
+        self
+    }
+
+    /// Set the timestamp before which this transaction is valid
+    #[instrument(skip(self))]
+    pub fn valid_before(&mut self, valid_before: Time) -> &mut Self {
+        self.plan.valid_before = valid_before.into();
         self
     }
 

--- a/view/src/planner.rs
+++ b/view/src/planner.rs
@@ -118,13 +118,6 @@ impl<R: RngCore + CryptoRng> Planner<R> {
         )
     }
 
-    /// Set the expiry height for the transaction plan.
-    #[instrument(skip(self))]
-    pub fn expiry_height(&mut self, expiry_height: u64) -> &mut Self {
-        self.plan.expiry_height = expiry_height;
-        self
-    }
-
     /// Set the timestamp after which this transaction is valid
     #[instrument(skip(self))]
     pub fn valid_after(&mut self, valid_after: Time) -> &mut Self {

--- a/view/src/service.rs
+++ b/view/src/service.rs
@@ -342,18 +342,14 @@ impl ViewProtocolService for ViewService {
         let prq = request.into_inner();
 
         let mut planner = Planner::new(OsRng);
-        planner
-            .fee(
-                match prq.fee {
-                    Some(x) => x,
-                    None => Fee::default().into(),
-                }
-                .try_into()
-                .map_err(|e| {
-                    tonic::Status::invalid_argument(format!("Could not parse fee: {e:#}"))
-                })?,
-            )
-            .expiry_height(prq.expiry_height);
+        planner.fee(
+            match prq.fee {
+                Some(x) => x,
+                None => Fee::default().into(),
+            }
+            .try_into()
+            .map_err(|e| tonic::Status::invalid_argument(format!("Could not parse fee: {e:#}")))?,
+        );
 
         if let Some(timestamp) = prq.valid_after {
             let time = tendermint::Time::parse_from_rfc3339(timestamp.as_str()).map_err(|e| {

--- a/view/src/service.rs
+++ b/view/src/service.rs
@@ -355,6 +355,19 @@ impl ViewProtocolService for ViewService {
             )
             .expiry_height(prq.expiry_height);
 
+        if let Some(timestamp) = prq.valid_after {
+            let time = tendermint::Time::parse_from_rfc3339(timestamp.as_str()).map_err(|e| {
+                tonic::Status::invalid_argument(format!("Could not parse valid_after: {e:#}"))
+            })?;
+            planner.valid_after(time);
+        }
+
+        if let Some(timestamp) = prq.valid_before {
+            let time = tendermint::Time::parse_from_rfc3339(timestamp.as_str()).map_err(|e| {
+                tonic::Status::invalid_argument(format!("Could not parse valid_before: {e:#}"))
+            })?;
+            planner.valid_before(time);
+        }
         for output in prq.outputs {
             let address: penumbra_crypto::Address = output
                 .address


### PR DESCRIPTION
This PR aspires to implement https://github.com/penumbra-zone/penumbra/issues/1915

I have removed expiry height, and added 2 new fields for valid_before / valid_after.

TODO:
- [x] Figure out how to add a state machine test for this behavior
- [x] Remove expiry_height
- [x] Do due diligence on time representations
- [ ] Get a pass from the penumbra dev team on:
  - [ ] Wording in documentation / errors
  - [ ] Proto numbering
- [ ] Have the PR pass review :D