### PR TITLE
dex: update positions after execution

### DIFF
--- a/component/src/dex/position_manager.rs
+++ b/component/src/dex/position_manager.rs
@@ -68,6 +68,7 @@ pub trait PositionManager: StateWrite + PositionRead {
             ))?;
 
         metadata.reserves = new_reserves;
+        self.put_position(metadata);
 
         Ok((unfilled, output))
     }


### PR DESCRIPTION
This is an omission from #2125 - when we execute (fill) against a position, we should persist the updated reserves.