### PR TITLE
proof-params: add hardcoded hashes for proving keys

### DIFF
--- a/crypto/src/proofs/groth16.rs
+++ b/crypto/src/proofs/groth16.rs
@@ -7,7 +7,7 @@ mod traits;
 pub use output::{OutputCircuit, OutputProof};
 pub use spend::{SpendCircuit, SpendProof};
 pub use swap::{SwapCircuit, SwapProof};
-pub use traits::{ParameterSetup, VerifyingKeyExt};
+pub use traits::{ParameterSetup, ProvingKeyExt, VerifyingKeyExt};
 
 /// The length of our Groth16 proofs in bytes.
 pub const GROTH16_PROOF_LENGTH_BYTES: usize = 192;

--- a/crypto/src/proofs/groth16/traits.rs
+++ b/crypto/src/proofs/groth16/traits.rs
@@ -17,13 +17,34 @@ pub trait VerifyingKeyExt {
     fn debug_id(&self) -> String;
 }
 
-impl VerifyingKeyExt for PreparedVerifyingKey<Bls12_377> {
+impl VerifyingKeyExt for VerifyingKey<Bls12_377> {
     fn debug_id(&self) -> String {
         let mut buf = Vec::new();
-        self.vk.serialize(&mut buf).unwrap();
+        self.serialize(&mut buf).unwrap();
         use sha2::Digest;
         let hash = sha2::Sha256::digest(&buf);
         use bech32::ToBase32;
-        bech32::encode("vk", hash.to_base32(), bech32::Variant::Bech32m).unwrap()
+        bech32::encode("groth16vk", hash.to_base32(), bech32::Variant::Bech32m).unwrap()
+    }
+}
+
+impl VerifyingKeyExt for PreparedVerifyingKey<Bls12_377> {
+    fn debug_id(&self) -> String {
+        self.vk.debug_id()
+    }
+}
+
+pub trait ProvingKeyExt {
+    fn debug_id(&self) -> String;
+}
+
+impl ProvingKeyExt for ProvingKey<Bls12_377> {
+    fn debug_id(&self) -> String {
+        let mut buf = Vec::new();
+        self.serialize(&mut buf).unwrap();
+        use sha2::Digest;
+        let hash = sha2::Sha256::digest(&buf);
+        use bech32::ToBase32;
+        bech32::encode("groth16pk", hash.to_base32(), bech32::Variant::Bech32m).unwrap()
     }
 }

--- a/proof-params/src/gen/output_id.rs
+++ b/proof-params/src/gen/output_id.rs
@@ -1,0 +1,3 @@
+pub const PROVING_KEY_ID: &'static str =
+    "groth16pk1n9sa93f968qphdkpccfl49ctxhv8yw36fuum2hscen2snyz5smhs9nyj88";
+pub const VERIFICATION_KEY_ID: &'static str = "DUMMY_VALUE";

--- a/proof-params/src/gen/spend_id.rs
+++ b/proof-params/src/gen/spend_id.rs
@@ -1,0 +1,3 @@
+pub const PROVING_KEY_ID: &'static str =
+    "groth16pk1vtxptxc88jjkcklwumdd7a223m278r64dzxjptpuyy9j6hvfjg7syts3e7";
+pub const VERIFICATION_KEY_ID: &'static str = "DUMMY_VALUE";

--- a/proof-params/src/gen/swap_id.rs
+++ b/proof-params/src/gen/swap_id.rs
@@ -1,0 +1,3 @@
+pub const PROVING_KEY_ID: &'static str =
+    "groth16pk1glwxcejqaym5rqgspj55mj92kw894augenqw2tdynjjqjr9h7zlqd7zagw";
+pub const VERIFICATION_KEY_ID: &'static str = "DUMMY_VALUE";

--- a/proof-params/src/lib.rs
+++ b/proof-params/src/lib.rs
@@ -15,6 +15,10 @@ pub static SPEND_PROOF_PROVING_KEY: Lazy<ProvingKey<Bls12_377>> =
 pub static SPEND_PROOF_VERIFICATION_KEY: Lazy<PreparedVerifyingKey<Bls12_377>> =
     Lazy::new(|| spend_verification_parameters().into());
 
+pub mod spend {
+    include!("gen/spend_id.rs");
+}
+
 /// Proving key for the output proof.
 #[cfg(feature = "proving-keys")]
 pub static OUTPUT_PROOF_PROVING_KEY: Lazy<ProvingKey<Bls12_377>> =
@@ -24,6 +28,10 @@ pub static OUTPUT_PROOF_PROVING_KEY: Lazy<ProvingKey<Bls12_377>> =
 pub static OUTPUT_PROOF_VERIFICATION_KEY: Lazy<PreparedVerifyingKey<Bls12_377>> =
     Lazy::new(|| output_verification_parameters().into());
 
+pub mod output {
+    include!("gen/output_id.rs");
+}
+
 #[cfg(feature = "proving-keys")]
 /// Proving key for the swap proof.
 pub static SWAP_PROOF_PROVING_KEY: Lazy<ProvingKey<Bls12_377>> =
@@ -32,6 +40,10 @@ pub static SWAP_PROOF_PROVING_KEY: Lazy<ProvingKey<Bls12_377>> =
 /// Verification key for the swap proof.
 pub static SWAP_PROOF_VERIFICATION_KEY: Lazy<PreparedVerifyingKey<Bls12_377>> =
     Lazy::new(|| swap_verification_parameters().into());
+
+pub mod swap {
+    include!("gen/swap_id.rs");
+}
 
 // Note: Here we are using `CanonicalDeserialize::deserialize_unchecked` as the
 // parameters are being loaded from a trusted source (our source code).

--- a/proof-params/src/proving_keys.rs
+++ b/proof-params/src/proving_keys.rs
@@ -2,24 +2,25 @@ use ark_groth16::ProvingKey;
 use ark_serialize::CanonicalDeserialize;
 
 use decaf377::Bls12_377;
+use penumbra_crypto::proofs::groth16::ProvingKeyExt;
 
 pub fn output_proving_parameters() -> ProvingKey<Bls12_377> {
     let pk_params = include_bytes!("gen/output_pk.bin");
-    load_proving_parameters(pk_params)
+    load_proving_parameters(pk_params, crate::output::PROVING_KEY_ID)
 }
 
 pub fn spend_proving_parameters() -> ProvingKey<Bls12_377> {
     let pk_params = include_bytes!("gen/spend_pk.bin");
-    load_proving_parameters(pk_params)
+    load_proving_parameters(pk_params, crate::spend::PROVING_KEY_ID)
 }
 
 pub fn swap_proving_parameters() -> ProvingKey<Bls12_377> {
     let pk_params = include_bytes!("gen/swap_pk.bin");
-    load_proving_parameters(pk_params)
+    load_proving_parameters(pk_params, crate::swap::PROVING_KEY_ID)
 }
 
 /// Given a byte slice, deserialize it into a proving key.
-pub fn load_proving_parameters(pk_params: &[u8]) -> ProvingKey<Bls12_377> {
+pub fn load_proving_parameters(pk_params: &[u8], expected_id: &str) -> ProvingKey<Bls12_377> {
     // If the system does not have Git LFS installed, then the files will
     // exist but they will be tiny pointers. We want to detect this and
     // panic if so, alerting the user that they should go and install Git LFS.
@@ -27,5 +28,14 @@ pub fn load_proving_parameters(pk_params: &[u8]) -> ProvingKey<Bls12_377> {
         panic!("proving key is too small; did you install Git LFS?")
     }
     // TODO: Instead of panicking, download here using the Git LFS pointer?
-    ProvingKey::deserialize_unchecked(pk_params).expect("can deserialize ProvingKey")
+    let pk = ProvingKey::deserialize_unchecked(pk_params).expect("can deserialize ProvingKey");
+    let pk_id = pk.debug_id();
+    // Double-check that the ID of the proving key we loaded matches the hardcoded one,
+    // in case there was some problem with git-lfs updating the file, or something.
+    assert_eq!(
+        expected_id, pk_id,
+        "proving key ID mismatch: expected {}, loaded {}",
+        expected_id, pk_id
+    );
+    pk
 }

--- a/tools/parameter-setup/src/main.rs
+++ b/tools/parameter-setup/src/main.rs
@@ -7,7 +7,9 @@ use std::{
 use ark_groth16::{ProvingKey, VerifyingKey};
 use ark_serialize::CanonicalSerialize;
 use decaf377::Bls12_377;
-use penumbra_crypto::proofs::groth16::{OutputCircuit, ParameterSetup, SpendCircuit, SwapCircuit};
+use penumbra_crypto::proofs::groth16::{
+    OutputCircuit, ParameterSetup, ProvingKeyExt, SpendCircuit, SwapCircuit, VerifyingKeyExt,
+};
 
 fn main() -> Result<()> {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -41,6 +43,7 @@ fn write_params(
 ) -> Result<()> {
     let pk_location = target_dir.join(format!("{}_pk.bin", name));
     let vk_location = target_dir.join(format!("{}_vk.param", name));
+    let id_location = target_dir.join(format!("{}_id.rs", name));
 
     let pk_file = fs::File::create(&pk_location)?;
     let vk_file = fs::File::create(&vk_location)?;
@@ -50,6 +53,18 @@ fn write_params(
 
     ProvingKey::serialize_unchecked(pk, pk_writer).expect("can serialize ProvingKey");
     VerifyingKey::serialize_unchecked(vk, vk_writer).expect("can serialize VerifyingKey");
+
+    let pk_id = pk.debug_id();
+    let vk_id = vk.debug_id();
+    std::fs::write(
+        id_location,
+        format!(
+            r#"
+pub const PROVING_KEY_ID: &'static str = "{pk_id}";
+pub const VERIFICATION_KEY_ID: &'static str = "{vk_id}";
+"#,
+        ),
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
Not sure if this is the best approach; AFAICT there's not a way to run the parameter generator without overwriting the existing parameters, so I manually set the debug hashes to the values for the existing parameters.