### PR TITLE
wip: relayer config generation

### DIFF
--- a/deployments/relayer/README.md
+++ b/deployments/relayer/README.md
@@ -1,0 +1,21 @@
+# relayer config
+
+Stores config generation scripts for use with the [relayer](https://github.com/cosmos/relayer),
+for IBC functionality. Prior to mainnet, we use `relayer` to synchronize actions
+from testnet-preview to testnet.
+
+## Running it
+
+```
+./generate-configs preview
+./generate-configs testnet
+./configure-relayer
+./run-relayer
+```
+
+## Further reading
+The config format for the JSON files are adapted from the [example-configs](https://github.com/cosmos/relayer/tree/main/docs/example-configs)
+in the relayer repo. Our configs will get out of date very quickly: the preview chain id changes
+on every merge into main, for instance. Short-term, that's fine: we want to exercise IBC
+in our CI deployments, and dynamically generating the configs is good enough. Longer term, we'll want
+to upload our configs to the [chain-registry repo](https://github.com/cosmos/chain-registry).

--- a/deployments/relayer/README.md
+++ b/deployments/relayer/README.md
@@ -9,7 +9,7 @@ from testnet-preview to testnet.
 ```
 ./generate-configs preview
 ./generate-configs testnet
-./configure-relayer
+./configure-relayer penumbra-preview penumbra-testnet
 ./run-relayer
 ```
 

--- a/deployments/relayer/configs/penumbra-preview.json
+++ b/deployments/relayer/configs/penumbra-preview.json
@@ -1,0 +1,16 @@
+{
+  "type": "penumbra",
+  "value": {
+    "key": "default",
+    "chain-id": "penumbra-testnet-carme-e248c323",
+    "rpc-addr": "https://rpc.testnet-preview.penumbra.zone:443",
+    "account-prefix": "penumbrav2t",
+    "keyring-backend": "test",
+    "gas-adjustment": 1.0,
+    "gas-prices": "0.00upenumbra",
+    "debug": true,
+    "timeout": "20s",
+    "output-format": "json",
+    "sign-mode": "direct"
+  }
+}

--- a/deployments/relayer/configs/penumbra-testnet.json
+++ b/deployments/relayer/configs/penumbra-testnet.json
@@ -1,0 +1,16 @@
+{
+  "type": "penumbra",
+  "value": {
+    "key": "default",
+    "chain-id": "penumbra-testnet-carme",
+    "rpc-addr": "https://rpc.testnet.penumbra.zone:443",
+    "account-prefix": "penumbrav2t",
+    "keyring-backend": "test",
+    "gas-adjustment": 1.0,
+    "gas-prices": "0.00upenumbra",
+    "debug": true,
+    "timeout": "20s",
+    "output-format": "json",
+    "sign-mode": "direct"
+  }
+}

--- a/deployments/relayer/configs/penumbra.tpl
+++ b/deployments/relayer/configs/penumbra.tpl
@@ -1,0 +1,16 @@
+{
+  "type": "penumbra",
+  "value": {
+    "key": "default",
+    "chain-id": "$PENUMBRA_CHAIN_ID",
+    "rpc-addr": "$PENUMBRA_RPC_URL",
+    "account-prefix": "penumbrav2t",
+    "keyring-backend": "test",
+    "gas-adjustment": 1.0,
+    "gas-prices": "0.00upenumbra",
+    "debug": true,
+    "timeout": "20s",
+    "output-format": "json",
+    "sign-mode": "direct"
+  }
+}

--- a/deployments/relayer/configure-relayer
+++ b/deployments/relayer/configure-relayer
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Configure relayer from scratch; nukes any previous state, so use with caution.
+# Follows the config steps documented in relayer README:
+# https://github.com/cosmos/relayer/
+set -euo pipefail
+
+
+rm -rf ~/.relayer
+rly config init --memo "Automatic IBC for Penumbra, via relayer"
+
+# Must serve JSON files over network; `file:///` URLs are not supported.
+python3 -m http.server --directory configs/ &
+job_pid="$!"
+trap 'kill -9 "$job_pid"' EXIT
+sleep 2
+
+>&2 echo "Generating relayer configs..."
+rly chains add penumbra-testnet --url http://localhost:8000/penumbra-testnet.json
+rly chains add penumbra-preview --url http://localhost:8000/penumbra-preview.json
+
+# Ideally we wouldn't need to bother with generating keys for the relayer paths,
+# because Penumbra hasn't implemented fees yet, so there's no need for a wallet to pay out of.
+# If we skip keygen, though, then `rly transact link <path>` shows an error:
+#
+#   Error: key default not found on src chain penumbra-testnet-carme-dac8be27
+>&2 echo "Generating key for testnet:"
+rly keys add penumbra-testnet default
+>&2 echo "Generating key for preview:"
+rly keys add penumbra-preview default
+
+# TODO: configure paths. We can't fetch from an external registry, so we'll
+# need to munge the YAML config directly. See docs at
+# https://github.com/cosmos/relayer/blob/main/docs/create-path-across-chain.md
+testnet_chain_id="$(jq -r '.value["chain-id"]' configs/penumbra-testnet.json)"
+preview_chain_id="$(jq -r '.value["chain-id"]' configs/penumbra-preview.json)"
+rly paths new "$preview_chain_id" "$testnet_chain_id" penumbra_path
+
+>&2 echo "Emitting status info:"
+rly chains list
+rly paths list

--- a/deployments/relayer/configure-relayer
+++ b/deployments/relayer/configure-relayer
@@ -4,6 +4,12 @@
 # https://github.com/cosmos/relayer/
 set -euo pipefail
 
+if [[ $# -lt 2 ]] ; then
+    >&2 echo "ERROR: networks not specified. Use, e.g., 'penumbra-testnet penumbra-preview'."
+    >&2 echo "Usage: $0 <network-1> <network-2>"
+    exit 1
+fi
+
 
 rm -rf ~/.relayer
 rly config init --memo "Automatic IBC for Penumbra, via relayer"
@@ -15,25 +21,25 @@ trap 'kill -9 "$job_pid"' EXIT
 sleep 2
 
 >&2 echo "Generating relayer configs..."
-rly chains add penumbra-testnet --url http://localhost:8000/penumbra-testnet.json
-rly chains add penumbra-preview --url http://localhost:8000/penumbra-preview.json
+rly chains add $1 --url http://localhost:8000/$1.json
+rly chains add $2 --url http://localhost:8000/$2.json
 
 # Ideally we wouldn't need to bother with generating keys for the relayer paths,
 # because Penumbra hasn't implemented fees yet, so there's no need for a wallet to pay out of.
 # If we skip keygen, though, then `rly transact link <path>` shows an error:
 #
 #   Error: key default not found on src chain penumbra-testnet-carme-dac8be27
->&2 echo "Generating key for testnet:"
-rly keys add penumbra-testnet default
->&2 echo "Generating key for preview:"
-rly keys add penumbra-preview default
+>&2 echo "Generating key for $1:"
+rly keys add $1 default
+>&2 echo "Generating key for $2:"
+rly keys add $2 default
 
 # TODO: configure paths. We can't fetch from an external registry, so we'll
 # need to munge the YAML config directly. See docs at
 # https://github.com/cosmos/relayer/blob/main/docs/create-path-across-chain.md
-testnet_chain_id="$(jq -r '.value["chain-id"]' configs/penumbra-testnet.json)"
-preview_chain_id="$(jq -r '.value["chain-id"]' configs/penumbra-preview.json)"
-rly paths new "$preview_chain_id" "$testnet_chain_id" penumbra_path
+chain_1_id="$(jq -r '.value["chain-id"]' configs/$1.json)"
+chain_2_id="$(jq -r '.value["chain-id"]' configs/$2.json)"
+rly paths new "$chain_1_id" "$chain_2_id" penumbra_path
 
 >&2 echo "Emitting status info:"
 rly chains list

--- a/deployments/relayer/generate-configs
+++ b/deployments/relayer/generate-configs
@@ -27,6 +27,10 @@ case $penumbra_network in
         PENUMBRA_RPC_URL="https://rpc.testnet.penumbra.zone:443"
         PENUMBRA_CHAIN_ID="$(get_chain_id "$PENUMBRA_RPC_URL")"
         ;;
+    local)
+        PENUMBRA_RPC_URL="http://localhost:26657"
+        PENUMBRA_CHAIN_ID="$(get_chain_id "$PENUMBRA_RPC_URL")"
+        ;;
     *)
         >&2 echo "ERROR: network '$penumbra_network' not supported"
         exit 2

--- a/deployments/relayer/generate-configs
+++ b/deployments/relayer/generate-configs
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+
+if [[ $# -lt 1 ]] ; then
+    >&2 echo "ERROR: no network declared. Use either 'testnet' or 'preview'."
+    >&2 echo "Usage: $0 <network>"
+    exit 1
+fi
+penumbra_network="${1:-}"
+shift 1
+
+function get_chain_id() {
+    local u
+    u="${1:-}"
+    shift 1
+    curl -s "${u}/status" | jq -r .result.node_info.network
+}
+
+case $penumbra_network in
+  # N.B. the port suffix on the URL is required; otherwise, rly complains about missing port.
+    preview)
+        PENUMBRA_RPC_URL="https://rpc.testnet-preview.penumbra.zone:443"
+        PENUMBRA_CHAIN_ID="$(get_chain_id "$PENUMBRA_RPC_URL")"
+        ;;
+    testnet)
+        PENUMBRA_RPC_URL="https://rpc.testnet.penumbra.zone:443"
+        PENUMBRA_CHAIN_ID="$(get_chain_id "$PENUMBRA_RPC_URL")"
+        ;;
+    *)
+        >&2 echo "ERROR: network '$penumbra_network' not supported"
+        exit 2
+        ;;
+esac
+
+export PENUMBRA_RPC_URL
+export PENUMBRA_CHAIN_ID
+envsubst < configs/penumbra.tpl > "configs/penumbra-${penumbra_network}.json"

--- a/deployments/relayer/justfile
+++ b/deployments/relayer/justfile
@@ -1,0 +1,11 @@
+all:
+   just configs
+   just run
+
+configs:
+    ./generate-configs preview
+    ./generate-configs testnet
+
+run:
+    ./configure-relayer
+    ./run-relayer

--- a/deployments/relayer/run-relayer
+++ b/deployments/relayer/run-relayer
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Wrapper script to finalize configuration on relayer,
+# and submit a transaction to verify manual relaying of cross-chain
+# info for Penumbra. (Doesn't work yet =)
+
+
+>&2 echo "Attempting to 'transact link' the path..."
+rly --debug transact link penumbra_path


### PR DESCRIPTION
Towards #465. Records initial config generation logic for using `rly` (built from the WIP PR at https://github.com/cosmos/relayer/pull/1124). 

The plan is to post transactions between testnet & preview, using the relayer, which must be configured with chain info for both networks, as well as wallet identities. No path configuration logic exists yet; will work with @avahowell to get that straightened out soon. 