### PR TITLE
`pqli q dex liquidity-positions` implementation

### DIFF
--- a/component/src/dex/position_manager.rs
+++ b/component/src/dex/position_manager.rs
@@ -7,7 +7,7 @@ use penumbra_crypto::{
     },
     Value,
 };
-use penumbra_proto::{DomainType, StateReadProto, StateWriteProto};
+use penumbra_proto::{StateReadProto, StateWriteProto};
 use penumbra_storage::{StateRead, StateWrite};
 
 use super::state_key;

--- a/component/src/dex/position_manager.rs
+++ b/component/src/dex/position_manager.rs
@@ -17,6 +17,16 @@ use std::pin::Pin;
 
 #[async_trait]
 pub trait PositionRead: StateRead {
+    fn all_positions(&self) -> Pin<Box<dyn Stream<Item = Result<position::Metadata>> + Send + '_>> {
+        let prefix = state_key::all_positions();
+        self.prefix(&prefix)
+            .map(|entry| match entry {
+                Ok((_, metadata)) => Ok(metadata),
+                Err(e) => Err(e),
+            })
+            .boxed()
+    }
+
     async fn positions_by_price(
         &self,
         pair: DirectedTradingPair,

--- a/component/src/dex/state_key.rs
+++ b/component/src/dex/state_key.rs
@@ -10,6 +10,10 @@ pub fn position_by_id(id: &position::Id) -> String {
     format!("dex/position/{id}")
 }
 
+pub fn all_positions() -> &'static str {
+    "dex/position/"
+}
+
 /// Encompasses non-consensus state keys.
 pub(crate) mod internal {
     use super::*;
@@ -17,6 +21,7 @@ pub(crate) mod internal {
 
     pub mod price_index {
         use super::*;
+
         pub fn prefix(pair: &DirectedTradingPair) -> [u8; 71] {
             let mut key = [0u8; 71];
             key[0..7].copy_from_slice(b"dex/pi/");

--- a/pcli/src/command.rs
+++ b/pcli/src/command.rs
@@ -53,14 +53,14 @@ pub enum Command {
 }
 
 impl Command {
-    /// Determine if this command requires a network sync before it executes.
+    /// Determine if this command can run in "offline" mode.
     pub fn offline(&self) -> bool {
         match self {
             Command::Transaction(cmd) => cmd.offline(),
             Command::View(cmd) => cmd.offline(),
             Command::Keys(cmd) => cmd.offline(),
             Command::Validator(cmd) => cmd.offline(),
-            Command::Query(_) => true,
+            Command::Query(_) => false,
             Command::Debug(cmd) => cmd.offline(),
         }
     }

--- a/pcli/src/command.rs
+++ b/pcli/src/command.rs
@@ -60,6 +60,8 @@ impl Command {
             Command::View(cmd) => cmd.offline(),
             Command::Keys(cmd) => cmd.offline(),
             Command::Validator(cmd) => cmd.offline(),
+            // TODO: revert this to `true` after all `pcli q` commands are updated
+            // to not use the view service any more.
             Command::Query(_) => false,
             Command::Debug(cmd) => cmd.offline(),
         }

--- a/pcli/src/command/query/dex.rs
+++ b/pcli/src/command/query/dex.rs
@@ -236,6 +236,7 @@ impl DexCmd {
                 let mut table = Table::new();
                 table.load_preset(presets::NOTHING);
                 table.set_header(vec![
+                    "ID",
                     "Trading Pair",
                     "State",
                     "Reserves",
@@ -257,6 +258,7 @@ impl DexCmd {
                         .map(|bd| format!("{bd}"))
                         .unwrap_or("unknown".to_string());
                     table.add_row(vec![
+                        format!("{}", position.position.id()),
                         format!("({}, {})", asset_1, asset_2),
                         position.state.to_string(),
                         format!("({}, {})", position.reserves.r1, position.reserves.r2),

--- a/pcli/src/command/query/dex.rs
+++ b/pcli/src/command/query/dex.rs
@@ -122,34 +122,6 @@ impl DexCmd {
             .context("cannot parse batch swap output data")
     }
 
-    // fn status_stream(
-    //     &mut self,
-    //     account_group_id: AccountGroupId,
-    // ) -> Pin<
-    //     Box<
-    //         dyn Future<
-    //                 Output = Result<
-    //                     Pin<Box<dyn Stream<Item = Result<StatusStreamResponse>> + Send + 'static>>,
-    //                 >,
-    //             > + Send
-    //             + 'static,
-    //     >,
-    // > {
-    //     let mut self2 = self.clone();
-    //     async move {
-    //         let stream = self2.status_stream(tonic::Request::new(pb::StatusStreamRequest {
-    //             account_group_id: Some(account_group_id.into()),
-    //             ..Default::default()
-    //         }));
-    //         let stream = stream.await?.into_inner();
-
-    //         Ok(stream
-    //             .map_err(|e| anyhow::anyhow!("view service error: {}", e))
-    //             .and_then(|msg| async move { StatusStreamResponse::try_from(msg) })
-    //             .boxed())
-    //     }
-    //     .boxed()
-    // }
     pub async fn get_liquidity_positions(
         &self,
         mut client: SpecificQueryServiceClient<Channel>,
@@ -164,20 +136,6 @@ impl DexCmd {
                 + 'static,
         >,
     > {
-        //     let mut self2 = self.clone();
-        //     async move {
-        //         let stream = self2.status_stream(tonic::Request::new(pb::StatusStreamRequest {
-        //             account_group_id: Some(account_group_id.into()),
-        //             ..Default::default()
-        //         }));
-        //         let stream = stream.await?.into_inner();
-
-        //         Ok(stream
-        //             .map_err(|e| anyhow::anyhow!("view service error: {}", e))
-        //             .and_then(|msg| async move { StatusStreamResponse::try_from(msg) })
-        //             .boxed())
-        //     }
-        //     .boxed()
         async move {
             let stream = client.liquidity_positions(LiquidityPositionsRequest {
                 only_mine,

--- a/pcli/src/command/query/dex.rs
+++ b/pcli/src/command/query/dex.rs
@@ -271,7 +271,7 @@ impl DexCmd {
                 only_open,
             } => {
                 let client = app.specific_client().await.unwrap();
-                let chain_id = app.view().chain_params().await?.chain_id;
+                let chain_id = app.view.as_mut().unwrap().chain_params().await?.chain_id;
 
                 let mut positions_stream = self
                     .get_liquidity_positions(client, *only_mine, *only_open, chain_id)

--- a/proto/proto/buf.lock
+++ b/proto/proto/buf.lock
@@ -16,7 +16,7 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: ibc
-    commit: ec2d72296d5b4264b121cf9976ca2a52
+    commit: d6a99e4eff7443b1b9c887d1feb2b23f
   - remote: buf.build
     owner: cosmos
     repository: ics23

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -169,7 +169,7 @@ message LiquidityPositionsRequest {
 }
 
 message LiquidityPositionsResponse {
-  core.dex.v1alpha1.Position data = 1;
+  core.dex.v1alpha1.PositionMetadata data = 1;
 }
 
 // Requests CPMM reserves data associated with a given trading pair from the view service.

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -90,6 +90,7 @@ service SpecificQueryService {
   rpc ValidatorPenalty(ValidatorPenaltyRequest) returns (ValidatorPenaltyResponse);
   rpc NextValidatorRate(NextValidatorRateRequest) returns (NextValidatorRateResponse);
   rpc BatchSwapOutputData(BatchSwapOutputDataRequest) returns (BatchSwapOutputDataResponse);
+  rpc LiquidityPositions(LiquidityPositionsRequest) returns (LiquidityPositionsResponse);
   rpc StubCPMMReserves(StubCPMMReservesRequest) returns (StubCPMMReservesResponse);
   rpc AssetInfo(AssetInfoRequest) returns (AssetInfoResponse);
   rpc ProposalInfo(ProposalInfoRequest) returns (ProposalInfoResponse);
@@ -157,6 +158,18 @@ message BatchSwapOutputDataRequest {
 
 message BatchSwapOutputDataResponse {
   core.dex.v1alpha1.BatchSwapOutputData data = 1;
+}
+
+// Requests liquidity position data from the view service.
+message LiquidityPositionsRequest {
+  // The expected chain id (empty string if no expectation).
+  string chain_id = 1;
+  bool only_mine = 2;
+  bool only_open = 3;
+}
+
+message LiquidityPositionsResponse {
+  repeated core.dex.v1alpha1.Position data = 1;
 }
 
 // Requests CPMM reserves data associated with a given trading pair from the view service.

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -90,7 +90,7 @@ service SpecificQueryService {
   rpc ValidatorPenalty(ValidatorPenaltyRequest) returns (ValidatorPenaltyResponse);
   rpc NextValidatorRate(NextValidatorRateRequest) returns (NextValidatorRateResponse);
   rpc BatchSwapOutputData(BatchSwapOutputDataRequest) returns (BatchSwapOutputDataResponse);
-  rpc LiquidityPositions(LiquidityPositionsRequest) returns (LiquidityPositionsResponse);
+  rpc LiquidityPositions(LiquidityPositionsRequest) returns (stream LiquidityPositionsResponse);
   rpc StubCPMMReserves(StubCPMMReservesRequest) returns (StubCPMMReservesResponse);
   rpc AssetInfo(AssetInfoRequest) returns (AssetInfoResponse);
   rpc ProposalInfo(ProposalInfoRequest) returns (ProposalInfoResponse);
@@ -169,7 +169,7 @@ message LiquidityPositionsRequest {
 }
 
 message LiquidityPositionsResponse {
-  repeated core.dex.v1alpha1.Position data = 1;
+  core.dex.v1alpha1.Position data = 1;
 }
 
 // Requests CPMM reserves data associated with a given trading pair from the view service.

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -164,7 +164,6 @@ message BatchSwapOutputDataResponse {
 message LiquidityPositionsRequest {
   // The expected chain id (empty string if no expectation).
   string chain_id = 1;
-  bool only_mine = 2;
   bool only_open = 3;
 }
 

--- a/proto/src/gen/penumbra.client.v1alpha1.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.rs
@@ -191,7 +191,9 @@ pub struct LiquidityPositionsRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LiquidityPositionsResponse {
     #[prost(message, optional, tag = "1")]
-    pub data: ::core::option::Option<super::super::core::dex::v1alpha1::Position>,
+    pub data: ::core::option::Option<
+        super::super::core::dex::v1alpha1::PositionMetadata,
+    >,
 }
 /// Requests CPMM reserves data associated with a given trading pair from the view service.
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/proto/src/gen/penumbra.client.v1alpha1.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.rs
@@ -175,6 +175,24 @@ pub struct BatchSwapOutputDataResponse {
         super::super::core::dex::v1alpha1::BatchSwapOutputData,
     >,
 }
+/// Requests liquidity position data from the view service.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LiquidityPositionsRequest {
+    /// The expected chain id (empty string if no expectation).
+    #[prost(string, tag = "1")]
+    pub chain_id: ::prost::alloc::string::String,
+    #[prost(bool, tag = "2")]
+    pub only_mine: bool,
+    #[prost(bool, tag = "3")]
+    pub only_open: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LiquidityPositionsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub data: ::prost::alloc::vec::Vec<super::super::core::dex::v1alpha1::Position>,
+}
 /// Requests CPMM reserves data associated with a given trading pair from the view service.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -815,6 +833,25 @@ pub mod specific_query_service_client {
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.client.v1alpha1.SpecificQueryService/BatchSwapOutputData",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn liquidity_positions(
+            &mut self,
+            request: impl tonic::IntoRequest<super::LiquidityPositionsRequest>,
+        ) -> Result<tonic::Response<super::LiquidityPositionsResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/penumbra.client.v1alpha1.SpecificQueryService/LiquidityPositions",
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
@@ -1472,6 +1509,10 @@ pub mod specific_query_service_server {
             &self,
             request: tonic::Request<super::BatchSwapOutputDataRequest>,
         ) -> Result<tonic::Response<super::BatchSwapOutputDataResponse>, tonic::Status>;
+        async fn liquidity_positions(
+            &self,
+            request: tonic::Request<super::LiquidityPositionsRequest>,
+        ) -> Result<tonic::Response<super::LiquidityPositionsResponse>, tonic::Status>;
         async fn stub_cpmm_reserves(
             &self,
             request: tonic::Request<super::StubCpmmReservesRequest>,
@@ -1767,6 +1808,46 @@ pub mod specific_query_service_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = BatchSwapOutputDataSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/penumbra.client.v1alpha1.SpecificQueryService/LiquidityPositions" => {
+                    #[allow(non_camel_case_types)]
+                    struct LiquidityPositionsSvc<T: SpecificQueryService>(pub Arc<T>);
+                    impl<
+                        T: SpecificQueryService,
+                    > tonic::server::UnaryService<super::LiquidityPositionsRequest>
+                    for LiquidityPositionsSvc<T> {
+                        type Response = super::LiquidityPositionsResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::LiquidityPositionsRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).liquidity_positions(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = LiquidityPositionsSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/proto/src/gen/penumbra.client.v1alpha1.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.rs
@@ -182,8 +182,6 @@ pub struct LiquidityPositionsRequest {
     /// The expected chain id (empty string if no expectation).
     #[prost(string, tag = "1")]
     pub chain_id: ::prost::alloc::string::String,
-    #[prost(bool, tag = "2")]
-    pub only_mine: bool,
     #[prost(bool, tag = "3")]
     pub only_open: bool,
 }

--- a/proto/src/gen/penumbra.client.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.serde.rs
@@ -2386,18 +2386,12 @@ impl serde::Serialize for LiquidityPositionsRequest {
         if !self.chain_id.is_empty() {
             len += 1;
         }
-        if self.only_mine {
-            len += 1;
-        }
         if self.only_open {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("penumbra.client.v1alpha1.LiquidityPositionsRequest", len)?;
         if !self.chain_id.is_empty() {
             struct_ser.serialize_field("chainId", &self.chain_id)?;
-        }
-        if self.only_mine {
-            struct_ser.serialize_field("onlyMine", &self.only_mine)?;
         }
         if self.only_open {
             struct_ser.serialize_field("onlyOpen", &self.only_open)?;
@@ -2414,8 +2408,6 @@ impl<'de> serde::Deserialize<'de> for LiquidityPositionsRequest {
         const FIELDS: &[&str] = &[
             "chain_id",
             "chainId",
-            "only_mine",
-            "onlyMine",
             "only_open",
             "onlyOpen",
         ];
@@ -2423,7 +2415,6 @@ impl<'de> serde::Deserialize<'de> for LiquidityPositionsRequest {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             ChainId,
-            OnlyMine,
             OnlyOpen,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -2447,7 +2438,6 @@ impl<'de> serde::Deserialize<'de> for LiquidityPositionsRequest {
                     {
                         match value {
                             "chainId" | "chain_id" => Ok(GeneratedField::ChainId),
-                            "onlyMine" | "only_mine" => Ok(GeneratedField::OnlyMine),
                             "onlyOpen" | "only_open" => Ok(GeneratedField::OnlyOpen),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
@@ -2469,7 +2459,6 @@ impl<'de> serde::Deserialize<'de> for LiquidityPositionsRequest {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut chain_id__ = None;
-                let mut only_mine__ = None;
                 let mut only_open__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
@@ -2478,12 +2467,6 @@ impl<'de> serde::Deserialize<'de> for LiquidityPositionsRequest {
                                 return Err(serde::de::Error::duplicate_field("chainId"));
                             }
                             chain_id__ = Some(map.next_value()?);
-                        }
-                        GeneratedField::OnlyMine => {
-                            if only_mine__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("onlyMine"));
-                            }
-                            only_mine__ = Some(map.next_value()?);
                         }
                         GeneratedField::OnlyOpen => {
                             if only_open__.is_some() {
@@ -2495,7 +2478,6 @@ impl<'de> serde::Deserialize<'de> for LiquidityPositionsRequest {
                 }
                 Ok(LiquidityPositionsRequest {
                     chain_id: chain_id__.unwrap_or_default(),
-                    only_mine: only_mine__.unwrap_or_default(),
                     only_open: only_open__.unwrap_or_default(),
                 })
             }

--- a/proto/src/gen/penumbra.client.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.serde.rs
@@ -2375,6 +2375,225 @@ impl<'de> serde::Deserialize<'de> for KeyValueResponse {
         deserializer.deserialize_struct("penumbra.client.v1alpha1.KeyValueResponse", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for LiquidityPositionsRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.chain_id.is_empty() {
+            len += 1;
+        }
+        if self.only_mine {
+            len += 1;
+        }
+        if self.only_open {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.client.v1alpha1.LiquidityPositionsRequest", len)?;
+        if !self.chain_id.is_empty() {
+            struct_ser.serialize_field("chainId", &self.chain_id)?;
+        }
+        if self.only_mine {
+            struct_ser.serialize_field("onlyMine", &self.only_mine)?;
+        }
+        if self.only_open {
+            struct_ser.serialize_field("onlyOpen", &self.only_open)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for LiquidityPositionsRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "chain_id",
+            "chainId",
+            "only_mine",
+            "onlyMine",
+            "only_open",
+            "onlyOpen",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            ChainId,
+            OnlyMine,
+            OnlyOpen,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "chainId" | "chain_id" => Ok(GeneratedField::ChainId),
+                            "onlyMine" | "only_mine" => Ok(GeneratedField::OnlyMine),
+                            "onlyOpen" | "only_open" => Ok(GeneratedField::OnlyOpen),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = LiquidityPositionsRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.client.v1alpha1.LiquidityPositionsRequest")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<LiquidityPositionsRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut chain_id__ = None;
+                let mut only_mine__ = None;
+                let mut only_open__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::ChainId => {
+                            if chain_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("chainId"));
+                            }
+                            chain_id__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::OnlyMine => {
+                            if only_mine__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("onlyMine"));
+                            }
+                            only_mine__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::OnlyOpen => {
+                            if only_open__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("onlyOpen"));
+                            }
+                            only_open__ = Some(map.next_value()?);
+                        }
+                    }
+                }
+                Ok(LiquidityPositionsRequest {
+                    chain_id: chain_id__.unwrap_or_default(),
+                    only_mine: only_mine__.unwrap_or_default(),
+                    only_open: only_open__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.client.v1alpha1.LiquidityPositionsRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for LiquidityPositionsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.data.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.client.v1alpha1.LiquidityPositionsResponse", len)?;
+        if !self.data.is_empty() {
+            struct_ser.serialize_field("data", &self.data)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for LiquidityPositionsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "data",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Data,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "data" => Ok(GeneratedField::Data),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = LiquidityPositionsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.client.v1alpha1.LiquidityPositionsResponse")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<LiquidityPositionsResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut data__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::Data => {
+                            if data__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("data"));
+                            }
+                            data__ = Some(map.next_value()?);
+                        }
+                    }
+                }
+                Ok(LiquidityPositionsResponse {
+                    data: data__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.client.v1alpha1.LiquidityPositionsResponse", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for NextValidatorRateRequest {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/proto/src/gen/penumbra.client.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.serde.rs
@@ -2511,12 +2511,12 @@ impl serde::Serialize for LiquidityPositionsResponse {
     {
         use serde::ser::SerializeStruct;
         let mut len = 0;
-        if !self.data.is_empty() {
+        if self.data.is_some() {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("penumbra.client.v1alpha1.LiquidityPositionsResponse", len)?;
-        if !self.data.is_empty() {
-            struct_ser.serialize_field("data", &self.data)?;
+        if let Some(v) = self.data.as_ref() {
+            struct_ser.serialize_field("data", v)?;
         }
         struct_ser.end()
     }
@@ -2582,12 +2582,12 @@ impl<'de> serde::Deserialize<'de> for LiquidityPositionsResponse {
                             if data__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("data"));
                             }
-                            data__ = Some(map.next_value()?);
+                            data__ = map.next_value()?;
                         }
                     }
                 }
                 Ok(LiquidityPositionsResponse {
-                    data: data__.unwrap_or_default(),
+                    data: data__,
                 })
             }
         }


### PR DESCRIPTION
This adds a new `pcli q dex liquidity-positions` command with an optional filter (`--only-open`) that will query a node for known liquidity positions and print them in a basic table view.