### PR TITLE
pcli: mark `pcli q` as not requiring a chain sync

### DIFF
--- a/pcli/src/command.rs
+++ b/pcli/src/command.rs
@@ -60,7 +60,7 @@ impl Command {
             Command::View(cmd) => cmd.offline(),
             Command::Keys(cmd) => cmd.offline(),
             Command::Validator(cmd) => cmd.offline(),
-            Command::Query(_) => false,
+            Command::Query(_) => true,
             Command::Debug(cmd) => cmd.offline(),
         }
     }

--- a/pcli/src/command/query/governance.rs
+++ b/pcli/src/command/query/governance.rs
@@ -13,7 +13,6 @@ use penumbra_transaction::{
     proposal::{self, Proposal},
     vote::Vote,
 };
-use penumbra_view::ViewClient;
 use serde::Serialize;
 use serde_json::json;
 
@@ -64,7 +63,7 @@ impl GovernanceCmd {
                     let mut unfinished = client
                         .prefix_value(PrefixValueRequest {
                             prefix: all_unfinished_proposals().into(),
-                            chain_id: app.view().chain_params().await?.chain_id,
+                            ..Default::default()
                         })
                         .await?
                         .into_inner();


### PR DESCRIPTION
It's just querying a fullnode, so there's no need to sync local state, and not waiting to sync local state makes it more useful in debugging (e.g., it's possible to query multiple chains simultaneously).