### PR TITLE
pclientd: fix config file format for FVK

### DIFF
--- a/pclientd/src/lib.rs
+++ b/pclientd/src/lib.rs
@@ -16,7 +16,7 @@ use penumbra_proto::{
 };
 use penumbra_view::{Storage, ViewService};
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
+use serde_with::{serde_as, DisplayFromStr};
 
 use std::fs;
 use std::fs::File;
@@ -27,10 +27,11 @@ use tonic::transport::Server;
 #[serde_as]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PclientdConfig {
+    /// FVK for both view and custody modes
+    #[serde_as(as = "DisplayFromStr")]
+    pub fvk: FullViewingKey,
     /// Optional KMS config for custody mode
     pub kms_config: Option<soft_kms::Config>,
-    /// FVK for both view and custody modes
-    pub fvk: FullViewingKey,
 }
 
 impl PclientdConfig {


### PR DESCRIPTION
It now uses the string format, like so (shown is the test account):
```toml
fvk = 'penumbrafullviewingkey1f33fr3zrquh869s3h8d0pjx4fpa9fyut2utw7x5y7xdcxz6z7c8sgf5hslrkpf3mh8d26vufsq8y666chx0x0su06ay3rkwu74zuwqq9w8aza'

[kms_config]
spend_key = 'penumbraspendkey1e9gf5g8jfraap4jqul7e80vv0zrnwpsm4ke0df38ejrfh430nu4s9gc22d'
```
Closes #2186