### PR TITLE
measure: print stats on downloaded compact blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3720,6 +3726,7 @@ name = "penumbra-measure"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytesize",
  "clap 3.2.23",
  "indicatif",
  "penumbra-chain",

--- a/measure/Cargo.toml
+++ b/measure/Cargo.toml
@@ -19,6 +19,7 @@ url = "2.2"
 indicatif = "0.16"
 reqwest = "0.11"
 serde_json = "1"
+bytesize = "1.2"
 
 [build-dependencies]
 vergen = "5"


### PR DESCRIPTION
```
     Running `target/release/measure stream-blocks`
[2s] ██████████████████████████████████████████████████   57106/57106   23771/s ETA: 0s
Fetched at least 6.2 MB
Fetched 57107 compact blocks, containing:
	5900 nullifiers
	18667 state payloads, containing:
		18646 note payloads
		7 swap payloads
		14 rolled up payloads
```