### PR TITLE
Use URLs and SocketAddrs for CLI args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,6 +3454,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber 0.2.25",
+ "url",
  "vergen",
 ]
 
@@ -3982,6 +3983,7 @@ dependencies = [
  "tonic-web",
  "tracing",
  "tracing-subscriber 0.2.25",
+ "url",
  "vergen",
 ]
 

--- a/deployments/helm/templates/fn-deployments.yaml
+++ b/deployments/helm/templates/fn-deployments.yaml
@@ -163,8 +163,10 @@ spec:
             - start
             - --home
             - /home/pd
-            - --host
-            - 0.0.0.0
+            - --grpc-bind
+            - 0.0.0.0:8080
+            - --metrics-bind
+            - 0.0.0.0:9000
         - name: health-check
           image: "{{ $.Values.health.image }}:{{ $.Values.health.version }}"
           imagePullPolicy: IfNotPresent

--- a/deployments/helm/templates/val-deployments.yaml
+++ b/deployments/helm/templates/val-deployments.yaml
@@ -176,8 +176,10 @@ spec:
             - start
             - --home
             - /home/pd
-            - --host
-            - 0.0.0.0
+            - --grpc-bind
+            - 0.0.0.0:8080
+            - --metrics-bind
+            - 0.0.0.0:9000
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/deployments/scripts/smoke-test.sh
+++ b/deployments/scripts/smoke-test.sh
@@ -33,12 +33,12 @@ echo "Waiting $TESTNET_BOOTTIME seconds for network to boot..."
 sleep "$TESTNET_BOOTTIME"
 
 echo "Running pclientd integration tests against network"
-PENUMBRA_NODE_HOSTNAME="127.0.0.1" \
+PENUMBRA_NODE_PD_URL="http://127.0.0.1:8080" \
     PCLI_UNLEASH_DANGER="yes" \
     cargo test --quiet --release --features sct-divergence-check --package pclientd -- --ignored --test-threads 1 --nocapture
 
 echo "Running pcli integration tests against network"
-PENUMBRA_NODE_HOSTNAME="127.0.0.1" \
+PENUMBRA_NODE_PD_URL="http://127.0.0.1:8080" \
     PCLI_UNLEASH_DANGER="yes" \
     cargo test --quiet --release --features sct-divergence-check,download-proving-keys --package pcli -- --ignored --test-threads 1 --nocapture
 

--- a/docs/guide/src/dev/devnet-quickstart.md
+++ b/docs/guide/src/dev/devnet-quickstart.md
@@ -89,5 +89,5 @@ To run the smoke tests:
 1. Make sure you have a devnet running (see previous steps)
 2. Run integration tests:
 ```shell
-PENUMBRA_NODE_HOSTNAME=127.0.0.1 PCLI_UNLEASH_DANGER=yes cargo test --package pcli -- --ignored --test-threads 1
+PENUMBRA_NODE_PD_URL=http://127.0.0.1:8080 PCLI_UNLEASH_DANGER=yes cargo test --package pcli -- --ignored --test-threads 1
 ```

--- a/docs/guide/src/pcli/pclientd.md
+++ b/docs/guide/src/pcli/pclientd.md
@@ -9,20 +9,19 @@ pcli keys export full-viewing-key
 Next, use the FVK it prints to initialize the `pclientd` state:
 
 ```shell
-pclientd init FVK_STRING
+pclientd --home /path/to/state/dir init FVK_STRING
 ```
 
-The location of the `pclientd` state can be changed with the `-s` parameter.
 Finally, run
 
 ```shell
-pclientd start
+pclientd --home /path/to/state/dir start
 ```
 
 to start the view server, and invoke `pcli` with
 
 ```shell
-pcli -v 127.0.0.1:8081
+pcli -v 127.0.0.1:8081 q validator list
 ```
 
 to use it instead of an in-process view service.

--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -31,7 +31,7 @@ This will delete the entire testnet data directory.
 Next, generate a set of configs for the current testnet:
 
 ```shell
-cargo run --bin pd --release -- testnet join --external-address IP_ADDRESS --moniker MY_NODE_NAME
+cargo run --bin pd --release -- testnet join --external-address tcp://IP_ADDRESS:26656 --moniker MY_NODE_NAME
 ```
 
 where `IP_ADDRESS` (like `1.2.3.4`) is the public IP address of the node you're running,

--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -31,7 +31,7 @@ This will delete the entire testnet data directory.
 Next, generate a set of configs for the current testnet:
 
 ```shell
-cargo run --bin pd --release -- testnet join --external-address tcp://IP_ADDRESS:26656 --moniker MY_NODE_NAME
+cargo run --bin pd --release -- testnet join --external-address IP_ADDRESS:26656 --moniker MY_NODE_NAME
 ```
 
 where `IP_ADDRESS` (like `1.2.3.4`) is the public IP address of the node you're running,

--- a/pcli/tests/network_integration.rs
+++ b/pcli/tests/network_integration.rs
@@ -3,7 +3,7 @@
 //! These tests are marked with `#[ignore]`, but can be run with:
 //! `cargo test --package pcli -- --ignored --test-threads 1`
 //!
-//! Tests against the network in the `PENUMBRA_NODE_HOSTNAME` environment variable.
+//! Tests against the network in the `PENUMBRA_NODE_PD_URL` environment variable.
 //!
 //! Tests assume that the initial state of the test account is after genesis,
 //! where no tokens have been delegated, and the address with index 0

--- a/pclientd/Cargo.toml
+++ b/pclientd/Cargo.toml
@@ -34,6 +34,7 @@ serde = { version = "1", features = ["derive"] }
 serde_with = { version = "1.11", features = ["hex"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
+url = "2"
 http = "0.2.9"
 http-body = "0.4.5"
 tower = "0.4.0"

--- a/pclientd/src/lib.rs
+++ b/pclientd/src/lib.rs
@@ -88,11 +88,7 @@ pub enum Command {
     /// Start the view service.
     Start {
         /// Bind the view service to this socket.
-        #[clap(
-            long,
-            env = "PENUMBRA_PCLIENTD_BIND",
-            default_value = "127.0.0.1:8081"
-        )]
+        #[clap(long, env = "PENUMBRA_PCLIENTD_BIND", default_value = "127.0.0.1:8081")]
         bind_addr: SocketAddr,
     },
 }

--- a/pclientd/tests/network_integration.rs
+++ b/pclientd/tests/network_integration.rs
@@ -1,6 +1,6 @@
-//! Basic integration testing of `pcli` versus a target testnet.
+//! Basic integration testing of `pclientd` versus a target testnet.
 //!
-//! Tests against the network in the `PENUMBRA_NODE_HOSTNAME` environment variable.
+//! Tests against the network in the `PENUMBRA_NODE_PD_URL` environment variable.
 //!
 //! Tests assume that the initial state of the test account is after genesis,
 //! where no tokens have been delegated, and the address with index 0

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -144,9 +144,9 @@ enum TestnetCommand {
         moniker: Option<String>,
         /// Public URL to advertise for this node's Tendermint P2P service.
         /// Setting this option will instruct other nodes on the network to connect
-        /// to yours. Must be in the form of a full URL, e.g. "tcp://1.2.3.4:26656".
-        #[clap(long, env = "PENUMBRA_PD_TM_EXTERNAL_URL")]
-        external_address: Option<Url>,
+        /// to yours. Must be in the form of a socket, e.g. "1.2.3.4:26656".
+        #[clap(long, env = "PENUMBRA_PD_TM_EXTERNAL_ADDR")]
+        external_address: Option<SocketAddr>,
         /// When generating Tendermint config, use this socket to bind the Tendermint RPC service.
         #[clap(
             long,
@@ -335,7 +335,10 @@ async fn main() -> anyhow::Result<()> {
 
             // Check whether an external address was set, and parse as TendermintAddress.
             let external_address: Option<TendermintAddress> = match external_address {
-                Some(a) => parse_tm_address(None, &a).ok(),
+                Some(a) => {
+                    let u = Url::parse(format!("tcp://{}", a).as_str())?;
+                    parse_tm_address(None, &u).ok()
+                }
                 None => None,
             };
 

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -148,18 +148,10 @@ enum TestnetCommand {
         #[clap(long, env = "PENUMBRA_PD_TM_EXTERNAL_ADDR")]
         external_address: Option<SocketAddr>,
         /// When generating Tendermint config, use this socket to bind the Tendermint RPC service.
-        #[clap(
-            long,
-            env = "PENUMBRA_PD_TM_RPC_BIND",
-            default_value = "0.0.0.0:26657"
-        )]
+        #[clap(long, env = "PENUMBRA_PD_TM_RPC_BIND", default_value = "0.0.0.0:26657")]
         tendermint_rpc_bind: SocketAddr,
         /// When generating Tendermint config, use this socket to bind the Tendermint P2P service.
-        #[clap(
-            long,
-            env = "PENUMBRA_PD_TM_P2P_BIND",
-            default_value = "0.0.0.0:26656"
-        )]
+        #[clap(long, env = "PENUMBRA_PD_TM_P2P_BIND", default_value = "0.0.0.0:26656")]
         tendermint_p2p_bind: SocketAddr,
     },
 

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -25,6 +25,7 @@ use rand_core::OsRng;
 use tokio::runtime;
 use tonic::transport::Server;
 use tracing_subscriber::{prelude::*, EnvFilter};
+use url::Url;
 
 use tendermint_config::net::Address as TendermintAddress;
 
@@ -47,24 +48,41 @@ struct Opt {
 enum RootCommand {
     /// Start running the ABCI and wallet services.
     Start {
-        /// The path used to store pd-releated data, including the Rocks database.
-        #[clap(long)]
+        /// The path used to store pd-related data, including the Rocks database.
+        #[clap(long, env = "PENUMBRA_PD_HOME")]
         home: PathBuf,
-        /// Bind the services to this host.
-        #[clap(long, default_value = "127.0.0.1")]
-        host: String,
-        /// Bind the ABCI server to this port.
-        #[clap(short, long, default_value = "26658")]
-        abci_port: u16,
-        /// Bind the gRPC server to this port.
-        #[clap(short, long, default_value = "8080")]
-        grpc_port: u16,
-        /// bind the metrics endpoint to this port.
-        #[clap(short, long, default_value = "9000")]
-        metrics_port: u16,
-        /// Proxy Tendermint requests against the gRPC server to this address.
-        #[clap(short, long, default_value = "http://127.0.0.1:26657")]
-        tendermint_addr: url::Url,
+        /// Bind the ABCI server to this socket.
+        #[clap(
+            short,
+            long,
+            env = "PENUMBRA_PD_ABCI_BIND",
+            default_value = "127.0.0.1:26658"
+        )]
+        abci_bind: SocketAddr,
+        /// Bind the gRPC server to this socket.
+        #[clap(
+            short,
+            long,
+            env = "PENUMBRA_PD_GRPC_BIND",
+            default_value = "127.0.0.1:8080"
+        )]
+        grpc_bind: SocketAddr,
+        /// Bind the metrics endpoint to this socket.
+        #[clap(
+            short,
+            long,
+            env = "PENUMBRA_PD_METRICS_BIND",
+            default_value = "127.0.0.1:9000"
+        )]
+        metrics_bind: SocketAddr,
+        /// Proxy Tendermint requests against the gRPC server to this URL.
+        #[clap(
+            short,
+            long,
+            env = "PENUMBRA_PD_TM_PROXY_URL",
+            default_value = "http://127.0.0.1:26657"
+        )]
+        tendermint_addr: Url,
     },
     /// Generate, join, or reset a testnet.
     Testnet {
@@ -114,18 +132,35 @@ enum TestnetCommand {
 
     /// Like `testnet generate`, but joins the testnet to which the specified node belongs
     Join {
-        #[clap(default_value = "testnet.penumbra.zone")]
-        node: String,
-        // Default: node-#
+        /// URL of the remote Tendermint RPC endpoint for bootstrapping connection.
+        #[clap(
+            env = "PENUMBRA_PD_JOIN_URL",
+            default_value = "http://testnet.penumbra.zone:26657"
+        )]
+        node: Url,
         /// Human-readable name to identify node on network
         // Default: 'node-#'
-        #[clap(long)]
+        #[clap(long, env = "PENUMBRA_PD_TM_MONIKER")]
         moniker: Option<String>,
-        /// Public IP address to advertise for this node's Tendermint P2P service.
+        /// Public URL to advertise for this node's Tendermint P2P service.
         /// Setting this option will instruct other nodes on the network to connect
-        /// to yours.
-        #[clap(long)]
-        external_address: Option<String>,
+        /// to yours. Must be in the form of a full URL, e.g. "tcp://1.2.3.4:26656".
+        #[clap(long, env = "PENUMBRA_PD_TM_EXTERNAL_URL")]
+        external_address: Option<Url>,
+        /// When generating Tendermint config, use this socket to bind the Tendermint RPC service.
+        #[clap(
+            long,
+            env = "PENUMBRA_PD_TM_RPC_BIND",
+            default_value = "0.0.0.0:26657"
+        )]
+        tendermint_rpc_bind: SocketAddr,
+        /// When generating Tendermint config, use this socket to bind the Tendermint P2P service.
+        #[clap(
+            long,
+            env = "PENUMBRA_PD_TM_P2P_BIND",
+            default_value = "0.0.0.0:26656"
+        )]
+        tendermint_p2p_bind: SocketAddr,
     },
 
     /// Reset all `pd` testnet state.
@@ -175,13 +210,12 @@ async fn main() -> anyhow::Result<()> {
     match opt.cmd {
         RootCommand::Start {
             home,
-            host,
-            abci_port,
-            grpc_port,
-            metrics_port,
+            abci_bind,
+            grpc_bind,
+            metrics_bind,
             tendermint_addr,
         } => {
-            tracing::info!(?host, ?abci_port, ?grpc_port, "starting pd");
+            tracing::info!(?abci_bind, ?grpc_bind, ?metrics_bind, "starting pd");
 
             let mut rocks_path = home.clone();
             rocks_path.push("rocksdb");
@@ -206,7 +240,7 @@ async fn main() -> anyhow::Result<()> {
                         .info(info.clone())
                         .finish()
                         .unwrap()
-                        .listen(format!("{host}:{abci_port}")),
+                        .listen(abci_bind),
                 )
                 .expect("failed to spawn abci server");
 
@@ -232,21 +266,13 @@ async fn main() -> anyhow::Result<()> {
                         .add_service(tonic_web::enable(TendermintProxyServiceServer::new(
                             tm_proxy.clone(),
                         )))
-                        .serve(
-                            format!("{host}:{grpc_port}")
-                                .parse()
-                                .expect("this is a valid address"),
-                        ),
+                        .serve(grpc_bind),
                 )
                 .expect("failed to spawn grpc server");
 
             // Configure a Prometheus recorder and exporter.
             let (recorder, exporter) = PrometheusBuilder::new()
-                .with_http_listener(
-                    format!("{host}:{metrics_port}")
-                        .parse::<SocketAddr>()
-                        .expect("this is a valid address"),
-                )
+                .with_http_listener(metrics_bind)
                 .build()
                 .expect("failed to build prometheus recorder");
 
@@ -292,6 +318,8 @@ async fn main() -> anyhow::Result<()> {
                     node,
                     moniker,
                     external_address,
+                    tendermint_rpc_bind,
+                    tendermint_p2p_bind,
                 },
             testnet_dir,
         } => {
@@ -319,7 +347,15 @@ async fn main() -> anyhow::Result<()> {
 
             // Join the target testnet, looking up network info and writing
             // local configs for pd and tendermint.
-            testnet_join(output_dir, &node, &node_name, external_address).await?;
+            testnet_join(
+                output_dir,
+                node,
+                &node_name,
+                external_address,
+                tendermint_rpc_bind,
+                tendermint_p2p_bind,
+            )
+            .await?;
         }
 
         RootCommand::Testnet {

--- a/pd/src/testnet/generate.rs
+++ b/pd/src/testnet/generate.rs
@@ -22,6 +22,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tendermint::{node, public_key::Algorithm, Genesis, Time};
+use url::Url;
 
 /// Create a new testnet definition, including genesis and at least one
 /// validator config. Write all configs to the target testnet dir,
@@ -232,12 +233,12 @@ pub fn testnet_generate(
             .map(|(n, ip)| {
                 (
                     node::Id::from(validator_keys[n].node_key_pk.ed25519().unwrap()),
-                    format!("{ip}:26656"),
+                    Url::parse(format!("{ip}:26656").as_str()).unwrap(),
                 )
             })
             .filter_map(|(id, ip)| parse_tm_address(Some(&id), &ip).ok())
             .collect::<Vec<_>>();
-        let mut tm_config = generate_tm_config(&node_name, ips_minus_mine, None)?;
+        let mut tm_config = generate_tm_config(&node_name, ips_minus_mine, None, None, None)?;
         if let Some(timeout_commit) = timeout_commit {
             tm_config.consensus.timeout_commit = timeout_commit;
         }

--- a/view/Cargo.toml
+++ b/view/Cargo.toml
@@ -41,6 +41,7 @@ tracing = "0.1"
 tracing-subscriber = "0.2"
 tonic = "0.8.1"
 tonic-web = "0.4.0"
+url = "2"
 bytes = { version = "1", features = ["serde"] }
 prost = "0.11"
 futures = "0.3"

--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -22,6 +22,7 @@ use sqlx::{migrate::MigrateDatabase, query, Pool, Row, Sqlite};
 use std::{collections::BTreeMap, num::NonZeroU64, str::FromStr, sync::Arc};
 use tct::Commitment;
 use tokio::sync::broadcast::{self, error::RecvError};
+use url::Url;
 
 use crate::{sync::FilteredBlock, SpendableNoteRecord, SwapRecord};
 
@@ -51,15 +52,13 @@ impl Storage {
     pub async fn load_or_initialize(
         storage_path: impl AsRef<Utf8Path>,
         fvk: &FullViewingKey,
-        node: String,
-        pd_port: u16,
+        node: Url,
     ) -> anyhow::Result<Self> {
         let storage_path = storage_path.as_ref();
         if storage_path.exists() {
             Self::load(storage_path.as_str()).await
         } else {
-            let mut client =
-                ObliviousQueryServiceClient::connect(format!("http://{node}:{pd_port}")).await?;
+            let mut client = ObliviousQueryServiceClient::connect(node.to_string()).await?;
             let params = client
                 .chain_parameters(tonic::Request::new(ChainParametersRequest {
                     chain_id: String::new(),

--- a/view/src/worker.rs
+++ b/view/src/worker.rs
@@ -18,6 +18,7 @@ use penumbra_transaction::Transaction;
 use sha2::Digest;
 use tokio::sync::{watch, RwLock};
 use tonic::transport::Channel;
+use url::Url;
 
 #[cfg(feature = "sct-divergence-check")]
 use penumbra_proto::client::v1alpha1::specific_query_service_client::SpecificQueryServiceClient;
@@ -48,8 +49,7 @@ impl Worker {
     /// - a channel for notifying the client of sync progress.
     pub async fn new(
         storage: Storage,
-        node: String,
-        pd_port: u16,
+        node: Url,
     ) -> Result<
         (
             Self,
@@ -71,14 +71,11 @@ impl Worker {
         // Mark the current height as seen, since it's not new.
         sync_height_rx.borrow_and_update();
 
-        let client =
-            ObliviousQueryServiceClient::connect(format!("http://{node}:{pd_port}")).await?;
+        let client = ObliviousQueryServiceClient::connect(node.to_string()).await?;
         #[cfg(feature = "sct-divergence-check")]
-        let specific_client =
-            SpecificQueryServiceClient::connect(format!("http://{node}:{pd_port}")).await?;
+        let specific_client = SpecificQueryServiceClient::connect(node.to_string()).await?;
 
-        let tm_client =
-            TendermintProxyServiceClient::connect(format!("http://{node}:{pd_port}")).await?;
+        let tm_client = TendermintProxyServiceClient::connect(node.to_string()).await?;
 
         Ok((
             Self {


### PR DESCRIPTION
Updates the CLI args for pcli, pd, and pclientd to use `net::SocketAddr` types for local bind addresses, and `url::Url` types for remote endpoint specification. This makes the CLI args more verbose, but also more explicit and more flexible. For instance, it's now possible to bind pd's metrics port to localhost, but the grpc pd service to a different interface.
    
Also adds env var options for the new CLI args, to standardize config from other wrapper tools and testing environments.

To see the new options at a glance:

```
cargo build --release
./target/release/pcli -h
./target/release/pclientd -h
./target/release/pclientd start -h
./target/release/pd start -h
./target/release/pd testnet join -h
```

Closes #2196. Closes #2240.
