### PR TITLE
add `local` option to relayer-configs

### DIFF
--- a/deployments/relayer/README.md
+++ b/deployments/relayer/README.md
@@ -9,7 +9,7 @@ from testnet-preview to testnet.
 ```
 ./generate-configs preview
 ./generate-configs testnet
-./configure-relayer
+./configure-relayer penumbra-preview penumbra-testnet
 ./run-relayer
 ```
 

--- a/deployments/relayer/configure-relayer
+++ b/deployments/relayer/configure-relayer
@@ -4,6 +4,12 @@
 # https://github.com/cosmos/relayer/
 set -euo pipefail
 
+if [[ $# -lt 2 ]] ; then
+    >&2 echo "ERROR: networks not specified. Use, e.g., 'penumbra-testnet penumbra-preview'."
+    >&2 echo "Usage: $0 <network-1> <network-2>"
+    exit 1
+fi
+
 
 rm -rf ~/.relayer
 rly config init --memo "Automatic IBC for Penumbra, via relayer"
@@ -15,25 +21,25 @@ trap 'kill -9 "$job_pid"' EXIT
 sleep 2
 
 >&2 echo "Generating relayer configs..."
-rly chains add penumbra-testnet --url http://localhost:8000/penumbra-testnet.json
-rly chains add penumbra-preview --url http://localhost:8000/penumbra-preview.json
+rly chains add $1 --url http://localhost:8000/$1.json
+rly chains add $2 --url http://localhost:8000/$2.json
 
 # Ideally we wouldn't need to bother with generating keys for the relayer paths,
 # because Penumbra hasn't implemented fees yet, so there's no need for a wallet to pay out of.
 # If we skip keygen, though, then `rly transact link <path>` shows an error:
 #
 #   Error: key default not found on src chain penumbra-testnet-carme-dac8be27
->&2 echo "Generating key for testnet:"
-rly keys add penumbra-testnet default
->&2 echo "Generating key for preview:"
-rly keys add penumbra-preview default
+>&2 echo "Generating key for $1:"
+rly keys add $1 default
+>&2 echo "Generating key for $2:"
+rly keys add $2 default
 
 # TODO: configure paths. We can't fetch from an external registry, so we'll
 # need to munge the YAML config directly. See docs at
 # https://github.com/cosmos/relayer/blob/main/docs/create-path-across-chain.md
-testnet_chain_id="$(jq -r '.value["chain-id"]' configs/penumbra-testnet.json)"
-preview_chain_id="$(jq -r '.value["chain-id"]' configs/penumbra-preview.json)"
-rly paths new "$preview_chain_id" "$testnet_chain_id" penumbra_path
+chain_1_id="$(jq -r '.value["chain-id"]' configs/$1.json)"
+chain_2_id="$(jq -r '.value["chain-id"]' configs/$2.json)"
+rly paths new "$chain_1_id" "$chain_2_id" penumbra_path
 
 >&2 echo "Emitting status info:"
 rly chains list

--- a/deployments/relayer/generate-configs
+++ b/deployments/relayer/generate-configs
@@ -27,6 +27,10 @@ case $penumbra_network in
         PENUMBRA_RPC_URL="https://rpc.testnet.penumbra.zone:443"
         PENUMBRA_CHAIN_ID="$(get_chain_id "$PENUMBRA_RPC_URL")"
         ;;
+    local)
+        PENUMBRA_RPC_URL="http://localhost:26657"
+        PENUMBRA_CHAIN_ID="$(get_chain_id "$PENUMBRA_RPC_URL")"
+        ;;
     *)
         >&2 echo "ERROR: network '$penumbra_network' not supported"
         exit 2


### PR DESCRIPTION
This adds a `local` option for testing a local devnet against `preview` or `testnet`.