### PR TITLE
#2223: Remove use of view service from `pcli q` commands

### DIFF
--- a/chain/src/known_assets.rs
+++ b/chain/src/known_assets.rs
@@ -1,4 +1,4 @@
-use penumbra_crypto::asset::Asset;
+use penumbra_crypto::asset::{self, Asset};
 use penumbra_proto::{
     client::v1alpha1::AssetListResponse, core::chain::v1alpha1 as pb, DomainType,
 };
@@ -42,5 +42,11 @@ impl From<KnownAssets> for AssetListResponse {
         Self {
             asset_list: Some(assets.into()),
         }
+    }
+}
+
+impl From<KnownAssets> for asset::Cache {
+    fn from(assets: KnownAssets) -> Self {
+        Self::from_iter(assets.0.into_iter().map(|asset| asset.denom))
     }
 }

--- a/pcli/src/command.rs
+++ b/pcli/src/command.rs
@@ -60,8 +60,6 @@ impl Command {
             Command::View(cmd) => cmd.offline(),
             Command::Keys(cmd) => cmd.offline(),
             Command::Validator(cmd) => cmd.offline(),
-            // TODO: revert this to `true` after all `pcli q` commands are updated
-            // to not use the view service any more.
             Command::Query(_) => true,
             Command::Debug(cmd) => cmd.offline(),
         }

--- a/pcli/src/command/query/chain.rs
+++ b/pcli/src/command/query/chain.rs
@@ -101,6 +101,7 @@ impl ChainCmd {
 
         let mut client = app.oblivious_client().await?;
 
+        // TODO: is it possible to use the TendermintProxyService instead here??
         let info = client
             .info(InfoRequest {
                 version: "".to_string(),

--- a/pcli/src/command/query/dao.rs
+++ b/pcli/src/command/query/dao.rs
@@ -1,9 +1,13 @@
 use std::collections::BTreeMap;
 
 use anyhow::Result;
+use penumbra_chain::KnownAssets;
 use penumbra_component::dao;
-use penumbra_crypto::{asset::Denom, Amount, Value};
-use penumbra_view::ViewClient;
+use penumbra_crypto::{
+    asset::{Cache, Denom},
+    Amount, Asset, Value,
+};
+use penumbra_proto::client::v1alpha1::{AssetListRequest, ChainParametersRequest};
 
 use crate::App;
 
@@ -13,6 +17,39 @@ pub enum DaoCmd {
 }
 
 impl DaoCmd {
+    // TODO: this is duplicated between various pcli q subcommands, is there a single place it could live?
+    async fn get_asset_cache(&self, app: &mut App) -> Result<(String, Cache)> {
+        let mut oblivious_client = app.oblivious_client().await?;
+
+        let chain_params = oblivious_client
+            .chain_parameters(tonic::Request::new(ChainParametersRequest {
+                chain_id: "".to_string(),
+            }))
+            .await?
+            .into_inner()
+            .chain_parameters
+            .ok_or_else(|| anyhow::anyhow!("empty ChainParametersResponse message"))?;
+
+        let chain_id = chain_params.chain_id;
+        let assets = oblivious_client
+            .asset_list(tonic::Request::new(AssetListRequest {
+                chain_id: chain_id.clone(),
+            }))
+            .await?
+            .into_inner()
+            .asset_list
+            .ok_or_else(|| anyhow::anyhow!("empty AssetListResponse message"))?
+            .assets;
+
+        let mut known_assets = KnownAssets(vec![]);
+        for new_asset in assets {
+            let new_asset = Asset::try_from(new_asset)?;
+            known_assets.0.push(new_asset);
+        }
+
+        Ok((chain_id, known_assets.into()))
+    }
+
     pub async fn exec(&self, app: &mut App) -> Result<()> {
         match self {
             DaoCmd::Balance { asset } => self.print_balance(app, asset).await,
@@ -20,7 +57,7 @@ impl DaoCmd {
     }
 
     pub async fn print_balance(&self, app: &mut App, asset: &Option<String>) -> Result<()> {
-        let denom_by_asset = app.view().assets().await?;
+        let (_chain_id, denom_by_asset) = self.get_asset_cache(app).await?;
         let asset_by_denom = denom_by_asset
             .iter()
             .map(|(asset, denom)| (denom, asset))

--- a/pcli/src/command/query/dex.rs
+++ b/pcli/src/command/query/dex.rs
@@ -45,6 +45,7 @@ pub enum DexCmd {
 }
 
 impl DexCmd {
+    // TODO: this is duplicated between various pcli q subcommands, is there a single place it could live?
     async fn get_asset_cache(&self, app: &mut App) -> Result<(String, Cache)> {
         let mut oblivious_client = app.oblivious_client().await?;
 

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -28,6 +28,31 @@ service ObliviousQueryService {
   rpc EpochByHeight(EpochByHeightRequest) returns (EpochByHeightResponse);
   rpc ValidatorInfo(ValidatorInfoRequest) returns (stream ValidatorInfoResponse);
   rpc AssetList(AssetListRequest) returns (AssetListResponse);
+  rpc Info(InfoRequest) returns (InfoResponse);
+}
+
+// Requests information about the chain state as known by the node.
+message InfoRequest {
+  // The Tendermint software semantic version.
+  string version = 1;
+  // The Tendermint block protocol version.
+  uint64 block_version = 2;
+  // The Tendermint p2p protocol version.
+  uint64 p2p_version = 3;
+}
+
+// Contains information about the chain state as known by the node.
+message InfoResponse {
+    // Some arbitrary information.
+    bytes data = 1;
+    // The application software semantic version.
+    string version = 2;
+    // The application protocol version.
+    uint64 app_version = 3;
+    // The latest block for which the app has called [`Commit`](super::super::Request::Commit).
+    uint64 last_block_height = 4;
+    // The latest result of [`Commit`](super::super::Request::Commit).
+    bytes last_block_app_hash = 5;
 }
 
 // Requests a range of compact block data.

--- a/proto/src/gen/penumbra.client.v1alpha1.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.rs
@@ -1,3 +1,37 @@
+/// Requests information about the chain state as known by the node.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InfoRequest {
+    /// The Tendermint software semantic version.
+    #[prost(string, tag = "1")]
+    pub version: ::prost::alloc::string::String,
+    /// The Tendermint block protocol version.
+    #[prost(uint64, tag = "2")]
+    pub block_version: u64,
+    /// The Tendermint p2p protocol version.
+    #[prost(uint64, tag = "3")]
+    pub p2p_version: u64,
+}
+/// Contains information about the chain state as known by the node.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InfoResponse {
+    /// Some arbitrary information.
+    #[prost(bytes = "vec", tag = "1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+    /// The application software semantic version.
+    #[prost(string, tag = "2")]
+    pub version: ::prost::alloc::string::String,
+    /// The application protocol version.
+    #[prost(uint64, tag = "3")]
+    pub app_version: u64,
+    /// The latest block for which the app has called \[`Commit`\](super::super::Request::Commit).
+    #[prost(uint64, tag = "4")]
+    pub last_block_height: u64,
+    /// The latest result of \[`Commit`\](super::super::Request::Commit).
+    #[prost(bytes = "vec", tag = "5")]
+    pub last_block_app_hash: ::prost::alloc::vec::Vec<u8>,
+}
 /// Requests a range of compact block data.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -695,6 +729,25 @@ pub mod oblivious_query_service_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn info(
+            &mut self,
+            request: impl tonic::IntoRequest<super::InfoRequest>,
+        ) -> Result<tonic::Response<super::InfoResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/penumbra.client.v1alpha1.ObliviousQueryService/Info",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 /// Generated client implementations.
@@ -1252,6 +1305,10 @@ pub mod oblivious_query_service_server {
             &self,
             request: tonic::Request<super::AssetListRequest>,
         ) -> Result<tonic::Response<super::AssetListResponse>, tonic::Status>;
+        async fn info(
+            &self,
+            request: tonic::Request<super::InfoRequest>,
+        ) -> Result<tonic::Response<super::InfoResponse>, tonic::Status>;
     }
     /// Methods for accessing chain state that are "oblivious" in the sense that they
     /// do not request specific portions of the chain state that could reveal private
@@ -1508,6 +1565,43 @@ pub mod oblivious_query_service_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = AssetListSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/penumbra.client.v1alpha1.ObliviousQueryService/Info" => {
+                    #[allow(non_camel_case_types)]
+                    struct InfoSvc<T: ObliviousQueryService>(pub Arc<T>);
+                    impl<
+                        T: ObliviousQueryService,
+                    > tonic::server::UnaryService<super::InfoRequest> for InfoSvc<T> {
+                        type Response = super::InfoResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::InfoRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).info(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = InfoSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/proto/src/gen/penumbra.client.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.serde.rs
@@ -2323,6 +2323,307 @@ impl<'de> serde::Deserialize<'de> for GetTxResponse {
         deserializer.deserialize_struct("penumbra.client.v1alpha1.GetTxResponse", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for InfoRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.version.is_empty() {
+            len += 1;
+        }
+        if self.block_version != 0 {
+            len += 1;
+        }
+        if self.p2p_version != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.client.v1alpha1.InfoRequest", len)?;
+        if !self.version.is_empty() {
+            struct_ser.serialize_field("version", &self.version)?;
+        }
+        if self.block_version != 0 {
+            struct_ser.serialize_field("blockVersion", ToString::to_string(&self.block_version).as_str())?;
+        }
+        if self.p2p_version != 0 {
+            struct_ser.serialize_field("p2pVersion", ToString::to_string(&self.p2p_version).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for InfoRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "version",
+            "block_version",
+            "blockVersion",
+            "p2p_version",
+            "p2pVersion",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Version,
+            BlockVersion,
+            P2pVersion,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "version" => Ok(GeneratedField::Version),
+                            "blockVersion" | "block_version" => Ok(GeneratedField::BlockVersion),
+                            "p2pVersion" | "p2p_version" => Ok(GeneratedField::P2pVersion),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = InfoRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.client.v1alpha1.InfoRequest")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<InfoRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut version__ = None;
+                let mut block_version__ = None;
+                let mut p2p_version__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::Version => {
+                            if version__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("version"));
+                            }
+                            version__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::BlockVersion => {
+                            if block_version__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("blockVersion"));
+                            }
+                            block_version__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::P2pVersion => {
+                            if p2p_version__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("p2pVersion"));
+                            }
+                            p2p_version__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(InfoRequest {
+                    version: version__.unwrap_or_default(),
+                    block_version: block_version__.unwrap_or_default(),
+                    p2p_version: p2p_version__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.client.v1alpha1.InfoRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for InfoResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.data.is_empty() {
+            len += 1;
+        }
+        if !self.version.is_empty() {
+            len += 1;
+        }
+        if self.app_version != 0 {
+            len += 1;
+        }
+        if self.last_block_height != 0 {
+            len += 1;
+        }
+        if !self.last_block_app_hash.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.client.v1alpha1.InfoResponse", len)?;
+        if !self.data.is_empty() {
+            struct_ser.serialize_field("data", pbjson::private::base64::encode(&self.data).as_str())?;
+        }
+        if !self.version.is_empty() {
+            struct_ser.serialize_field("version", &self.version)?;
+        }
+        if self.app_version != 0 {
+            struct_ser.serialize_field("appVersion", ToString::to_string(&self.app_version).as_str())?;
+        }
+        if self.last_block_height != 0 {
+            struct_ser.serialize_field("lastBlockHeight", ToString::to_string(&self.last_block_height).as_str())?;
+        }
+        if !self.last_block_app_hash.is_empty() {
+            struct_ser.serialize_field("lastBlockAppHash", pbjson::private::base64::encode(&self.last_block_app_hash).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for InfoResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "data",
+            "version",
+            "app_version",
+            "appVersion",
+            "last_block_height",
+            "lastBlockHeight",
+            "last_block_app_hash",
+            "lastBlockAppHash",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Data,
+            Version,
+            AppVersion,
+            LastBlockHeight,
+            LastBlockAppHash,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "data" => Ok(GeneratedField::Data),
+                            "version" => Ok(GeneratedField::Version),
+                            "appVersion" | "app_version" => Ok(GeneratedField::AppVersion),
+                            "lastBlockHeight" | "last_block_height" => Ok(GeneratedField::LastBlockHeight),
+                            "lastBlockAppHash" | "last_block_app_hash" => Ok(GeneratedField::LastBlockAppHash),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = InfoResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.client.v1alpha1.InfoResponse")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<InfoResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut data__ = None;
+                let mut version__ = None;
+                let mut app_version__ = None;
+                let mut last_block_height__ = None;
+                let mut last_block_app_hash__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::Data => {
+                            if data__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("data"));
+                            }
+                            data__ = 
+                                Some(map.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Version => {
+                            if version__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("version"));
+                            }
+                            version__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::AppVersion => {
+                            if app_version__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("appVersion"));
+                            }
+                            app_version__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::LastBlockHeight => {
+                            if last_block_height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lastBlockHeight"));
+                            }
+                            last_block_height__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::LastBlockAppHash => {
+                            if last_block_app_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lastBlockAppHash"));
+                            }
+                            last_block_app_hash__ = 
+                                Some(map.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(InfoResponse {
+                    data: data__.unwrap_or_default(),
+                    version: version__.unwrap_or_default(),
+                    app_version: app_version__.unwrap_or_default(),
+                    last_block_height: last_block_height__.unwrap_or_default(),
+                    last_block_app_hash: last_block_app_hash__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.client.v1alpha1.InfoResponse", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for KeyValueRequest {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>


### PR DESCRIPTION
This allows the various `pcli q` commands to run entirely in offline mode.

I realized after writing this that I possibly could have used the existing `TendermintProxyService` rather than adding an `info` call proxy to `ObliviousQueryService`, but this can be cleaned up in a subsequent PR.

Closes #2223 