### PR TITLE
dex: fix inflation bug with clearer formulas

### DIFF
--- a/crypto/src/fixpoint.rs
+++ b/crypto/src/fixpoint.rs
@@ -20,6 +20,12 @@ pub enum Error {
     SliceLength(usize),
 }
 
+impl Default for U128x128 {
+    fn default() -> Self {
+        Self::from(0u64)
+    }
+}
+
 impl Debug for U128x128 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let (integral, fractional) = self.0.into_words();


### PR DESCRIPTION
I didn't notice this while reviewing, because the 1/2 typo was buried in conversions; this makes them clearer and adds a test. (We should add more test cases).