### PR TITLE
build: straighten out feature flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ target/
 
 # Python3
 .venv
+
+# Ignoring lock file for the parameter-setup tool.
+tools/parameter-setup/Cargo.lock

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -31,6 +31,6 @@ tracing = "0.1"
 num-rational = "0.4"
 
 [features]
-default = ["std", "storage"]
+default = ["std", "penumbra-storage"]
 std = ["ark-ff/std"]
-storage = ["penumbra-storage", "penumbra-proto/penumbra-storage" ]
+penumbra-storage = ["dep:penumbra-storage", "penumbra-proto/penumbra-storage" ]

--- a/chain/src/view.rs
+++ b/chain/src/view.rs
@@ -2,7 +2,9 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
+#[cfg(feature = "penumbra-storage")]
 use penumbra_proto::{StateReadProto, StateWriteProto};
+#[cfg(feature = "penumbra-storage")]
 use penumbra_storage::{StateRead, StateWrite};
 use tendermint::Time;
 

--- a/measure/Cargo.toml
+++ b/measure/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-penumbra-proto = { path = "../proto" }
+penumbra-proto = { path = "../proto", features = ["rpc"] }
 penumbra-chain = { path = "../chain" }
 
 tokio = { version = "1.21.1", features = ["full"] }
@@ -14,10 +14,10 @@ tonic = "0.8.1"
 anyhow = "1"
 clap = { version = "3", features = ["derive", "env"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2.2"
 indicatif = "0.16"
-reqwest = "0.11"
+reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1"
 bytesize = "1.2"
 

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -94,7 +94,7 @@ base64 = "0.20"
 console-subscriber = "0.1.8"
 metrics-tracing-context = "0.11.0"
 metrics-util = "0.13"
-clap = { version = "3", features = ["derive"] }
+clap = { version = "3", features = ["derive", "env"] }
 
 [build-dependencies]
 vergen = "5"

--- a/proof-params/build.rs
+++ b/proof-params/build.rs
@@ -31,6 +31,7 @@ fn main() {
     }
 }
 
+#[cfg(feature = "proving-keys")]
 /// Check that the proving key is not a Git LFS pointer.
 pub fn check_proving_key(file: &str) -> anyhow::Result<()> {
     let mut bytes = Vec::new();

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -32,3 +32,4 @@ tendermint = "0.29.0"
 
 [features]
 rpc = ["dep:tonic", "ibc-proto/client"]
+penumbra-storage = ["dep:penumbra-storage"]

--- a/tct/Cargo.toml
+++ b/tct/Cargo.toml
@@ -36,7 +36,7 @@ proptest-derive = { version = "0.3", optional = true }
 [features]
 internal = []
 arbitrary = ["proptest", "proptest-derive"]
-r1cs = ["ark-r1cs-std", "ark-relations", "decaf377/r1cs"]
+r1cs = ["ark-r1cs-std", "ark-relations", "decaf377/r1cs", "poseidon377/r1cs"]
 parallel = ["ark-r1cs-std/parallel", "ark-ff/parallel", "decaf377/parallel", "poseidon377/parallel"]
 
 [dev-dependencies]


### PR DESCRIPTION
Several of our crates failed to build under certain combinations of feature flags. Stepped through those crates and adjusted the feature logic where required.
    
Regarding runtime for this CI check, the wall time isn't bad, especially if we parallelize it with the other rust checks:
    
      command: cargo check-all-features --release
      warm cache: 1m39s
      cold cache: 12m4s
    
Notably, the disk usage is an order of magnitude higher:
    
      dir size of `target/`
      cargo build --release: ~3.4GB
      cargo check-all-features --release 25G(!)
    
In order to support that additional disk usage in CI caching layers, we'll likely have to pony up for more space on our CI runners.  Still, that's well worth the confidence that we have working builds across all feature combinations.
