### PR TITLE
ci: relayer container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,6 @@
-notes/**
-.github
-.firebaserc
-theme
-book.toml
-*.md
-Dockerfile
-docker-compose.yml
-*.json
+docs/
+.github/
 target/**
+
+# We'll generate relayer configs dynamically for now
+deployments/relayer/configs/*

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -95,3 +95,42 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  build-and-push-relayer:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Docker Hub container registry (for pulls)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to the GitHub container registry (for pushes)
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/penumbra-zone/relayer
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64
+          file: deployments/containerfiles/Dockerfile-relayer
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/deployments/containerfiles/Dockerfile-relayer
+++ b/deployments/containerfiles/Dockerfile-relayer
@@ -1,0 +1,28 @@
+FROM ghcr.io/cosmos/relayer:main AS upstream
+FROM docker.io/debian:stable
+
+# Normal user config build args
+ARG UID=1000
+ARG GID=1000
+ARG USERNAME=penumbra
+
+# Install apt deps.
+RUN apt-get update && apt-get install -y \
+        gettext-base \
+        curl \
+        jq \
+        && rm -r /var/lib/apt/lists
+
+# Copy rly binary from upstream image
+COPY --from=upstream /bin/rly /bin/rly
+
+# Create normal user account
+RUN groupadd -g ${GID} ${USERNAME} && useradd -m -d /home/${USERNAME} -g ${GID} -u ${UID} ${USERNAME}
+
+# Prepare custom config script
+RUN mkdir -p /usr/src/penumbra-relayer
+COPY deployments/relayer/ /usr/src/penumbra-relayer/
+WORKDIR /usr/src/penumbra-relayer
+RUN chown -R ${USERNAME}:${USERNAME} /usr/src/penumbra-relayer
+USER ${USERNAME}
+ENTRYPOINT ["/usr/src/penumbra-relayer/entrypoint.sh"]

--- a/deployments/relayer/configs/penumbra-preview.json
+++ b/deployments/relayer/configs/penumbra-preview.json
@@ -2,7 +2,7 @@
   "type": "penumbra",
   "value": {
     "key": "default",
-    "chain-id": "penumbra-testnet-pasiphae-fceecc9b",
+    "chain-id": "penumbra-testnet-pasiphae-5872bf50",
     "rpc-addr": "https://rpc.testnet-preview.penumbra.zone:443",
     "account-prefix": "penumbrav2t",
     "keyring-backend": "test",

--- a/deployments/relayer/configure-relayer
+++ b/deployments/relayer/configure-relayer
@@ -17,7 +17,8 @@ rly chains add-dir configs/
 #   Error: key default not found on src chain penumbra-testnet-carme-dac8be27
 for chain in $(rly chains list --json | jq 'keys | join("\n")' -r) ; do
     >&2 echo "Generating key for $chain"
-    rly keys add "$chain" default
+    # We silence output to avoid dumping seed phrases to screen/logging.
+    rly keys add "$chain" default > /dev/null
 done
 
 function create_paths() {

--- a/deployments/relayer/entrypoint.sh
+++ b/deployments/relayer/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Container entrypoint for running an IBC relayer for Penumbra,
+# specifically between penumbra-testnet and penumbra-preview.
+set -euo pipefail
+
+
+# Generate latest configs, polling chain id from RPC endpoints
+cd /usr/src/penumbra-relayer || exit 1
+./generate-configs preview
+./generate-configs testnet
+
+# Generate relayer YAML config, specifying Penumbra path.
+./configure-relayer
+rly --debug transact link penumbra_path
+cat <<EOM
+##############################################
+Finished configuring the relayer for Penumbra!
+Starting service...
+##############################################
+EOM
+# Run the relayer as a blocking service
+exec rly start penumbra_path


### PR DESCRIPTION
Towards #465. Here we define a container image that wraps the upstream cosmos/relayer image with the custom scripting for bootstrapping clients on the Penumbra testnet and preview networks. No other chain configs are part of this container image as of yet. The container image will be publicly available as `ghcr.io/penumbra-zone/relayer`. It isn't yet deployed to the cluster: that'll come next.