### PR TITLE
proto: enable grpc reflection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.bin filter=lfs diff=lfs merge=lfs -text
+proto/src/gen/proto_descriptor.bin filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -69,6 +69,9 @@ jobs:
         run: |
           cd tools/proto-compiler
           cargo run
+          cd ../..
+          # Ignore changes to the unstable proto_descriptor output
+          git checkout -- proto/src/gen/proto_descriptor.bin
           s="$(git status --porcelain)"
           if [[ -n "$s" ]]; then
               echo "ERROR: protobuf files must be regenerated and committed:"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,6 +14,8 @@ jobs:
     environment: smoke-test
     steps:
       - uses: actions/checkout@v2
+        with:
+          lfs: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3464,6 +3464,7 @@ dependencies = [
  "tokio-stream",
  "toml 0.5.11",
  "tonic",
+ "tonic-reflection",
  "tonic-web",
  "tower",
  "tracing",
@@ -3536,6 +3537,7 @@ dependencies = [
  "tokio-util 0.7.7",
  "toml 0.5.11",
  "tonic",
+ "tonic-reflection",
  "tonic-web",
  "tower",
  "tower-abci",
@@ -5956,6 +5958,20 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67494bad4dda4c9bffae901dfe14e2b2c0f760adb4706dc10beeb81799f7f7b2"
+dependencies = [
+ "bytes",
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/pclientd/Cargo.toml
+++ b/pclientd/Cargo.toml
@@ -40,6 +40,7 @@ http-body = "0.4.5"
 tower = "0.4.0"
 tonic = "0.8.1"
 tonic-web = "0.4.0"
+tonic-reflection = "0.6"
 bytes = { version = "1", features = ["serde"] }
 prost = "0.11"
 futures = "0.3"

--- a/pd/Cargo.toml
+++ b/pd/Cargo.toml
@@ -65,6 +65,7 @@ prost-types = "0.11"
 pbjson-types = "0.5"
 tonic = "0.8.1"
 tonic-web = "0.4.0"
+tonic-reflection = "0.6"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
 url = "2"
 pin-project = "1"

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -274,6 +274,14 @@ async fn main() -> anyhow::Result<()> {
                         .add_service(tonic_web::enable(TendermintProxyServiceServer::new(
                             tm_proxy.clone(),
                         )))
+                        .add_service(tonic_web::enable(
+                            tonic_reflection::server::Builder::configure()
+                                .register_encoded_file_descriptor_set(
+                                    penumbra_proto::FILE_DESCRIPTOR_SET,
+                                )
+                                .build()
+                                .with_context(|| "could not configure grpc reflection service")?,
+                        ))
                         .serve(grpc_bind),
                 )
                 .expect("failed to spawn grpc server");

--- a/proto/src/gen/proto_descriptor.bin
+++ b/proto/src/gen/proto_descriptor.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:531673bc794a2c5028361d953cf3dfc705636edb5167a8cc3591004df51c2055
+size 311829

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -266,3 +266,6 @@ pub mod tendermint {
         include!("gen/tendermint.p2p.rs");
     }
 }
+
+#[cfg(feature = "rpc")]
+pub const FILE_DESCRIPTOR_SET: &[u8] = include_bytes!("gen/proto_descriptor.bin");

--- a/tools/proto-compiler/src/main.rs
+++ b/tools/proto-compiler/src/main.rs
@@ -12,8 +12,7 @@ fn main() -> Result<()> {
         .join("gen");
     println!("{}", target_dir.display());
 
-    let tmpdir = tempfile::tempdir().unwrap();
-    let descriptor_path = tmpdir.path().to_owned().join("proto_descriptor.bin");
+    let descriptor_path = target_dir.join("proto_descriptor.bin");
 
     let mut config = prost_build::Config::new();
     config.out_dir(&target_dir);


### PR DESCRIPTION
To do this, we have to save the `proto_descriptor.bin` generated by Prost/Tonic.  It's currently 300KB and changes with every proto edit, so I attempted to configure it to use git lfs.

Then, in the `pclientd` and `pd` binaries, we add a grpc-web enabled version of the reflection service.

Closes #2299.