### PR TITLE
pcli: add stub export account-group-id for use with grpcui

### DIFF
--- a/pcli/src/command/keys.rs
+++ b/pcli/src/command/keys.rs
@@ -35,6 +35,8 @@ pub enum ImportCmd {
 pub enum ExportCmd {
     /// Export the full viewing key for the wallet.
     FullViewingKey,
+    /// Export the account group ID.
+    AccountGroupId,
 }
 
 impl KeysCmd {
@@ -85,6 +87,11 @@ impl KeysCmd {
             KeysCmd::Export(ExportCmd::FullViewingKey) => {
                 let wallet = KeyStore::load(data_dir.join(crate::CUSTODY_FILE_NAME))?;
                 println!("{}", wallet.spend_key.full_viewing_key());
+            }
+            KeysCmd::Export(ExportCmd::AccountGroupId) => {
+                let wallet = KeyStore::load(data_dir.join(crate::CUSTODY_FILE_NAME))?;
+                let account_group_id = wallet.spend_key.full_viewing_key().account_group_id();
+                println!("{}", serde_json::to_string_pretty(&account_group_id)?);
             }
             KeysCmd::Delete => {
                 let wallet_path = data_dir.join(crate::CUSTODY_FILE_NAME);


### PR DESCRIPTION
This lets you copy paste a base64 encoded string to access the `pclientd` rpcs