### PR TITLE
build: fix tm proxy feature for proto dep

### DIFF
--- a/tendermint-proxy/Cargo.toml
+++ b/tendermint-proxy/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 # Penumbra dependencies
-penumbra-proto = { path = "../proto" }
+penumbra-proto = { path = "../proto", features = ["rpc"] }
 penumbra-transaction = { path = "../transaction" }
 
 # External dependencies


### PR DESCRIPTION
This One Cool Change™ allows `cargo check-all-features --release` to pass without error. The tendermint-proxy crate (#2253) has a hard dependency on the "rpc" feature within the proto crate, so let's declare that explicitly.