### PR TITLE
pcli: try to support HTTPS URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6109,7 +6109,9 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-derive",
+ "rustls-pemfile",
  "tokio",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-util 0.7.7",
  "tower",
@@ -6117,6 +6119,7 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]

--- a/pcli/Cargo.toml
+++ b/pcli/Cargo.toml
@@ -54,7 +54,7 @@ tokio-stream = "0.1"
 tokio-util = "0.7"
 tower = { version = "0.4", features = ["full"] }
 tracing = "0.1"
-tonic = "0.8.1"
+tonic = { version = "0.8.1", features = ["tls-webpki-roots", "tls"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
 pin-project = "1"
 serde_json = "1"


### PR DESCRIPTION
I haven't got this working against https://grpc.testnet.penumbra.zone, which fails with
```
Error: status: Internal, message: "grpc-status header missing, mapped from HTTP status code 400", details: [], metadata: MetadataMap { headers: {"content-length": "0", "date": "Sat, 08 Apr 2023 21:51:34 GMT", "via": "1.1 google", "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"} }
```
but I think this isn't a problem with the `pcli` support, so this could be good to merge anyways (but not yet advertise).  Once we can get HTTPS working with grpc.testnet.penumbra.zone, we can switch the default endpoint over.