### PR TITLE
view: increase detection buffer sizes

### DIFF
--- a/view/src/storage.rs
+++ b/view/src/storage.rs
@@ -156,9 +156,9 @@ impl Storage {
         Ok(Storage {
             pool,
             uncommitted_height: Arc::new(Mutex::new(None)),
-            scanned_notes_tx: broadcast::channel(10).0,
-            scanned_nullifiers_tx: broadcast::channel(10).0,
-            scanned_swaps_tx: broadcast::channel(10).0,
+            scanned_notes_tx: broadcast::channel(128).0,
+            scanned_nullifiers_tx: broadcast::channel(512).0,
+            scanned_swaps_tx: broadcast::channel(128).0,
         })
     }
 


### PR DESCRIPTION
This avoids failures in propagating detections when transactions have many spends or outputs.