### PR TITLE
dex: correct definition of "effective price"

### DIFF
--- a/app/src/dex/position_manager.rs
+++ b/app/src/dex/position_manager.rs
@@ -129,7 +129,7 @@ pub trait PositionManager: StateWrite + PositionRead {
         input: Value,
         pair: DirectedTradingPair,
     ) -> Result<(Value, Value, Vec<position::Id>)> {
-        let mut position_ids = self.positions_by_price(pair).await;
+        let mut position_ids = self.positions_by_price(&pair);
 
         let zero = Value {
             asset_id: input.asset_id,

--- a/app/src/dex/router/path.rs
+++ b/app/src/dex/router/path.rs
@@ -53,7 +53,7 @@ impl<S: StateRead + 'static> Path<S> {
     }
 
     // Making this consuming forces callers to explicitly fork the path first.
-    pub async fn extend_to(mut self, new_end: asset::Id) -> Result<Option<Path<S>>> {
+    pub async fn extend_to(self, new_end: asset::Id) -> Result<Option<Path<S>>> {
         let span = tracing::debug_span!(parent: &self.span, "extend_to", new_end = ?new_end);
         // Passing to an inner function lets us control the span more precisely than if
         // we used the #[instrument] macro (which does something similar to this internally).
@@ -74,9 +74,9 @@ impl<S: StateRead + 'static> Path<S> {
         // Update and return the path.
         // TODO: gross
         let hop_price = if self.end() == &best_price_position.phi.pair.asset_1() {
-            best_price_position.phi.component.effective_price()
+            best_price_position.phi.component.bid_price()
         } else {
-            best_price_position.phi.component.flip().effective_price()
+            best_price_position.phi.component.ask_price()
         };
 
         if let Some(path_price) = self.price * hop_price {

--- a/app/src/dex/tests.rs
+++ b/app/src/dex/tests.rs
@@ -222,20 +222,21 @@ mod test {
         is well-ordered.
         */
 
-        let reserves = Reserves {
+        let reserves_1 = Reserves {
             r1: 0u64.into(),
             r2: 120_000u64.into(),
         };
+        let reserves_2 = reserves_1.clone();
+        let reserves_3 = reserves_1.clone();
 
         // Building positions:
-
         let position_1 = Position::new(
             OsRng,
             pair,
             9u32,
             1_000_000u64.into(),
             1_200_000u64.into(),
-            reserves.clone(),
+            reserves_1,
         );
 
         // Order B's trading function, with a 10 bps fee.
@@ -245,7 +246,7 @@ mod test {
             10u32,
             1_000_000u64.into(),
             1_200_000u64.into(),
-            reserves.clone(),
+            reserves_2,
         );
 
         // Order C's trading function with an 11 bps fee
@@ -255,7 +256,7 @@ mod test {
             11u32,
             1_000_000u64.into(),
             1_200_000u64.into(),
-            reserves.clone(),
+            reserves_3,
         );
 
         let position_1_id = position_1.id();
@@ -278,9 +279,12 @@ mod test {
             asset_id: gm.id(),
         };
 
-        let (unfilled, output) = state_test_1
+        let (unfilled, output, positions_touched) = state_test_1
             .fill(delta_1, DirectedTradingPair::new(gm.id(), gn.id()))
             .await?;
+
+        assert_eq!(positions_touched.len(), 1);
+        assert_eq!(positions_touched[0], position_1_id);
 
         assert_eq!(unfilled.amount, Amount::zero());
         assert_eq!(output.amount, 120_000u64.into());
@@ -303,9 +307,13 @@ mod test {
             asset_id: gm.id(),
         };
 
-        let (unfilled, output) = state_test_2
+        let (unfilled, output, positions_touched) = state_test_2
             .fill(delta_1, DirectedTradingPair::new(gm.id(), gn.id()))
             .await?;
+
+        assert_eq!(positions_touched.len(), 2);
+        assert_eq!(positions_touched[0], position_1_id);
+        assert_eq!(positions_touched[1], position_2_id);
 
         assert_eq!(unfilled.amount, Amount::zero());
         assert_eq!(output.amount, 240_000u64.into());
@@ -328,9 +336,14 @@ mod test {
             asset_id: gm.id(),
         };
 
-        let (unfilled, output) = state_test_3
+        let (unfilled, output, positions_touched) = state_test_3
             .fill(delta_1, DirectedTradingPair::new(gm.id(), gn.id()))
             .await?;
+
+        assert_eq!(positions_touched.len(), 3);
+        assert_eq!(positions_touched[0], position_1_id);
+        assert_eq!(positions_touched[1], position_2_id);
+        assert_eq!(positions_touched[2], position_3_id);
 
         assert_eq!(unfilled.amount, Amount::zero());
         assert_eq!(output.amount, 360_000u64.into());

--- a/app/src/dex/tests.rs
+++ b/app/src/dex/tests.rs
@@ -45,8 +45,8 @@ mod test {
             OsRng,
             pair,
             0u32,
-            1_000_000u64.into(),
             1_200_000u64.into(),
+            1_000_000u64.into(),
             reserves,
         );
 
@@ -234,8 +234,8 @@ mod test {
             OsRng,
             pair,
             9u32,
-            1_000_000u64.into(),
             1_200_000u64.into(),
+            1_000_000u64.into(),
             reserves_1,
         );
 
@@ -244,8 +244,8 @@ mod test {
             OsRng,
             pair,
             10u32,
-            1_000_000u64.into(),
             1_200_000u64.into(),
+            1_000_000u64.into(),
             reserves_2,
         );
 
@@ -254,8 +254,8 @@ mod test {
             OsRng,
             pair,
             11u32,
-            1_000_000u64.into(),
             1_200_000u64.into(),
+            1_000_000u64.into(),
             reserves_3,
         );
 

--- a/crypto/src/dex/lp/trading_function.rs
+++ b/crypto/src/dex/lp/trading_function.rs
@@ -372,10 +372,12 @@ mod tests {
         assert_eq!(btf.effective_price(), price_with_fee);
         let bytes2 = btf.effective_price_key_bytes();
 
-        // Assert that the encoded effective prices' lexicographic order
-        // matches their numerical order.
+        // Assert that the effective price ordering (cheaper is better) matches the
+        // encoded lexicographic ordering.
+        //
+        // The cheaper price (bytes1) vs. the more expensive price (bytes2)
 
-        assert!(bytes1 > bytes2);
+        assert!(bytes2 > bytes1);
     }
 
     #[test]

--- a/crypto/src/dex/lp/trading_function.rs
+++ b/crypto/src/dex/lp/trading_function.rs
@@ -229,9 +229,10 @@ impl BareTradingFunction {
             //  fillable_delta_1_exact = ceil(RHS) is integral (rounded), and
             //  delta_1 is integral by definition.
             //
-            //  where delta_1 is integral, therefore we have:
+            //  Therefore, we have:
             //
             //  delta_1 > fillable_delta_1_exact, or in other words:
+            //
             //  unfilled_amount > 0.
             let unfilled_amount = delta_1 - fillable_delta_1_exact;
 
@@ -264,6 +265,9 @@ impl BareTradingFunction {
             .expect("gamma, q != 0")
     }
 
+    /// Applies the effective price formula with extra-parameters for the numerator
+    /// and denominator. This is useful to conserve precision by operating multiplications
+    /// before the checked division is applied.
     pub fn effective_price_with_precompute(
         &self,
         num: U128x128,

--- a/crypto/src/dex/lp/trading_function.rs
+++ b/crypto/src/dex/lp/trading_function.rs
@@ -296,6 +296,15 @@ impl BareTradingFunction {
     pub fn gamma(&self) -> U128x128 {
         (U128x128::from(10_000 - self.fee) / U128x128::from(10_000u64)).expect("10_000 != 0")
     }
+
+    /// Compose two trading functions together
+    /// TODO(erwan): might have a use for working out capacity, but probably to deprecate.
+    pub fn compose(&self, phi: BareTradingFunction) -> BareTradingFunction {
+        let fee = self.fee * phi.fee;
+        let r1 = self.p * phi.p;
+        let r2 = self.q * phi.q;
+        BareTradingFunction::new(fee, r1, r2)
+    }
 }
 
 impl DomainType for BareTradingFunction {
@@ -332,8 +341,6 @@ impl From<BareTradingFunction> for pb::BareTradingFunction {
 
 #[cfg(test)]
 mod tests {
-    use proptest::strategy::W;
-
     use super::*;
 
     #[test]

--- a/crypto/src/dex/lp/trading_function.rs
+++ b/crypto/src/dex/lp/trading_function.rs
@@ -370,7 +370,7 @@ mod tests {
         let bytes2 = btf.effective_price_key_bytes();
         let price2 = btf.ask_price();
 
-        // Asserts that the lexicographic ordering of the encoded prices matches 
+        // Asserts that the lexicographic ordering of the encoded prices matches
         // their ask price ordering (smaller = better).
         //
         // price1: trading function with 0 bps fee.

--- a/proto/proto/buf.lock
+++ b/proto/proto/buf.lock
@@ -8,7 +8,7 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: cosmos-sdk
-    commit: 58a30ac6287449edae0db1540a7e5010
+    commit: 6ebeaa90891f46db815bd031a01c0381
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto


### PR DESCRIPTION
The definition we use elsewhere is that a better price is a lower one; this aligns the `effective_price` method to that definition.

WIP: need to update rounding edge-case tests.