### PR TITLE
ci: pin tag for upstream relayer image

### DIFF
--- a/deployments/containerfiles/Dockerfile-relayer
+++ b/deployments/containerfiles/Dockerfile-relayer
@@ -1,4 +1,7 @@
-FROM ghcr.io/cosmos/relayer:main AS upstream
+# FROM ghcr.io/cosmos/relayer:main AS upstream
+# Temporarily track upstream image built from unmerged PR:
+# https://github.com/cosmos/relayer/pull/1168
+FROM ghcr.io/penumbra-zone/relayer:penumbra-proto-update AS upstream
 FROM docker.io/debian:stable
 
 # Normal user config build args


### PR DESCRIPTION
Trying out a new version of the relayer, including updated protobufs, from PR [0]. Built that container locally, based on the checked out PR, and pushed to ghcr within our GH org.

Refs #2330 

[0] https://github.com/cosmos/relayer/pull/1168