### PR TITLE
Vendor Cosmos SDK `DenomMetadata` and serve for `AssetInfoRequest`

### DIFF
--- a/pd/src/info/specific.rs
+++ b/pd/src/info/specific.rs
@@ -22,6 +22,7 @@ use penumbra_proto::{
         ProposalInfoResponse, ProposalRateDataRequest, ProposalRateDataResponse,
         StubCpmmReservesRequest, ValidatorStatusRequest,
     },
+    core::crypto::v1alpha1::{DenomMetadata, DenomUnit},
     StateReadProto as _,
 };
 
@@ -317,8 +318,26 @@ impl SpecificQueryService for Info {
         let rsp = match denom {
             Some(denom) => {
                 tracing::debug!(?id, ?denom, "found denom");
+
+                let base_unit = DenomUnit {
+                    denom: denom.to_string(),
+                    exponent: 0,
+                    aliases: vec![],
+                };
+
                 AssetInfoResponse {
-                    asset: Some(Asset { id, denom }.into()),
+                    denom_metadata: Some(DenomMetadata {
+                        base: base_unit.denom.clone(),
+                        display: base_unit.denom.clone(),
+                        denom_units: vec![base_unit],
+                        penumbra_asset_id: Some(id.into()),
+                        // TODO: Keep track of this metadata and report it for Penumbra's own assets
+                        name: Default::default(),
+                        description: Default::default(),
+                        symbol: Default::default(),
+                        uri: Default::default(),
+                        uri_hash: Default::default(),
+                    }),
                 }
             }
             None => {

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -240,7 +240,7 @@ message AssetInfoResponse {
   // If present, information on the requested asset.
   //
   // If the requested asset was unknown, this field will not be present.
-  core.crypto.v1alpha1.Asset asset = 1;
+  core.crypto.v1alpha1.DenomMetadata denom_metadata = 1;
 }
 
 message ProposalInfoRequest {

--- a/proto/proto/penumbra/core/crypto/v1alpha1/crypto.proto
+++ b/proto/proto/penumbra/core/crypto/v1alpha1/crypto.proto
@@ -219,3 +219,46 @@ message ZKUndelegateClaimProof {
 message ZKDelegatorVoteProof {
     bytes inner = 1;
 }
+
+// DenomMetadata represents a struct that describes a basic token.
+//
+// Vendored from Cosmos SDK, plus an extra field for the Penumbra asset ID.
+message DenomMetadata {
+    string description = 1;
+    // denom_units represents the list of DenomUnit's for a given coin
+    repeated DenomUnit denom_units = 2;
+    // base represents the base denom (should be the DenomUnit with exponent = 0).
+    string base = 3;
+    // display indicates the suggested denom that should be
+    // displayed in clients.
+    string display = 4;
+    // name defines the name of the token (eg: Cosmos Atom)
+    string name = 5;
+    // symbol is the token symbol usually shown on exchanges (eg: ATOM). This can
+    // be the same as the display.
+    string symbol = 6;
+    // URI to a document (on or off-chain) that contains additional information. Optional.
+    string uri = 7;
+    // URIHash is a sha256 hash of a document pointed by URI. It's used to verify that
+    // the document didn't change. Optional.
+    string uri_hash = 8;
+
+    // the asset ID on Penumbra for this denomination.
+    AssetId penumbra_asset_id = 1984;
+}
+
+// DenomUnit represents a struct that describes a given denomination unit of the basic token.
+//
+// Vendored from Cosmos SDK.
+message DenomUnit {
+    // denom represents the string name of the given denom unit (e.g uatom).
+    string denom = 1;
+    // exponent represents power of 10 exponent that one must
+    // raise the base_denom to in order to equal the given DenomUnit's denom
+    // 1 denom = 10^exponent base_denom
+    // (e.g. with a base_denom of uatom, one can create a DenomUnit of 'atom' with
+    // exponent = 6, thus: 1 atom = 10^6 uatom).
+    uint32 exponent = 2;
+    // aliases is a list of string aliases for the given denom
+    repeated string aliases = 3;
+}

--- a/proto/src/gen/penumbra.client.v1alpha1.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.rs
@@ -295,7 +295,9 @@ pub struct AssetInfoResponse {
     ///
     /// If the requested asset was unknown, this field will not be present.
     #[prost(message, optional, tag = "1")]
-    pub asset: ::core::option::Option<super::super::core::crypto::v1alpha1::Asset>,
+    pub denom_metadata: ::core::option::Option<
+        super::super::core::crypto::v1alpha1::DenomMetadata,
+    >,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/proto/src/gen/penumbra.client.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.serde.rs
@@ -262,12 +262,12 @@ impl serde::Serialize for AssetInfoResponse {
     {
         use serde::ser::SerializeStruct;
         let mut len = 0;
-        if self.asset.is_some() {
+        if self.denom_metadata.is_some() {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("penumbra.client.v1alpha1.AssetInfoResponse", len)?;
-        if let Some(v) = self.asset.as_ref() {
-            struct_ser.serialize_field("asset", v)?;
+        if let Some(v) = self.denom_metadata.as_ref() {
+            struct_ser.serialize_field("denomMetadata", v)?;
         }
         struct_ser.end()
     }
@@ -279,12 +279,13 @@ impl<'de> serde::Deserialize<'de> for AssetInfoResponse {
         D: serde::Deserializer<'de>,
     {
         const FIELDS: &[&str] = &[
-            "asset",
+            "denom_metadata",
+            "denomMetadata",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
-            Asset,
+            DenomMetadata,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -306,7 +307,7 @@ impl<'de> serde::Deserialize<'de> for AssetInfoResponse {
                         E: serde::de::Error,
                     {
                         match value {
-                            "asset" => Ok(GeneratedField::Asset),
+                            "denomMetadata" | "denom_metadata" => Ok(GeneratedField::DenomMetadata),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -326,19 +327,19 @@ impl<'de> serde::Deserialize<'de> for AssetInfoResponse {
                 where
                     V: serde::de::MapAccess<'de>,
             {
-                let mut asset__ = None;
+                let mut denom_metadata__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
-                        GeneratedField::Asset => {
-                            if asset__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("asset"));
+                        GeneratedField::DenomMetadata => {
+                            if denom_metadata__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("denomMetadata"));
                             }
-                            asset__ = map.next_value()?;
+                            denom_metadata__ = map.next_value()?;
                         }
                     }
                 }
                 Ok(AssetInfoResponse {
-                    asset: asset__,
+                    denom_metadata: denom_metadata__,
                 })
             }
         }

--- a/proto/src/gen/penumbra.core.crypto.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.crypto.v1alpha1.rs
@@ -338,3 +338,59 @@ pub struct ZkDelegatorVoteProof {
     #[prost(bytes = "vec", tag = "1")]
     pub inner: ::prost::alloc::vec::Vec<u8>,
 }
+/// DenomMetadata represents a struct that describes a basic token.
+///
+/// Vendored from Cosmos SDK, plus an extra field for the Penumbra asset ID.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DenomMetadata {
+    #[prost(string, tag = "1")]
+    pub description: ::prost::alloc::string::String,
+    /// denom_units represents the list of DenomUnit's for a given coin
+    #[prost(message, repeated, tag = "2")]
+    pub denom_units: ::prost::alloc::vec::Vec<DenomUnit>,
+    /// base represents the base denom (should be the DenomUnit with exponent = 0).
+    #[prost(string, tag = "3")]
+    pub base: ::prost::alloc::string::String,
+    /// display indicates the suggested denom that should be
+    /// displayed in clients.
+    #[prost(string, tag = "4")]
+    pub display: ::prost::alloc::string::String,
+    /// name defines the name of the token (eg: Cosmos Atom)
+    #[prost(string, tag = "5")]
+    pub name: ::prost::alloc::string::String,
+    /// symbol is the token symbol usually shown on exchanges (eg: ATOM). This can
+    /// be the same as the display.
+    #[prost(string, tag = "6")]
+    pub symbol: ::prost::alloc::string::String,
+    /// URI to a document (on or off-chain) that contains additional information. Optional.
+    #[prost(string, tag = "7")]
+    pub uri: ::prost::alloc::string::String,
+    /// URIHash is a sha256 hash of a document pointed by URI. It's used to verify that
+    /// the document didn't change. Optional.
+    #[prost(string, tag = "8")]
+    pub uri_hash: ::prost::alloc::string::String,
+    /// the asset ID on Penumbra for this denomination.
+    #[prost(message, optional, tag = "1984")]
+    pub penumbra_asset_id: ::core::option::Option<AssetId>,
+}
+/// DenomUnit represents a struct that describes a given denomination unit of the basic token.
+///
+/// Vendored from Cosmos SDK.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DenomUnit {
+    /// denom represents the string name of the given denom unit (e.g uatom).
+    #[prost(string, tag = "1")]
+    pub denom: ::prost::alloc::string::String,
+    /// exponent represents power of 10 exponent that one must
+    /// raise the base_denom to in order to equal the given DenomUnit's denom
+    /// 1 denom = 10^exponent base_denom
+    /// (e.g. with a base_denom of uatom, one can create a DenomUnit of 'atom' with
+    /// exponent = 6, thus: 1 atom = 10^6 uatom).
+    #[prost(uint32, tag = "2")]
+    pub exponent: u32,
+    /// aliases is a list of string aliases for the given denom
+    #[prost(string, repeated, tag = "3")]
+    pub aliases: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}

--- a/proto/src/gen/penumbra.core.crypto.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.core.crypto.v1alpha1.serde.rs
@@ -1398,6 +1398,363 @@ impl<'de> serde::Deserialize<'de> for Denom {
         deserializer.deserialize_struct("penumbra.core.crypto.v1alpha1.Denom", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for DenomMetadata {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.description.is_empty() {
+            len += 1;
+        }
+        if !self.denom_units.is_empty() {
+            len += 1;
+        }
+        if !self.base.is_empty() {
+            len += 1;
+        }
+        if !self.display.is_empty() {
+            len += 1;
+        }
+        if !self.name.is_empty() {
+            len += 1;
+        }
+        if !self.symbol.is_empty() {
+            len += 1;
+        }
+        if !self.uri.is_empty() {
+            len += 1;
+        }
+        if !self.uri_hash.is_empty() {
+            len += 1;
+        }
+        if self.penumbra_asset_id.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.core.crypto.v1alpha1.DenomMetadata", len)?;
+        if !self.description.is_empty() {
+            struct_ser.serialize_field("description", &self.description)?;
+        }
+        if !self.denom_units.is_empty() {
+            struct_ser.serialize_field("denomUnits", &self.denom_units)?;
+        }
+        if !self.base.is_empty() {
+            struct_ser.serialize_field("base", &self.base)?;
+        }
+        if !self.display.is_empty() {
+            struct_ser.serialize_field("display", &self.display)?;
+        }
+        if !self.name.is_empty() {
+            struct_ser.serialize_field("name", &self.name)?;
+        }
+        if !self.symbol.is_empty() {
+            struct_ser.serialize_field("symbol", &self.symbol)?;
+        }
+        if !self.uri.is_empty() {
+            struct_ser.serialize_field("uri", &self.uri)?;
+        }
+        if !self.uri_hash.is_empty() {
+            struct_ser.serialize_field("uriHash", &self.uri_hash)?;
+        }
+        if let Some(v) = self.penumbra_asset_id.as_ref() {
+            struct_ser.serialize_field("penumbraAssetId", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for DenomMetadata {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "description",
+            "denom_units",
+            "denomUnits",
+            "base",
+            "display",
+            "name",
+            "symbol",
+            "uri",
+            "uri_hash",
+            "uriHash",
+            "penumbra_asset_id",
+            "penumbraAssetId",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Description,
+            DenomUnits,
+            Base,
+            Display,
+            Name,
+            Symbol,
+            Uri,
+            UriHash,
+            PenumbraAssetId,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "description" => Ok(GeneratedField::Description),
+                            "denomUnits" | "denom_units" => Ok(GeneratedField::DenomUnits),
+                            "base" => Ok(GeneratedField::Base),
+                            "display" => Ok(GeneratedField::Display),
+                            "name" => Ok(GeneratedField::Name),
+                            "symbol" => Ok(GeneratedField::Symbol),
+                            "uri" => Ok(GeneratedField::Uri),
+                            "uriHash" | "uri_hash" => Ok(GeneratedField::UriHash),
+                            "penumbraAssetId" | "penumbra_asset_id" => Ok(GeneratedField::PenumbraAssetId),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = DenomMetadata;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.core.crypto.v1alpha1.DenomMetadata")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<DenomMetadata, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut description__ = None;
+                let mut denom_units__ = None;
+                let mut base__ = None;
+                let mut display__ = None;
+                let mut name__ = None;
+                let mut symbol__ = None;
+                let mut uri__ = None;
+                let mut uri_hash__ = None;
+                let mut penumbra_asset_id__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::Description => {
+                            if description__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("description"));
+                            }
+                            description__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::DenomUnits => {
+                            if denom_units__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("denomUnits"));
+                            }
+                            denom_units__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::Base => {
+                            if base__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("base"));
+                            }
+                            base__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::Display => {
+                            if display__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("display"));
+                            }
+                            display__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::Name => {
+                            if name__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("name"));
+                            }
+                            name__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::Symbol => {
+                            if symbol__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("symbol"));
+                            }
+                            symbol__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::Uri => {
+                            if uri__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("uri"));
+                            }
+                            uri__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::UriHash => {
+                            if uri_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("uriHash"));
+                            }
+                            uri_hash__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::PenumbraAssetId => {
+                            if penumbra_asset_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("penumbraAssetId"));
+                            }
+                            penumbra_asset_id__ = map.next_value()?;
+                        }
+                    }
+                }
+                Ok(DenomMetadata {
+                    description: description__.unwrap_or_default(),
+                    denom_units: denom_units__.unwrap_or_default(),
+                    base: base__.unwrap_or_default(),
+                    display: display__.unwrap_or_default(),
+                    name: name__.unwrap_or_default(),
+                    symbol: symbol__.unwrap_or_default(),
+                    uri: uri__.unwrap_or_default(),
+                    uri_hash: uri_hash__.unwrap_or_default(),
+                    penumbra_asset_id: penumbra_asset_id__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.core.crypto.v1alpha1.DenomMetadata", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for DenomUnit {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.denom.is_empty() {
+            len += 1;
+        }
+        if self.exponent != 0 {
+            len += 1;
+        }
+        if !self.aliases.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.core.crypto.v1alpha1.DenomUnit", len)?;
+        if !self.denom.is_empty() {
+            struct_ser.serialize_field("denom", &self.denom)?;
+        }
+        if self.exponent != 0 {
+            struct_ser.serialize_field("exponent", &self.exponent)?;
+        }
+        if !self.aliases.is_empty() {
+            struct_ser.serialize_field("aliases", &self.aliases)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for DenomUnit {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "denom",
+            "exponent",
+            "aliases",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Denom,
+            Exponent,
+            Aliases,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "denom" => Ok(GeneratedField::Denom),
+                            "exponent" => Ok(GeneratedField::Exponent),
+                            "aliases" => Ok(GeneratedField::Aliases),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = DenomUnit;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.core.crypto.v1alpha1.DenomUnit")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<DenomUnit, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut denom__ = None;
+                let mut exponent__ = None;
+                let mut aliases__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::Denom => {
+                            if denom__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("denom"));
+                            }
+                            denom__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::Exponent => {
+                            if exponent__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("exponent"));
+                            }
+                            exponent__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Aliases => {
+                            if aliases__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("aliases"));
+                            }
+                            aliases__ = Some(map.next_value()?);
+                        }
+                    }
+                }
+                Ok(DenomUnit {
+                    denom: denom__.unwrap_or_default(),
+                    exponent: exponent__.unwrap_or_default(),
+                    aliases: aliases__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.core.crypto.v1alpha1.DenomUnit", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for Diversifier {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/proto/src/gen/proto_descriptor.bin
+++ b/proto/src/gen/proto_descriptor.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:316f0f93950e03a8dd7d7362028def11aa0b4429b524adf4b5ca558861751f68
-size 335732
+oid sha256:e4f258ec588fa21d6db75c81cdee4aef895f7bd321d466f36e71e9fd410a884c
+size 338318


### PR DESCRIPTION
We don't currently consume `AssetInfoResponse` in the client (we fetch all the assets in one go), so this doesn't need to alter client implementation.

Currently this does not report any special information for penumbra native denominations; that is, it only reports the base denom and no information about suggested name or symbol, etc. Should that be in a follow-up PR or in this one?