### PR TITLE
build: fail proto if missing proto descriptor

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -30,6 +30,9 @@ ibc = "0.29"
 ics23 = "0.9.0"
 tendermint = "0.29.0"
 
+[build-dependencies]
+anyhow = "1"
+
 [features]
 rpc = ["dep:tonic", "ibc-proto/client"]
 penumbra-storage = ["dep:penumbra-storage"]

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,0 +1,40 @@
+use anyhow::Context;
+use std::io::Read;
+
+fn main() -> anyhow::Result<()> {
+    let f = "src/gen/proto_descriptor.bin";
+    check_file_is_not_lfs_pointer(f)?;
+    Ok(())
+}
+
+// Support for gRPC server reflection requires that we load
+// a `proto_descriptor.bin` file at build time. We store that file
+// in git-lfs, so if git-lfs isn't installed, it'll be a plaintext pointer
+// file, rather than a larger binary blob. Let's just check for a filesize
+// greater than ~500bytes, that's a good enough check for whether the file
+// has been properly checked out from lfs.
+pub fn check_file_is_not_lfs_pointer(file: &str) -> anyhow::Result<()> {
+    let mut bytes = Vec::new();
+    {
+        let f = std::fs::File::open(file).with_context(|| "can open proto descriptor file")?;
+        let mut reader = std::io::BufReader::new(f);
+        reader
+            .read_to_end(&mut bytes)
+            .with_context(|| "can read proto descriptor file")?;
+    }
+    // We expect ~300Kb for the descriptor file, so 500b is a conservative minimum.
+    if bytes.len() < 500 {
+        let msg = format!(
+            "Error: the protobuf descriptor file is too small.
+Check that you have git-lfs installed, then run:
+
+   git lfs fetch
+   git lfs checkout
+
+and retry the build."
+        );
+
+        return Err(anyhow::anyhow!(msg));
+    }
+    return Ok(());
+}


### PR DESCRIPTION
If the build machine lacks git-lfs, then the binary `proto_descriptor.bin` file will just be a plaintext pointer file. Let's check that file's size, and if it's too small, we error out with some helpful recovery steps.

Closes #2354.

### Testing

If you want to test this locally:

```
# First, uninstall git-lfs from your system. 
# Then clone the repo fresh:
git clone https://github.com/penumbra-zone/penumbra penumbra-no-lfs
cd penumbra-no-lfs
cargo build --release
```

You should see an error message. If you don't, the logic in this PR is bad, and should be fixed. If you do, follow the recovery steps in that error message. If they resolve the situation, great! If you're still stuck, that means we should fix up the message.