### PR TITLE
Fix `Path::extend` orientation

### DIFF
--- a/app/src/dex/router/path.rs
+++ b/app/src/dex/router/path.rs
@@ -71,15 +71,15 @@ impl<S: StateRead + 'static> Path<S> {
         use super::super::position_manager::Inner as _;
         self.state.deindex_position(&best_price_position);
 
-        // Update and return the path.
-        // TODO: gross
-        let hop_price = if self.end() == &best_price_position.phi.pair.asset_1() {
-            best_price_position.phi.component.effective_price_inv()
-        } else {
-            best_price_position.phi.component.effective_price()
-        };
+        // Compute the effective price of a trade in the direction self.end()=>new_end
+        let hop_price = best_price_position
+            .phi
+            .orient_end(new_end)
+            .unwrap()
+            .effective_price();
 
         if let Some(path_price) = self.price * hop_price {
+            // Update and return the path.
             tracing::debug!(%path_price, %hop_price, id = ?best_price_position.id(), "extended path");
             self.price = path_price;
             self.nodes.push(new_end);

--- a/app/src/dex/router/path.rs
+++ b/app/src/dex/router/path.rs
@@ -74,9 +74,9 @@ impl<S: StateRead + 'static> Path<S> {
         // Update and return the path.
         // TODO: gross
         let hop_price = if self.end() == &best_price_position.phi.pair.asset_1() {
-            best_price_position.phi.component.bid_price()
+            best_price_position.phi.component.effective_price_inv()
         } else {
-            best_price_position.phi.component.ask_price()
+            best_price_position.phi.component.effective_price()
         };
 
         if let Some(path_price) = self.price * hop_price {

--- a/crypto/src/asset/denom.rs
+++ b/crypto/src/asset/denom.rs
@@ -296,6 +296,10 @@ impl Unit {
             .expect("there must be an entry for unit_index")
             .exponent
     }
+
+    pub fn unit_amount(&self) -> asset::Amount {
+        10u128.pow(self.exponent().into()).into()
+    }
 }
 
 impl Hash for Unit {

--- a/crypto/src/dex/lp/trading_function.rs
+++ b/crypto/src/dex/lp/trading_function.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
+use crate::asset;
 use crate::dex::TradingPair;
 use crate::fixpoint::U128x128;
 use crate::Amount;
@@ -69,6 +70,26 @@ impl TradingFunction {
                 input.asset_id,
                 self.pair
             ))
+        }
+    }
+
+    pub fn orient_end(&self, end: asset::Id) -> Option<BareTradingFunction> {
+        if end == self.pair.asset_2() {
+            Some(self.component.clone())
+        } else if end == self.pair.asset_1() {
+            Some(self.component.flip())
+        } else {
+            None
+        }
+    }
+
+    pub fn orient_start(&self, start: asset::Id) -> Option<BareTradingFunction> {
+        if start == self.pair.asset_1() {
+            Some(self.component.clone())
+        } else if start == self.pair.asset_2() {
+            Some(self.component.flip())
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
This PR cherry-picks from and replaces #2362.

This PR:
```
cheap: 0.6668667066733344
expensive: 1.0003000600100016
```
#2362:
```
cheap: 0.666466686666
expensive: 0.999700029999
```
The `expensive` path is going `gm=>gn=>pusd=>penumbra`; per the comment, the relative prices are 1:2, 2:1, 1:1, so this should be unit price plus the cost of fees, and that means that the price has to be _greater_ than 1, because the fees increase the cost.

Side note: the exchange rates seem wrong, we should have gm:gn be the unit price pair (as if they were two different path representations) and have the gm/gn:pusd and penumbra:pusd pairs be the free-floating ones.