### PR TITLE
docs: how to run relayer via local devnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ target/
 
 # Ignoring lock file for the parameter-setup tool.
 tools/parameter-setup/Cargo.lock
+
+# Relayer config referencing local devnet, will always be unique
+# to current host env.
+deployments/relayer/configs/penumbra-local.json

--- a/deployments/relayer/README.md
+++ b/deployments/relayer/README.md
@@ -17,6 +17,18 @@ Or, you can use `just` to run it all, soup to nuts. See the path configuration
 block in the `./configure-relayer` script for some example paths between chains
 that aren't yet known to work.
 
+## Updating proto definitions in relayer
+Sometimes the protos between preview & testnet get out of sync. When this happens,
+we must submit a PR upstream to the relayer repo. See [example here](https://github.com/cosmos/relayer/pull/1170),
+along with instructions on the commands to generate the protos for the golang repo.
+Until the protos are back in sync, relaying between Penumbra chains may not work.
+
+## Running a local devnet
+By default the relayer scripts configure a path between testnet and preview.
+For debugging, it can be useful to use a path between a local devnet and preview,
+potentially even on the same git commit. See the instructions in [GH 2252](https://github.com/penumbra-zone/penumbra/issues/2252)
+for details on how to set it up. You may need to edit the chain ids in `./configure-relayer`.
+
 ## Further reading
 The config format for the JSON files are adapted from the [example-configs](https://github.com/cosmos/relayer/tree/main/docs/example-configs)
 in the relayer repo. Our configs will get out of date very quickly: the preview chain id changes

--- a/deployments/relayer/generate-configs
+++ b/deployments/relayer/generate-configs
@@ -3,7 +3,7 @@ set -euo pipefail
 
 
 if [[ $# -lt 1 ]] ; then
-    >&2 echo "ERROR: no network declared. Use either 'testnet' or 'preview'."
+    >&2 echo "ERROR: no network declared. Use one of: testnet, preview, or local."
     >&2 echo "Usage: $0 <network>"
     exit 1
 fi


### PR DESCRIPTION
Adds some docs on maintenance tasks and common testing procedures. Links out to information elsewhere, just making it discoverable via the relayer README.

Refs #465, #2252.