### PR TITLE
ci: update tag format for deploy workflow

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -26,7 +26,7 @@ on:
         default: '1000:1000'
   push:
     tags:
-      - '[0-9][0-9][0-9]-*'
+      - '*-?v[0-9]+*'
 jobs:
   # Before deploying, we must wait for the container build to complete,
   # so that the relevant tag is present in container registry.


### PR DESCRIPTION
Using the new `v1.2.3` semver tag format, managed by cargo-release, to trigger testnet deployments. Refs #1961, #2360.