### PR TITLE
dex(router): implement fill phase with stacked constraints

### DIFF
--- a/app/src/dex/router/fill_route.rs
+++ b/app/src/dex/router/fill_route.rs
@@ -131,6 +131,7 @@ pub trait FillRoute: StateWrite + Sized {
             if effective_price > spill_price {
                 println!("spill price hit");
                 tracing::debug!(?effective_price, ?spill_price, "spill price hit.");
+                panic!("spill price hit");
                 break 'filling;
             }
 
@@ -178,12 +179,8 @@ pub trait FillRoute: StateWrite + Sized {
                     // When multiple constraints are found on different hops, we have to consider the case when
                     // the last constraint is not the smallest. So we want to select the smallest upper bound on
                     // `delta_1_star` that allows every constraint to be satisfied.
-                    let inv_effective_price = (U128x128::from(1u64) / effective_price).unwrap();
-                    let delta_1_star = (U128x128::from(lambda_2) * inv_effective_price).unwrap();
-                    let delta_1_star: Amount = delta_1_star.round_up().try_into()?;
-
                     let min_delta_1_star = constraining_hops.iter().fold(
-                        delta_1_star,
+                        saturating_input.clone(),
                         |current_min, (_, saturating_input, _)| {
                             Amount::min(current_min, saturating_input.clone())
                         },
@@ -234,7 +231,7 @@ pub trait FillRoute: StateWrite + Sized {
                 println!("zero current value.");
                 // Note: this can be hit during dust fills
                 // TODO(erwan): craft `test_dust_fill_zero_value` to prove this.
-                // panic!("zero current value");
+                panic!("zero current value");
                 break 'filling;
             }
 


### PR DESCRIPTION
The main idea behind our current approach to solving executing builds off the assumption that there exists a route between `source` and `target` that has:
- at least infinitesimal capacity
- an execution price similar, or better, than the spill price

The current implementation assumes that the latest constraining hop is also the most constraining one. But this is not necessarily the case, and execution along such routes does fail. This PR changes the implementation of the execution algorithm to pick the smallest "maximum `delta_1`" so that every iteration of the fill-phase lifts the most constraining hop.

