### PR TITLE
docs: update release steps

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_testnet.md
+++ b/.github/ISSUE_TEMPLATE/release_testnet.md
@@ -33,7 +33,11 @@ Thursday:
 Following Monday (release day):
 
 - [ ] Verify that `testnet-preview.penumbra.zone` is operational; it is redeployed on every push to main, and is an exact preview of what is about to be deployed.
-- [ ] Create new git tag e.g. `006-orthosie` on `main` (tags created on any other branches will not transfer when merged in) and push to shared remote: `git tag -a <tag_name>` - **must be annotated tag, i.e. `git tag -a`** for Vergen build. This will create a `Waiting` GitHub Action for deployment.
+- [ ] Bump the version number and push its tag, via [cargo-release](https://crates.io/crates/cargo-release).
+    - [ ] Run `cargo release minor` for a new testnet, or `cargo release patch` for a bugfix. For the latter, make sure you're on a dedicated release branch.
+    - [ ] Push the commit and newly generated tag, e.g. `v0.51.0`, to the remote.
+- [ ] Wait for the "Release" workflow to complete: it'll take ~90m, most of which is the macOS builds.
+- [ ] Edit the newly created (and published) release object, then click "Generate release notes." Cut and paste the generated text from the bottom to the top of the post, then save it.
 - [ ] You must [manually review](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments) the `Waiting` deployment in the GitHub Action UI before the deployment will begin. Monitor the GitHub action to ensure it completes after it is approved.
 - [ ] Delegate to the Penumbra Labs CI validators; use amounts of ~200k `penumbra` per validator.
 - [ ] Update the User Guide to mention the newly created git tag.


### PR DESCRIPTION
Documents the new release workflow, based on cargo-release, as described in #1961. We used these steps for the first time in testnet 51 #2360.