### PR TITLE
ci: fix patch release workflow

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -5,18 +5,6 @@ name: Deploy testnet-preview.penumbra.zone
 on:
   workflow_dispatch:
     inputs:
-      nvals:
-        description: 'Number of validators at genesis'
-        required: true
-        default: '2'
-      nfullnodes:
-        description: 'Number of fullnodes at genesis'
-        required: true
-        default: '2'
-      image_repository:
-        description: 'Docker image to deploy'
-        required: true
-        default: 'ghcr.io/penumbra-zone/penumbra'
       image_tag:
         description: 'Docker image tag to deploy'
         # The container tag "main" comes from the name of the main branch.
@@ -24,10 +12,6 @@ on:
         # as "latest" maps to the most recent tag (i.e. weekly testnet).
         default: "main"
         required: true
-      image_uid_gid:
-        description: 'Docker image user uid:gid'
-        required: true
-        default: '1000:1000'
   push:
     branches:
       - main
@@ -67,10 +51,6 @@ jobs:
       - name: deploy
         run: |-
           cd deployments/
-          export NVALS='${{ github.event.inputs.nvals }}'
-          export NFULLNODES='${{ github.event.inputs.nfullnodes }}'
-          export IMAGE='${{ github.event.inputs.image_repository }}'
           export PENUMBRA_VERSION='main'
-          export PENUMBRA_UID_GID='${{ github.event.inputs.image_uid_gid }}'
           export HELM_RELEASE='penumbra-testnet-preview'
           ./ci.sh

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -5,25 +5,12 @@ name: Deploy testnet.penumbra.zone
 on:
   workflow_dispatch:
     inputs:
-      nvals:
-        description: 'Number of validators at genesis'
-        required: true
-        default: '2'
-      nfullnodes:
-        description: 'Number of fullnodes at genesis'
-        required: true
-        default: '2'
-      image_repository:
-        description: 'Docker image to deploy'
-        required: true
-        default: 'ghcr.io/penumbra-zone/penumbra'
       image_tag:
         description: 'Docker image tag to deploy'
+        # We cannot set a meaningful default here, because we always want the latest tag.
+        # Inputs cannot reference special variables like `github.ref_name`, so we default
+        # to the value of `github.ref_name` when exporting the env var in the deploy step.
         required: true
-      image_uid_gid:
-        description: 'Docker image user uid:gid'
-        required: true
-        default: '1000:1000'
   push:
     tags:
       - '*-?v[0-9]+*'
@@ -64,10 +51,6 @@ jobs:
       - name: deploy
         run: |-
           cd deployments/
-          export NVALS='${{ github.event.inputs.nvals }}'
-          export NFULLNODES='${{ github.event.inputs.nfullnodes }}'
-          export IMAGE='${{ github.event.inputs.image_repository }}'
-          export PENUMBRA_VERSION='${{ github.event.inputs.image_tag }}'
-          export PENUMBRA_UID_GID='${{ github.event.inputs.image_uid_gid }}'
+          export PENUMBRA_VERSION='${{ github.event.inputs.image_tag || github.ref_name }}'
           export HELM_RELEASE='penumbra-testnet'
           ./ci.sh


### PR DESCRIPTION
The CI changes in #2387 were incomplete: they should have updated the PENUMBRA_VERSION var with the value of `github.ref_name`, so that the tag name is used to identify the container image. The default value of referencing an input will fail if the workflow is triggered from a tag, causing "main" to be deployed instead.

Although not strictly necessary, we modify the vars for the preview deploy, as well, to maintain parity.