### PR TITLE
wasm: rename `ViewClient` to `ViewServer`

### DIFF
--- a/proto/proto/buf.lock
+++ b/proto/proto/buf.lock
@@ -5,23 +5,29 @@ deps:
     owner: cosmos
     repository: cosmos-proto
     commit: 1935555c206d4afb9e94615dfd0fad31
+    digest: shake256:c74d91a3ac7ae07d579e90eee33abf9b29664047ac8816500cf22c081fec0d72d62c89ce0bebafc1f6fec7aa5315be72606717740ca95007248425102c365377
   - remote: buf.build
     owner: cosmos
     repository: cosmos-sdk
     commit: 14f154b98b9b4cf381a0878e8a9d4694
+    digest: shake256:579e3d9d8eeae1a10d3844ec0e6c8cc4af4cc71ed4a3ba4137eb44f2dd5fe236c202d73fe430cea72803be185333094cf18aaa6383a8283430b400fd4ecc4b64
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto
     commit: 34d970b699f84aa382f3c29773a60836
+    digest: shake256:3d3bee5229ba579e7d19ffe6e140986a228b48a8c7fe74348f308537ab95e9135210e81812489d42cd8941d33ff71f11583174ccc5972e86e6112924b6ce9f04
   - remote: buf.build
     owner: cosmos
     repository: ibc
     commit: 9d4584f693fb4030b9bb11c3179a02be
+    digest: shake256:c94ee6a581dfecad456e4c78bd4ef7797b730c0d5650251efb552c912ab600dee1bb97a07e3a9b7cdaa5c5de701bd1bd55cdfa94b87c4213bdaf1e5e828da92c
   - remote: buf.build
     owner: cosmos
     repository: ics23
     commit: 55085f7c710a45f58fa09947208eb70b
+    digest: shake256:9bf0bc495b5a11c88d163d39ef521bc4b00bc1374a05758c91d82821bdc61f09e8c2c51dda8452529bf80137f34d852561eacbe9550a59015d51cecb0dacb628
   - remote: buf.build
     owner: googleapis
     repository: googleapis
     commit: 75b4300737fb4efca0831636be94e517
+    digest: shake256:d865f55b8ceb838c90c28b09894ab43d07f42551108c23760004a6a4e28fe24d3a1f7380a3c9278edb329a338a9cc5db8ad9f394de548e70d534e98504972d67

--- a/proto/proto/buf.lock
+++ b/proto/proto/buf.lock
@@ -5,29 +5,23 @@ deps:
     owner: cosmos
     repository: cosmos-proto
     commit: 1935555c206d4afb9e94615dfd0fad31
-    digest: shake256:c74d91a3ac7ae07d579e90eee33abf9b29664047ac8816500cf22c081fec0d72d62c89ce0bebafc1f6fec7aa5315be72606717740ca95007248425102c365377
   - remote: buf.build
     owner: cosmos
     repository: cosmos-sdk
-    commit: 51aaa75f36aa4190b2965726557f499e
-    digest: shake256:fab0021db39a20737093bda0096c3f6b01f1a87f93675532488fce92768992ea39023d57fa6a4b68d25a93b63f48af6404f0de54b35e22ae2b4ea8a9d10b723f
+    commit: 14f154b98b9b4cf381a0878e8a9d4694
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto
     commit: 34d970b699f84aa382f3c29773a60836
-    digest: shake256:3d3bee5229ba579e7d19ffe6e140986a228b48a8c7fe74348f308537ab95e9135210e81812489d42cd8941d33ff71f11583174ccc5972e86e6112924b6ce9f04
   - remote: buf.build
     owner: cosmos
     repository: ibc
     commit: 9d4584f693fb4030b9bb11c3179a02be
-    digest: shake256:c94ee6a581dfecad456e4c78bd4ef7797b730c0d5650251efb552c912ab600dee1bb97a07e3a9b7cdaa5c5de701bd1bd55cdfa94b87c4213bdaf1e5e828da92c
   - remote: buf.build
     owner: cosmos
     repository: ics23
     commit: 55085f7c710a45f58fa09947208eb70b
-    digest: shake256:9bf0bc495b5a11c88d163d39ef521bc4b00bc1374a05758c91d82821bdc61f09e8c2c51dda8452529bf80137f34d852561eacbe9550a59015d51cecb0dacb628
   - remote: buf.build
     owner: googleapis
     repository: googleapis
     commit: 75b4300737fb4efca0831636be94e517
-    digest: shake256:d865f55b8ceb838c90c28b09894ab43d07f42551108c23760004a6a4e28fe24d3a1f7380a3c9278edb329a338a9cc5db8ad9f394de548e70d534e98504972d67

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,11 +1,11 @@
 extern crate core;
 
-mod mock_client;
 mod note_record;
 mod planner;
 mod swap_record;
 mod tx;
 mod utils;
+mod view_server;
 use penumbra_proto::{core::crypto::v1alpha1 as pb, serializers::bech32str, DomainType};
 
 use penumbra_crypto::{Address, FullViewingKey};
@@ -18,8 +18,8 @@ use wasm_bindgen::prelude::*;
 
 use penumbra_transaction::Transaction;
 
-pub use mock_client::ViewClient;
 pub use tx::send_plan;
+pub use view_server::ViewServer;
 
 #[wasm_bindgen]
 pub fn generate_spend_key(seed_phrase: &str) -> JsValue {

--- a/wasm/src/tx.rs
+++ b/wasm/src/tx.rs
@@ -14,10 +14,10 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
-use crate::mock_client::{load_tree, StoredTree};
 use crate::note_record::SpendableNoteRecord;
 use crate::planner::Planner;
 use crate::utils;
+use crate::view_server::{load_tree, StoredTree};
 use web_sys::console as web_console;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/wasm/src/view_server.rs
+++ b/wasm/src/view_server.rs
@@ -49,7 +49,7 @@ impl ScanBlockResult {
 }
 
 #[wasm_bindgen]
-pub struct ViewClient {
+pub struct ViewServer {
     latest_height: u64,
     epoch_duration: u64,
     fvk: FullViewingKey,
@@ -59,9 +59,9 @@ pub struct ViewClient {
 }
 
 #[wasm_bindgen]
-impl ViewClient {
+impl ViewServer {
     #[wasm_bindgen(constructor)]
-    pub fn new(full_viewing_key: &str, epoch_duration: u64, stored_tree: JsValue) -> ViewClient {
+    pub fn new(full_viewing_key: &str, epoch_duration: u64, stored_tree: JsValue) -> ViewServer {
         utils::set_panic_hook();
         let fvk = FullViewingKey::from_str(full_viewing_key.as_ref())
             .context("The provided string is not a valid FullViewingKey")


### PR DESCRIPTION
It should be called the `ViewServer`, because it serves the view RPC; it's a client to a fullnode.