### PR TITLE
pclientd: fix envfilter setting, unbreaking bin

### DIFF
--- a/pclientd/src/main.rs
+++ b/pclientd/src/main.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<()> {
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_ansi(atty::is(atty::Stream::Stdout))
         .with_target(false);
-    let filter_layer = EnvFilter::try_from_default_env()?;
+    let filter_layer = EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("info"))?;
     let registry = tracing_subscriber::registry()
         .with(filter_layer)
         .with(fmt_layer);


### PR DESCRIPTION
The envfilter setting pulled in via #2327 inadvertently broke the `pclientd` binary, by preventing it from running if the env var RUST_LOG was not set (the default behavior). The other bins like pd and narsild handled this error appropriately, via `or_else` and setting a default of "info". Porting that logic to pclientd resolves.