### PR TITLE
IBC quality of life changes for relayer work

### DIFF
--- a/chain/src/params.rs
+++ b/chain/src/params.rs
@@ -204,8 +204,8 @@ impl Default for ChainParameters {
             // 3bps -> 11% return over 365 epochs
             base_reward_rate: 3_0000,
             ibc_enabled: true,
-            inbound_ics20_transfers_enabled: false,
-            outbound_ics20_transfers_enabled: false,
+            inbound_ics20_transfers_enabled: true,
+            outbound_ics20_transfers_enabled: true,
             // governance
             proposal_voting_blocks: 17_280, // 24 hours, at a 5 second block time
             proposal_deposit_amount: 10_000_000u64.into(), // 10,000,000 upenumbra = 10 penumbra

--- a/pcli/src/command/query/ibc_query.rs
+++ b/pcli/src/command/query/ibc_query.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use colored_json::prelude::*;
 use ibc_types::clients::ics07_tendermint::client_state::ClientState as TendermintClientState;
 use ibc_types::core::ics03_connection::connection::ConnectionEnd;
@@ -31,7 +31,8 @@ impl IbcCmd {
                         key,
                         ..Default::default()
                     })
-                    .await?
+                    .await
+                    .context(format!("Failed to find client {client_id}"))?
                     .into_inner()
                     .value;
 
@@ -46,7 +47,8 @@ impl IbcCmd {
                         key,
                         ..Default::default()
                     })
-                    .await?
+                    .await
+                    .context(format!("Failed to find connection {connection_id}"))?
                     .into_inner()
                     .value;
 
@@ -61,7 +63,8 @@ impl IbcCmd {
                         key,
                         ..Default::default()
                     })
-                    .await?
+                    .await
+                    .context(format!("Failed to find channel {port}:{channel_id}"))?
                     .into_inner()
                     .value;
 


### PR DESCRIPTION
Two changes:

* more readable error msgs for `pcli q ibc`, hopefully unobjectionable
* changes default chain params to enable inbound/outbound transfers

Regarding the latter, it looks like that's effectively a no-op. But I'm clicking it on anyway in case the relayer code is checking those values in ways I don't understand.

Will continue to test relayer against preview/devnet post-merge in #2330.