### PR TITLE
pcli(dex_utils): create harness for RMMs

### DIFF
--- a/pcli/src/command/tx.rs
+++ b/pcli/src/command/tx.rs
@@ -797,10 +797,9 @@ impl TxCmd {
                         r2: Amount::zero(),
                     },
                 );
-
-                // `spread` is another name for `fee`, which is at most 10_000 bps.
-                if *spread > 10_000 {
-                    anyhow::bail!("spread parameter must be at most 10_000bps (i.e. 100%)");
+                // `spread` is another name for `fee`, which is at most 5000 bps.
+                if *spread > 5000 {
+                    anyhow::bail!("spread parameter must be at most 5000bps (i.e. 50%)");
                 }
 
                 let position = Position::new(OsRng, trading_pair, *spread, p, q, reserves);
@@ -910,9 +909,9 @@ impl TxCmd {
                     },
                 );
 
-                // `spread` is another name for `fee`, which is at most 10_000 bps.
-                if *spread > 10_000 {
-                    anyhow::bail!("spread parameter must be at most 10_000bps (i.e. 100%)");
+                // `spread` is another name for `fee`, which is at most 5000 bps.
+                if *spread > 5000 {
+                    anyhow::bail!("spread parameter must be at most 5000bps (i.e. 50%)");
                 }
 
                 let position = Position::new(OsRng, trading_pair, *spread, p, q, reserves);

--- a/pcli/src/command/view/approximate.rs
+++ b/pcli/src/command/view/approximate.rs
@@ -1,0 +1,22 @@
+use penumbra_crypto::dex::TradingPair;
+use penumbra_crypto::Value;
+
+/// Queries the chain for a transaction by hash.
+#[derive(Debug, clap::Subcommand)]
+pub enum ApproximateCmd {
+    ConstantProduct {
+        pair: TradingPair,
+        quantity: Value,
+    },
+    Linear {
+        pair: TradingPair,
+        quantity_1: Value,
+        quantity_2: Value,
+    },
+}
+
+impl ApproximateCmd {
+    pub fn offline(&self) -> bool {
+        false
+    }
+}

--- a/pcli/src/dex_utils.rs
+++ b/pcli/src/dex_utils.rs
@@ -1,0 +1,6 @@
+/*
+   Client-side DEX utilities, such as trading function approximation,
+   and automated order execution strategies.
+
+*/
+pub mod approximate;

--- a/pcli/src/dex_utils/approximate.rs
+++ b/pcli/src/dex_utils/approximate.rs
@@ -1,0 +1,5 @@
+use penumbra_crypto::{dex::lp::position::Position, fixpoint::U128x128, Value};
+
+pub fn approximate_xyk(_invariant_k: &Value, _current_price: U128x128) -> Vec<Position> {
+    todo!()
+}

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -14,11 +14,11 @@ use url::Url;
 
 mod box_grpc_svc;
 mod command;
+mod dex_utils;
 mod legacy;
 mod network;
 mod opt;
 mod warning;
-mod dex_utils;
 
 use opt::Opt;
 use penumbra_wallet::KeyStore;

--- a/pcli/src/main.rs
+++ b/pcli/src/main.rs
@@ -18,6 +18,7 @@ mod legacy;
 mod network;
 mod opt;
 mod warning;
+mod dex_utils;
 
 use opt::Opt;
 use penumbra_wallet::KeyStore;


### PR DESCRIPTION
Closes #2319 .

This PR creates a `pcli::dex_utils` module which will be home to client-side dex utilities such as the trading function approximations, the online order execution (e.g. TWAP, VWAP etc.), and more. It also stubs a new pcli command:

`pcli view approximate constant-product <PAIR> <VALUE>`