### PR TITLE
router(dex): make `fill_route` take `hops`

### DIFF
--- a/app/src/dex/router/tests.rs
+++ b/app/src/dex/router/tests.rs
@@ -560,7 +560,7 @@ async fn fill_route_constraint_stacked() -> anyhow::Result<()> {
         amount: Amount::from(4u64) * gm.unit_amount(),
     };
 
-    let route = vec![gm.id(), gn.id(), penumbra.id(), pusd.id()];
+    let route = vec![gn.id(), penumbra.id(), pusd.id()];
 
     let spill_price = U128x128::from(Amount::from(1_000_000_000u64) * pusd.unit_amount());
 
@@ -666,7 +666,7 @@ async fn fill_route_constraint_1() -> anyhow::Result<()> {
         amount: Amount::from(4u64) * gm.unit_amount(),
     };
 
-    let route = vec![gm.id(), gn.id(), penumbra.id(), pusd.id()];
+    let route = vec![gn.id(), penumbra.id(), pusd.id()];
 
     let spill_price = U128x128::from(Amount::from(1_000_000_000u64) * pusd.unit_amount());
 
@@ -747,7 +747,7 @@ async fn fill_route_unconstrained() -> anyhow::Result<()> {
         amount: Amount::from(1u64) * gm.unit_amount(),
     };
 
-    let route = vec![gm.id(), gn.id(), penumbra.id(), pusd.id()];
+    let route = vec![gn.id(), penumbra.id(), pusd.id()];
 
     let spill_price =
         (U128x128::from(1_000_000_000_000u64) * U128x128::from(pusd.unit_amount())).unwrap();
@@ -825,7 +825,7 @@ async fn fill_route_hit_spill_price() -> anyhow::Result<()> {
         amount: Amount::from(3u64) * gm.unit_amount(),
     };
 
-    let route = vec![gm.id(), gn.id(), penumbra.id(), pusd.id()];
+    let route = vec![gn.id(), penumbra.id(), pusd.id()];
 
     let valuation_penumbra =
         (U128x128::from(price1400) * U128x128::from(pusd.unit_amount())).unwrap();


### PR DESCRIPTION
Previously, `fill_route` was expecting its `route` parameter to contain an end-to-route from some `source` to a desired `target`. In practice however, `path_search` returns the "hops" between a known `source` and a target (i.e. the route minus the source). This PR adjusts tests and `fill_route` to work with that api. 