### PR TITLE
build: fix pd rebuild on testnet dir

### DIFF
--- a/pd/build.rs
+++ b/pd/build.rs
@@ -19,13 +19,18 @@ fn setup_testnet_config() -> anyhow::Result<()> {
         .join("testnets");
 
     // Get the most recent testnet name and its configuration directory
-    let (latest_testnet_name, latest_testnet_dir) = latest_testnet(&testnets_path)?;
+    let (latest_testnet_name, latest_testnet_dirname) = latest_testnet(&testnets_path)?;
+
+    let latest_testnet_dirpath = Path::join(&testnets_path, &latest_testnet_dirname);
 
     // Output the name of the most recent testnet as a build-time environment variable
-    println!("cargo:rustc-env=PD_LATEST_TESTNET_NAME={latest_testnet_name}");
+    println!("cargo:rustc-env=PD_LATEST_TESTNET_NAME={latest_testnet_dirname}");
 
     // Ensure that changes to the allocations files trigger a rebuild of pd.
-    println!("cargo:rerun-if-changed={latest_testnet_dir}");
+    println!(
+        "cargo:rerun-if-changed={}",
+        latest_testnet_dirpath.display()
+    );
 
     // For each association of environment variable to filename, set the full path to that file in
     // the environment variable, so that we can include its contents at build time
@@ -33,7 +38,7 @@ fn setup_testnet_config() -> anyhow::Result<()> {
         ("PD_LATEST_TESTNET_ALLOCATIONS", "allocations.csv"),
         ("PD_LATEST_TESTNET_VALIDATORS", "validators.json"),
     ] {
-        let path = testnets_path.join(&latest_testnet_dir).join(filename);
+        let path = testnets_path.join(&latest_testnet_dirname).join(filename);
         println!(
             "cargo:rustc-env={}={}",
             env_var,

--- a/tct-visualize/build.rs
+++ b/tct-visualize/build.rs
@@ -1,8 +1,8 @@
 fn main() {
     // Inform cargo about the resources that are baked into the binary
     let resources = [
-        "examples/key-control.js",
-        "examples/tct-live-edit-help.html",
+        "src/bin/key-control.js",
+        "src/bin/tct-live-edit-help.html",
         "src/live/view/index.html",
         "src/live/view/index.js",
         "src/live/view/reset.css",


### PR DESCRIPTION
Fixes build caching for pd. Follow up to #2292. Ensures that the testnet directory referenced by the pd build script is a fullpath, rather than a dirname. The dirname didn't resolve to a valid relpath from the perspective of the build, so cargo was always rebuilding pd, even when no code had changed.

For reference, the command I used to identify the always-marked-dirty dir build dep was:

  CARGO_LOG=cargo::core::compiler::fingerprint=info cargo build --release --bin pd

The speedup on hot builds of pd is ~100x, 30s -> 0.3s on my machine. Benchmarks from local runs:

On main:

```
❯ hyperfine --warmup 2 --runs 5 'cargo build --release --bin pd' 
Benchmark 1: cargo build --release --bin pd
  Time (mean ± σ):     32.689 s ±  0.244 s    [User: 143.447 s, System: 3.406 s]
  Range (min … max):   32.394 s … 33.009 s    5 runs

```

On this feature branch:

```
❯ hyperfine --warmup 2 --runs 5 'cargo build --release --bin pd' 
Benchmark 1: cargo build --release --bin pd
  Time (mean ± σ):     305.5 ms ±   2.2 ms    [User: 236.6 ms, System: 67.0 ms]
  Range (min … max):   302.5 ms … 307.3 ms    5 runs
```

