### PR TITLE
dex: add epoch height to `BatchSwapOutputData`

### DIFF
--- a/app/src/action_handler/actions/swap_claim.rs
+++ b/app/src/action_handler/actions/swap_claim.rs
@@ -20,7 +20,6 @@ impl ActionHandler for SwapClaim {
                 context.anchor,
                 self.body.nullifier,
                 self.body.output_data,
-                self.epoch_duration,
                 self.body.output_1_commitment,
                 self.body.output_2_commitment,
                 self.body.fee.clone(),

--- a/app/src/stubdex/component.rs
+++ b/app/src/stubdex/component.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use penumbra_chain::component::StateReadExt as _;
 use penumbra_component::Component;
 use penumbra_crypto::dex::lp::Reserves;
 use penumbra_crypto::{
@@ -101,8 +102,13 @@ impl Component for StubDex {
                 (delta_1, delta_2, 0u64.into(), 0u64.into())
             };
 
+            let height = end_block.height.try_into().unwrap();
+            let current_epoch = state.get_current_epoch().await.unwrap();
+            let epoch_height = current_epoch.start_height;
+            let intra_epoch_height = height - current_epoch.start_height;
+
             let output_data = BatchSwapOutputData {
-                height: end_block.height.try_into().unwrap(),
+                height,
                 trading_pair,
                 delta_1,
                 delta_2,
@@ -110,6 +116,8 @@ impl Component for StubDex {
                 lambda_2_2,
                 lambda_1_2,
                 lambda_2_1,
+                epoch_height,
+                intra_epoch_height,
             };
             tracing::debug!(?output_data);
             state.set_output_data(output_data);

--- a/app/src/stubdex/component.rs
+++ b/app/src/stubdex/component.rs
@@ -104,8 +104,7 @@ impl Component for StubDex {
 
             let height = end_block.height.try_into().unwrap();
             let current_epoch = state.get_current_epoch().await.unwrap();
-            let epoch_height = current_epoch.start_height;
-            let intra_epoch_height = height - current_epoch.start_height;
+            let epoch_height: u64 = current_epoch.start_height;
 
             let output_data = BatchSwapOutputData {
                 height,
@@ -117,7 +116,6 @@ impl Component for StubDex {
                 lambda_1_2,
                 lambda_2_1,
                 epoch_height,
-                intra_epoch_height,
             };
             tracing::debug!(?output_data);
             state.set_output_data(output_data);

--- a/crypto/src/dex/swap.rs
+++ b/crypto/src/dex/swap.rs
@@ -49,8 +49,6 @@ pub struct BatchSwapOutputData {
     pub trading_pair: TradingPair,
     /// The starting block height of the epoch for which the batch swap data is valid.
     pub epoch_height: u64,
-    // The intra-epoch block height for which the batch swap data is valid.
-    pub intra_epoch_height: u64,
 }
 
 impl BatchSwapOutputData {
@@ -111,7 +109,6 @@ impl From<BatchSwapOutputData> for pb::BatchSwapOutputData {
             lambda_1_2: Some(s.lambda_1_2.into()),
             lambda_2_2: Some(s.lambda_2_2.into()),
             epoch_height: s.epoch_height,
-            intra_epoch_height: s.intra_epoch_height,
         }
     }
 }
@@ -158,7 +155,6 @@ impl TryFrom<pb::BatchSwapOutputData> for BatchSwapOutputData {
                 .ok_or_else(|| anyhow!("Missing trading_pair"))?
                 .try_into()?,
             epoch_height: s.epoch_height,
-            intra_epoch_height: s.intra_epoch_height,
         })
     }
 }

--- a/crypto/src/dex/swap.rs
+++ b/crypto/src/dex/swap.rs
@@ -47,6 +47,10 @@ pub struct BatchSwapOutputData {
     pub height: u64,
     /// The trading pair associated with the batch swap.
     pub trading_pair: TradingPair,
+    /// The starting block height of the epoch for which the batch swap data is valid.
+    pub epoch_height: u64,
+    // The intra-epoch block height for which the batch swap data is valid.
+    pub intra_epoch_height: u64,
 }
 
 impl BatchSwapOutputData {
@@ -106,6 +110,8 @@ impl From<BatchSwapOutputData> for pb::BatchSwapOutputData {
             lambda_2_1: Some(s.lambda_2_1.into()),
             lambda_1_2: Some(s.lambda_1_2.into()),
             lambda_2_2: Some(s.lambda_2_2.into()),
+            epoch_height: s.epoch_height,
+            intra_epoch_height: s.intra_epoch_height,
         }
     }
 }
@@ -151,6 +157,8 @@ impl TryFrom<pb::BatchSwapOutputData> for BatchSwapOutputData {
                 .trading_pair
                 .ok_or_else(|| anyhow!("Missing trading_pair"))?
                 .try_into()?,
+            epoch_height: s.epoch_height,
+            intra_epoch_height: s.intra_epoch_height,
         })
     }
 }

--- a/crypto/src/proofs/transparent.rs
+++ b/crypto/src/proofs/transparent.rs
@@ -45,7 +45,6 @@ impl SwapClaimProof {
         anchor: tct::Root,
         nullifier: Nullifier,
         output_data: BatchSwapOutputData,
-        epoch_duration: u64,
         note_commitment_1: note::Commitment,
         note_commitment_2: note::Commitment,
         fee: Fee,
@@ -73,9 +72,7 @@ impl SwapClaimProof {
         // Validate the swap commitment's height matches the output data's height.
         let position = self.swap_commitment_proof.position();
         let block = position.block();
-        let epoch = position.epoch();
-        let note_commitment_block_height: u64 =
-            epoch_duration * u64::from(epoch) + u64::from(block);
+        let note_commitment_block_height: u64 = output_data.epoch_height + u64::from(block);
         ensure!(
             note_commitment_block_height == output_data.height,
             "note commitment was not for clearing price height"

--- a/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
+++ b/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
@@ -175,6 +175,10 @@ message BatchSwapOutputData {
   uint64 height = 7;
   // The trading pair associated with the batch swap.
   TradingPair trading_pair = 8;
+  // The starting block height of the epoch for which the batch swap data is valid.
+  uint64 epoch_height = 9;
+  // The intra-epoch block height for which the batch swap data is valid.
+  uint64 intra_epoch_height = 10;
 }
 
 // The trading function for a specific pair.

--- a/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
+++ b/proto/proto/penumbra/core/dex/v1alpha1/dex.proto
@@ -177,8 +177,6 @@ message BatchSwapOutputData {
   TradingPair trading_pair = 8;
   // The starting block height of the epoch for which the batch swap data is valid.
   uint64 epoch_height = 9;
-  // The intra-epoch block height for which the batch swap data is valid.
-  uint64 intra_epoch_height = 10;
 }
 
 // The trading function for a specific pair.

--- a/proto/src/gen/penumbra.core.dex.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.dex.v1alpha1.rs
@@ -272,9 +272,6 @@ pub struct BatchSwapOutputData {
     /// The starting block height of the epoch for which the batch swap data is valid.
     #[prost(uint64, tag = "9")]
     pub epoch_height: u64,
-    /// The intra-epoch block height for which the batch swap data is valid.
-    #[prost(uint64, tag = "10")]
-    pub intra_epoch_height: u64,
 }
 /// The trading function for a specific pair.
 /// For a pair (asset_1, asset_2), a trading function is defined by:

--- a/proto/src/gen/penumbra.core.dex.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.dex.v1alpha1.rs
@@ -269,6 +269,12 @@ pub struct BatchSwapOutputData {
     /// The trading pair associated with the batch swap.
     #[prost(message, optional, tag = "8")]
     pub trading_pair: ::core::option::Option<TradingPair>,
+    /// The starting block height of the epoch for which the batch swap data is valid.
+    #[prost(uint64, tag = "9")]
+    pub epoch_height: u64,
+    /// The intra-epoch block height for which the batch swap data is valid.
+    #[prost(uint64, tag = "10")]
+    pub intra_epoch_height: u64,
 }
 /// The trading function for a specific pair.
 /// For a pair (asset_1, asset_2), a trading function is defined by:

--- a/proto/src/gen/penumbra.core.dex.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.core.dex.v1alpha1.serde.rs
@@ -160,9 +160,6 @@ impl serde::Serialize for BatchSwapOutputData {
         if self.epoch_height != 0 {
             len += 1;
         }
-        if self.intra_epoch_height != 0 {
-            len += 1;
-        }
         let mut struct_ser = serializer.serialize_struct("penumbra.core.dex.v1alpha1.BatchSwapOutputData", len)?;
         if let Some(v) = self.delta_1.as_ref() {
             struct_ser.serialize_field("delta1", v)?;
@@ -191,9 +188,6 @@ impl serde::Serialize for BatchSwapOutputData {
         if self.epoch_height != 0 {
             struct_ser.serialize_field("epochHeight", ToString::to_string(&self.epoch_height).as_str())?;
         }
-        if self.intra_epoch_height != 0 {
-            struct_ser.serialize_field("intraEpochHeight", ToString::to_string(&self.intra_epoch_height).as_str())?;
-        }
         struct_ser.end()
     }
 }
@@ -221,8 +215,6 @@ impl<'de> serde::Deserialize<'de> for BatchSwapOutputData {
             "tradingPair",
             "epoch_height",
             "epochHeight",
-            "intra_epoch_height",
-            "intraEpochHeight",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -236,7 +228,6 @@ impl<'de> serde::Deserialize<'de> for BatchSwapOutputData {
             Height,
             TradingPair,
             EpochHeight,
-            IntraEpochHeight,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -267,7 +258,6 @@ impl<'de> serde::Deserialize<'de> for BatchSwapOutputData {
                             "height" => Ok(GeneratedField::Height),
                             "tradingPair" | "trading_pair" => Ok(GeneratedField::TradingPair),
                             "epochHeight" | "epoch_height" => Ok(GeneratedField::EpochHeight),
-                            "intraEpochHeight" | "intra_epoch_height" => Ok(GeneratedField::IntraEpochHeight),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -296,7 +286,6 @@ impl<'de> serde::Deserialize<'de> for BatchSwapOutputData {
                 let mut height__ = None;
                 let mut trading_pair__ = None;
                 let mut epoch_height__ = None;
-                let mut intra_epoch_height__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::Delta1 => {
@@ -357,14 +346,6 @@ impl<'de> serde::Deserialize<'de> for BatchSwapOutputData {
                                 Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
-                        GeneratedField::IntraEpochHeight => {
-                            if intra_epoch_height__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("intraEpochHeight"));
-                            }
-                            intra_epoch_height__ = 
-                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
-                            ;
-                        }
                     }
                 }
                 Ok(BatchSwapOutputData {
@@ -377,7 +358,6 @@ impl<'de> serde::Deserialize<'de> for BatchSwapOutputData {
                     height: height__.unwrap_or_default(),
                     trading_pair: trading_pair__,
                     epoch_height: epoch_height__.unwrap_or_default(),
-                    intra_epoch_height: intra_epoch_height__.unwrap_or_default(),
                 })
             }
         }

--- a/proto/src/gen/penumbra.core.dex.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.core.dex.v1alpha1.serde.rs
@@ -157,6 +157,12 @@ impl serde::Serialize for BatchSwapOutputData {
         if self.trading_pair.is_some() {
             len += 1;
         }
+        if self.epoch_height != 0 {
+            len += 1;
+        }
+        if self.intra_epoch_height != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("penumbra.core.dex.v1alpha1.BatchSwapOutputData", len)?;
         if let Some(v) = self.delta_1.as_ref() {
             struct_ser.serialize_field("delta1", v)?;
@@ -181,6 +187,12 @@ impl serde::Serialize for BatchSwapOutputData {
         }
         if let Some(v) = self.trading_pair.as_ref() {
             struct_ser.serialize_field("tradingPair", v)?;
+        }
+        if self.epoch_height != 0 {
+            struct_ser.serialize_field("epochHeight", ToString::to_string(&self.epoch_height).as_str())?;
+        }
+        if self.intra_epoch_height != 0 {
+            struct_ser.serialize_field("intraEpochHeight", ToString::to_string(&self.intra_epoch_height).as_str())?;
         }
         struct_ser.end()
     }
@@ -207,6 +219,10 @@ impl<'de> serde::Deserialize<'de> for BatchSwapOutputData {
             "height",
             "trading_pair",
             "tradingPair",
+            "epoch_height",
+            "epochHeight",
+            "intra_epoch_height",
+            "intraEpochHeight",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -219,6 +235,8 @@ impl<'de> serde::Deserialize<'de> for BatchSwapOutputData {
             Lambda22,
             Height,
             TradingPair,
+            EpochHeight,
+            IntraEpochHeight,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -248,6 +266,8 @@ impl<'de> serde::Deserialize<'de> for BatchSwapOutputData {
                             "lambda22" | "lambda_2_2" => Ok(GeneratedField::Lambda22),
                             "height" => Ok(GeneratedField::Height),
                             "tradingPair" | "trading_pair" => Ok(GeneratedField::TradingPair),
+                            "epochHeight" | "epoch_height" => Ok(GeneratedField::EpochHeight),
+                            "intraEpochHeight" | "intra_epoch_height" => Ok(GeneratedField::IntraEpochHeight),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -275,6 +295,8 @@ impl<'de> serde::Deserialize<'de> for BatchSwapOutputData {
                 let mut lambda_2_2__ = None;
                 let mut height__ = None;
                 let mut trading_pair__ = None;
+                let mut epoch_height__ = None;
+                let mut intra_epoch_height__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::Delta1 => {
@@ -327,6 +349,22 @@ impl<'de> serde::Deserialize<'de> for BatchSwapOutputData {
                             }
                             trading_pair__ = map.next_value()?;
                         }
+                        GeneratedField::EpochHeight => {
+                            if epoch_height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("epochHeight"));
+                            }
+                            epoch_height__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::IntraEpochHeight => {
+                            if intra_epoch_height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("intraEpochHeight"));
+                            }
+                            intra_epoch_height__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                     }
                 }
                 Ok(BatchSwapOutputData {
@@ -338,6 +376,8 @@ impl<'de> serde::Deserialize<'de> for BatchSwapOutputData {
                     lambda_2_2: lambda_2_2__,
                     height: height__.unwrap_or_default(),
                     trading_pair: trading_pair__,
+                    epoch_height: epoch_height__.unwrap_or_default(),
+                    intra_epoch_height: intra_epoch_height__.unwrap_or_default(),
                 })
             }
         }

--- a/proto/src/gen/proto_descriptor.bin
+++ b/proto/src/gen/proto_descriptor.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f269c31566dd347287d0d8eefe85f0dee2aa8aa86ab74242015ab44d5b5ebc3
-size 332067
+oid sha256:d4d0186cc0fe8f3fb7ccc94eb611890ef5b660a0cbc10dbea67e44ad91bd8fe3
+size 331890

--- a/proto/src/gen/proto_descriptor.bin
+++ b/proto/src/gen/proto_descriptor.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f6c789cdd82947335c58fc90f11ba231381bc9a3eb8ca65645f3e24015f79d56
-size 331714
+oid sha256:5f269c31566dd347287d0d8eefe85f0dee2aa8aa86ab74242015ab44d5b5ebc3
+size 332067


### PR DESCRIPTION
Closes #2351

Note also that I don't think we need the `epoch_duration` on the `SwapClaim`, but I don't want to make a breaking change to the protos. 

