### PR TITLE
Fix bad re-streams

### DIFF
--- a/app/src/dex/position_manager.rs
+++ b/app/src/dex/position_manager.rs
@@ -23,7 +23,9 @@ use std::{
 #[async_trait]
 pub trait PositionRead: StateRead {
     /// Return a stream of all [`position::Metadata`] available.
-    fn all_positions(&self) -> Pin<Box<dyn Stream<Item = Result<position::Position>> + Send + '_>> {
+    fn all_positions(
+        &self,
+    ) -> Pin<Box<dyn Stream<Item = Result<position::Position>> + Send + 'static>> {
         let prefix = state_key::all_positions();
         self.prefix(prefix)
             .map(|entry| match entry {

--- a/pd/src/info/specific.rs
+++ b/pd/src/info/specific.rs
@@ -12,6 +12,7 @@ use penumbra_chain::component::AppHashRead;
 use penumbra_chain::component::StateReadExt as _;
 use penumbra_crypto::asset::{self, Asset};
 use penumbra_crypto::dex::lp::position;
+use penumbra_crypto::dex::lp::position::Position;
 use penumbra_proto::{
     self as proto,
     client::v1alpha1::{
@@ -63,19 +64,27 @@ impl SpecificQueryService for Info {
         request: tonic::Request<LiquidityPositionsRequest>,
     ) -> Result<tonic::Response<Self::LiquidityPositionsStream>, Status> {
         let state = self.storage.latest_snapshot();
-        let stream_iter = state.all_positions().next().await.into_iter();
-        let s = try_stream! {
-            for item in stream_iter
-                .map(|item| item.map_err(|e| tonic::Status::internal(e.to_string()))) {
-                    let item = item.unwrap();
-                    if (request.get_ref().only_open && item.state == penumbra_crypto::dex::lp::position::State::Opened) || request.get_ref().only_open == false {
-                        yield LiquidityPositionsResponse { data: Some(item.into()) }
-                    }
-                }
-        };
 
+        let only_open = request.get_ref().only_open;
+        let s = state.all_positions();
         Ok(tonic::Response::new(
-            s.map_err(|e: anyhow::Error| {
+            s.filter(move |item| {
+                if item.is_err() {
+                    return futures::future::ready(false);
+                }
+                let item = item.as_ref().unwrap();
+                if (only_open && item.state == penumbra_crypto::dex::lp::position::State::Opened)
+                    || only_open == false
+                {
+                    futures::future::ready(true)
+                } else {
+                    futures::future::ready(false)
+                }
+            })
+            .map_ok(|i: Position| LiquidityPositionsResponse {
+                data: Some(i.into()),
+            })
+            .map_err(|e: anyhow::Error| {
                 tonic::Status::unavailable(format!("error getting prefix value from storage: {e}"))
             })
             // TODO: how do we instrument a Stream
@@ -376,21 +385,11 @@ impl SpecificQueryService for Info {
         let proposal_id = request.into_inner().proposal_id;
 
         use penumbra_app::governance::state_key;
-        let stream_iter = state
-            .prefix(&state_key::all_rate_data_at_proposal_start(proposal_id))
-            .next()
-            .await
-            .into_iter();
-        let s = try_stream! {
-            for item in stream_iter
-                .map(|item| item.map_err(|e| tonic::Status::internal(e.to_string()))) {
-                    yield item
-                }
-        };
 
+        let s = state.prefix(&state_key::all_rate_data_at_proposal_start(proposal_id));
         Ok(tonic::Response::new(
-            s.map_ok(|i: Result<(String, RateData), tonic::Status>| {
-                let (_key, rate_data) = i.unwrap();
+            s.map_ok(|i: (String, RateData)| {
+                let (_key, rate_data) = i;
                 ProposalRateDataResponse {
                     rate_data: Some(rate_data.into()),
                 }
@@ -471,25 +470,21 @@ impl SpecificQueryService for Info {
             return Err(Status::invalid_argument("prefix is empty"));
         }
 
-        let stream_iter = state.prefix_raw(&request.prefix).next().await.into_iter();
-        let s = try_stream! {
-            for item in stream_iter
-                .map(|item| item.map_err(|e| tonic::Status::internal(e.to_string()))) {
-                    yield item
-                }
-        };
-
         Ok(tonic::Response::new(
-            s.map_ok(|i: Result<(String, Vec<u8>), tonic::Status>| {
-                let (key, value) = i.unwrap();
-                PrefixValueResponse { key, value }
-            })
-            .map_err(|e: anyhow::Error| {
-                tonic::Status::unavailable(format!("error getting prefix value from storage: {e}"))
-            })
-            // TODO: how do we instrument a Stream
-            //.instrument(Span::current())
-            .boxed(),
+            state
+                .prefix_raw(&request.prefix)
+                .map_ok(|i: (String, Vec<u8>)| {
+                    let (key, value) = i;
+                    PrefixValueResponse { key, value }
+                })
+                .map_err(|e: anyhow::Error| {
+                    tonic::Status::unavailable(format!(
+                        "error getting prefix value from storage: {e}"
+                    ))
+                })
+                // TODO: how do we instrument a Stream
+                //.instrument(Span::current())
+                .boxed(),
         ))
     }
 }

--- a/proto/src/state/read.rs
+++ b/proto/src/state/read.rs
@@ -51,7 +51,7 @@ pub trait StateReadProto: StateRead + Send + Sync {
     fn prefix<'a, D>(
         &'a self,
         prefix: &'a str,
-    ) -> Pin<Box<dyn Stream<Item = Result<(String, D)>> + Send + 'a>>
+    ) -> Pin<Box<dyn Stream<Item = Result<(String, D)>> + Send + 'static>>
     where
         D: DomainType,
         <D as TryFrom<D::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
@@ -70,7 +70,7 @@ pub trait StateReadProto: StateRead + Send + Sync {
     fn prefix_proto<'a, P>(
         &'a self,
         prefix: &'a str,
-    ) -> Pin<Box<dyn Stream<Item = Result<(String, P)>> + Send + 'a>>
+    ) -> Pin<Box<dyn Stream<Item = Result<(String, P)>> + Send + 'static>>
     where
         P: Message + Default,
     {


### PR DESCRIPTION
There were some instances where we were attempting to re-stream streams across RPC boundaries in a way that only returned the last item. This replaces all instances of that pattern with a simpler implementation using stream combinators.