### PR TITLE
ci: cancel pending preview deploys

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -16,6 +16,12 @@ on:
     branches:
       - main
 
+# Cancel any pending preview deploys, in favor of a newer PR
+# that was just merged.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-container:
     name: Build container for preview


### PR DESCRIPTION
Sometimes we merge several PRs in succession, and currently that causes preview deploys to trigger in parallel, which leads to a race on container build and cluster deploy. Let's instead always prefer the most recent merge, cancelling prior builds if they're still ongoing.