### PR TITLE
dex: integration debugging

### DIFF
--- a/app/src/dex/component.rs
+++ b/app/src/dex/component.rs
@@ -46,8 +46,6 @@ impl Component for Dex {
                 .handle_batch_swaps(
                     trading_pair,
                     swap_flows,
-                    // TODO: pass a correct price_limit
-                    1u32.into(),
                     end_block.height.try_into().expect("missing height"),
                     current_epoch.start_height,
                 )

--- a/app/src/dex/position_manager.rs
+++ b/app/src/dex/position_manager.rs
@@ -18,7 +18,6 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     iter::FromIterator,
     pin::Pin,
-    sync::Arc,
 };
 
 #[async_trait]
@@ -290,7 +289,6 @@ pub(super) trait Inner: StateWrite {
                 end: pair.asset_2(),
             };
             let phi12 = phi.component.clone();
-            let k = state_key::internal::price_index::key(&pair12, &phi12, &id);
             self.nonconsensus_put_raw(
                 state_key::internal::price_index::key(&pair12, &phi12, &id),
                 vec![],
@@ -305,7 +303,6 @@ pub(super) trait Inner: StateWrite {
                 end: pair.asset_1(),
             };
             let phi21 = phi.component.flip();
-            let k = state_key::internal::price_index::key(&pair21, &phi21, &id);
             self.nonconsensus_put_raw(
                 state_key::internal::price_index::key(&pair21, &phi21, &id),
                 vec![],

--- a/app/src/dex/router/fill_route.rs
+++ b/app/src/dex/router/fill_route.rs
@@ -108,7 +108,7 @@ pub trait FillRoute: StateWrite + Sized {
         &mut self,
         mut input: Value,
         hops: &[asset::Id],
-        spill_price: U128x128,
+        spill_price: Option<U128x128>,
     ) -> Result<(Value, Value)> {
         let mut route = hops.to_vec();
         route.insert(0, input.asset_id);
@@ -152,7 +152,7 @@ pub trait FillRoute: StateWrite + Sized {
             tracing::debug!(num = constraining_hops.len(), "found constraints");
 
             //  Stop filling if the effective price exceeds the spill price.
-            if effective_price > spill_price {
+            if spill_price.map(|s| effective_price > s).unwrap_or(false) {
                 tracing::debug!(?effective_price, ?spill_price, "spill price hit!");
                 break 'filling;
             }

--- a/app/src/dex/router/path_search.rs
+++ b/app/src/dex/router/path_search.rs
@@ -8,8 +8,6 @@ use tracing::instrument;
 use crate::dex::PositionManager;
 
 use super::{Path, PathCache, PathEntry, SharedPathCache};
-use crate::dex::PositionRead;
-use penumbra_crypto::dex::DirectedTradingPair;
 
 #[async_trait]
 pub trait PathSearch: StateRead + Clone + 'static {
@@ -22,19 +20,6 @@ pub trait PathSearch: StateRead + Clone + 'static {
         max_hops: usize,
     ) -> Result<(Option<Vec<asset::Id>>, Option<U128x128>)> {
         tracing::debug!(?src, ?dst, ?max_hops, "searching for path");
-
-        /*
-
-
-        If I query the stream here, do i get the best position
-
-        */
-
-        let pair = DirectedTradingPair {
-            start: src,
-            end: dst,
-        };
-        let best_position = self.best_position(&pair).await;
 
         // Work in a new stack of state changes, which we can completely discard
         // at the end of routing

--- a/app/src/dex/router/route_and_fill.rs
+++ b/app/src/dex/router/route_and_fill.rs
@@ -4,15 +4,14 @@ use anyhow::Result;
 use async_trait::async_trait;
 use penumbra_crypto::{
     asset,
-    dex::{BatchSwapOutputData, DirectedTradingPair, TradingPair},
-    fixpoint::U128x128,
+    dex::{BatchSwapOutputData, TradingPair},
     Amount, SwapFlow, Value,
 };
 use penumbra_storage::StateWrite;
 
 use crate::dex::{
     router::{FillRoute, PathSearch},
-    PositionManager, PositionRead, StateWriteExt,
+    PositionManager, StateWriteExt,
 };
 
 /// Ties together the routing and filling logic, to process
@@ -23,8 +22,6 @@ pub trait RouteAndFill: StateWrite + Sized {
         self: &mut Arc<Self>,
         trading_pair: TradingPair,
         batch_data: SwapFlow,
-        // TODO: use price_limit to clamp spill price or set to 1 for arb
-        price_limit: Amount,
         block_height: u64,
         epoch_height: u64,
     ) -> Result<()>
@@ -37,52 +34,18 @@ pub trait RouteAndFill: StateWrite + Sized {
 
         // Depending on the contents of the batch swap inputs, we might need to path search in either direction.
         let (lambda_2, unfilled_1) = if delta_1.value() > 0 {
-            // The price limit is the maximum price we're willing to pay for asset 1 -> asset 2.
-            // Since we don't have a good way of setting a mid-price based on positions and available liquidity designed right now
-            // let's just set it to the maximum price in any position to fill as much as possible.
-            let target_pair =
-                DirectedTradingPair::new(trading_pair.asset_1(), trading_pair.asset_2());
-            if let Some(worst_price_position) = self.worst_position(&target_pair).await? {
-                // There is input for asset 1, so we need to route for asset 1 -> asset 2
-                self.route_and_fill_inner(
-                    trading_pair.asset_1(),
-                    trading_pair.asset_2(),
-                    delta_1,
-                    Amount::try_from(worst_price_position.phi.component.effective_price())?,
-                )
+            // There is input for asset 1, so we need to route for asset 1 -> asset 2
+            self.route_and_fill_inner(trading_pair.asset_1(), trading_pair.asset_2(), delta_1)
                 .await?
-            } else {
-                (0u64.into(), delta_1)
-            }
         } else {
             // There was no input for asset 1, so there's 0 output for asset 2 from this side.
             (0u64.into(), delta_1)
         };
 
         let (lambda_1, unfilled_2) = if delta_2.value() > 0 {
-            // The price limit is the maximum price we're willing to pay for asset 2 -> asset 1.
-            // Since we don't have a good way of setting a mid-price based on positions and available liquidity designed right now
-            // let's just set it to the maximum price in any position to fill as much as possible.
-            let target_pair =
-                DirectedTradingPair::new(trading_pair.asset_2(), trading_pair.asset_1());
-            if let Some(worst_price_position) = self.worst_position(&target_pair).await? {
-                tracing::debug!(
-                    ?target_pair,
-                    ?worst_price_position,
-                    "routing and filling with price limit from worst position"
-                );
-                // There is input for asset 1, so we need to route for asset 1 -> asset 2
-                self.route_and_fill_inner(
-                    trading_pair.asset_2(),
-                    trading_pair.asset_1(),
-                    delta_2,
-                    Amount::try_from(worst_price_position.phi.component.effective_price())?,
-                )
+            // There is input for asset 1, so we need to route for asset 1 -> asset 2
+            self.route_and_fill_inner(trading_pair.asset_2(), trading_pair.asset_1(), delta_2)
                 .await?
-            } else {
-                tracing::debug!(?target_pair, "no worst priced position found");
-                (0u64.into(), delta_2)
-            }
         } else {
             // There was no input for asset 2, so there's 0 output for asset 1 from this side.
             (0u64.into(), delta_2)
@@ -112,7 +75,6 @@ pub trait RouteAndFill: StateWrite + Sized {
         asset_1: asset::Id,
         asset_2: asset::Id,
         delta_1: Amount,
-        price_limit: Amount,
     ) -> Result<(Amount, Amount)>
     where
         Self: 'static,
@@ -123,11 +85,6 @@ pub trait RouteAndFill: StateWrite + Sized {
             .path_search(asset_1, asset_2, 4)
             .await
             .unwrap();
-
-        let spill_price = match spill_price {
-            Some(spill_price) => spill_price,
-            None => U128x128::from(price_limit.value()),
-        };
 
         tracing::debug!("path is some? {}", path.is_some());
 

--- a/app/src/dex/router/tests.rs
+++ b/app/src/dex/router/tests.rs
@@ -5,6 +5,7 @@ use crate::dex::{StateReadExt, StateWriteExt};
 use crate::temp_storage_ext::TempStorageExt;
 use futures::StreamExt;
 use penumbra_crypto::dex::lp::position::Position;
+use penumbra_crypto::MockFlowCiphertext;
 use penumbra_crypto::{
     asset,
     asset::Unit,
@@ -15,7 +16,6 @@ use penumbra_crypto::{
     fixpoint::U128x128,
     Amount, Value,
 };
-use penumbra_crypto::{MockFlowCiphertext, SwapFlow};
 use penumbra_storage::ArcStateDeltaExt;
 use penumbra_storage::TempStorage;
 use penumbra_storage::{StateDelta, StateWrite};
@@ -557,9 +557,10 @@ async fn fill_route_constraint_stacked() -> anyhow::Result<()> {
 
     let spill_price = U128x128::from(Amount::from(1_000_000_000u64) * pusd.unit_amount());
 
-    let (unfilled, output) = FillRoute::fill_route(&mut state_tx, delta_1, &route, spill_price)
-        .await
-        .unwrap();
+    let (unfilled, output) =
+        FillRoute::fill_route(&mut state_tx, delta_1, &route, Some(spill_price))
+            .await
+            .unwrap();
 
     // let output_cal = U128x128::ratio(output.amount, pusd.unit_amount()).unwrap();
     let desired_output: Amount = (Amount::from(10_000u64)
@@ -655,9 +656,10 @@ async fn fill_route_constraint_1() -> anyhow::Result<()> {
 
     let spill_price = U128x128::from(Amount::from(1_000_000_000u64) * pusd.unit_amount());
 
-    let (unfilled, output) = FillRoute::fill_route(&mut state_tx, delta_1, &route, spill_price)
-        .await
-        .unwrap();
+    let (unfilled, output) =
+        FillRoute::fill_route(&mut state_tx, delta_1, &route, Some(spill_price))
+            .await
+            .unwrap();
 
     let desired_output: Amount = (Amount::from(10_000u64)
         + Amount::from(3100u64)
@@ -737,9 +739,10 @@ async fn fill_route_unconstrained() -> anyhow::Result<()> {
     let spill_price =
         (U128x128::from(1_000_000_000_000u64) * U128x128::from(pusd.unit_amount())).unwrap();
 
-    let (unfilled, output) = FillRoute::fill_route(&mut state_tx, delta_1, &route, spill_price)
-        .await
-        .unwrap();
+    let (unfilled, output) =
+        FillRoute::fill_route(&mut state_tx, delta_1, &route, Some(spill_price))
+            .await
+            .unwrap();
 
     let desired_output = Amount::from(3000u64) * pusd.unit_amount();
 
@@ -817,9 +820,10 @@ async fn fill_route_hit_spill_price() -> anyhow::Result<()> {
     let valuation_gm = (U128x128::from(one) * U128x128::from(gm.unit_amount())).unwrap();
     let spill_price = U128x128::ratio(valuation_gm, valuation_penumbra).unwrap();
 
-    let (unfilled, output) = FillRoute::fill_route(&mut state_tx, delta_1, &route, spill_price)
-        .await
-        .unwrap();
+    let (unfilled, output) =
+        FillRoute::fill_route(&mut state_tx, delta_1, &route, Some(spill_price))
+            .await
+            .unwrap();
 
     let desired_output = Amount::from(2900u64) * pusd.unit_amount();
 
@@ -909,7 +913,7 @@ async fn best_position_route_and_fill() -> anyhow::Result<()> {
         .unwrap()
         .put_swap_flow(&trading_pair, swap_flow.clone());
     state
-        .handle_batch_swaps(trading_pair, swap_flow, 0u32.into(), 0, 0)
+        .handle_batch_swaps(trading_pair, swap_flow, 0u32.into(), 0)
         .await
         .expect("unable to process batch swaps");
 

--- a/app/src/dex/tests.rs
+++ b/app/src/dex/tests.rs
@@ -1,5 +1,5 @@
 use anyhow::Ok;
-use futures::{FutureExt, StreamExt};
+use futures::StreamExt;
 use penumbra_crypto::{
     asset::{self},
     dex::{

--- a/pcli/src/command/tx/liquidity_position.rs
+++ b/pcli/src/command/tx/liquidity_position.rs
@@ -170,9 +170,9 @@ impl OrderCmd {
                     .default_unit();
 
                 // We're buying 1 unit of the desired asset...
-                let p = desired_unit.unit_amount();
+                let q = desired_unit.unit_amount();
                 // ... for the given amount of the price asset.
-                let q = buy_order.price.amount;
+                let p = buy_order.price.amount;
 
                 // we want to end up with (r1, r2) = (0, desired)
                 // amm is p * r1 + q * r2 = k
@@ -209,9 +209,9 @@ impl OrderCmd {
                     .default_unit();
 
                 // We're selling 1 unit of the selling asset...
-                let p = selling_unit.unit_amount();
+                let q = selling_unit.unit_amount();
                 // ... for the given amount of the price asset.
-                let q = sell_order.price.amount;
+                let p = sell_order.price.amount;
 
                 (
                     pair,


### PR DESCRIPTION
Something's still wrong here, because we're doing pessimal routing:
```
cargo run --release --bin pcli -- -n http://localhost:8080 tx position order sell 200penumbra@1.3gm
cargo run --release --bin pcli -- -n http://localhost:8080 tx position order sell 20penumbra@1.2gm
cargo run --release --bin pcli -- -n http://localhost:8080 tx position order sell 10penumbra@1.1gm
```
```
cargo run --release --bin pcli -- -n http://localhost:8080 q dex liquidity-positions
 ID                                                                Trading Pair    State   Reserves  Trading Function
 plpid1drwgws98rry6xqcax9dtavfh3s4j7u6sr2mdd43qsm775ultm3pql8rleg  (gm, penumbra)  opened  (0, 10)   fee: 0bps, p/q: 1.100000, q/p: 0.909091
 plpid1rzrcq2rm6pgdtv2ffxfry92zaxek0z4vjwl423r3j5vduyz0mveq4k4yjm  (gm, penumbra)  opened  (0, 200)  fee: 0bps, p/q: 1.300000, q/p: 0.769231
 plpid1vzkrgpshpnchlfyvncpku6kzqvze2d8f4ydk0jjqlruy3z7tx4qstxr79j  (gm, penumbra)  opened  (0, 20)   fee: 0bps, p/q: 1.200000, q/p: 0.833333
 ```
```
     Running `target/release/pcli -n 'http://localhost:8080' tx swap 80gm --into penumbra`
2023-05-03T17:44:08.032733Z  INFO pcli::opt: using local view service path=/Users/hdevalence/Library/Application Support/zone.penumbra.pcli/pcli-view.sqlite
2023-05-03T17:44:08.062440Z  INFO penumbra_view::worker: starting client sync
Scanning blocks from last sync height 45 to latest height 45
[0s] ██████████████████████████████████████████████████       0/0       0/s ETA: 0s
building transaction...
finished proving in 1.991 seconds [3 actions, 2 proofs, 2361 bytes]
broadcasting transaction and awaiting confirmation...
transaction confirmed and detected: a1e1706e1f0720646e30c473e3862df8d5f090c2f33a6cb71e232f57fd0e2527
Swap submitted and batch confirmed!
You will receive outputs of 0ugm and 104penumbra. Claiming now...
building transaction...
finished proving in 0.001 seconds [1 actions, 0 proofs, 3162 bytes]
broadcasting transaction and awaiting confirmation...
```
But `104/80 = 1.3`:
```
 ID                                                                Trading Pair    State   Reserves  Trading Function
 plpid1drwgws98rry6xqcax9dtavfh3s4j7u6sr2mdd43qsm775ultm3pql8rleg  (gm, penumbra)  opened  (0, 10)   fee: 0bps, p/q: 1.100000, q/p: 0.909091
 plpid1rzrcq2rm6pgdtv2ffxfry92zaxek0z4vjwl423r3j5vduyz0mveq4k4yjm  (gm, penumbra)  opened  (80, 96)  fee: 0bps, p/q: 1.300000, q/p: 0.769231
 plpid1vzkrgpshpnchlfyvncpku6kzqvze2d8f4ydk0jjqlruy3z7tx4qstxr79j  (gm, penumbra)  opened  (0, 20)   fee: 0bps, p/q: 1.200000, q/p: 0.833333
 ```