### PR TITLE
ci: update rust cache action v1 -> v2

### DIFF
--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -24,7 +24,7 @@ jobs:
           toolchain: nightly
           override: true
       - name: Load Rust caching
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
       - name: Load get-version action to grab version component of deployment path
         uses: battila7/get-version-action@v2
         id: get_version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,8 @@ jobs:
           toolchain: stable
           override: true
       - uses: taiki-e/install-action@nextest
-      - uses: Swatinem/rust-cache@v1
+      - name: Load rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Run tests with nextest
         uses: actions-rs/cargo@v1
         with:
@@ -35,7 +36,8 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - name: Load rust cache
+        uses: Swatinem/rust-cache@v2
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:
@@ -52,7 +54,8 @@ jobs:
   #        profile: minimal
   #        toolchain: stable
   #        override: true
-  #    - uses: Swatinem/rust-cache@v1
+  #    - name: Load rust cache
+  #      uses: Swatinem/rust-cache@v2
   #    - run: rustup component add clippy
   #    - uses: actions-rs/cargo@v1
   #      with:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -20,7 +20,8 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - uses: Swatinem/rust-cache@v1
+      - name: Load rust cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Install tendermint binary
         run: |


### PR DESCRIPTION
We've gone over the 10GB per-repo limit for workflow caches on GH. GH will automatically evict caches not used for a week or longer, but we've had a bunch of active PRs with plenty of rebases, and went over, ~22GB/10GB. Manually cleaned up old caches in the GitHub UI [1] to unbreak workflow runs. This change brings us up to speed with the latest release for the associated GH action helper, which has some updated caching settings in the changelog. May need to follow up with refinements to ensure that we don't hit the cache limit again.

N.B. GH does not allow us to purchase a cache increase per repo, which is unfortunate.

[0] https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
[1] https://github.com/penumbra-zone/penumbra/actions/caches