### PR TITLE
fix: put starting block height of epoch into BSOD

### DIFF
--- a/app/src/dex/component.rs
+++ b/app/src/dex/component.rs
@@ -49,7 +49,7 @@ impl Component for Dex {
                     // TODO: pass a correct price_limit
                     1u32.into(),
                     end_block.height.try_into().expect("missing height"),
-                    current_epoch.index,
+                    current_epoch.start_height,
                 )
                 .await
                 .expect("unable to process batch swaps");

--- a/app/src/dex/router/route_and_fill.rs
+++ b/app/src/dex/router/route_and_fill.rs
@@ -26,7 +26,7 @@ pub trait RouteAndFill: StateWrite + Sized {
         // TODO: use price_limit to clamp spill price or set to 1 for arb
         price_limit: Amount,
         block_height: u64,
-        epoch_index: u64,
+        epoch_height: u64,
     ) -> Result<()>
     where
         Self: 'static,
@@ -90,8 +90,7 @@ pub trait RouteAndFill: StateWrite + Sized {
 
         let output_data = BatchSwapOutputData {
             height: block_height,
-            // TODO: should be called epoch_index
-            epoch_height: epoch_index,
+            epoch_height,
             trading_pair,
             delta_1,
             delta_2,

--- a/pcli/tests/network_integration.rs
+++ b/pcli/tests/network_integration.rs
@@ -282,28 +282,10 @@ fn swap() {
             "swap",
             "--into",
             "gn",
-            "1penumbra",
+            "1upenumbra",
         ])
         .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS));
     swap_cmd.assert().success();
-
-    // HACK: remove once #1749 is fixed
-    thread::sleep(std::time::Duration::from_secs(10));
-
-    // Cleanup: Swap the gn back (will fail if we received no gn in the above swap).
-    let mut swap_back_cmd = Command::cargo_bin("pcli").unwrap();
-    swap_back_cmd
-        .args([
-            "--data-path",
-            tmpdir.path().to_str().unwrap(),
-            "tx",
-            "swap",
-            "--into",
-            "penumbra",
-            "0.9gn",
-        ])
-        .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS));
-    swap_back_cmd.assert().success();
 }
 
 #[ignore]


### PR DESCRIPTION
This fixes the swap integration test failure seen [here](https://github.com/penumbra-zone/penumbra/actions/runs/4874596015/jobs/8695739703)