### PR TITLE
test(integration): Fix dex smoketests

### DIFF
--- a/app/src/dex/router/route_and_fill.rs
+++ b/app/src/dex/router/route_and_fill.rs
@@ -43,7 +43,7 @@ pub trait RouteAndFill: StateWrite + Sized {
         };
 
         let (lambda_1, unfilled_2) = if delta_2.value() > 0 {
-            // There is input for asset 1, so we need to route for asset 1 -> asset 2
+            // There is input for asset 2, so we need to route for asset 2 -> asset 1
             self.route_and_fill_inner(trading_pair.asset_2(), trading_pair.asset_1(), delta_2)
                 .await?
         } else {

--- a/pcli/tests/network_integration.rs
+++ b/pcli/tests/network_integration.rs
@@ -336,6 +336,8 @@ fn swap() {
         .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS));
     swap_cmd.assert().success();
 
+    // Sleep to allow the outputs from the swap to be processed.
+    thread::sleep(*UNBONDING_DURATION);
     let mut balance_cmd = Command::cargo_bin("pcli").unwrap();
     balance_cmd
         .args([


### PR DESCRIPTION
The existing dex smoketests assumed the genesis liquidity pools would exist and were failing as a result.

They've been updated to exercise liquidity position opening to enable the swap to run.

We should probably add a full LP lifecycle test.