### PR TITLE
Fill across consecutive routes until all input exhausted or no route can be found

### DIFF
--- a/app/src/dex/component.rs
+++ b/app/src/dex/component.rs
@@ -40,8 +40,6 @@ impl Component for Dex {
         let current_epoch = state.epoch().await.unwrap();
         // For each batch swap during the block, calculate clearing prices and set in the JMT.
         for (trading_pair, swap_flows) in state.swap_flows() {
-            // Arc::get_mut(state)
-            //     .expect("one state ref only")
             state
                 .handle_batch_swaps(
                     trading_pair,

--- a/app/src/dex/router/tests.rs
+++ b/app/src/dex/router/tests.rs
@@ -306,7 +306,6 @@ fn create_test_positions_basic<S: StateWrite>(s: &mut S, misprice: bool) {
     s.put_position(position_8);
 }
 
-
 /// Create a `Position` to buy `asset_1` using `asset_2` with explicit p/q.
 /// e.g. "Buy `quantity` of `asset_1` for `price` units of `asset_2` each.
 fn limit_buy_pq(market: Market, quantity: Amount, p: Amount, q: Amount, fee: u32) -> Position {
@@ -322,7 +321,6 @@ fn limit_buy_pq(market: Market, quantity: Amount, p: Amount, q: Amount, fee: u32
         },
     )
 }
-
 
 /// Create a `Position` to buy `asset_1` using `asset_2`.
 /// e.g. "Buy `quantity` of `asset_1` for `price` units of `asset_2` each.


### PR DESCRIPTION
This fixes the dex execution so that all available routes will be exercised during filling of batch swaps.