### PR TITLE
dex: burn rounding error rather than halting the chain

### DIFF
--- a/app/src/dex/router/fill_route.rs
+++ b/app/src/dex/router/fill_route.rs
@@ -226,17 +226,19 @@ pub trait FillRoute: StateWrite + Sized {
                 // This should not happen, since the `current_capacity` is the
                 // saturating input for the route.
                 if unfilled.amount > 0u64.into() {
-                    tracing::error!(
-                        ?pair,
+                    tracing::warn!(
                         ?unfilled,
-                        ?position,
                         ?current_value,
-                        "residual unfilled amount here"
+                        ?position,
+                        ?pair,
+                        "burning unexpected residual unfilled amount"
                     );
+                    /*
                     return Err(anyhow::anyhow!(
                         "internal error: unfilled amount after filling against {:?}",
                         position.id(),
                     ));
+                    */
                 }
                 current_value = output;
 


### PR DESCRIPTION
After running these commands, similar to our test code:
```
cargo run --release --bin pcli -- -n http://localhost:8080 tx position order sell 25gn@1gm
cargo run --release --bin pcli -- -n http://localhost:8080 tx position order buy 1pusd@20gm
cargo run --release --bin pcli -- -n http://localhost:8080 tx position order buy 1pusd@20gm
cargo run --release --bin pcli -- -n http://localhost:8080 tx position order buy 5penumbra@1gm
cargo run --release --bin pcli -- -n http://localhost:8080 tx position order sell 1pusd@5penumbra
cargo run --release --bin pcli -- -n http://localhost:8080 tx swap 10penumbra --into gn
```
I saw this chain halt: https://gist.github.com/hdevalence/2ee2c17d6092dca701b45821b2cc9b0f

This commit changes the code to instead burn any rounding error and warn loudly about it. (We should also figure out what the cause is and fix that).