### PR TITLE
pcli: print height of detected transactions

### DIFF
--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -59,8 +59,15 @@ impl App {
         transaction: Transaction,
     ) -> Result<TransactionId, anyhow::Error> {
         println!("broadcasting transaction and awaiting confirmation...");
-        let id = self.view().broadcast_transaction(transaction, true).await?;
-        println!("transaction confirmed and detected: {}", id);
+        let (id, detection_height) = self.view().broadcast_transaction(transaction, true).await?;
+        if detection_height != 0 {
+            println!(
+                "transaction confirmed and detected: {} @ {}",
+                id, detection_height
+            );
+        } else {
+            println!("transaction confirmed and detected: {}", id);
+        }
         Ok(id)
     }
 

--- a/pcli/src/network.rs
+++ b/pcli/src/network.rs
@@ -62,7 +62,7 @@ impl App {
         let (id, detection_height) = self.view().broadcast_transaction(transaction, true).await?;
         if detection_height != 0 {
             println!(
-                "transaction confirmed and detected: {} @ {}",
+                "transaction confirmed and detected: {} @ height {}",
                 id, detection_height
             );
         } else {

--- a/proto/proto/penumbra/view/v1alpha1/view.proto
+++ b/proto/proto/penumbra/view/v1alpha1/view.proto
@@ -90,6 +90,9 @@ message BroadcastTransactionRequest {
 message BroadcastTransactionResponse {
   // The hash of the transaction that was broadcast.
   core.transaction.v1alpha1.Id id = 1;
+  // The height in which the transaction was detected as included in the chain, if any.
+  // Will not be included unless await_detection was true.
+  uint64 detection_height = 2;
 }
 
 message TransactionPlannerRequest {

--- a/proto/src/gen/penumbra.view.v1alpha1.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.rs
@@ -16,6 +16,10 @@ pub struct BroadcastTransactionResponse {
     /// The hash of the transaction that was broadcast.
     #[prost(message, optional, tag = "1")]
     pub id: ::core::option::Option<super::super::core::transaction::v1alpha1::Id>,
+    /// The height in which the transaction was detected as included in the chain, if any.
+    /// Will not be included unless await_detection was true.
+    #[prost(uint64, tag = "2")]
+    pub detection_height: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/proto/src/gen/penumbra.view.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.serde.rs
@@ -790,9 +790,15 @@ impl serde::Serialize for BroadcastTransactionResponse {
         if self.id.is_some() {
             len += 1;
         }
+        if self.detection_height != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("penumbra.view.v1alpha1.BroadcastTransactionResponse", len)?;
         if let Some(v) = self.id.as_ref() {
             struct_ser.serialize_field("id", v)?;
+        }
+        if self.detection_height != 0 {
+            struct_ser.serialize_field("detectionHeight", ToString::to_string(&self.detection_height).as_str())?;
         }
         struct_ser.end()
     }
@@ -805,11 +811,14 @@ impl<'de> serde::Deserialize<'de> for BroadcastTransactionResponse {
     {
         const FIELDS: &[&str] = &[
             "id",
+            "detection_height",
+            "detectionHeight",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Id,
+            DetectionHeight,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -832,6 +841,7 @@ impl<'de> serde::Deserialize<'de> for BroadcastTransactionResponse {
                     {
                         match value {
                             "id" => Ok(GeneratedField::Id),
+                            "detectionHeight" | "detection_height" => Ok(GeneratedField::DetectionHeight),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -852,6 +862,7 @@ impl<'de> serde::Deserialize<'de> for BroadcastTransactionResponse {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut id__ = None;
+                let mut detection_height__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::Id => {
@@ -860,10 +871,19 @@ impl<'de> serde::Deserialize<'de> for BroadcastTransactionResponse {
                             }
                             id__ = map.next_value()?;
                         }
+                        GeneratedField::DetectionHeight => {
+                            if detection_height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("detectionHeight"));
+                            }
+                            detection_height__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                     }
                 }
                 Ok(BroadcastTransactionResponse {
                     id: id__,
+                    detection_height: detection_height__.unwrap_or_default(),
                 })
             }
         }

--- a/proto/src/gen/proto_descriptor.bin
+++ b/proto/src/gen/proto_descriptor.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c3738e1fced8473c9581602a2b841971380294006dd9bbafa58acd937db6a909
-size 334703
+oid sha256:19fd627a63cd8577fd808063c0d831716c4f56d765bd811541fd63a92f49aedc
+size 334952


### PR DESCRIPTION
This is useful for working with the DEX, where most of the queries are height-based.
Example output:
```
     Running `target/release/pcli -n 'http://testnet-preview.penumbra.zone:8080' tx lp order buy '20penumbra@0.9gn' --spread 50`
Scanning blocks from last sync height 522 to latest height 522
[0s] ██████████████████████████████████████████████████       0/0       0/s ETA: 0s
building transaction...
finished proving in 0.874 seconds [4 actions, 3 proofs, 2542 bytes]
broadcasting transaction and awaiting confirmation...
transaction confirmed and detected: 278a6b0a6e7781097551dff250094c0494c32569470bf4f6411c832865d3b68c @ 523
```