### PR TITLE
pcli: add proposal cost to query chain params

### DIFF
--- a/pcli/src/command/query/chain.rs
+++ b/pcli/src/command/query/chain.rs
@@ -81,6 +81,10 @@ impl ChainCmd {
                 "Missed Blocks Max",
                 &format!("{}", params.missed_blocks_maximum),
             ])
+            .add_row(vec![
+                "Proposal Deposit Amount (upenumbra)",
+                &format!("{}", params.proposal_deposit_amount),
+            ])
             .add_row(vec!["IBC Enabled", &format!("{}", params.ibc_enabled)])
             .add_row(vec![
                 "Inbound ICS-20 Enabled",


### PR DESCRIPTION
Wanted to look this up, and the first place I checked didn't have it. Exposing it in the `pcli query chain params` output for visibility.