### PR TITLE
grpc: re-enable http/1

### DIFF
--- a/narsil/src/bin/narsild.rs
+++ b/narsil/src/bin/narsild.rs
@@ -182,7 +182,7 @@ async fn main() -> anyhow::Result<()> {
                             None => tracing::error_span!("grpc"),
                         })
                         // Allow HTTP/1, which will be used by grpc-web connections.
-                        //.accept_http1(true)
+                        .accept_http1(true)
                         // Wrap each of the gRPC services in a tonic-web proxy:
                         .add_service(tonic_web::enable(LedgerServiceServer::new(info.clone())))
                         .add_service(tonic_web::enable(TendermintProxyServiceServer::new(

--- a/pclientd/src/lib.rs
+++ b/pclientd/src/lib.rs
@@ -241,7 +241,7 @@ impl Opt {
                 });
 
                 let server = Server::builder()
-                    //.accept_http1(true)
+                    .accept_http1(true)
                     .add_service(tonic_web::enable(view_service))
                     .add_optional_service(custody_service.map(|s| tonic_web::enable(s)))
                     .add_service(tonic_web::enable(oblivious_query_proxy))

--- a/pd/src/main.rs
+++ b/pd/src/main.rs
@@ -287,7 +287,7 @@ async fn main() -> anyhow::Result<()> {
                     None => tracing::error_span!("grpc"),
                 })
                 // Allow HTTP/1, which will be used by grpc-web connections.
-                //.accept_http1(true)
+                .accept_http1(true)
                 // Wrap each of the gRPC services in a tonic-web proxy:
                 .add_service(tonic_web::enable(ObliviousQueryServiceServer::new(
                     info.clone(),


### PR DESCRIPTION
This restores the ability to use web clients, like https://studio.buf.build, or the browser extension, against local instances of these services.  I also tested (by temporarily running this branch on `pd-tls.penumbra.zone` with auto-https enabled) to check that it doesn't interfere with https support, either for browser clients or for `pcli`.