### PR TITLE
pd: add query handlers for packet queries

### DIFF
--- a/crates/ibc/src/component/channel.rs
+++ b/crates/ibc/src/component/channel.rs
@@ -131,6 +131,19 @@ pub trait StateReadExt: StateRead {
             .map(|res| res.is_some())
     }
 
+    async fn seen_packet_by_channel(
+        &self,
+        channel_id: &ChannelId,
+        port_id: &PortId,
+        sequence: u64,
+    ) -> Result<bool> {
+        self.get_proto::<String>(&state_key::receipt_by_channel(
+            port_id, channel_id, sequence,
+        ))
+        .await
+        .map(|res| res.is_some())
+    }
+
     async fn get_packet_commitment(&self, packet: &Packet) -> Result<Option<Vec<u8>>> {
         let commitment = self
             .get_proto::<Vec<u8>>(&state_key::packet_commitment(packet))

--- a/crates/ibc/src/component/channel.rs
+++ b/crates/ibc/src/component/channel.rs
@@ -159,6 +159,28 @@ pub trait StateReadExt: StateRead {
         Ok(commitment)
     }
 
+    async fn get_packet_commitment_by_id(
+        &self,
+        channel_id: &ChannelId,
+        port_id: &PortId,
+        sequence: u64,
+    ) -> Result<Option<Vec<u8>>> {
+        let commitment = self
+            .get_proto::<Vec<u8>>(&state_key::packet_commitment_by_port(
+                port_id, channel_id, sequence,
+            ))
+            .await?;
+
+        // this is for the special case where the commitment is empty, we consider this None.
+        if let Some(commitment) = commitment.as_ref() {
+            if commitment.is_empty() {
+                return Ok(None);
+            }
+        }
+
+        Ok(commitment)
+    }
+
     async fn get_packet_acknowledgement(
         &self,
         port_id: &PortId,

--- a/crates/ibc/src/component/state_key.rs
+++ b/crates/ibc/src/component/state_key.rs
@@ -81,6 +81,15 @@ pub fn packet_receipt(packet: &Packet) -> String {
     )
 }
 
+pub fn receipt_by_channel(port_id: &PortId, channel_id: &ChannelId, sequence: u64) -> String {
+    format!(
+        "receipts/ports/{port_id}/channels/{channel_id}/receipts/{sequence}",
+        port_id = port_id,
+        channel_id = channel_id,
+        sequence = sequence
+    )
+}
+
 pub fn packet_commitment(packet: &Packet) -> String {
     format!(
         "commitments/ports/{}/channels/{}/packets/{}",

--- a/deployments/relayer/configs/penumbra-preview.json
+++ b/deployments/relayer/configs/penumbra-preview.json
@@ -2,7 +2,7 @@
   "type": "penumbra",
   "value": {
     "key": "default",
-    "chain-id": "penumbra-testnet-elara-86f051fb",
+    "chain-id": "penumbra-testnet-elara-5ef698c5",
     "rpc-addr": "https://rpc.testnet-preview.penumbra.zone:443",
     "account-prefix": "penumbrav2t",
     "keyring-backend": "test",


### PR DESCRIPTION
these are required for packet relay compatibility with the cosmos relayer 