### PR TITLE
Added wrapper function for wasm, TXV/TXP serialization and deserialization in JsValue, insert in notes_by_nullifier 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-wasm"
-version = "0.51.0"
+version = "0.51.1"
 dependencies = [
  "anyhow",
  "base64 0.20.0",

--- a/wasm/src/view_server.rs
+++ b/wasm/src/view_server.rs
@@ -288,7 +288,7 @@ impl ViewServer {
                                 source,
                             };
                             new_notes.push(note_record.clone());
-                            self.notes.insert(payload.note_commitment, note_recor.clone());
+                            self.notes.insert(payload.note_commitment, note_record.clone());
                             self.notes_by_nullifier.insert(nullifier, note_record.clone());
 
                         }


### PR DESCRIPTION
- Added a transaction_info wrapper function that deserializes JsValue into Transaction, and serializes TransactionPerspective and TransactionView into JsValue
- Added insert in notes_by_nullifier in block scan function   
Extras: 
We originally planned to change the initialization of ViewServer and pass in data about known notes during initialization. But we changed the architecture of the wallet extension so that it queries TxP and TxV from wasm during block scans and stores all transaction information in indexedDb, and in this scenario the ViewServer state will always have the notes we need to get TxP and TxV 