### PR TITLE
dex: exact spill price handling in `FillRoute`

### DIFF
--- a/app/src/dex/router/fill_route.rs
+++ b/app/src/dex/router/fill_route.rs
@@ -147,7 +147,7 @@ async fn fill_route_inner<S: StateWrite + Sized>(
         // - `None` on the spill price means no limit.
         // - `None` on the actual price means infinite price.
         let should_apply = if let Some(spill_price) = spill_price {
-            let below_limit = tx.actual_price().map(|p| p < spill_price).unwrap_or(false);
+            let below_limit = tx.actual_price().map(|p| p <= spill_price).unwrap_or(false);
 
             // We should apply if we're below the limit, or we haven't yet made progress.
             below_limit || !filled_once

--- a/app/src/dex/router/fill_route.rs
+++ b/app/src/dex/router/fill_route.rs
@@ -9,7 +9,10 @@ use futures::{Stream, StreamExt};
 use penumbra_crypto::{
     asset,
     dex::{
-        lp::position::{self, Position},
+        lp::{
+            position::{self, Position},
+            Reserves,
+        },
         DirectedTradingPair,
     },
     fixpoint::U128x128,
@@ -22,7 +25,19 @@ use crate::dex::{PositionManager, PositionRead};
 
 #[async_trait]
 pub trait FillRoute: StateWrite + Sized {
+    /// Fills a trade of a given `input` amount along a given route of `hops`,
+    /// optionally using `spill_price` to put limits on execution.
     ///
+    /// Note: this method will always execute at least one sub-trade along the
+    /// route, even if it would exceed the spill price (i.e., the spill price is
+    /// only used after consuming at least one position along the route). This
+    /// covers an edge case in routing, which computes approximate spill prices:
+    /// if there were two routes with very similar prices, and both of their
+    /// estimated prices were underestimates, the routing could potentially
+    /// switch back and forth between them without making progress. Ensuring we
+    /// always consume at least one position prevents this possibility.
+    ///
+    /// If this behavior is not desired, use `fill_route_exact` instead.
     ///
     /// # Invariants
     ///
@@ -30,205 +45,179 @@ pub trait FillRoute: StateWrite + Sized {
     #[instrument(skip(self, input, hops, spill_price))]
     async fn fill_route(
         &mut self,
-        mut input: Value,
+        input: Value,
         hops: &[asset::Id],
         spill_price: Option<U128x128>,
     ) -> Result<(Value, Value)> {
-        // Build a transaction for this execution, so if we error out at any
-        // point we don't leave the state in an inconsistent state.  This is
-        // particularly important for this method, because we lift position data
-        // out of the state and modify it in-memory, writing it only as we fully
-        // consume positions.
-        let mut this = StateDelta::new(self);
+        fill_route_inner(self, input, hops, spill_price, true).await
+    }
 
-        // Switch from representing hops implicitly as a sequence of asset IDs to
-        // representing them explicitly as a sequence of directed trading pairs.
-        let route = std::iter::once(input.asset_id)
-            .chain(hops.iter().cloned())
-            .collect::<Vec<_>>();
-        // Break down the route into a sequence of pairs to visit.
-        let pairs = breakdown_route(&route)?;
-
-        tracing::debug!(
-            input = ?input.amount,
-            ?route,
-            ?spill_price,
-        );
-
-        // Record a trace of the execution along the current route,
-        // starting with all-zero amounts.
-        let mut trace: Vec<Value> = std::iter::once(Value {
-            amount: 0u64.into(),
-            asset_id: input.asset_id,
-        })
-        .chain(hops.iter().map(|asset_id| Value {
-            amount: 0u64.into(),
-            asset_id: asset_id.clone(),
-        }))
-        .collect();
-
-        let mut output = Value {
-            amount: 0u64.into(),
-            asset_id: route
-                .last()
-                .cloned()
-                .ok_or_else(|| anyhow::anyhow!("called fill_route with empty route"))?,
-        };
-
-        let mut frontier = Frontier::load(&mut this, pairs).await?;
-        tracing::debug!(?frontier, "assembled initial frontier");
-
-        'filling: loop {
-            // INVARIANT: we must ensure that in each iteration of the loop, either:
-            //
-            // * we completely exhaust the input amount, or
-            // * we completely exhaust the reserves of one of the active positions.
-
-            // Phase 1 (Sensing): determine the index of the constraining position by
-            // executing along the frontier, tracking which hops are
-            // constraining.
-            let constraining_index = frontier.sense_capacity_constraint(input);
-
-            // Phase 2 (Filling): execute along the path, using the constraint information we sensed above.
-
-            // Special case:
-            // If there was no constraining index, we can completely fill the input amount,
-            // upholding the invariant for loop exits by exhausting the input amount.
-            let Some(constraining_index) = constraining_index else {
-                tracing::debug!("no constraining index found, completely filling input amount");
-
-                // Because there's no constraint, we can completely fill the entire input amount.
-                let current_input = input;
-                // We have to manually update the trace here, because fill_forward
-                // doesn't handle the input amount, only things that come after it.
-                trace[0].amount += current_input.amount;
-                let current_output = frontier.fill_forward(0, input, &mut trace);
-
-                // Update the input and output amounts tracked outside of the loop:
-                input.amount = input.amount - current_input.amount;
-                output.amount = output.amount + current_output.amount;
-
-                tracing::debug!(
-                    current_input = ?current_input.amount,
-                    current_output = ?current_output.amount,
-                    input = ?input.amount,
-                    output = ?output.amount,
-                    "filled input amount completely, breaking loop"
-                );
-
-                break 'filling;
-            };
-
-            // If there was a constraining position along the path, we want to
-            // completely consume its reserves, then work "outwards" along the
-            // path, propagating rounding errors forwards to the end of the path
-            // and backwards to the input.
-
-            // Example:
-            // 0     1     2     3      4         [trace index]
-            // UM => GM => GN => USD => ETH       [asset id]
-            //     0     1     2      3           [pair index]
-            //
-            // Suppose that pair 2 is the constraining pair, with 0.1 USD
-            // reserves.  To completely consume the 0.1 USD reserves, we need
-            // work backwards along the path to compute a sequence of input
-            // amounts that are valid trades to get to 0.1 USD output at pair 2,
-            // and work forwards to compute the corresponding output amounts at
-            // the end of the path.
-
-            // We want to completely consume the 0.1 USD reserves, then work backwards
-            // along the path to compute input amounts that are valid trades to get
-
-            let exactly_consumed_reserves = Value {
-                amount: frontier.positions[constraining_index]
-                    .reserves_for(frontier.pairs[constraining_index].end)
-                    .expect("asset ids should match"),
-                asset_id: frontier.pairs[constraining_index].end,
-            };
-
-            tracing::debug!(
-                constraining_index,
-                exactly_consumed_reserves = ?exactly_consumed_reserves.amount,
-                "found constraining index, attempting to completely consume reserves"
-            );
-
-            // Work backwards along the path from the constraining position.
-            let current_input =
-                frontier.fill_backward(constraining_index, exactly_consumed_reserves, &mut trace);
-
-            // Now we know the amount of input we need to supply to exactly
-            // consume the reserves of the constraining position, and have
-            // updated reserves for all positions up to and including the
-            // constraining one.
-
-            // Finally, we work forwards along the path from the constraining
-            // position to the output:
-            let current_output = frontier.fill_forward(
-                constraining_index + 1,
-                exactly_consumed_reserves,
-                &mut trace,
-            );
-            // Now we know the amount of output we can supply, and have updated
-            // reserves for all positions on the frontier.
-
-            // Phase 3: update the frontier and prepare for the next iteration.
-
-            // Update the input and output amounts tracked outside of the loop:
-            input.amount = input.amount - current_input.amount;
-            output.amount = output.amount + current_output.amount;
-
-            tracing::debug!(
-                current_input = ?current_input.amount,
-                current_output = ?current_output.amount,
-                input = ?input.amount,
-                output = ?output.amount,
-                "completed fill iteration, updating frontier"
-            );
-
-            // Try to find a new position to replace the one we just filled.
-            if !frontier.replace_position(constraining_index).await? {
-                tracing::debug!("no more positions to replace, breaking loop");
-                break 'filling;
-            };
-
-            let current_effective_price =
-                U128x128::from(current_input.amount) / U128x128::from(current_output.amount);
-
-            // Check whether we should stop filling because we've exceeded the spill price:
-            // TODO: is comparing Options the right behavior here? can we
-            // continue rolling over dust positions without allowing arbitrarily
-            // higher prices than the requested spill price?
-            if spill_price.is_some() && current_effective_price > spill_price {
-                tracing::debug!(
-                    // HACK: render infinite price as 0
-                    spill_price = %spill_price.unwrap_or_default(),
-                    current_effective_price = %current_effective_price.unwrap_or_default(),
-                    "exceeded spill price, breaking loop"
-                );
-                break 'filling;
-            }
-        }
-
-        // We need to save these positions, because we mutated their state, even
-        // if we didn't fully consume their reserves.
-        frontier.save();
-
-        // Add the trace to the object store:
-        tracing::debug!(?trace, "recording trace of filled route");
-        let mut swap_execution: im::Vector<Vec<Value>> =
-            this.object_get("swap_execution").unwrap_or_default();
-        swap_execution.push_back(trace);
-        this.object_put("swap_execution", swap_execution);
-
-        // Apply the state transaction now that we've reached the end without errors.
-        this.apply();
-
-        // cleanup / finalization
-        Ok((input, output))
+    /// Like `fill_route`, but with exact spill price checks at the cost of
+    /// potentially not making progress.
+    ///
+    /// Use `fill_route` instead unless you have a specific reason to use this
+    /// method.
+    ///
+    /// # Invariants
+    ///
+    /// It is an error to call `fill_route_exact` on a route that does not have
+    /// at least one position for each hop.
+    #[instrument(skip(self, input, hops, spill_price))]
+    async fn fill_route_exact(
+        &mut self,
+        input: Value,
+        hops: &[asset::Id],
+        spill_price: U128x128,
+    ) -> Result<(Value, Value)> {
+        fill_route_inner(self, input, hops, Some(spill_price), false).await
     }
 }
 
 impl<S: StateWrite> FillRoute for S {}
+
+async fn fill_route_inner<S: StateWrite + Sized>(
+    state: S,
+    mut input: Value,
+    hops: &[asset::Id],
+    spill_price: Option<U128x128>,
+    ensure_progress: bool,
+) -> Result<(Value, Value)> {
+    // Build a transaction for this execution, so if we error out at any
+    // point we don't leave the state in an inconsistent state.  This is
+    // particularly important for this method, because we lift position data
+    // out of the state and modify it in-memory, writing it only as we fully
+    // consume positions.
+    let mut this = StateDelta::new(state);
+
+    // Switch from representing hops implicitly as a sequence of asset IDs to
+    // representing them explicitly as a sequence of directed trading pairs.
+    let route = std::iter::once(input.asset_id)
+        .chain(hops.iter().cloned())
+        .collect::<Vec<_>>();
+    // Break down the route into a sequence of pairs to visit.
+    let pairs = breakdown_route(&route)?;
+
+    tracing::debug!(
+        input = ?input.amount,
+        ?route,
+        ?spill_price,
+    );
+
+    let mut output = Value {
+        amount: 0u64.into(),
+        asset_id: route
+            .last()
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("called fill_route with empty route"))?,
+    };
+
+    let mut frontier = Frontier::load(&mut this, pairs).await?;
+    tracing::debug!(?frontier, "assembled initial frontier");
+
+    // Tracks whether we've already filled at least once, so we can skip the spill price check
+    // until we've consumed at least one position.
+    let mut filled_once = if ensure_progress {
+        false
+    } else {
+        // If we don't need to ensure progress, we can act as if we've already filled once.
+        true
+    };
+
+    'filling: loop {
+        // INVARIANT: we must ensure that in each iteration of the loop, either:
+        //
+        // * we completely exhaust the input amount, or
+        // * we completely exhaust the reserves of one of the active positions.
+
+        // Phase 1 (Sensing): determine the index of the constraining position by
+        // executing along the frontier, tracking which hops are
+        // constraining.
+        let constraining_index = frontier.sense_capacity_constraint(input);
+
+        // Phase 2 (Filling): transactionally execute along the path, using
+        // the constraint information we sensed above.
+        let tx = match constraining_index {
+            Some(constraining_index) => frontier.fill_constrained(constraining_index),
+            None => frontier.fill_unconstrained(input),
+        };
+
+        // Phase 3 (Committing): commit the transaction if the actual price was less than the spill price.
+
+        // WATCH OUT:
+        // - `None` on the spill price means no limit.
+        // - `None` on the actual price means infinite price.
+        let should_apply = if let Some(spill_price) = spill_price {
+            let below_limit = tx.actual_price().map(|p| p < spill_price).unwrap_or(false);
+
+            // We should apply if we're below the limit, or we haven't yet made progress.
+            below_limit || !filled_once
+        } else {
+            true
+        };
+
+        if !should_apply {
+            tracing::debug!(
+                // Hack to get an f64-formatted version of the prices; want %p but Option<_> isn't Display
+                spill_price = ?spill_price.map(|x| x.to_string()),
+                actual_price = ?tx.actual_price().map(|x| x.to_string()),
+                "exceeded spill price, breaking loop"
+            );
+            // Discard the unapplied transaction, and break out of the filling loop.
+            break 'filling;
+        }
+
+        let (current_input, current_output) = frontier.apply(tx);
+        filled_once = true;
+
+        // Update the input and output amounts tracked outside of the loop:
+        input.amount = input.amount - current_input;
+        output.amount = output.amount + current_output;
+
+        tracing::debug!(
+            ?current_input,
+            ?current_output,
+            input = ?input.amount,
+            output = ?output.amount,
+            "completed fill iteration, updating frontier"
+        );
+
+        if let Some(constraining_index) = constraining_index {
+            // If we consumed a position, we need to update the frontier and
+            // continue, or exit if no more positions are available.
+            if !frontier.replace_position(constraining_index).await? {
+                tracing::debug!("no more positions to replace, breaking loop");
+                break 'filling;
+            } else {
+                continue 'filling;
+            }
+        } else {
+            // Otherwise, we should be done and it's time to break out of the filling loop.
+            assert_eq!(input.amount, 0u64.into());
+            tracing::debug!("filled input amount completely, breaking loop");
+            break 'filling;
+        }
+    }
+
+    // We need to save these positions, because we mutated their state, even
+    // if we didn't fully consume their reserves.
+    frontier.save();
+
+    let trace = std::mem::take(&mut frontier.trace);
+    std::mem::drop(frontier);
+
+    // Add the trace to the object store:
+    tracing::debug!(?trace, "recording trace of filled route");
+    let mut swap_execution: im::Vector<Vec<Value>> =
+        this.object_get("swap_execution").unwrap_or_default();
+    swap_execution.push_back(trace);
+    this.object_put("swap_execution", swap_execution);
+
+    // Apply the state transaction now that we've reached the end without errors.
+    this.apply();
+
+    // cleanup / finalization
+    Ok((input, output))
+}
 
 /// Breaksdown a route into a collection of `DirectedTradingPair`, this is mostly useful
 /// for debugging right now.
@@ -265,6 +254,39 @@ struct Frontier<S> {
     pub state: S,
     /// A stream of positions for each pair on the route, ordered by price.
     pub positions_by_price: PositionsByPrice,
+    /// A trace of the execution along the route.
+    pub trace: Vec<Value>,
+}
+
+struct FrontierTx {
+    new_reserves: Vec<Option<Reserves>>,
+    trace: Vec<Option<Amount>>,
+}
+
+impl FrontierTx {
+    fn new<S>(frontier: &Frontier<S>) -> FrontierTx {
+        FrontierTx {
+            new_reserves: vec![None; frontier.positions.len()],
+            trace: vec![None; frontier.trace.len()],
+        }
+    }
+
+    fn actual_price(&self) -> Option<U128x128> {
+        let input: U128x128 = self
+            .trace
+            .first()
+            .unwrap()
+            .expect("input amount is set in a complete trace")
+            .into();
+        let output: U128x128 = self
+            .trace
+            .last()
+            .unwrap()
+            .expect("output amount is set in a complete trace")
+            .into();
+
+        input / output
+    }
 }
 
 impl<S> std::fmt::Debug for Frontier<S> {
@@ -273,6 +295,7 @@ impl<S> std::fmt::Debug for Frontier<S> {
             .field("pairs", &self.pairs)
             .field("positions", &self.positions)
             .field("position_ids", &self.position_ids)
+            .field("trace", &self.trace)
             .finish_non_exhaustive()
     }
 }
@@ -321,12 +344,25 @@ impl<S: StateRead + StateWrite> Frontier<S> {
             }
         }
 
+        // Record a trace of the execution along the current route,
+        // starting with all-zero amounts.
+        let trace: Vec<Value> = std::iter::once(Value {
+            amount: 0u64.into(),
+            asset_id: pairs.first().unwrap().start,
+        })
+        .chain(pairs.iter().map(|pair| Value {
+            amount: 0u64.into(),
+            asset_id: pair.end,
+        }))
+        .collect();
+
         Ok(Frontier {
             positions,
             position_ids,
             pairs,
             state,
             positions_by_price,
+            trace,
         })
     }
 
@@ -334,6 +370,26 @@ impl<S: StateRead + StateWrite> Frontier<S> {
         for position in &self.positions {
             self.state.put_position(position.clone());
         }
+    }
+
+    /// Apply the [`FrontierTx`] to the frontier, returning the input and output
+    /// amounts it added to the trace.
+    fn apply(&mut self, changes: FrontierTx) -> (Amount, Amount) {
+        self.trace[0].amount +=
+            changes.trace[0].expect("all trace amounts must be set when applying changes");
+        for (i, new_reserves) in changes.new_reserves.into_iter().enumerate() {
+            let new_reserves =
+                new_reserves.expect("all new reserves must be set when applying changes");
+            let trace =
+                changes.trace[i + 1].expect("all trace amounts must be set when applying changes");
+            self.positions[i].reserves = new_reserves;
+            self.trace[i + 1].amount += trace;
+        }
+
+        (
+            changes.trace.first().unwrap().unwrap(),
+            changes.trace.last().unwrap().unwrap(),
+        )
     }
 
     // Returns Ok(true) if a new position was found to replace the given one,
@@ -439,8 +495,63 @@ impl<S: StateRead + StateWrite> Frontier<S> {
         constraining_index
     }
 
-    #[instrument(skip(self, input, trace), fields(input = ?input.amount))]
-    fn fill_forward(&mut self, start_index: usize, input: Value, trace: &mut Vec<Value>) -> Value {
+    #[instrument(skip(self, input), fields(input = ?input.amount))]
+    fn fill_unconstrained(&self, input: Value) -> FrontierTx {
+        assert_eq!(input.asset_id, self.pairs.first().unwrap().start);
+
+        let mut tx = FrontierTx::new(&self);
+        // We have to manually update the trace here, because fill_forward
+        // doesn't handle the input amount, only things that come after it.
+        tx.trace[0] = Some(input.amount);
+        // Now fill forward along the frontier, accumulating changes into the new tx.
+        self.fill_forward(&mut tx, 0, input);
+
+        tx
+    }
+
+    fn fill_constrained(&self, constraining_index: usize) -> FrontierTx {
+        let mut tx = FrontierTx::new(&self);
+
+        // If there was a constraining position along the path, we want to
+        // completely consume its reserves, then work "outwards" along the
+        // path, propagating rounding errors forwards to the end of the path
+        // and backwards to the input.
+
+        // Example:
+        // 0     1     2     3      4         [trace index]
+        // UM => GM => GN => USD => ETH       [asset id]
+        //     0     1     2      3           [pair index]
+        //
+        // Suppose that pair 2 is the constraining pair, with 0.1 USD
+        // reserves.  To completely consume the 0.1 USD reserves, we need
+        // work backwards along the path to compute a sequence of input
+        // amounts that are valid trades to get to 0.1 USD output at pair 2,
+        // and work forwards to compute the corresponding output amounts at
+        // the end of the path.
+
+        let exactly_consumed_reserves = Value {
+            amount: self.positions[constraining_index]
+                .reserves_for(self.pairs[constraining_index].end)
+                .expect("asset ids should match"),
+            asset_id: self.pairs[constraining_index].end,
+        };
+
+        tracing::debug!(
+            constraining_index,
+            exactly_consumed_reserves = ?exactly_consumed_reserves.amount,
+            "attempting to completely consume reserves of constraining position"
+        );
+
+        // Work backwards along the path from the constraining position.
+        self.fill_backward(&mut tx, constraining_index, exactly_consumed_reserves);
+        // Work forwards along the path from the constraining position.
+        self.fill_forward(&mut tx, constraining_index + 1, exactly_consumed_reserves);
+
+        tx
+    }
+
+    #[instrument(skip(self, input, tx), fields(input = ?input.amount))]
+    fn fill_forward(&self, tx: &mut FrontierTx, start_index: usize, input: Value) {
         tracing::debug!("filling forward along frontier");
         let mut current_value = input;
 
@@ -456,25 +567,19 @@ impl<S: StateRead + StateWrite> Frontier<S> {
                 "unfilled amount for unconstrained frontier should be zero"
             );
 
-            self.positions[i].reserves = new_reserves;
-            current_value = output;
-            trace[i + 1].amount += output.amount;
-        }
+            tx.new_reserves[i] = Some(new_reserves);
+            tx.trace[i + 1] = Some(output.amount);
 
-        current_value
+            current_value = output;
+        }
     }
 
-    #[instrument(skip(self, output, trace), fields(output = ?output.amount))]
-    fn fill_backward(
-        &mut self,
-        start_index: usize,
-        output: Value,
-        trace: &mut Vec<Value>,
-    ) -> Value {
+    #[instrument(skip(self, output, tx), fields(output = ?output.amount))]
+    fn fill_backward(&self, tx: &mut FrontierTx, start_index: usize, output: Value) {
         tracing::debug!("filling backward along frontier");
         let mut current_value = output;
         for i in (0..=start_index).rev() {
-            trace[i + 1].amount += current_value.amount;
+            tx.trace[i + 1] = Some(current_value.amount);
 
             let (new_reserves, prev_input) = self.positions[i]
                 .phi
@@ -493,11 +598,10 @@ impl<S: StateRead + StateWrite> Frontier<S> {
                 "found previous input for current value"
             );
 
-            self.positions[i].reserves = new_reserves;
+            tx.new_reserves[i] = Some(new_reserves);
             current_value = prev_input;
         }
-        trace[0].amount += current_value.amount;
 
-        current_value
+        tx.trace[0] = Some(current_value.amount);
     }
 }

--- a/app/src/dex/router/tests.rs
+++ b/app/src/dex/router/tests.rs
@@ -797,8 +797,6 @@ async fn fill_route_unconstrained() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-// TODO: re-enamble after correcting spill behavior.
-#[ignore]
 /// Test that we only fill up to the specified spill price.
 /// TODO(erwan): stub, fleshing this out later.
 async fn fill_route_hit_spill_price() -> anyhow::Result<()> {
@@ -892,7 +890,6 @@ async fn fill_route_underflow_effective_price() -> anyhow::Result<()> {
     Ok(())
 }
 
-// TODO: remove this ignore once the test passes
 #[tokio::test]
 async fn simple_route() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();

--- a/app/src/dex/router/tests.rs
+++ b/app/src/dex/router/tests.rs
@@ -452,6 +452,7 @@ async fn position_get_best_price() -> anyhow::Result<()> {
 /// Test that positions are fetched in-order and that updating reserves
 /// deindex them correctly.
 async fn test_multiple_similar_position() -> anyhow::Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
     let storage = TempStorage::new().await?.apply_default_genesis().await?;
     let mut state = Arc::new(StateDelta::new(storage.latest_snapshot()));
     let mut state_tx = state.try_begin_transaction().unwrap();
@@ -498,6 +499,7 @@ async fn test_multiple_similar_position() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn fill_route_constraint_stacked() -> anyhow::Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
     let storage = TempStorage::new().await?.apply_default_genesis().await?;
     let mut state = Arc::new(StateDelta::new(storage.latest_snapshot()));
     let mut state_tx = state.try_begin_transaction().unwrap();


### PR DESCRIPTION
This PR changes the `FillRoute` implementation to fill each successive frontier transactionally, letting us inspect the exact, actual price and compare it with the spill price.  This avoids the situation in the current code where the spill price is only checked _after_ committing to exceeding it.

The current behavior _is_ retained in one special case, however: if we haven't consumed _any_ positions, by default we don't consider the spill price.  The motivation is that the spill price is an estimate, and we haven't ruled out the possibility that there could be two very similar routes, each with an estimated price below their actual price, which could cause the spill/fill cycle to alternate between them, always avoiding doing any filling because the fill would be more than the (underestimated) price of the alternative.   By default, `fill_route` will now ignore the spill price until executing at least once, to ensure that routing makes progress.  Callers can opt out of this behavior with `fill_route_exact`.