### PR TITLE
Remove existing usage of u64

### DIFF
--- a/app/src/action_handler/actions/delegate.rs
+++ b/app/src/action_handler/actions/delegate.rs
@@ -75,9 +75,10 @@ impl ActionHandler for Delegate {
         //
         // should give approximately the same results, they may not give
         // exactly the same results.
-        let expected_delegation_amount = next_rate_data.delegation_amount(d.unbonded_amount.into());
+        let expected_delegation_amount =
+            next_rate_data.delegation_amount(d.unbonded_amount.value() as u64);
 
-        if expected_delegation_amount != u64::from(d.delegation_amount) {
+        if expected_delegation_amount != d.delegation_amount.value() as u64 {
             return Err(anyhow::anyhow!(
                     "given {} unbonded stake, expected {} delegation tokens but description produces {}",
                     d.unbonded_amount,

--- a/app/src/action_handler/actions/undelegate.rs
+++ b/app/src/action_handler/actions/undelegate.rs
@@ -51,10 +51,11 @@ impl ActionHandler for Undelegate {
         //
         // should give approximately the same results, they may not give
         // exactly the same results.
-        let expected_unbonded_amount = rate_data.unbonded_amount(u.delegation_amount.into());
+        let expected_unbonded_amount =
+            rate_data.unbonded_amount(u.delegation_amount.value() as u64);
 
         ensure!(
-            u64::from(u.unbonded_amount) == expected_unbonded_amount,
+            u.unbonded_amount.value() as u64 == expected_unbonded_amount,
             "undelegation amount {} does not match expected amount {}",
             u.unbonded_amount,
             expected_unbonded_amount,

--- a/app/src/governance/view.rs
+++ b/app/src/governance/view.rs
@@ -261,7 +261,8 @@ pub trait StateReadExt: StateRead + crate::stake::StateReadExt {
             };
 
         // Check that the unbonded amount is correct relative to that exchange rate
-        if rate_data.unbonded_amount(value.amount.into()) != u64::from(*unbonded_amount) {
+        if rate_data.unbonded_amount(value.amount.value() as u64) != unbonded_amount.value() as u64
+        {
             anyhow::bail!(
                 "unbonded amount {}{} does not correspond to {} staked delegation tokens for validator {} using the exchange rate at the start of proposal {}",
                 unbonded_amount,
@@ -710,7 +711,7 @@ pub trait StateWriteExt: StateWrite {
         unbonded_amount: Amount,
     ) -> Result<()> {
         // Convert the unbonded amount into voting power
-        let power = u64::from(unbonded_amount);
+        let power = unbonded_amount.value() as u64;
         let tally: Tally = (vote, power).into();
 
         // Record the vote

--- a/app/src/stake/component.rs
+++ b/app/src/stake/component.rs
@@ -372,12 +372,12 @@ pub(crate) trait StakingImpl: StateWriteExt {
             let total_delegations = delegations_by_validator
                 .get(&validator.identity_key)
                 .into_iter()
-                .flat_map(|ds| ds.iter().map(|d| u64::from(d.delegation_amount)))
+                .flat_map(|ds| ds.iter().map(|d| d.delegation_amount.value() as u64))
                 .sum::<u64>();
             let total_undelegations = undelegations_by_validator
                 .get(&validator.identity_key)
                 .into_iter()
-                .flat_map(|us| us.iter().map(|u| u64::from(u.delegation_amount)))
+                .flat_map(|us| us.iter().map(|u| u.delegation_amount.value() as u64))
                 .sum::<u64>();
             let delegation_delta = (total_delegations as i64) - (total_undelegations as i64);
 

--- a/app/src/stake/rate.rs
+++ b/app/src/stake/rate.rs
@@ -161,7 +161,7 @@ impl RateData {
     /// undelegates `delegation_amount` of the validator's delegation tokens.
     pub fn build_undelegate(&self, delegation_amount: Amount) -> Undelegate {
         // TODO: port to amounts
-        let delegation_amount_u64 = u64::try_from(delegation_amount).unwrap();
+        let delegation_amount_u64 = delegation_amount.value() as u64;
         Undelegate {
             start_epoch_index: self.epoch_index,
             delegation_amount,

--- a/chain/src/params.rs
+++ b/chain/src/params.rs
@@ -120,7 +120,10 @@ impl TryFrom<pb_chain::ChainParameters> for ChainParameters {
             inbound_ics20_transfers_enabled: msg.inbound_ics20_transfers_enabled,
             outbound_ics20_transfers_enabled: msg.outbound_ics20_transfers_enabled,
             proposal_voting_blocks: msg.proposal_voting_blocks,
-            proposal_deposit_amount: msg.proposal_deposit_amount.into(),
+            proposal_deposit_amount: msg
+                .proposal_deposit_amount
+                .ok_or_else(|| anyhow::anyhow!("missing proposal_deposit_amount"))?
+                .try_into()?,
             proposal_valid_quorum: msg
                 .proposal_valid_quorum
                 .parse()
@@ -176,7 +179,7 @@ impl From<ChainParameters> for pb_chain::ChainParameters {
             inbound_ics20_transfers_enabled: params.inbound_ics20_transfers_enabled,
             outbound_ics20_transfers_enabled: params.outbound_ics20_transfers_enabled,
             proposal_voting_blocks: params.proposal_voting_blocks,
-            proposal_deposit_amount: params.proposal_deposit_amount.into(),
+            proposal_deposit_amount: Some(params.proposal_deposit_amount.into()),
             proposal_valid_quorum: params.proposal_valid_quorum.to_string(),
             proposal_pass_threshold: params.proposal_pass_threshold.to_string(),
             proposal_slash_threshold: params.proposal_slash_threshold.to_string(),

--- a/crypto/src/asset.rs
+++ b/crypto/src/asset.rs
@@ -196,17 +196,17 @@ mod tests {
     proptest! {
         #[test]
         fn displaydenom_parsing_formatting_roundtrip(
-            v: u32
+            v: u128
         ) {
             let penumbra_display_denom = REGISTRY.parse_unit("penumbra");
             let formatted = penumbra_display_denom.format_value(v.into());
             let parsed = penumbra_display_denom.parse_value(&formatted);
-            assert_eq!(v, u32::from(parsed.unwrap()));
+            assert_eq!(v, u128::from(parsed.unwrap()));
 
             let mpenumbra_display_denom = REGISTRY.parse_unit("mpenumbra");
             let formatted = mpenumbra_display_denom.format_value(v.into());
             let parsed = mpenumbra_display_denom.parse_value(&formatted);
-            assert_eq!(v, u32::from(parsed.unwrap()));
+            assert_eq!(v, u128::from(parsed.unwrap()));
         }
     }
 }

--- a/crypto/src/asset/amount.rs
+++ b/crypto/src/asset/amount.rs
@@ -8,7 +8,7 @@ use std::{fmt::Display, iter::Sum, num::NonZeroU128, ops};
 use crate::{fixpoint::U128x128, Fq, Fr};
 use decaf377::{r1cs::FqVar, FieldExt};
 
-#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Clone, Copy)]
+#[derive(Serialize, Default, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 #[serde(try_from = "pb::Amount", into = "pb::Amount")]
 pub struct Amount {
     inner: u128,
@@ -251,33 +251,11 @@ impl From<u64> for Amount {
     }
 }
 
-impl From<Amount> for u64 {
-    fn from(amount: Amount) -> u64 {
-        amount.inner as u64
-    }
-}
-
-impl TryFrom<Amount> for i64 {
-    type Error = anyhow::Error;
-    fn try_from(value: Amount) -> Result<Self, Self::Error> {
-        value
-            .inner
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("failed conversion!"))
-    }
-}
-
 impl From<u32> for Amount {
     fn from(amount: u32) -> Amount {
         Amount {
             inner: amount as u128,
         }
-    }
-}
-
-impl From<Amount> for u32 {
-    fn from(amount: Amount) -> u32 {
-        amount.inner as u32
     }
 }
 

--- a/pcli/src/command/query/chain.rs
+++ b/pcli/src/command/query/chain.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use comfy_table::{presets, Table};
 use futures::TryStreamExt;
 use penumbra_app::stake::validator;
+use penumbra_chain::params::ChainParameters;
 use penumbra_proto::client::v1alpha1::{ChainParametersRequest, InfoRequest};
 
 // TODO: remove this subcommand and merge into `pcli q`
@@ -34,14 +35,15 @@ impl ChainCmd {
     pub async fn print_chain_params(&self, app: &mut App) -> Result<()> {
         let mut oblivious_client = app.oblivious_client().await?;
 
-        let params = oblivious_client
+        let params: ChainParameters = oblivious_client
             .chain_parameters(tonic::Request::new(ChainParametersRequest {
                 chain_id: "".to_string(),
             }))
             .await?
             .into_inner()
             .chain_parameters
-            .ok_or_else(|| anyhow::anyhow!("empty ChainParametersResponse message"))?;
+            .ok_or_else(|| anyhow::anyhow!("empty ChainParametersResponse message"))?
+            .try_into()?;
 
         println!("Chain Parameters:");
         let mut table = Table::new();

--- a/pcli/src/command/tx.rs
+++ b/pcli/src/command/tx.rs
@@ -454,7 +454,8 @@ impl TxCmd {
                     app.view.as_mut().unwrap(),
                     OsRng,
                     rate_data,
-                    unbonded_amount.into(),
+                    // TODO: fix and also delete plan::delegate entirely!
+                    unbonded_amount.value() as u64,
                     fee,
                     AddressIndex::new(*source),
                 )

--- a/pcli/src/command/tx/approximate.rs
+++ b/pcli/src/command/tx/approximate.rs
@@ -36,6 +36,7 @@ pub struct ConstantProduct {
 }
 
 impl ApproximateCmd {
+    // TODO unused?
     pub fn _offline(&self) -> bool {
         false
     }

--- a/pcli/src/command/view/staked.rs
+++ b/pcli/src/command/view/staked.rs
@@ -46,7 +46,7 @@ impl StakedCmd {
         let notes = view_client
             .unspent_notes_by_asset_and_address(account_group_id)
             .await?;
-        let mut total = 0u64;
+        let mut total = 0u128;
 
         let mut table = Table::new();
         table.load_preset(presets::NOTHING);
@@ -74,16 +74,16 @@ impl StakedCmd {
             let delegation = Value {
                 amount: notes_by_address
                     .values()
-                    .flat_map(|notes| notes.iter().map(|n| u64::from(n.note.amount())))
-                    .sum::<u64>()
-                    .into(),
+                    .flat_map(|notes| notes.iter().map(|n| n.note.amount()))
+                    .sum(),
                 asset_id: dt.id(),
             };
 
             let unbonded = Value {
                 amount: info
                     .rate_data
-                    .unbonded_amount(delegation.amount.into())
+                    // TODO fix with new rate calcs
+                    .unbonded_amount(delegation.amount.value() as u64)
                     .into(),
                 asset_id: *STAKING_TOKEN_ASSET_ID,
             };
@@ -97,7 +97,7 @@ impl StakedCmd {
                 delegation.format(&asset_cache),
             ]);
 
-            total += u64::from(unbonded.amount);
+            total += u128::from(unbonded.amount);
         }
 
         let unbonded = Value {
@@ -105,13 +105,13 @@ impl StakedCmd {
                 .get(&*STAKING_TOKEN_ASSET_ID)
                 .unwrap_or(&BTreeMap::default())
                 .values()
-                .flat_map(|notes| notes.iter().map(|n| u64::from(n.note.amount())))
-                .sum::<u64>()
+                .flat_map(|notes| notes.iter().map(|n| u128::from(n.note.amount())))
+                .sum::<u128>()
                 .into(),
             asset_id: *STAKING_TOKEN_ASSET_ID,
         };
 
-        total += u64::from(unbonded.amount);
+        total += u128::from(unbonded.amount);
 
         table.add_row(vec![
             "Unbonded Stake".to_string(),

--- a/proto/proto/penumbra/core/chain/v1alpha1/chain.proto
+++ b/proto/proto/penumbra/core/chain/v1alpha1/chain.proto
@@ -38,7 +38,7 @@ message ChainParameters {
   // The number of blocks during which a proposal is voted on.
   uint64 proposal_voting_blocks = 20;
   // The deposit required to create a proposal.
-  uint64 proposal_deposit_amount = 21;
+  crypto.v1alpha1.Amount proposal_deposit_amount = 21;
   // The quorum required for a proposal to be considered valid, as a fraction of the total stake
   // weight of the network.
   string proposal_valid_quorum = 22;

--- a/proto/proto/penumbra/view/v1alpha1/view.proto
+++ b/proto/proto/penumbra/view/v1alpha1/view.proto
@@ -226,7 +226,7 @@ message NotesRequest {
   // If set, stop returning notes once the total exceeds this amount.
   //
   // Ignored if `asset_id` is unset or if `include_spent` is set.
-  uint64 amount_to_spend = 5;
+  core.crypto.v1alpha1.Amount amount_to_spend = 6;
 
   // Identifies the account group to query.
   optional core.crypto.v1alpha1.AccountGroupId account_group_id = 14;

--- a/proto/src/gen/penumbra.core.chain.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.chain.v1alpha1.rs
@@ -42,8 +42,10 @@ pub struct ChainParameters {
     #[prost(uint64, tag = "20")]
     pub proposal_voting_blocks: u64,
     /// The deposit required to create a proposal.
-    #[prost(uint64, tag = "21")]
-    pub proposal_deposit_amount: u64,
+    #[prost(message, optional, tag = "21")]
+    pub proposal_deposit_amount: ::core::option::Option<
+        super::super::crypto::v1alpha1::Amount,
+    >,
     /// The quorum required for a proposal to be considered valid, as a fraction of the total stake
     /// weight of the network.
     #[prost(string, tag = "22")]

--- a/proto/src/gen/penumbra.core.chain.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.core.chain.v1alpha1.serde.rs
@@ -194,7 +194,7 @@ impl serde::Serialize for ChainParameters {
         if self.proposal_voting_blocks != 0 {
             len += 1;
         }
-        if self.proposal_deposit_amount != 0 {
+        if self.proposal_deposit_amount.is_some() {
             len += 1;
         }
         if !self.proposal_valid_quorum.is_empty() {
@@ -249,8 +249,8 @@ impl serde::Serialize for ChainParameters {
         if self.proposal_voting_blocks != 0 {
             struct_ser.serialize_field("proposalVotingBlocks", ToString::to_string(&self.proposal_voting_blocks).as_str())?;
         }
-        if self.proposal_deposit_amount != 0 {
-            struct_ser.serialize_field("proposalDepositAmount", ToString::to_string(&self.proposal_deposit_amount).as_str())?;
+        if let Some(v) = self.proposal_deposit_amount.as_ref() {
+            struct_ser.serialize_field("proposalDepositAmount", v)?;
         }
         if !self.proposal_valid_quorum.is_empty() {
             struct_ser.serialize_field("proposalValidQuorum", &self.proposal_valid_quorum)?;
@@ -510,9 +510,7 @@ impl<'de> serde::Deserialize<'de> for ChainParameters {
                             if proposal_deposit_amount__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("proposalDepositAmount"));
                             }
-                            proposal_deposit_amount__ = 
-                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
-                            ;
+                            proposal_deposit_amount__ = map.next_value()?;
                         }
                         GeneratedField::ProposalValidQuorum => {
                             if proposal_valid_quorum__.is_some() {
@@ -554,7 +552,7 @@ impl<'de> serde::Deserialize<'de> for ChainParameters {
                     inbound_ics20_transfers_enabled: inbound_ics20_transfers_enabled__.unwrap_or_default(),
                     outbound_ics20_transfers_enabled: outbound_ics20_transfers_enabled__.unwrap_or_default(),
                     proposal_voting_blocks: proposal_voting_blocks__.unwrap_or_default(),
-                    proposal_deposit_amount: proposal_deposit_amount__.unwrap_or_default(),
+                    proposal_deposit_amount: proposal_deposit_amount__,
                     proposal_valid_quorum: proposal_valid_quorum__.unwrap_or_default(),
                     proposal_pass_threshold: proposal_pass_threshold__.unwrap_or_default(),
                     proposal_slash_threshold: proposal_slash_threshold__.unwrap_or_default(),

--- a/proto/src/gen/penumbra.view.v1alpha1.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.rs
@@ -247,8 +247,10 @@ pub struct NotesRequest {
     /// If set, stop returning notes once the total exceeds this amount.
     ///
     /// Ignored if `asset_id` is unset or if `include_spent` is set.
-    #[prost(uint64, tag = "5")]
-    pub amount_to_spend: u64,
+    #[prost(message, optional, tag = "6")]
+    pub amount_to_spend: ::core::option::Option<
+        super::super::core::crypto::v1alpha1::Amount,
+    >,
     /// Identifies the account group to query.
     #[prost(message, optional, tag = "14")]
     pub account_group_id: ::core::option::Option<

--- a/proto/src/gen/penumbra.view.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.serde.rs
@@ -2037,7 +2037,7 @@ impl serde::Serialize for NotesRequest {
         if self.address_index.is_some() {
             len += 1;
         }
-        if self.amount_to_spend != 0 {
+        if self.amount_to_spend.is_some() {
             len += 1;
         }
         if self.account_group_id.is_some() {
@@ -2053,8 +2053,8 @@ impl serde::Serialize for NotesRequest {
         if let Some(v) = self.address_index.as_ref() {
             struct_ser.serialize_field("addressIndex", v)?;
         }
-        if self.amount_to_spend != 0 {
-            struct_ser.serialize_field("amountToSpend", ToString::to_string(&self.amount_to_spend).as_str())?;
+        if let Some(v) = self.amount_to_spend.as_ref() {
+            struct_ser.serialize_field("amountToSpend", v)?;
         }
         if let Some(v) = self.account_group_id.as_ref() {
             struct_ser.serialize_field("accountGroupId", v)?;
@@ -2162,9 +2162,7 @@ impl<'de> serde::Deserialize<'de> for NotesRequest {
                             if amount_to_spend__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("amountToSpend"));
                             }
-                            amount_to_spend__ = 
-                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
-                            ;
+                            amount_to_spend__ = map.next_value()?;
                         }
                         GeneratedField::AccountGroupId => {
                             if account_group_id__.is_some() {
@@ -2178,7 +2176,7 @@ impl<'de> serde::Deserialize<'de> for NotesRequest {
                     include_spent: include_spent__.unwrap_or_default(),
                     asset_id: asset_id__,
                     address_index: address_index__,
-                    amount_to_spend: amount_to_spend__.unwrap_or_default(),
+                    amount_to_spend: amount_to_spend__,
                     account_group_id: account_group_id__,
                 })
             }

--- a/proto/src/gen/proto_descriptor.bin
+++ b/proto/src/gen/proto_descriptor.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c4fcc2b686d2608b3592d1f1080b39714088f31d9c0db6cc5771fa983087b30
-size 334607
+oid sha256:055cdc3d4258b2626ce52f0310ec26fbd03d13d8256aa6b501ac44862e41a18c
+size 334685

--- a/view/src/planner.rs
+++ b/view/src/planner.rs
@@ -101,7 +101,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
                     account_group_id: Some(account_group_id.into()),
                     asset_id: Some(asset_id.into()),
                     address_index: Some(source.into()),
-                    amount_to_spend: amount.into(),
+                    amount_to_spend: Some(amount.into()),
                     include_spent: false,
                     ..Default::default()
                 })
@@ -450,7 +450,6 @@ impl<R: RngCore + CryptoRng> Planner<R> {
         self.plan_with_spendable_and_votable_notes(
             &chain_params,
             &fmd_params,
-            source,
             spendable_notes,
             voting_notes,
             self_address,
@@ -463,12 +462,18 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     /// [`Planner::note_requests`].
     ///
     /// Clears the contents of the planner, which can be re-used.
-    #[instrument(skip(self, chain_params, fmd_params, self_address, spendable_notes))]
+    #[instrument(skip(
+        self,
+        chain_params,
+        fmd_params,
+        self_address,
+        spendable_notes,
+        votable_notes,
+    ))]
     pub fn plan_with_spendable_and_votable_notes(
         &mut self,
         chain_params: &ChainParameters,
         fmd_params: &FmdParameters,
-        source: AddressIndex,
         spendable_notes: Vec<SpendableNoteRecord>,
         votable_notes: Vec<Vec<(SpendableNoteRecord, IdentityKey)>>,
         self_address: Address,
@@ -515,7 +520,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
                 // and continue to the next one.
                 let Some(rate_data) = rate_data.get(&identity_key) else { continue };
                 let unbonded_amount = rate_data
-                    .unbonded_amount(record.note.amount().into())
+                    .unbonded_amount(record.note.amount().value() as u64)
                     .into();
 
                 // If the delegation token is unspent, "roll it over" by spending it (this will

--- a/wallet/src/plan.rs
+++ b/wallet/src/plan.rs
@@ -288,9 +288,7 @@ where
             tracing::debug!(?asset_id, "processing asset");
 
             // Sort notes by amount, ascending, so the biggest notes are at the end...
-            records.sort_by(|a, b| {
-                a.note.value().amount.cmp(&b.note.value().amount)
-            });
+            records.sort_by(|a, b| a.note.value().amount.cmp(&b.note.value().amount));
             // ... so that when we use chunks_exact, we get SWEEP_COUNT sized
             // chunks, ignoring the biggest notes in the remainder.
             for group in records.chunks_exact(SWEEP_COUNT) {

--- a/wallet/src/plan.rs
+++ b/wallet/src/plan.rs
@@ -289,7 +289,7 @@ where
 
             // Sort notes by amount, ascending, so the biggest notes are at the end...
             records.sort_by(|a, b| {
-                u64::from(a.note.value().amount).cmp(&u64::from(b.note.value().amount))
+                a.note.value().amount.cmp(&b.note.value().amount)
             });
             // ... so that when we use chunks_exact, we get SWEEP_COUNT sized
             // chunks, ignoring the biggest notes in the remainder.


### PR DESCRIPTION
There are still some instances of u64 used for token amounts expressed in terms of penumbra tokens, but @hdevalence and @plaidfinch assure me that won't be an issue.