### PR TITLE
crypto(fixpoint): add overflow failure test

### DIFF
--- a/crypto/src/fixpoint/tests.rs
+++ b/crypto/src/fixpoint/tests.rs
@@ -20,3 +20,13 @@ proptest! {
     }
 
 }
+
+#[test]
+#[should_panic]
+fn multiply_large_failure() {
+    let a = 1788000000000000000000u128;
+    let b = 1000000000000000000000u128;
+    let a_fp: U128x128 = a.into();
+    let b_fp: U128x128 = b.into();
+    let c_fp = (a_fp * b_fp).expect("overflow loudly!");
+}


### PR DESCRIPTION
This test should fail and overflow loudly, but instead it fails silently producing a nonsensical value.