### PR TITLE
dex: remove complex candidate set computation

### DIFF
--- a/app/src/dex/router/params.rs
+++ b/app/src/dex/router/params.rs
@@ -16,6 +16,12 @@ impl Default for RoutingParams {
             fixed_candidates: Arc::new(vec![
                 asset::REGISTRY.parse_unit("test_usd").id(),
                 asset::REGISTRY.parse_unit("penumbra").id(),
+                // TODO: remove after fixing candidate set implementation?
+                asset::REGISTRY.parse_unit("gm").id(),
+                asset::REGISTRY.parse_unit("gn").id(),
+                asset::REGISTRY.parse_unit("atom").id(),
+                asset::REGISTRY.parse_unit("osmo").id(),
+                asset::REGISTRY.parse_unit("btc").id(),
             ]),
             max_hops: 4,
         }


### PR DESCRIPTION
The existing implementation isn't safe to deploy, because it scans every single position in the entire dex on every iteration of edge relaxation during routing.