### PR TITLE
dex: make SwapExecutions directed

### DIFF
--- a/app/src/dex/state_key.rs
+++ b/app/src/dex/state_key.rs
@@ -23,12 +23,10 @@ pub fn output_data(height: u64, trading_pair: TradingPair) -> String {
     )
 }
 
-pub fn swap_execution(height: u64, trading_pair: TradingPair) -> String {
+pub fn swap_execution(height: u64, trading_pair: &DirectedTradingPair) -> String {
     format!(
         "dex/swap_execution/{:020}/{}/{}",
-        height,
-        &trading_pair.asset_1(),
-        &trading_pair.asset_2()
+        height, &trading_pair.start, &trading_pair.end,
     )
 }
 

--- a/app/src/dex/tests.rs
+++ b/app/src/dex/tests.rs
@@ -504,7 +504,16 @@ async fn swap_execution_tests() -> anyhow::Result<()> {
         .expect("unable to process batch swaps");
 
     // Swap execution should have a single trace consisting of `[1gn, 1penumbra]`.
-    let swap_execution = state.swap_execution(0, trading_pair).await?.unwrap();
+    let swap_execution = state
+        .swap_execution(
+            0,
+            &DirectedTradingPair {
+                start: gn.id(),
+                end: penumbra.id(),
+            },
+        )
+        .await?
+        .unwrap();
 
     assert_eq!(
         swap_execution.traces,
@@ -610,7 +619,16 @@ async fn swap_execution_tests() -> anyhow::Result<()> {
     );
 
     // Swap execution should have two traces.
-    let swap_execution = state.swap_execution(0, trading_pair).await?.unwrap();
+    let swap_execution = state
+        .swap_execution(
+            0,
+            &DirectedTradingPair {
+                start: penumbra.id(),
+                end: gn.id(),
+            },
+        )
+        .await?
+        .unwrap();
 
     assert_eq!(
         swap_execution.traces,

--- a/pcli/src/command/query/dex.rs
+++ b/pcli/src/command/query/dex.rs
@@ -38,7 +38,7 @@ pub enum DexCmd {
         #[clap(long)]
         height: u64,
         /// The trading pair to query for the swap execution.
-        trading_pair: TradingPair,
+        trading_pair: DirectedTradingPair,
     },
     /// Display information about all liquidity positions known to the chain.
     AllPositions {
@@ -81,7 +81,7 @@ impl DexCmd {
         &self,
         app: &mut App,
         height: &u64,
-        trading_pair: &TradingPair,
+        trading_pair: &DirectedTradingPair,
     ) -> Result<SwapExecution> {
         let mut client = app.specific_client().await?;
         client
@@ -147,7 +147,7 @@ impl DexCmd {
         &self,
         app: &mut App,
         height: &u64,
-        trading_pair: &TradingPair,
+        trading_pair: &DirectedTradingPair,
     ) -> Result<()> {
         let swap_execution = self.get_swap_execution(app, height, trading_pair).await?;
 

--- a/pd/src/info/specific.rs
+++ b/pd/src/info/specific.rs
@@ -397,7 +397,7 @@ impl SpecificQueryService for Info {
     }
 
     #[instrument(skip(self, request))]
-    /// Get the batch swap data associated with a given trading pair and height.
+    /// Get the swap execution data associated with a given trading pair and height.
     async fn swap_execution(
         &self,
         request: tonic::Request<SwapExecutionRequest>,
@@ -416,7 +416,7 @@ impl SpecificQueryService for Info {
             .map_err(|_| Status::invalid_argument("invalid trading_pair"))?;
 
         let swap_execution = state
-            .swap_execution(height, trading_pair)
+            .swap_execution(height, &trading_pair)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 

--- a/proto/proto/penumbra/client/v1alpha1/client.proto
+++ b/proto/proto/penumbra/client/v1alpha1/client.proto
@@ -189,7 +189,7 @@ message SwapExecutionRequest {
   // The expected chain id (empty string if no expectation).
   string chain_id = 1;
   uint64 height = 2;
-  core.dex.v1alpha1.TradingPair trading_pair = 3;
+  core.dex.v1alpha1.DirectedTradingPair trading_pair = 3;
 }
 
 message SwapExecutionResponse {

--- a/proto/src/gen/penumbra.client.v1alpha1.rs
+++ b/proto/src/gen/penumbra.client.v1alpha1.rs
@@ -214,7 +214,7 @@ pub struct SwapExecutionRequest {
     pub height: u64,
     #[prost(message, optional, tag = "3")]
     pub trading_pair: ::core::option::Option<
-        super::super::core::dex::v1alpha1::TradingPair,
+        super::super::core::dex::v1alpha1::DirectedTradingPair,
     >,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/proto/src/gen/proto_descriptor.bin
+++ b/proto/src/gen/proto_descriptor.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:19fd627a63cd8577fd808063c0d831716c4f56d765bd811541fd63a92f49aedc
-size 334952
+oid sha256:912162b6bfd91238945defbfc6b127be24de0f50b0c9420e7bcebea685226243
+size 334960


### PR DESCRIPTION
I'm not sure we should land this for testnet 52; it was more complicated to make these changes and it feels like the code is doing the wrong thing.  It's not really clear to me why the execution traces should be stored as ambient global state in the object store, rather than just being returned by the methods that do execution. But that refactoring isn't something we should stuff in before the deadline.