### PR TITLE
Fix `anyhow::Error` type bounds to use `From` instead of `Into`

### DIFF
--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -161,7 +161,7 @@ pub mod penumbra {
                 pub async fn key_domain<T>(&mut self, key: impl AsRef<str>) -> anyhow::Result<T>
                 where
                     T: crate::DomainType,
-                    <T as TryFrom<T::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
+                    anyhow::Error: From<<T as TryFrom<T::Proto>>::Error>,
                     C: tonic::client::GrpcService<BoxBody> + 'static,
                     C::ResponseBody: Send,
                     <C as tonic::client::GrpcService<BoxBody>>::ResponseBody:
@@ -188,7 +188,7 @@ pub mod penumbra {
                 >
                 where
                     T: crate::DomainType + Send + 'static + Unpin,
-                    <T as TryFrom<T::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
+                    anyhow::Error: From<<T as TryFrom<T::Proto>>::Error>,
                     C: tonic::client::GrpcService<BoxBody> + 'static,
                     C::ResponseBody: Send,
                     <C as tonic::client::GrpcService<BoxBody>>::ResponseBody:

--- a/proto/src/protobuf.rs
+++ b/proto/src/protobuf.rs
@@ -5,7 +5,7 @@ pub trait DomainType
 where
     Self: Clone + Sized + TryFrom<Self::Proto>,
     Self::Proto: prost::Message + Default + From<Self> + Send + Sync + 'static,
-    <Self as TryFrom<Self::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
+    anyhow::Error: From<<Self as TryFrom<Self::Proto>>::Error>,
 {
     type Proto;
 

--- a/proto/src/state/future.rs
+++ b/proto/src/state/future.rs
@@ -50,7 +50,7 @@ impl<D, F> Future for DomainFuture<D, F>
 where
     F: Future<Output = Result<Option<Vec<u8>>>>,
     D: DomainType,
-    <D as TryFrom<D::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
+    anyhow::Error: From<<D as TryFrom<D::Proto>>::Error>,
 {
     type Output = Result<Option<D>>;
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -59,7 +59,7 @@ where
             Poll::Ready(Ok(Some(bytes))) => {
                 let v = D::Proto::decode(&*bytes).context("could not decode proto from bytes")?;
                 let v = D::try_from(v)
-                    .map_err(Into::into)
+                    .map_err(anyhow::Error::from)
                     .context("could not parse domain type from proto")?;
                 Poll::Ready(Ok(Some(v)))
             }

--- a/proto/src/state/read.rs
+++ b/proto/src/state/read.rs
@@ -21,7 +21,7 @@ pub trait StateReadProto: StateRead + Send + Sync {
     fn get<D>(&self, key: &str) -> DomainFuture<D, Self::GetRawFut>
     where
         D: DomainType + std::fmt::Debug,
-        <D as TryFrom<D::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
+        anyhow::Error: From<<D as TryFrom<D::Proto>>::Error>,
     {
         DomainFuture {
             inner: self.get_raw(key),
@@ -54,7 +54,7 @@ pub trait StateReadProto: StateRead + Send + Sync {
     ) -> Pin<Box<dyn Stream<Item = Result<(String, D)>> + Send + 'static>>
     where
         D: DomainType,
-        <D as TryFrom<D::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
+        anyhow::Error: From<<D as TryFrom<D::Proto>>::Error>,
     {
         Box::pin(self.prefix_proto(prefix).map(|p| match p {
             Ok(p) => match D::try_from(p.1) {

--- a/proto/src/state/write.rs
+++ b/proto/src/state/write.rs
@@ -9,7 +9,7 @@ pub trait StateWriteProto: StateWrite + Send + Sync {
     fn put<D>(&mut self, key: String, value: D)
     where
         D: DomainType,
-        <D as TryFrom<D::Proto>>::Error: Into<anyhow::Error> + Send + Sync + 'static,
+        anyhow::Error: From<<D as TryFrom<D::Proto>>::Error>,
     {
         self.put_proto(key, D::Proto::from(value));
     }


### PR DESCRIPTION
As documented in [this Stack Overflow post](https://stackoverflow.com/questions/72626885/using-tryinto-generics-with-anyhowerror), the correct type bound to use is `From` instead of `Into` because `?` desugars to `.from()` instead of `.into()`. This also removes the need for the explicit `Send + Sync + 'static` bounds.