### PR TITLE
fix(pd): look up listenaddr from tm rpc

### DIFF
--- a/deployments/scripts/rust-docs
+++ b/deployments/scripts/rust-docs
@@ -24,6 +24,7 @@ export RUSTDOCFLAGS="--enable-index-page -Zunstable-options --cfg docsrs"
 # shellcheck disable=SC2086
 cargo +nightly doc --no-deps \
   -p tendermint \
+  -p tendermint-config \
   -p tower-abci \
   -p jmt@0.3.0 \
   -p ark-ff \

--- a/pd/src/testnet.rs
+++ b/pd/src/testnet.rs
@@ -56,7 +56,6 @@ pub fn generate_tm_config(
         tm_config.p2p.laddr =
             parse_tm_address(None, &Url::parse(format!("tcp://{}", p2p).as_str())?)?;
     }
-    //Ok(toml::to_string(&tm_config)?)
     Ok(tm_config)
 }
 

--- a/pd/src/testnet/join.rs
+++ b/pd/src/testnet/join.rs
@@ -39,27 +39,17 @@ pub async fn testnet_join(
     let genesis = serde_json::value::from_value(genesis_json)?;
     tracing::info!("fetched genesis");
 
-    let status_url = node.join("/status")?;
-    let node_id = client
-        .get(status_url)
-        .send()
-        .await?
-        .json::<serde_json::Value>()
-        .await?
-        .get_mut("result")
-        .and_then(|v| v.get_mut("node_info"))
-        .and_then(|v| v.get_mut("id"))
-        .ok_or_else(|| anyhow::anyhow!("could not parse JSON from response"))?
-        .take();
-    let node_id: tendermint::node::Id = serde_json::value::from_value(node_id)?;
-    tracing::info!(?node_id, "fetched node id");
-    let node_tm_address = parse_tm_address(Some(&node_id), &node)?;
-
     // Look up more peers from the target node, so that generated tendermint config
     // contains multiple addresses, making peering easier.
     let mut peers = Vec::new();
+    if let Some(node_tm_address) = fetch_listen_address(&node).await {
+        peers.push(node_tm_address);
+    } else {
+        // We consider it odd that a bootstrap node has a remotely accessible
+        // RPC endpoint, but no P2P listener enabled.
+        tracing::warn!("Failed to find listenaddr for {}", &node);
+    }
     let new_peers = fetch_peers(&node).await?;
-    peers.push(node_tm_address);
     peers.extend(new_peers);
     tracing::info!(?peers);
 
@@ -76,9 +66,62 @@ pub async fn testnet_join(
     Ok(())
 }
 
-/// Query the Tendermint node's RPC endpoint and return a list of all known peers
-/// by their `external_address`es. Omits private/special addresses like `localhost`
-/// or `0.0.0.0`.
+/// Query the Tendermint node's RPC endpoint at `tm_url` and return the listener
+/// address for the P2P endpoint. Returns an [Option<TendermintAddress>] because
+/// it's possible that no p2p listener is configured.
+pub async fn fetch_listen_address(tm_url: &Url) -> Option<TendermintAddress> {
+    let client = reqwest::Client::new();
+    // We cannot assume the RPC URL is the same as the P2P address,
+    // so we use the RPC URL to look up the P2P listening address.
+    let listen_info = client
+        .get(tm_url.join("net_info").ok()?)
+        .send()
+        .await
+        .ok()?
+        .json::<serde_json::Value>()
+        .await
+        .ok()?
+        .get_mut("result")
+        .and_then(|v| v.get_mut("listeners"))
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    tracing::debug!(?listen_info, "found listener info from bootstrap node");
+    let first_entry = listen_info[0].as_str().unwrap_or_default();
+    let listen_addr = parse_tm_address_listener(first_entry)?;
+
+    // Next we'll look up the node_id, so we can assemble a self-authenticating
+    // Tendermint Address, in the form of <id>@<url>.
+    let node_id = client
+        .get(tm_url.join("/status").ok()?)
+        .send()
+        .await
+        .ok()?
+        .json::<serde_json::Value>()
+        .await
+        .ok()?
+        .get_mut("result")
+        .and_then(|v| v.get_mut("node_info"))
+        .and_then(|v| v.get_mut("id"))
+        .ok_or_else(|| anyhow::anyhow!("could not parse JSON from response"))
+        .ok()?
+        .take();
+
+    let node_id: tendermint::node::Id = serde_json::value::from_value(node_id).ok()?;
+    tracing::debug!(?node_id, "fetched node id");
+
+    let listen_addr_url = Url::parse(&format!("{}", &listen_addr)).ok()?;
+    tracing::info!(
+        ?listen_addr_url,
+        "fetched listener address for bootstrap node"
+    );
+    parse_tm_address(Some(&node_id), &listen_addr_url).ok()
+}
+
+/// Query the Tendermint node's RPC endpoint at `tm_url` and return a list
+/// of all known peers by their `external_address`es. Omits private/special
+/// addresses like `localhost` or `0.0.0.0`.
 pub async fn fetch_peers(tm_url: &Url) -> anyhow::Result<Vec<TendermintAddress>> {
     let client = reqwest::Client::new();
     let net_info_url = tm_url.join("/net_info")?;
@@ -143,17 +186,101 @@ fn address_could_be_external(address: &str) -> bool {
     }
 }
 
+/// Extract a [TendermintAddress] obtained from the RPC `/net_info` endpoint.
+/// The raw value is a String formatted as:
+///
+///   * `Listener(@35.226.255.25:26656)` or
+///   * `Listener(@tcp://35.226.255.25:26656)` or
+///   * `Listener(@)`
+///
+/// It may be possible for a node [Id] to proceed the `@`.
+pub fn parse_tm_address_listener(s: &str) -> Option<TendermintAddress> {
+    let re = regex::Regex::new(r"Listener\(.*@(tcp://)?(.*)\)").ok()?;
+    let groups = re.captures(s).unwrap();
+    let r: Option<String> = groups.get(2).map_or(None, |m| Some(m.as_str().to_string()));
+    match r {
+        Some(t) => {
+            // Haven't observed a local addr in Listener field, but let's make sure
+            // it's a public addr
+            if address_could_be_external(&t) {
+                t.parse::<TendermintAddress>().ok()
+            } else {
+                None
+            }
+        }
+        None => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    // The '35.226.255.25' IPv4 address used throughout these tests is a reserved
+    // GCP IP, used by Penumbra Labs on the testnet cluster.
     #[test]
     fn external_address_detection() {
         assert!(!address_could_be_external("127.0.0.1"));
         assert!(!address_could_be_external("0.0.0.0"));
         assert!(!address_could_be_external("0.0.0.0:80"));
         assert!(!address_could_be_external("192.168.4.1:26657"));
-        // Real GCP IPv4 address, used for `testnet.penumbra.zone` 2023Q1.
         assert!(!address_could_be_external("35.226.255.25"));
         assert!(address_could_be_external("35.226.255.25:26657"));
+    }
+
+    // Some of these tests duplicate tests in the upstream Tendermint crates.
+    // The underlying structs upstream are mostly just Strings, though, and since
+    // our code wrangles these types for interpolation in config files from multiple
+    // API endpoint sources, it's important to validate expected behavior.
+    #[test]
+    fn parse_tendermint_address_tcp() -> anyhow::Result<()> {
+        let tm1 = parse_tm_address(None, &Url::parse("tcp://35.226.255.25:26656")?)?;
+        match tm1 {
+            TendermintAddress::Tcp {
+                peer_id,
+                host,
+                port,
+            } => {
+                assert!(peer_id == None);
+                assert!(port == 26656);
+                assert!(host == "35.226.255.25");
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+    #[test]
+    // The Tendermint RPC net_info endpoint will return Listener information
+    // formatted as:
+    //
+    //   * `Listener(@35.226.255.25:26656)` or
+    //   * `Listener(@tcp://35.226.255.25:26656)` or
+    //   * `Listener(@)`
+    //
+    // I've yet to observe a node_id preceding the `@`.
+    fn parse_tendermint_address_listener() -> anyhow::Result<()> {
+        let l1 = "Listener(@35.226.255.25:26656)";
+        let r1 = parse_tm_address_listener(l1);
+        assert!(r1 == Some("35.226.255.25:26656".parse::<TendermintAddress>()?));
+
+        let l2 = "Listener(tcp://@35.226.255.25:26656)";
+        let r2 = parse_tm_address_listener(l2);
+        assert!(r2 == Some("tcp://35.226.255.25:26656".parse::<TendermintAddress>()?));
+
+        let l3 = "Listener(@)";
+        let r3 = parse_tm_address_listener(l3);
+        assert!(r3 == None);
+
+        Ok(())
+    }
+    #[test]
+    fn parse_tendermint_address_from_listener() -> anyhow::Result<()> {
+        // Most upstream Tendermint types are just String structs, so there's
+        // no handling of the `Listener()` wrapper. We must regex it out.
+        let l = tendermint::node::info::ListenAddress::new(
+            "Listener(@35.226.255.25:26656)".to_string(),
+        );
+        let tm1 = TendermintAddress::from_listen_address(&l);
+        assert!(tm1 == None);
+        Ok(())
     }
 }


### PR DESCRIPTION
When joining a testnet, `pd` will inspect the RPC endpoint for the bootstrap node and copy its known peers into the generated Tendermint config. To date, since #1847, that logic has also interpolated an incorrect address for the bootstrap node (by default currently `testnet.penumbra.zone:26657`): the RPC address shouldn't be used, the P2P address should be. This is particularly important when as we move toward updating our configs to default to HTTPS: we can no longer assume that the host portion of a service URL will be the same between the RPC and P2P endpoints. Instead, let's use the RPC to inspect what the correct ListenAddress is.

## Testing and review

First, verify the misbehavior on main branch:

```
git checkout main
cargo run --release --bin pd -- testnet unsafe-reset-all
cargo run --release --bin pd -- testnet join https://rpc.testnet.penumbra.zone
grep ^seed ~/.penumbra/testnet_data/node0/tendermint/config/config.toml
```

Observe that the first host in there is `rpc.testnet.penumbra.zone:26656`, which won't work: 26656 isn't even open on that IP. Next, try it on this feature branch:

```
git checkout smarter-seed-addr-lookup
cargo run --release --bin pd -- testnet unsafe-reset-all
cargo run --release --bin pd -- testnet join https://rpc.testnet.penumbra.zone
grep ^seed ~/.penumbra/testnet_data/node0/tendermint/config/config.toml
```

Observe that the first host in there is no longer a DNS name, but an IP address. Critically, the IP address is not the same as that for the RPC service:

```
❯ host rpc.testnet.penumbra.zone
rpc.testnet.penumbra.zone has address 34.111.241.130
```

Instead, the first node in the TM config should be `35.226.255.25:26656`, which maps to the exposed p2p port for the tendermint service on fn-0 in the testnet deployment.