### PR TITLE
Improved order display in `pcli`.

### DIFF
--- a/crypto/src/dex/lp/order.rs
+++ b/crypto/src/dex/lp/order.rs
@@ -94,8 +94,13 @@ impl BuyOrder {
         })
     }
 
-    /// Formats this `BuyOrder` as a string.
-    pub fn format(&self, cache: &asset::Cache) -> Result<String> {
+    /// Returns a formatted representation of the price component.  This is
+    /// returned as a string because it implicitly depends on the unit of the
+    /// offered asset, so shouldn't be used for computation; it's split out for
+    /// use in tables.
+    ///
+    /// Errors if the assets in `self` aren't in `cache`.
+    pub fn price_str(&self, cache: &asset::Cache) -> Result<String> {
         let desired_unit = cache
             .get(&self.desired.asset_id)
             .map(|d| d.default_unit())
@@ -121,6 +126,13 @@ impl BuyOrder {
             asset_id: self.offered.asset_id,
         }
         .format(&cache);
+
+        Ok(price_str)
+    }
+
+    /// Formats this `BuyOrder` as a string.
+    pub fn format(&self, cache: &asset::Cache) -> Result<String> {
+        let price_str = self.price_str(cache)?;
         let desired_str = self.desired.format(&cache);
 
         if self.fee != 0 {
@@ -167,8 +179,13 @@ impl SellOrder {
         })
     }
 
-    /// Formats this `SellOrder` as a string.
-    pub fn format(&self, cache: &asset::Cache) -> Result<String> {
+    /// Returns a formatted representation of the price component.  This is
+    /// returned as a string because it implicitly depends on the unit of the
+    /// offered asset, so shouldn't be used for computation; it's split out for
+    /// use in tables.
+    ///
+    /// Errors if the assets in `self` aren't in `cache`.
+    pub fn price_str(&self, cache: &asset::Cache) -> Result<String> {
         let offered_unit = cache
             .get(&self.offered.asset_id)
             .map(|d| d.default_unit())
@@ -194,6 +211,13 @@ impl SellOrder {
             asset_id: self.desired.asset_id,
         }
         .format(&cache);
+
+        Ok(price_str)
+    }
+
+    /// Formats this `SellOrder` as a string.
+    pub fn format(&self, cache: &asset::Cache) -> Result<String> {
+        let price_str = self.price_str(cache)?;
         let offered_str = self.offered.format(&cache);
 
         if self.fee != 0 {

--- a/crypto/src/dex/lp/order.rs
+++ b/crypto/src/dex/lp/order.rs
@@ -47,7 +47,7 @@ fn parse_parts(input: &str) -> Result<(&str, &str, u32)> {
 }
 
 fn extract_unit(input: &str) -> Result<Unit> {
-    let unit_re = Regex::new(r"[0-9.]+([^0-9.]+)")?;
+    let unit_re = Regex::new(r"[0-9.]+([^0-9.].*+)$")?;
     if let Some(captures) = unit_re.captures(input) {
         let unit = captures.get(1).expect("matched regex").as_str();
         Ok(asset::REGISTRY.parse_unit(unit))

--- a/pcli/src/command/query/dex.rs
+++ b/pcli/src/command/query/dex.rs
@@ -1,11 +1,9 @@
-use crate::command::utils;
 use anyhow::{Context, Result};
 use comfy_table::{presets, Table};
 use futures::{Stream, StreamExt, TryStreamExt};
 use std::pin::Pin;
 
 use penumbra_crypto::{
-    asset,
     dex::{
         execution::SwapExecution,
         lp::position::{self, Position},
@@ -21,7 +19,10 @@ use penumbra_proto::client::v1alpha1::{
 use penumbra_view::ViewClient;
 use tonic::transport::Channel;
 
-use crate::App;
+use crate::{
+    command::utils::{self, render_positions},
+    App,
+};
 
 #[derive(Debug, clap::Subcommand)]
 pub enum DexCmd {
@@ -349,48 +350,4 @@ impl DexCmd {
 
         Ok(())
     }
-}
-
-fn render_positions(asset_cache: &asset::Cache, positions: &[Position]) -> String {
-    let mut table = Table::new();
-    table.load_preset(presets::NOTHING);
-    table.set_header(vec![
-        "ID",
-        "Trading Pair",
-        "State",
-        "Reserves",
-        "Trading Function",
-    ]);
-
-    for position in positions {
-        let trading_pair = position.phi.pair;
-        let denom_1 = asset_cache
-            .get(&trading_pair.asset_1())
-            .expect("asset should be known to view service");
-        let denom_2 = asset_cache
-            .get(&trading_pair.asset_2())
-            .expect("asset should be known to view service");
-
-        let display_denom_1 = denom_1.default_unit();
-        let display_denom_2 = denom_2.default_unit();
-
-        table.add_row(vec![
-            format!("{}", position.id()),
-            format!("({}, {})", display_denom_1, display_denom_2),
-            position.state.to_string(),
-            format!(
-                "({}, {})",
-                display_denom_1.format_value(position.reserves.r1),
-                display_denom_2.format_value(position.reserves.r2)
-            ),
-            format!(
-                "fee: {}bps, p/q: {:.6}, q/p: {:.6}",
-                position.phi.component.fee,
-                f64::from(position.phi.component.p) / f64::from(position.phi.component.q),
-                f64::from(position.phi.component.q) / f64::from(position.phi.component.p),
-            ),
-        ]);
-    }
-
-    format!("{table}")
 }

--- a/pcli/src/command/tx/replicate.rs
+++ b/pcli/src/command/tx/replicate.rs
@@ -10,7 +10,7 @@ use penumbra_crypto::dex::DirectedUnitPair;
 use penumbra_crypto::keys::AddressIndex;
 use penumbra_crypto::{Amount, Value};
 use penumbra_proto::client::v1alpha1::SpreadRequest;
-use penumbra_view::Planner;
+use penumbra_view::{Planner, ViewClient};
 use rand_core::OsRng;
 use std::io::Write;
 
@@ -117,9 +117,10 @@ impl ConstantProduct {
         // TODO(erwan): would be nice to print current balance?
 
         println!("You will create the following pools:");
+        let asset_cache = app.view().assets().await?;
         println!(
             "{}",
-            crate::command::utils::render_xyk_approximation(pair.clone(), &positions)
+            crate::command::utils::render_positions(&asset_cache, &positions),
         );
 
         if let Some(debug_file) = &self.debug_file {

--- a/pcli/src/command/utils.rs
+++ b/pcli/src/command/utils.rs
@@ -1,119 +1,101 @@
 use comfy_table::{presets, Table};
-use penumbra_crypto::{
-    asset::{self},
-    dex::{lp::position::Position, DirectedUnitPair},
-    fixpoint::U128x128,
-};
+use penumbra_crypto::{asset, dex::lp::position::Position, Value};
 
 pub(crate) fn render_positions(asset_cache: &asset::Cache, positions: &[Position]) -> String {
     let mut table = Table::new();
     table.load_preset(presets::NOTHING);
-    table.set_header(vec![
-        "ID",
-        "Trading Pair",
-        "State",
-        "Reserves",
-        "Trading Function",
-    ]);
+    table.set_header(vec!["ID", "State", "Fee", "Sell Price", "Reserves"]);
+    table
+        .get_column_mut(2)
+        .unwrap()
+        .set_cell_alignment(comfy_table::CellAlignment::Right);
+    table
+        .get_column_mut(3)
+        .unwrap()
+        .set_cell_alignment(comfy_table::CellAlignment::Right);
+    table
+        .get_column_mut(4)
+        .unwrap()
+        .set_cell_alignment(comfy_table::CellAlignment::Right);
 
     for position in positions {
         let trading_pair = position.phi.pair;
         let denom_1 = asset_cache.get(&trading_pair.asset_1());
         let denom_2 = asset_cache.get(&trading_pair.asset_2());
 
-        // if either of the assets is unknown, just show the asset IDs
-        let (d_display, v_display) = if denom_1.is_none() || denom_2.is_none() {
-            (
-                format!("({}, {})", trading_pair.asset_1(), trading_pair.asset_2()),
-                format!(
-                    "({} {}, {} {})",
-                    position.reserves.r1,
-                    trading_pair.asset_1(),
-                    position.reserves.r2,
-                    trading_pair.asset_2(),
-                ),
-            )
-        } else {
-            let display_denom_1 = denom_1.unwrap().default_unit();
-            let display_denom_2 = denom_2.unwrap().default_unit();
-            (
-                format!("({}, {})", display_denom_1, display_denom_2),
-                format!(
-                    "({}, {})",
-                    display_denom_1.format_value(position.reserves.r1),
-                    display_denom_2.format_value(position.reserves.r2)
-                ),
-            )
-        };
-
-        table.add_row(vec![
-            format!("{}", position.id()),
-            d_display,
-            position.state.to_string(),
-            v_display,
-            format!(
-                "fee: {}bps, p/q: {:.6}, q/p: {:.18}",
-                position.phi.component.fee,
-                f64::from(position.phi.component.p) / f64::from(position.phi.component.q),
-                f64::from(position.phi.component.q) / f64::from(position.phi.component.p),
-            ),
-        ]);
-    }
-
-    format!("{table}")
-}
-
-pub(crate) fn render_xyk_approximation(pair: DirectedUnitPair, positions: &[Position]) -> String {
-    let mut table = Table::new();
-    table.load_preset(presets::NOTHING);
-    table.set_header(vec![
-        "ID",
-        "Trading Pair",
-        "Reserves",
-        "Pool fee",
-        "Price summary",
-        format!("{} to {}", pair.start, pair.end).as_str(),
-        format!("{} to {}", pair.end, pair.start).as_str(),
-    ]);
-
-    for position in positions {
-        let fee = position.phi.component.fee;
-        let well_directed_phi = position.phi.orient_end(pair.end.id()).unwrap();
-        // TODO(erwan): refactor with `BuyOrder`?
-        let start = pair.start.unit_amount();
-        let end = pair.end.unit_amount();
-        let fp_start: U128x128 = start.try_into().unwrap();
-        let fp_end: U128x128 = end.try_into().unwrap();
-        let cross = (fp_start / fp_end).unwrap();
-        let cross_inv = (fp_end / fp_start).unwrap();
-        let price_a_to_b = (well_directed_phi.effective_price_inv() * cross).unwrap();
-        let price_b_to_a = (well_directed_phi.effective_price() * cross_inv).unwrap();
-
-        let asset_1_to_2 = format!("{} @ {:>10.05}", pair.to_string(), price_a_to_b);
-        let asset_2_to_1 = format!("{} @ {:>10.05}", pair.flip().to_string(), price_b_to_a);
-
-        // We display a price summary that is the relevant cost of conversion (since one of the reserves is 0).
-        let price_summary = if position.reserves_for(pair.end.id()).unwrap() == 0u64.into() {
-            asset_2_to_1.clone()
-        } else {
-            asset_1_to_2.clone()
-        };
-
-        table.add_row(vec![
-            format!("{}", position.id()),
-            format!("{}", pair.to_string()),
-            format!(
-                "({}, {})",
-                pair.start
-                    .format_value(position.reserves_for(pair.start.id()).unwrap()),
-                pair.end
-                    .format_value(position.reserves_for(pair.end.id()).unwrap()),
-            ),
-            format!("{fee:>5}bps"),
-            price_summary,
-            asset_1_to_2,
-            asset_2_to_1,
-        ]);
+        match (denom_1, denom_2) {
+            (Some(_), Some(_)) => {
+                if let Some(sell_order) = position.interpret_as_sell() {
+                    table.add_row(vec![
+                        position.id().to_string(),
+                        position.state.to_string(),
+                        format!("{}bps", position.phi.component.fee),
+                        format!(
+                            "{}",
+                            sell_order
+                                .price_str(&asset_cache)
+                                .expect("assets are known"),
+                        ),
+                        sell_order.offered.format(&asset_cache),
+                    ]);
+                } else if let Some((sell_order_1, sell_order_2)) = position.interpret_as_mixed() {
+                    table.add_row(vec![
+                        position.id().to_string(),
+                        position.state.to_string(),
+                        format!("{}bps", position.phi.component.fee),
+                        format!(
+                            "{}",
+                            sell_order_1
+                                .price_str(&asset_cache)
+                                .expect("assets are known"),
+                        ),
+                        sell_order_1.offered.format(&asset_cache),
+                    ]);
+                    table.add_row(vec![
+                        String::new(),
+                        String::new(),
+                        format!("{}bps", position.phi.component.fee),
+                        format!(
+                            "{}",
+                            sell_order_2
+                                .price_str(&asset_cache)
+                                .expect("assets are known"),
+                        ),
+                        sell_order_2.offered.format(&asset_cache),
+                    ]);
+                } else {
+                    table.add_row(vec![
+                        position.id().to_string(),
+                        position.state.to_string(),
+                        "Error interpreting position (this should not happen)".to_string(),
+                    ]);
+                }
+            }
+            (_, _) => {
+                table.add_row(vec![
+                    position.id().to_string(),
+                    position.state.to_string(),
+                    format!("{}bps", position.phi.component.fee),
+                    format!("Unknown asset"),
+                    Value {
+                        amount: position.reserves.r1,
+                        asset_id: position.phi.pair.asset_1(),
+                    }
+                    .format(&asset_cache),
+                ]);
+                table.add_row(vec![
+                    String::new(),
+                    String::new(),
+                    format!("{}bps", position.phi.component.fee),
+                    format!("Unknown asset"),
+                    Value {
+                        amount: position.reserves.r2,
+                        asset_id: position.phi.pair.asset_2(),
+                    }
+                    .format(&asset_cache),
+                ]);
+            }
+        }
     }
 
     format!("{table}")


### PR DESCRIPTION
New output:
```
 ID                                                                State     Fee        Sell Price               Reserves
 plpid1d264h47q89wyelffkur84qg3wl7xhk33qsdq4n64ecpshwd87cuqj569f3  opened   0bps  906.365mpenumbra      49.804882test_usd
 plpid1l98l8r4md6l27mlq3hestl297vmumq70mda7ft976574dc4dxqess0h2rj  opened   0bps      910mpenumbra             10test_usd
 plpid1tvdew6z7pzeefystptlf6fppq3atj9wuccngnt876kdzc5d637qsz87hwx  opened  30bps  909.091mpenumbra    8638.937729test_usd
                                                                           30bps  1.100001test_usd   38819.060718penumbra
 plpid1n78syzdvjarkzcx6kna5d9742zmkfvq48eesk3sjt323s625wytqgppzrd  opened   0bps         1penumbra            500test_usd
 plpid1w2dn9ddswhzm46ce6tc7cejq6dgf4xyans3r36pq5mx4sl8a4f5qyf8u87  opened   0bps  1.007072penumbra      52.537812test_usd
 plpid1nc8stk067rj94dpf95aqp6shkde2g7kcfqnyq0xud0nxtxv96pfs2vwt8c  opened  30bps  1.010102penumbra   54126.205531test_usd
 plpid1stkx9qt8keyaws4r2yzrwyjrx4mful2rn8ms6073nkpqz3ex9zhqwgg39d  opened   0bps  1.132956penumbra      55.782496test_usd
 plpid199r8qadj97e638tcfwc84yv2tdkx4nwmf7r3lnc928ns0ljgxt8srj3h53  opened  30bps  1.136364penumbra   57468.987772test_usd
 ```