### PR TITLE
compactblock: store in non-consensus store

### DIFF
--- a/crates/core/component/compact-block/src/component/view.rs
+++ b/crates/core/component/compact-block/src/component/view.rs
@@ -1,16 +1,19 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use penumbra_proto::{StateReadProto, StateWriteProto};
+use penumbra_proto::DomainType;
 use penumbra_storage::{StateRead, StateWrite};
 
 use crate::{state_key, CompactBlock};
 
 #[async_trait]
 pub trait StateReadExt: StateRead {
-    // formerly compact block methods
-
     async fn compact_block(&self, height: u64) -> Result<Option<CompactBlock>> {
-        self.get(&state_key::compact_block(height)).await
+        Ok(self
+            .nonconsensus_get_raw(&state_key::compact_block(height).as_bytes())
+            .await?
+            .map(|bytes| {
+                CompactBlock::decode(&mut bytes.as_slice()).expect("failed to decode compact block")
+            }))
     }
 }
 
@@ -20,7 +23,10 @@ impl<T: StateRead + ?Sized> StateReadExt for T {}
 pub trait StateWriteExt: StateWrite {
     fn set_compact_block(&mut self, compact_block: CompactBlock) {
         let height = compact_block.height;
-        self.put(state_key::compact_block(height), compact_block);
+        self.nonconsensus_put_raw(
+            state_key::compact_block(height).into_bytes(),
+            compact_block.encode_to_vec(),
+        );
     }
 }
 

--- a/crates/core/component/compact-block/src/state_key.rs
+++ b/crates/core/component/compact-block/src/state_key.rs
@@ -1,3 +1,3 @@
 pub fn compact_block(height: u64) -> String {
-    format!("compactblock/compact_block/{height}")
+    format!("compactblock/{height:020}")
 }


### PR DESCRIPTION
We don't ever use the compact block inside the chain state.  Strictly speaking, it's not necessary to store it inside the verifiable part of the chain state, and keeping it outside allows it to be accessed more efficiently when serving clients (it can just be read directly from RocksDB, in a linear order...)

We don't currently verify the CB data with a light client anyways, but even if we wanted to, we probably wouldn't want to verify every single CB's merkle inclusion proof separately. One idea we discussed informally some time ago is to write the hash of the current CB into the state (to allow individual verification) and also to write a hash chain accumulator that hashes in each successive CB, so a client can stream many CBs all at once, hash them together in sequence, and then verify the accumulator hash of all-downloaded-CBs using a Merkle proof.

This commit does none of these options, leaving them for later work, and just makes sure that the CB data is stored in ordinary RocksDB in linear order.