### PR TITLE
ci: debug output during failed wasm checks

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -50,3 +50,9 @@ jobs:
         run:
           wasm-pack build
         working-directory: crates/wasm
+
+      # Always show the results of `cargo tree`, even if the tests failed, since that
+      # output will be immediately useful in debugging.
+      - name: display mio deps
+        run: cargo tree --invert mio --edges features
+        if: always()


### PR DESCRIPTION
We want to see the output from `cargo tree` inspecting the dep graph of `mio` on any failure of the wasm workflow, since that's one of the first actions a dev would take in debugging.