### PR TITLE
ci: eliminate the chore of buf mod update

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           input: 'proto'
           # The 'main' branch of the GitHub repository that defines the module.
-          against: 'https://github.com/${GITHUB_REPOSITORY}.git#branch=main,subdir=crates/proto'
+          against: 'https://github.com/${GITHUB_REPOSITORY}.git#branch=main,subdir=proto'
 
   protobuf-fresh:
     name: Compile protobuf specs to rust code

--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -21,12 +21,11 @@ jobs:
       - uses: bufbuild/buf-lint-action@v1
         with:
           input: 'proto'
-      # Disabled because we don't have any changes to compare against
-      # - uses: bufbuild/buf-breaking-action@v1
-      #   with:
-      #     # The 'main' branch of the GitHub repository that defines the module.
-      #     against: 'https://github.com/${GITHUB_REPOSITORY}.git#branch=main'
-      #     input: 'proto'
+
+      # N.B. We don't check for breaking changes here, because we do so per-PR, and notify there.
+      # Occasionally we'll make breaking changes, the PR CI is notification enough of that.
+      # We still want to publish the resulting changes to the BSR.
+
       - uses: bufbuild/buf-push-action@v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}

--- a/docs/guide/src/dev/protobuf.md
+++ b/docs/guide/src/dev/protobuf.md
@@ -42,16 +42,18 @@ If the generated output would change in any way, CI will
 fail, prompting the developer to commit the changes.
 
 ## Updating buf lockfiles
-Occasionally the lockfile pinning protobuf dependencies will drift from latest,
-either due to changes in upstream Cosmos deps, or changes in our own. To update:
+We pin specific versions of upstream Cosmos deps in the buf lockfile
+for our proto definitions. Doing so avoids a tedious chore of needing
+to update the lockfile frequently when the upstream BSR entries change.
+We should review these deps periodically and bump them, as we would any other dependency.
 
 ```shell
 cd proto/penumbra
+# edit buf.yaml to remove the tags, i.e. suffix `:<tag>`
 buf mod update
 ```
 
-then commit and PR in the results. Eventually we hope to remove the need for this chore;
-see [GH2321](https://github.com/penumbra-zone/penumbra/issues/2321) for details.
+then commit and PR in the results.
 
 [`protoc` website]: https://grpc.io/docs/protoc-installation/#install-pre-compiled-binaries-any-os
 [proto-compiler]: https://github.com/penumbra-zone/penumbra/tree/main/tools/proto-compiler

--- a/proto/penumbra/buf.lock
+++ b/proto/penumbra/buf.lock
@@ -9,8 +9,8 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: cosmos-sdk
-    commit: d4bc9d92d0644dd4ba612b627205d155
-    digest: shake256:0fa92419bf81aa8436c5fbc6d0b3b41986ce5c7bf86ed00e0e32f20b853bdaddce3a3016542f12e449971131352155a4966dcc5bc42f849d0c3abce9e4143eef
+    commit: f68ef6b77d324ad1a46f4628241f011e
+    digest: shake256:dd4a174056ace17be122413b84e9d02bb68d99312e66333f1b267bc8636a1853868345d3a6928fb2e87639859c76bd4b57f0975ecd24b602c838fde20a8fdb77
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto

--- a/proto/penumbra/buf.yaml
+++ b/proto/penumbra/buf.yaml
@@ -1,13 +1,11 @@
 version: v1
 name: buf.build/penumbra-zone/penumbra
+# We pin versions of the upstream cosmos deps, to avoid the chore of bumping
+# the lockfile regularly, while still detecting uncommitted changes to our
+# protos in CI.
 deps:
-  - buf.build/cosmos/ibc
-  - buf.build/cosmos/cosmos-sdk
-build:
-  # Skip gogoproto from consideration during build, otherwise
-  # we get an error that the proto "exists in multiple locations".
-  excludes:
-    - gogoproto
+  - buf.build/cosmos/ibc:f642cdf6bc574f4eb8f784b3572848dc
+  - buf.build/cosmos/cosmos-sdk:f68ef6b77d324ad1a46f4628241f011e
 breaking:
   use:
     - FILE


### PR DESCRIPTION
We'll need to revisit these values periodically and update them as we would any other dependency. That's preferable to tolerating numerous false negatives in CI, forcing devs to commit updates manually to track upstream changes.

Closes #2321.