### PR TITLE
deploy: grow cluster 2 -> 4 nodes

### DIFF
--- a/deployments/terraform/modules/node/v1/variables.tf
+++ b/deployments/terraform/modules/node/v1/variables.tf
@@ -17,7 +17,7 @@ variable "cluster_zones" {
 
 variable "num_nodes" {
   description = "The number of nodes per zone"
-  default     = 1
+  default     = 2
 }
 
 ### The rest of the variables have logical defaults


### PR DESCRIPTION
We've been encountering cpu ceiling given recent box additions, so here we raise the total number of nodes in the nodepool from 2 to 4. N.B. the diff says 1 -> 2, but we use a multizonal architecture, with 2 zones by default, so (1 -> 2) * 2 = 4.