### PR TITLE
dex: discard previously executed macro routes (fix) 

### DIFF
--- a/crates/core/component/dex/src/component/router/route_and_fill.rs
+++ b/crates/core/component/dex/src/component/router/route_and_fill.rs
@@ -162,7 +162,10 @@ pub trait RouteAndFill: StateWrite + Sized {
                 break;
             }
 
-            // If we have already taken this path, then we are stuck in a loop.
+            // If we have already taken this path, then we could be stuck in a loop.
+            // This branch is part of testnet 53's arb cycle bug fix. This is probably
+            // not the best way to fix this bug, but it's a start.
+            // TODO(erwan): remove this branch once we have a better fix.
             if prev_path == path {
                 tracing::debug!("path is the same as previous path, exiting route_and_fill");
                 break;

--- a/crates/core/component/dex/src/component/router/route_and_fill.rs
+++ b/crates/core/component/dex/src/component/router/route_and_fill.rs
@@ -139,6 +139,9 @@ pub trait RouteAndFill: StateWrite + Sized {
         // All traces of trades that were executed.
         let mut traces: Vec<Vec<Value>> = Vec::new();
 
+        // the previous macro path that we have taken.
+        let mut prev_path: Vec<asset::Id> = vec![];
+
         // Continuously route and fill until either:
         // 1. We have no more delta_1 remaining
         // 2. A path can no longer be found
@@ -153,10 +156,19 @@ pub trait RouteAndFill: StateWrite + Sized {
                 tracing::debug!("no path found, exiting route_and_fill");
                 break;
             };
+
             if path.is_empty() {
                 tracing::debug!("empty path found, exiting route_and_fill");
                 break;
             }
+
+            // If we have already taken this path, then we are stuck in a loop.
+            if prev_path == path {
+                tracing::debug!("path is the same as previous path, exiting route_and_fill");
+                break;
+            }
+
+            prev_path = path.clone();
 
             (outer_lambda_2, outer_unfilled_1) = {
                 // path found, fill as much as we can

--- a/crates/core/component/dex/src/component/tests.rs
+++ b/crates/core/component/dex/src/component/tests.rs
@@ -807,13 +807,18 @@ async fn reproduce_arbitrage_loop_testnet_53() -> anyhow::Result<()> {
      *
      */
 
-    state_tx.put_position(limit_buy(penumbra_usd.clone(), 1u64.into(), 110u64.into()));
-    state_tx.put_position(limit_buy(penumbra_usd.clone(), 1u64.into(), 100u64.into()));
-    state_tx.put_position(limit_sell(
-        penumbra_usd.clone(),
-        10u64.into(),
-        100u64.into(),
-    ));
+    let mut buy_1 = limit_buy(penumbra_usd.clone(), 1u64.into(), 110u64.into());
+    buy_1.nonce = [1; 32];
+
+    let mut buy_2 = limit_buy(penumbra_usd.clone(), 1u64.into(), 100u64.into());
+    buy_2.nonce = [2; 32];
+
+    let mut sell_1 = limit_sell(penumbra_usd.clone(), 10u64.into(), 100u64.into());
+    sell_1.nonce = [0; 32];
+
+    state_tx.put_position(buy_1);
+    state_tx.put_position(buy_2);
+    state_tx.put_position(sell_1);
 
     state_tx.apply();
 


### PR DESCRIPTION
This PR fixes a bug that occurred at block 3424 of Testnet 53.