### PR TITLE
Add `pcli q simulate`

### DIFF
--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -109,7 +109,7 @@ pub enum TxCmd {
     Swap {
         /// The input amount to swap, written as a typed value 1.87penumbra, 12cubes, etc.
         input: String,
-        /// The denomination to swap the input into.
+        /// The denomination to swap the input into, e.g. `gm`
         #[clap(long, display_order = 100)]
         into: String,
         /// The transaction fee (paid in upenumbra).


### PR DESCRIPTION
Example output:
```
   Compiling pcli v0.53.0 (/Users/hdevalence/code/penumbra/penumbra/crates/bin/pcli)
    Finished release [optimized] target(s) in 23.75s
     Running `target/release/pcli -n 'http://localhost:8080' q dex simulate 100000penumbra --into test_usd`
Scanning blocks from last sync height 3423 to latest height 3423
[0s] ██████████████████████████████████████████████████       0/0       0/s ETA: 0s
100000penumbra => 93820.028565test_usd via:
    Trace                                          Subprice
    58.788mpenumbra =>       58200wtest_usd        1.010104penumbra/1test_usd
    52909.29182penumbra =>   52380.198901test_usd  1.010102penumbra/1test_usd
    70.221mpenumbra =>       61794wtest_usd        1.136373penumbra/1test_usd
    47090.579171penumbra =>  41439.70967test_usd   1.136364penumbra/1test_usd
```