### PR TITLE
dex(router): make `Frontier` position an append-only log

### DIFF
--- a/crates/core/component/dex/src/component/router/fill_route.rs
+++ b/crates/core/component/dex/src/component/router/fill_route.rs
@@ -467,7 +467,6 @@ impl<S: StateRead + StateWrite> Frontier<S> {
                 "replacing constraining position in frontier",
             );
 
-            self.position_ids.remove(&replaced_position_id);
             self.position_ids.insert(next_position_id);
             self.positions[index] = next_position;
 


### PR DESCRIPTION
This was suggested by @hdevalence, presumably to avoid churning over the same positions within a same frontier. I don't fully understand the ramifications of that change yet. I will adjust the PR description once I have worked out the consequences that this change has on the DEX engine.