### PR TITLE
wip: terminate based on the actual price

### DIFF
--- a/crates/core/component/dex/src/component/router/path_search.rs
+++ b/crates/core/component/dex/src/component/router/path_search.rs
@@ -13,7 +13,7 @@ use super::{Path, PathCache, PathEntry, RoutingParams, SharedPathCache};
 
 #[async_trait]
 pub trait PathSearch: StateRead + Clone + 'static {
-    /// Find the best route from `src` to `dst` with estimated price at most
+    /// Find the best route from `src` to `dst` with estimated price strictly less than
     /// `params.price_limit`, also returning the spill price for the next-best
     /// route, if one exists.
     #[instrument(skip(self, src, dst, params), fields(max_hops = params.max_hops))]
@@ -51,7 +51,7 @@ pub trait PathSearch: StateRead + Clone + 'static {
         tracing::debug!(price = %path.price, spill_price = %spill_price.unwrap_or_else(|| 0u64.into()), ?src, ?nodes, "found path");
 
         match price_limit {
-            Some(price_limit) if path.price > price_limit => {
+            Some(price_limit) if path.price >= price_limit => {
                 tracing::debug!(price = %path.price, price_limit = %price_limit, "path too expensive");
                 Ok((None, None))
             }


### PR DESCRIPTION
This aims to be a better solution than the temporary fix we did last week. Roughly, the idea is:

- `fill_route` always makes progress, so it will return an exact price;
- we can compare that exact price against the price limit.

This prevents looping infinitely based on no-profit arbs that are mis-estimated as being epsilon less than the price limit -- as soon as one of them actually executes, the exact price will be computed and checked against the price limit, terminating the process.