### PR TITLE
updates cli defaults to use HTTPS URLs

### DIFF
--- a/crates/bin/pcli/src/opt.rs
+++ b/crates/bin/pcli/src/opt.rs
@@ -34,7 +34,7 @@ pub struct Opt {
     #[clap(
         short,
         long,
-        default_value = "http://testnet.penumbra.zone:8080",
+        default_value = "https://grpc.testnet.penumbra.zone",
         env = "PENUMBRA_NODE_PD_URL",
         parse(try_from_str = Url::parse),
     )]

--- a/crates/bin/pclientd/src/lib.rs
+++ b/crates/bin/pclientd/src/lib.rs
@@ -69,7 +69,7 @@ pub struct Opt {
     #[clap(
         short,
         long,
-        default_value = "http://testnet.penumbra.zone:8080",
+        default_value = "https://grpc.testnet.penumbra.zone",
         env = "PENUMBRA_NODE_PD_URL"
     )]
     pub node: Url,

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -160,7 +160,7 @@ enum TestnetCommand {
         /// URL of the remote Tendermint RPC endpoint for bootstrapping connection.
         #[clap(
             env = "PENUMBRA_PD_JOIN_URL",
-            default_value = "http://testnet.penumbra.zone:26657"
+            default_value = "https://rpc.testnet.penumbra.zone"
         )]
         node: Url,
         /// Human-readable name to identify node on network

--- a/crates/misc/measure/src/main.rs
+++ b/crates/misc/measure/src/main.rs
@@ -26,7 +26,7 @@ pub struct Opt {
     #[clap(
         short,
         long,
-        default_value = "http://testnet.penumbra.zone:8080",
+        default_value = "https://grpc.testnet.penumbra.zone",
         env = "PENUMBRA_NODE_PD_URL",
         parse(try_from_str = url::Url::parse)
     )]
@@ -35,7 +35,7 @@ pub struct Opt {
     /// The URL for the Tendermint RPC endpoint of the remote node.
     #[clap(
         long,
-        default_value = "http://testnet.penumbra.zone:26657",
+        default_value = "https://rpc.testnet.penumbra.zone",
         env = "PENUMBRA_NODE_TM_URL"
     )]
     tendermint_url: Url,


### PR DESCRIPTION
As of Testnet 53 Himalia, the HTTPS endpoint for pd's gRPC service is live. We can now update the CLI defaults for all the binaries to use the HTTPS URLs for both pd and tendermint.

Refs #1886.