### PR TITLE
dex(router): track state before checking for termination

### DIFF
--- a/crates/core/component/dex/src/component/arb.rs
+++ b/crates/core/component/dex/src/component/arb.rs
@@ -72,6 +72,15 @@ pub trait Arbitrage: StateWrite + Sized {
             return Ok(Value { amount: 0u64.into(), asset_id: arb_token });
         };
 
+        tracing::info!(
+            ?filled_input,
+            ?output,
+            ?unfilled_input,
+            ?total_output,
+            ?arb_profit,
+            "arbitrage successful"
+        );
+
         if arb_profit == 0u64.into() {
             // If we didn't make any profit, we don't need to do anything,
             // and we can just discard the state delta entirely.

--- a/crates/core/component/dex/src/component/tests.rs
+++ b/crates/core/component/dex/src/component/tests.rs
@@ -769,9 +769,6 @@ async fn reproduce_arbitrage_loop_testnet_53() -> anyhow::Result<()> {
     let penumbra = asset::REGISTRY.parse_unit("penumbra");
     let test_usd = asset::REGISTRY.parse_unit("test_usd");
 
-    let penumbra = asset::REGISTRY.parse_unit("penumbra");
-    let test_usd = asset::REGISTRY.parse_unit("test_usd");
-
     tracing::info!(penumbra_id= ?penumbra.id());
     tracing::info!(test_usd_id = ?test_usd.id());
 
@@ -826,16 +823,16 @@ async fn reproduce_arbitrage_loop_testnet_53() -> anyhow::Result<()> {
 
     tracing::info!("we are triggering the arbitrage logic");
 
-    let op = tokio::time::timeout(
+    let arb_profit = tokio::time::timeout(
         tokio::time::Duration::from_secs(2),
         state.arbitrage(penumbra.id(), vec![penumbra.id(), test_usd.id()]),
     )
     .await??;
 
-    tracing::info!("the arbitrage logic has concluded!");
+    tracing::info!(profit = ?arb_profit, "the arbitrage logic has concluded!");
 
     tracing::info!("fetching the `ArbExecution`");
     let arb_execution = state.arb_execution(0).await?.expect("arb was performed");
-    println!("arb_execution: {arb_execution:?}");
+    tracing::info!(?arb_execution, "fetched arb execution!");
     Ok(())
 }

--- a/crates/core/component/dex/src/swap_execution.rs
+++ b/crates/core/component/dex/src/swap_execution.rs
@@ -13,21 +13,21 @@ pub struct SwapExecution {
 }
 
 impl SwapExecution {
+    /// Returns the price of the latest execution trace.
     pub fn max_price(&self) -> Result<Option<U128x128>> {
-        let Some(aggregate_input )= self.aggregate_input() else {
+        let Some((input, output)) = self.traces.last().and_then(|trace| {
+            let input = trace.first()?;
+            let output = trace.last()?;
+            Some((input, output))
+        }) else {
             return Ok(None)
         };
 
-        let Some(aggregate_output) = self.aggregate_output() else {
-            return Ok(None)
-        };
-
-        let price = U128x128::ratio(aggregate_input, aggregate_output)?;
-
+        let price = U128x128::ratio(input.amount, output.amount)?;
         Ok(Some(price))
     }
 
-    fn aggregate_input(&self) -> Option<Amount> {
+    pub fn aggregate_input(&self) -> Option<Amount> {
         self.traces
             .iter()
             .fold(Some(Amount::zero()), |acc, execution_trace| {
@@ -39,7 +39,7 @@ impl SwapExecution {
             })
     }
 
-    fn aggregate_output(&self) -> Option<Amount> {
+    pub fn aggregate_output(&self) -> Option<Amount> {
         self.traces
             .iter()
             .fold(Some(Amount::zero()), |acc, execution_trace| {


### PR DESCRIPTION
This PR makes sure that all the execution state is tracked _prior_ to checking termination conditions, so that interrupting a route and fill does not lead to inconsistencies between the reported state and the actual positions.