### PR TITLE
ci: debug logging for tendermint rpc calls

### DIFF
--- a/deployments/charts/penumbra/templates/fn-deployments.yaml
+++ b/deployments/charts/penumbra/templates/fn-deployments.yaml
@@ -151,6 +151,7 @@ spec:
           command:
             - tendermint
             - start
+            - --log_level="rpc-server:debug"
             - --home=/home/.tendermint
         - name: pd
           image: "{{ $.Values.penumbra.image }}:{{ $.Values.penumbra.version | default $.Chart.AppVersion }}"

--- a/deployments/charts/penumbra/templates/val-deployments.yaml
+++ b/deployments/charts/penumbra/templates/val-deployments.yaml
@@ -161,6 +161,7 @@ spec:
           command:
             - tendermint
             - start
+            - --log_level="rpc-server:debug"
             - --home=/home/.tendermint
         - name: pd
           image: "{{ $.Values.penumbra.image }}:{{ $.Values.penumbra.version }}"


### PR DESCRIPTION
Refs #2709. We don't dial up the verbosity to global debug on all tendermint modules, because that would generate nearly 10x as many log lines, based on local smoke test run with logging overrides. We may selectively dial up on modules such as consenesus. Relevant docs:

  * https://github.com/tendermint/tendermint/blob/main/docs/tendermint-core/running-in-production.md#logging
  * https://github.com/tendermint/tendermint/blob/main/docs/tendermint-core/how-to-read-logs.md#list-of-modules