### PR TITLE
fix(pd): ensure tendermint-addr is full url

### DIFF
--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -15,6 +15,7 @@ use futures::stream::TryStreamExt;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use pd::testnet::{
     generate::testnet_generate, get_testnet_dir, join::testnet_join, parse_tm_address,
+    url_has_necessary_parts,
 };
 use penumbra_proto::client::v1alpha1::{
     oblivious_query_service_server::ObliviousQueryServiceServer,
@@ -227,8 +228,17 @@ async fn main() -> anyhow::Result<()> {
                 ?grpc_bind,
                 ?grpc_auto_https,
                 ?metrics_bind,
+                ?tendermint_addr,
                 "starting pd"
             );
+
+            // Ensure we have all necessary parts in the URL
+            if !url_has_necessary_parts(&tendermint_addr) {
+                anyhow::bail!(
+                    "Failed to parse '--tendermint-addr' as URL: {}",
+                    tendermint_addr
+                )
+            }
 
             let mut rocks_path = home.clone();
             rocks_path.push("rocksdb");

--- a/crates/bin/pd/src/testnet.rs
+++ b/crates/bin/pd/src/testnet.rs
@@ -286,3 +286,8 @@ pub fn get_testnet_dir(testnet_dir: Option<PathBuf>) -> PathBuf {
         None => canonicalize_path("~/.penumbra/testnet_data"),
     }
 }
+
+/// Check that a [Url] has all the necessary parts defined for use as a CLI arg.
+pub fn url_has_necessary_parts(url: &Url) -> bool {
+    url.scheme() != "" && url.has_host() && url.port().is_some()
+}


### PR DESCRIPTION
Check for scheme, host, and port all to be defined, otherwise pd may start with an invalid address for the Tendermint RPC. Closes #2718.