### PR TITLE
fix: ensure ephemeral address of sender is put in memo field

### DIFF
--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -254,16 +254,13 @@ impl TxCmd {
                 let to = to
                     .parse()
                     .map_err(|_| anyhow::anyhow!("address is invalid"))?;
+                let memo_ephemeral_address =
+                    app.fvk.ephemeral_address(OsRng, AddressIndex::new(*from)).0;
 
-                let memo = memo.as_ref().map(|m| {
-                    let memo_ephemeral_address =
-                        app.fvk.ephemeral_address(OsRng, AddressIndex::new(*from)).0;
-
-                    MemoPlaintext {
-                        sender: memo_ephemeral_address,
-                        text: m.clone(),
-                    }
-                });
+                let memo_plaintext = MemoPlaintext {
+                    sender: memo_ephemeral_address,
+                    text: memo.clone().unwrap_or_default(),
+                };
 
                 let plan = plan::send(
                     app.fvk.account_group_id(),
@@ -273,7 +270,7 @@ impl TxCmd {
                     fee,
                     to,
                     AddressIndex::new(*from),
-                    memo,
+                    Some(memo_plaintext),
                 )
                 .await?;
                 app.build_and_submit_transaction(plan).await?;

--- a/crates/core/crypto/src/address.rs
+++ b/crates/core/crypto/src/address.rs
@@ -291,6 +291,10 @@ mod tests {
             alt_bech32m: bech32m_addr,
         }
         .encode_to_vec();
+        let proto_addr_direct: pb::Address = dest.into();
+        let addr_from_proto: Address = proto_addr_direct
+            .try_into()
+            .expect("can convert from proto back to address");
 
         let addr2 = Address::decode(proto_addr.as_ref()).expect("can decode valid address");
         let addr3 = Address::decode(proto_addr_bech32m.as_ref()).expect("can decode valid address");
@@ -298,6 +302,7 @@ mod tests {
         assert_eq!(addr, dest);
         assert_eq!(addr2, dest);
         assert_eq!(addr3, dest);
+        assert_eq!(addr_from_proto, dest);
     }
 
     #[test]

--- a/crates/core/crypto/src/keys/ivk.rs
+++ b/crates/core/crypto/src/keys/ivk.rs
@@ -131,6 +131,7 @@ impl IncomingViewingKeyVar {
 #[cfg(test)]
 mod test {
     use crate::keys::{SeedPhrase, SpendKey};
+    use proptest::prelude::*;
 
     use super::*;
 
@@ -141,6 +142,18 @@ mod test {
         let ivk = spend_key.full_viewing_key().incoming();
         let own_address = ivk.payment_address(AddressIndex::from(0u32)).0;
         assert!(ivk.views_address(&own_address));
+    }
+
+    proptest! {
+        #[test]
+        fn views_address_succeeds_on_own_ephemeral_address(address_index in any::<u32>()) {
+            let rng = rand::rngs::OsRng;
+            let spend_key = SpendKey::from_seed_phrase(SeedPhrase::generate(rng), 0);
+            let fvk = spend_key.full_viewing_key();
+            let (own_address, _) = fvk.ephemeral_address(rng, AddressIndex::from(address_index));
+            let ivk = fvk.incoming();
+            assert!(ivk.views_address(&own_address));
+        }
     }
 
     #[test]

--- a/crates/core/crypto/src/keys/ivk.rs
+++ b/crates/core/crypto/src/keys/ivk.rs
@@ -153,6 +153,9 @@ mod test {
             let (own_address, _) = fvk.ephemeral_address(rng, AddressIndex::from(address_index));
             let ivk = fvk.incoming();
             assert!(ivk.views_address(&own_address));
+
+            let derived_address_index = fvk.address_index(&own_address);
+            assert_eq!(derived_address_index.expect("index exists").account, AddressIndex::from(address_index).account);
         }
     }
 

--- a/crates/core/transaction/src/plan/memo.rs
+++ b/crates/core/transaction/src/plan/memo.rs
@@ -41,7 +41,7 @@ impl DomainType for MemoPlan {
 impl From<MemoPlan> for pb::MemoPlan {
     fn from(msg: MemoPlan) -> Self {
         let sender = Some(msg.plaintext.sender.into());
-        let text = msg.plaintext.text.into();
+        let text = msg.plaintext.text;
         Self {
             plaintext: Some(pb::MemoPlaintext { sender, text }),
             key: msg.key.to_vec().into(),


### PR DESCRIPTION
Closes #2692

The problem in #2692 was:
1. In `TxCmd::exec` we generate an ephemeral address, but in manipulating the `memo` variable (`Option<MemoPlaintext>`), we set the variable to `None` when there is no other memo text, even when we want to provide the ephemeral address in the memo field. Link [here](https://github.com/penumbra-zone/penumbra/blob/2063191218df1bb93f062be4d2479d64ea388b36/crates/bin/pcli/src/command/tx.rs#L258-L266) to relevant code. By setting `memo` to `None`, the ephemeral address is not used.
2. Then, while planning the transaction, we end up populating the previously empty memo field with a default memo, which fills the sender field with a dummy address that is not legible to the sender. 