### PR TITLE
Use current rate data instead of next rate data for delegate/undelegate requests (#2360)

### DIFF
--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -433,7 +433,7 @@ impl TxCmd {
 
                 let mut client = app.specific_client().await?;
                 let rate_data: RateData = client
-                    .next_validator_rate(tonic::Request::new(to.into()))
+                    .current_validator_rate(tonic::Request::new(to.into()))
                     .await?
                     .into_inner()
                     .try_into()?;
@@ -479,7 +479,7 @@ impl TxCmd {
 
                 let mut client = app.specific_client().await?;
                 let rate_data: RateData = client
-                    .next_validator_rate(tonic::Request::new(from.into()))
+                    .current_validator_rate(tonic::Request::new(from.into()))
                     .await?
                     .into_inner()
                     .try_into()?;

--- a/crates/core/component/stake/src/action_handler/delegate.rs
+++ b/crates/core/component/stake/src/action_handler/delegate.rs
@@ -20,7 +20,7 @@ impl ActionHandler for Delegate {
     async fn check_stateful<S: StateRead + 'static>(&self, state: Arc<S>) -> Result<()> {
         let d = self;
         let next_rate_data = state
-            .next_validator_rate(&d.validator_identity)
+            .current_validator_rate(&d.validator_identity)
             .await?
             .ok_or_else(|| anyhow::anyhow!("unknown validator identity {}", d.validator_identity))?
             .clone();

--- a/crates/core/component/stake/src/action_handler/undelegate.rs
+++ b/crates/core/component/stake/src/action_handler/undelegate.rs
@@ -18,7 +18,7 @@ impl ActionHandler for Undelegate {
     async fn check_stateful<S: StateRead + 'static>(&self, state: Arc<S>) -> Result<()> {
         let u = self;
         let rate_data = state
-            .next_validator_rate(&u.validator_identity)
+            .current_validator_rate(&u.validator_identity)
             .await?
             .ok_or_else(|| {
                 anyhow::anyhow!("unknown validator identity {}", u.validator_identity)

--- a/crates/core/component/stake/src/rate.rs
+++ b/crates/core/component/stake/src/rate.rs
@@ -1,6 +1,7 @@
 //! Staking reward and delegation token exchange rates.
 
 use penumbra_crypto::{stake::Penalty, Amount};
+use penumbra_proto::client::v1alpha1::CurrentValidatorRateResponse;
 use penumbra_proto::{
     client::v1alpha1::NextValidatorRateResponse, core::stake::v1alpha1 as pb, DomainType, TypeUrl,
 };
@@ -269,6 +270,25 @@ impl TryFrom<NextValidatorRateResponse> for RateData {
         value
             .data
             .ok_or_else(|| anyhow::anyhow!("empty NextValidatorRateResponse message"))?
+            .try_into()
+    }
+}
+
+impl From<RateData> for CurrentValidatorRateResponse {
+    fn from(r: RateData) -> Self {
+        CurrentValidatorRateResponse {
+            data: Some(r.into()),
+        }
+    }
+}
+
+impl TryFrom<CurrentValidatorRateResponse> for RateData {
+    type Error = anyhow::Error;
+
+    fn try_from(value: CurrentValidatorRateResponse) -> Result<Self, Self::Error> {
+        value
+            .data
+            .ok_or_else(|| anyhow::anyhow!("empty CurrentValidatorRateResponse message"))?
             .try_into()
     }
 }

--- a/crates/core/crypto/src/stake/identity_key.rs
+++ b/crates/core/crypto/src/stake/identity_key.rs
@@ -1,5 +1,5 @@
 use penumbra_proto::{
-    client::v1alpha1::NextValidatorRateRequest,
+    client::v1alpha1::{CurrentValidatorRateRequest, NextValidatorRateRequest},
     core::crypto::v1alpha1 as pb,
     serializers::bech32str::{self, validator_identity_key::BECH32_PREFIX},
     DomainType, TypeUrl,
@@ -85,6 +85,25 @@ impl TryFrom<NextValidatorRateRequest> for IdentityKey {
         value
             .identity_key
             .ok_or_else(|| anyhow::anyhow!("empty NextValidatorRateRequest message"))?
+            .try_into()
+    }
+}
+
+impl From<IdentityKey> for CurrentValidatorRateRequest {
+    fn from(k: IdentityKey) -> Self {
+        CurrentValidatorRateRequest {
+            identity_key: Some(k.into()),
+            chain_id: Default::default(),
+        }
+    }
+}
+
+impl TryFrom<CurrentValidatorRateRequest> for IdentityKey {
+    type Error = anyhow::Error;
+    fn try_from(value: CurrentValidatorRateRequest) -> Result<Self, Self::Error> {
+        value
+            .identity_key
+            .ok_or_else(|| anyhow::anyhow!("empty CurrentValidatorRateRequest message"))?
             .try_into()
     }
 }

--- a/crates/proto/src/gen/penumbra.client.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.client.v1alpha1.rs
@@ -170,6 +170,23 @@ pub struct ValidatorPenaltyResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CurrentValidatorRateRequest {
+    /// The expected chain id (empty string if no expectation).
+    #[prost(string, tag = "1")]
+    pub chain_id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub identity_key: ::core::option::Option<
+        super::super::core::crypto::v1alpha1::IdentityKey,
+    >,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CurrentValidatorRateResponse {
+    #[prost(message, optional, tag = "1")]
+    pub data: ::core::option::Option<super::super::core::stake::v1alpha1::RateData>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NextValidatorRateRequest {
     /// The expected chain id (empty string if no expectation).
     #[prost(string, tag = "1")]
@@ -1087,6 +1104,28 @@ pub mod specific_query_service_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn current_validator_rate(
+            &mut self,
+            request: impl tonic::IntoRequest<super::CurrentValidatorRateRequest>,
+        ) -> Result<
+            tonic::Response<super::CurrentValidatorRateResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/penumbra.client.v1alpha1.SpecificQueryService/CurrentValidatorRate",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
         pub async fn batch_swap_output_data(
             &mut self,
             request: impl tonic::IntoRequest<super::BatchSwapOutputDataRequest>,
@@ -1993,6 +2032,10 @@ pub mod specific_query_service_server {
             &self,
             request: tonic::Request<super::NextValidatorRateRequest>,
         ) -> Result<tonic::Response<super::NextValidatorRateResponse>, tonic::Status>;
+        async fn current_validator_rate(
+            &self,
+            request: tonic::Request<super::CurrentValidatorRateRequest>,
+        ) -> Result<tonic::Response<super::CurrentValidatorRateResponse>, tonic::Status>;
         async fn batch_swap_output_data(
             &self,
             request: tonic::Request<super::BatchSwapOutputDataRequest>,
@@ -2325,6 +2368,46 @@ pub mod specific_query_service_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = NextValidatorRateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/penumbra.client.v1alpha1.SpecificQueryService/CurrentValidatorRate" => {
+                    #[allow(non_camel_case_types)]
+                    struct CurrentValidatorRateSvc<T: SpecificQueryService>(pub Arc<T>);
+                    impl<
+                        T: SpecificQueryService,
+                    > tonic::server::UnaryService<super::CurrentValidatorRateRequest>
+                    for CurrentValidatorRateSvc<T> {
+                        type Response = super::CurrentValidatorRateResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::CurrentValidatorRateRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).current_validator_rate(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = CurrentValidatorRateSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/proto/src/gen/penumbra.client.v1alpha1.serde.rs
+++ b/crates/proto/src/gen/penumbra.client.v1alpha1.serde.rs
@@ -1777,6 +1777,207 @@ impl<'de> serde::Deserialize<'de> for CompactBlockRangeResponse {
         deserializer.deserialize_struct("penumbra.client.v1alpha1.CompactBlockRangeResponse", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for CurrentValidatorRateRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.chain_id.is_empty() {
+            len += 1;
+        }
+        if self.identity_key.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.client.v1alpha1.CurrentValidatorRateRequest", len)?;
+        if !self.chain_id.is_empty() {
+            struct_ser.serialize_field("chainId", &self.chain_id)?;
+        }
+        if let Some(v) = self.identity_key.as_ref() {
+            struct_ser.serialize_field("identityKey", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for CurrentValidatorRateRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "chain_id",
+            "chainId",
+            "identity_key",
+            "identityKey",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            ChainId,
+            IdentityKey,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "chainId" | "chain_id" => Ok(GeneratedField::ChainId),
+                            "identityKey" | "identity_key" => Ok(GeneratedField::IdentityKey),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = CurrentValidatorRateRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.client.v1alpha1.CurrentValidatorRateRequest")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<CurrentValidatorRateRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut chain_id__ = None;
+                let mut identity_key__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::ChainId => {
+                            if chain_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("chainId"));
+                            }
+                            chain_id__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::IdentityKey => {
+                            if identity_key__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("identityKey"));
+                            }
+                            identity_key__ = map.next_value()?;
+                        }
+                    }
+                }
+                Ok(CurrentValidatorRateRequest {
+                    chain_id: chain_id__.unwrap_or_default(),
+                    identity_key: identity_key__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.client.v1alpha1.CurrentValidatorRateRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for CurrentValidatorRateResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.data.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("penumbra.client.v1alpha1.CurrentValidatorRateResponse", len)?;
+        if let Some(v) = self.data.as_ref() {
+            struct_ser.serialize_field("data", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for CurrentValidatorRateResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "data",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Data,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "data" => Ok(GeneratedField::Data),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = CurrentValidatorRateResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct penumbra.client.v1alpha1.CurrentValidatorRateResponse")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> std::result::Result<CurrentValidatorRateResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut data__ = None;
+                while let Some(k) = map.next_key()? {
+                    match k {
+                        GeneratedField::Data => {
+                            if data__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("data"));
+                            }
+                            data__ = map.next_value()?;
+                        }
+                    }
+                }
+                Ok(CurrentValidatorRateResponse {
+                    data: data__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("penumbra.client.v1alpha1.CurrentValidatorRateResponse", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for DenomMetadataByIdRequest {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/crates/proto/src/gen/proto_descriptor.bin
+++ b/crates/proto/src/gen/proto_descriptor.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c628f6c9142ed4fa1a7207c61aec342525b864b4fb11df5e9327c3aa782aab3
-size 322986
+oid sha256:7c94b057ae4552ceda6c7833a708d1142da6205435655e46fc48b45aef9dd95d
+size 323701

--- a/proto/penumbra/penumbra/client/v1alpha1/client.proto
+++ b/proto/penumbra/penumbra/client/v1alpha1/client.proto
@@ -112,6 +112,7 @@ service SpecificQueryService {
   rpc ValidatorStatus(ValidatorStatusRequest) returns (ValidatorStatusResponse);
   rpc ValidatorPenalty(ValidatorPenaltyRequest) returns (ValidatorPenaltyResponse);
   rpc NextValidatorRate(NextValidatorRateRequest) returns (NextValidatorRateResponse);
+  rpc CurrentValidatorRate(CurrentValidatorRateRequest) returns (CurrentValidatorRateResponse);
 
   rpc BatchSwapOutputData(BatchSwapOutputDataRequest) returns (BatchSwapOutputDataResponse);
   rpc SwapExecution(SwapExecutionRequest) returns (SwapExecutionResponse);
@@ -173,6 +174,16 @@ message ValidatorPenaltyRequest {
 
 message ValidatorPenaltyResponse {
   core.stake.v1alpha1.Penalty penalty = 1;
+}
+
+message CurrentValidatorRateRequest {
+  // The expected chain id (empty string if no expectation).
+  string chain_id = 1;
+  core.crypto.v1alpha1.IdentityKey identity_key = 2;
+}
+
+message CurrentValidatorRateResponse {
+  core.stake.v1alpha1.RateData data = 1;
 }
 
 message NextValidatorRateRequest {


### PR DESCRIPTION
Part 1 of #2630. State machine tests to follow later.