### PR TITLE
dex(router): fix path search divergence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.13.2",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "rayon",
  "zeroize",
@@ -261,7 +261,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "digest 0.10.7",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint",
  "num-traits",
  "paste",
@@ -1500,7 +1500,7 @@ dependencies = [
  "clap 2.34.0",
  "criterion-plot 0.4.5",
  "csv",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -1527,7 +1527,7 @@ dependencies = [
  "ciborium",
  "clap 3.2.25",
  "criterion-plot 0.5.0",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -1548,7 +1548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1558,7 +1558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -3079,6 +3079,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,7 +3104,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "hex",
  "ics23",
- "itertools",
+ "itertools 0.10.5",
  "mirai-annotations",
  "num-derive",
  "num-traits",
@@ -3895,7 +3904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbb7b706f2afc610f3853550cdbbf6372fd324824a087806bd4480ea4996e24"
 dependencies = [
  "heck 0.4.1",
- "itertools",
+ "itertools 0.10.5",
  "prost",
  "prost-types",
 ]
@@ -4415,6 +4424,7 @@ dependencies = [
  "futures",
  "hex",
  "im",
+ "itertools 0.11.0",
  "metrics",
  "once_cell",
  "parking_lot 0.12.1",
@@ -5199,7 +5209,7 @@ checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools",
+ "itertools 0.10.5",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -5213,7 +5223,7 @@ checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools",
+ "itertools 0.10.5",
  "predicates-core",
 ]
 
@@ -5397,7 +5407,7 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -5418,7 +5428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2 1.0.60",
  "quote 1.0.28",
  "syn 1.0.109",

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -62,3 +62,4 @@ serde_json = "1.0.96"
 tracing-subscriber = "0.3.17"
 penumbra-transaction = { path = "../../transaction" }
 rand_chacha = "0.3"
+itertools = "0.11"

--- a/crates/core/component/dex/src/component/router/path_cache.rs
+++ b/crates/core/component/dex/src/component/router/path_cache.rs
@@ -23,9 +23,11 @@ impl<S: StateRead + 'static> PathEntry<S> {
     /// Update this entry with the new path, if it's better than the existing one.
     pub fn update(&mut self, new_path: Path<S>) {
         if new_path.price < self.path.price {
-            tracing::debug!(new_price = %new_path.price, old_price = %self.path.price, "updating path");
+            tracing::debug!(new_price = %new_path.price, old_price = %self.path.price, "new path is better");
             self.spill = Some(std::mem::replace(&mut self.path, new_path));
             self.active = true;
+        } else {
+            tracing::debug!(new_price = %new_path.price, old_price = %self.path.price, "new path is worse");
         }
     }
 }

--- a/crates/core/component/dex/src/component/router/path_cache.rs
+++ b/crates/core/component/dex/src/component/router/path_cache.rs
@@ -23,11 +23,21 @@ impl<S: StateRead + 'static> PathEntry<S> {
     /// Update this entry with the new path, if it's better than the existing one.
     pub fn update(&mut self, new_path: Path<S>) {
         if new_path.price < self.path.price {
-            tracing::debug!(new_price = %new_path.price, old_price = %self.path.price, "new path is better");
+            tracing::debug!(new_price = %new_path.price, old_price = %self.path.price, "found better path, updating cache");
             self.spill = Some(std::mem::replace(&mut self.path, new_path));
             self.active = true;
+        } else if let Some(spill) = &self.spill {
+            if new_path.price < spill.price {
+                tracing::debug!(new_spill_price = %new_path.price, old_spill_price = %spill.price, "found better spill path, updating cache");
+                self.spill = Some(new_path);
+                self.active = true;
+            } else {
+                tracing::debug!(new_price = %new_path.price, old_price = %self.path.price, "found worse spill & path, ignoring");
+            }
         } else {
-            tracing::debug!(new_price = %new_path.price, old_price = %self.path.price, "new path is worse");
+            tracing::debug!(new_price = %new_path.price, old_price = %self.path.price, "found worse path, and setting spill");
+            self.spill = Some(new_path);
+            self.active = true;
         }
     }
 }

--- a/crates/core/component/dex/src/component/router/tests.rs
+++ b/crates/core/component/dex/src/component/router/tests.rs
@@ -1590,3 +1590,31 @@ async fn path_search_testnet_53_1_reproduction() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+/// Assert that operations on `PathCache` are commutative by
+/// checking that we always find the correct best path and spill path
+/// for all possible update ordering.
+///               0.01
+/// ┌───────────────────────────────┐
+/// │                               │
+/// │         ┌─────┐            ┌──▼──┐
+/// │         │     │    1       │     │
+/// │  ┌──────┤  S  ├───────────►│  B  │◄────┐
+/// │  │      │     │            │     │     │
+/// │  │      └──▲──┘            └──┬──┘     │
+/// │  │         │                  │ 1      │
+/// │  │0.9   ┌──┴──┐            ┌──▼──┐     │
+/// │  │      │     │      0.8   │     │     │
+/// └──┼──────┤  D  │◄───────────┤  C  │     │ 0.01
+///    │      │     │            │     │     │
+///    │      └──┬──┘            └──▲──┘     │
+///    │         │ 1                │ 0.99   │
+///    │      ┌──▼──┐            ┌──▼──┐     │
+///    │      │     │     0.1    │     │     │
+///    └─────►│  E  ├───────────►│  T  ├─────┘
+///           │     │            │     │
+///           └─────┘            └─────┘
+async fn path_search_commutative() -> anyhow::Result<()> {
+    todo!("TODO(erwan)")
+}


### PR DESCRIPTION
During the course of testnet `v0.53.1`, the state of a validator diverged from the rest of the network. After investigating, we found that the source of non-determinism was located in the path search logic of the DEX engine. The search phase is performed by spinning up concurrent tasks that perform relaxation over the different routes available for a given `src: asset::Id`. These tasks share a concurrent cache (`PathCache`) which keep a record of the two best available `Path<S>` seen, where best means lower cost. Every time an entry in the path cache is updated, we check whether we should update the best and spill path. At tag `v0.53.1`, this was the logic for the update branch:

```rust
    pub fn update(&mut self, new_path: Path<S>) {
        if new_path.price < self.path.price {
            tracing::debug!(new_price = %new_path.price, old_price = %self.path.price, "updating path");
            self.spill = Some(std::mem::replace(&mut self.path, new_path));
            self.active = true;
        }
}
```

Note that it does not cover the case when a `new_path` has a worse price than the best available price, but a better price than the current spill price. Since the cache is handled by concurrent tasks held in a `JoinSet`, the relaxation phase resumes when all the futures have returned, but their order of execution is non-deterministic. This means that if the path cache entry has been updated with the best price, and a better spill path comes along, we won't be able to update the cache with the better spill path and instead will return whatever spill path was known at the moment the best path was discovered. In other words, the operations applied to the cache are non-commutative.

This PR includes:
- a simple unit-test that reproduces a basic version of the error encountered in `v0.53.1`
- a patch to the path search logic that handles spill paths during updates
