### PR TITLE
pcli: import seed phrase from stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3933,6 +3933,7 @@ dependencies = [
  "ark-ff",
  "assert_cmd",
  "async-stream 0.2.1",
+ "atty",
  "base64 0.21.2",
  "bincode",
  "blake2b_simd 0.5.11",
@@ -3977,6 +3978,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "regex",
+ "rpassword",
  "serde",
  "serde_json",
  "serde_with 1.14.0",
@@ -5793,6 +5795,27 @@ checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "winapi",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -47,6 +47,7 @@ ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", branch = "main
 
 ibc-proto = { version = "0.31.0" }
 ark-ff = { version = "0.4", default-features = false }
+atty = "0.2"
 ed25519-consensus = "2"
 futures = "0.3"
 async-stream = "0.2"
@@ -73,6 +74,7 @@ hex = "0.4"
 rand = "0.8"
 rand_chacha = "0.3.1"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
+rpassword = "7"
 indicatif = "0.16"
 http-body = "0.4.5"
 clap = { version = "3", features = ["derive", "env"] }

--- a/crates/bin/pcli/tests/network_integration.rs
+++ b/crates/bin/pcli/tests/network_integration.rs
@@ -56,8 +56,8 @@ fn load_wallet_into_tmpdir() -> TempDir {
             "keys",
             "import",
             "phrase",
-            SEED_PHRASE,
         ])
+        .write_stdin(SEED_PHRASE)
         .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS));
     setup_cmd
         .assert()

--- a/crates/wallet/src/key_store.rs
+++ b/crates/wallet/src/key_store.rs
@@ -15,8 +15,10 @@ impl KeyStore {
     /// Write the wallet data to the provided path.
     pub fn save(&self, path: impl AsRef<std::path::Path>) -> anyhow::Result<()> {
         if path.as_ref().exists() {
+            let p = path.as_ref().to_string_lossy();
             return Err(anyhow::anyhow!(
-                "Wallet file already exists, refusing to overwrite it"
+                "Wallet file already exists, refusing to overwrite it: {}",
+                &p
             ));
         }
         use std::io::Write;


### PR DESCRIPTION
Changes the behavior for `pcli keys import phrase` to prompt for a masked password input interactively. When run via a pipe, reads from stdin instead, which preserves the ability to import seed phrases from other tools.

Closes #2693.