### PR TITLE
crates: miscellaneous warning fixes, comment cleanup.

### DIFF
--- a/crates/core/component/dex/src/component/dex.rs
+++ b/crates/core/component/dex/src/component/dex.rs
@@ -46,7 +46,10 @@ impl Component for Dex {
                 .handle_batch_swaps(
                     trading_pair,
                     swap_flows,
-                    end_block.height.try_into().expect("missing height"),
+                    end_block
+                        .height
+                        .try_into()
+                        .expect("height is part of the end block data"),
                     current_epoch.start_height,
                     // Always include both ends of the target pair as fixed candidates.
                     RoutingParams::default_with_extra_candidates([
@@ -55,7 +58,7 @@ impl Component for Dex {
                     ]),
                 )
                 .await
-                .expect("unable to process batch swaps");
+                .expect("handling batch swaps is infaillible");
         }
 
         // Then, perform arbitrage:
@@ -122,7 +125,7 @@ pub trait StateReadExt: StateRead {
         self.get(&state_key::arb_execution(height)).await
     }
 
-    // Get the swap flow for the given trading pair accumulated in this block so far.
+    /// Get the swap flow for the given trading pair accumulated in this block so far.
     fn swap_flow(&self, pair: &TradingPair) -> SwapFlow {
         self.swap_flows().get(pair).cloned().unwrap_or_default()
     }

--- a/crates/core/component/dex/src/lp/trading_function.rs
+++ b/crates/core/component/dex/src/lp/trading_function.rs
@@ -215,8 +215,9 @@ impl BareTradingFunction {
         }
     }
 
+    #[deprecated(note = "this method is not yet implemented")]
     pub fn fill_input(&self, _reserves: &Reserves, _delta_1: Amount) -> Option<(Reserves, Amount)> {
-        todo!()
+        unimplemented!()
     }
 
     /// Determines the amount of asset 1 that can be filled for a given amount of asset 2,
@@ -423,9 +424,9 @@ impl BareTradingFunction {
     }
 
     /// Compose two trading functions together
-    /// TODO(erwan): might have a use for working out capacity, but probably to deprecate.
+    #[deprecated(note = "this method is not yet implemented")]
     pub fn compose(&self, _phi: BareTradingFunction) -> BareTradingFunction {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/crates/core/component/dex/src/swap/plaintext.rs
+++ b/crates/core/component/dex/src/swap/plaintext.rs
@@ -63,11 +63,8 @@ impl SwapPlaintext {
     pub fn output_notes(&self, batch_data: &BatchSwapOutputData) -> (Note, Note) {
         let (output_1_rseed, output_2_rseed) = self.output_rseeds();
 
-        let (lambda_1_i, lambda_2_i) = batch_data.pro_rata_outputs((
-            // TODO: fix up amount conversions
-            self.delta_1_i.try_into().unwrap(),
-            self.delta_2_i.try_into().unwrap(),
-        ));
+        let (lambda_1_i, lambda_2_i) =
+            batch_data.pro_rata_outputs((self.delta_1_i, self.delta_2_i));
 
         let output_1_note = Note::from_parts(
             self.claim_address,

--- a/crates/core/component/dex/src/swap_claim/view.rs
+++ b/crates/core/component/dex/src/swap_claim/view.rs
@@ -30,21 +30,6 @@ impl TryFrom<pbd::SwapClaimView> for SwapClaimView {
     type Error = anyhow::Error;
 
     fn try_from(v: pbd::SwapClaimView) -> Result<Self, Self::Error> {
-        // let swap_claim = v
-        //     .swap_claim
-        //     .ok_or_else(|| anyhow::anyhow!("missing swap_claim field"))?
-        //     .try_into()?;
-
-        // match (v.output_1, v.output_2) {
-        //     (Some(output_1), Some(output_2)) => Ok(SwapClaimView::Visible {
-        //         swap_claim,
-        //         output_1: output_1.try_into()?,
-        //         output_2: output_2.try_into()?,
-        //     }),
-        //     (None, None) => Ok(SwapClaimView::Opaque { swap_claim }),
-        //     _ => Err(anyhow::anyhow!("malformed swap_claim view")),
-        // }
-
         match v
             .swap_claim_view
             .ok_or_else(|| anyhow::anyhow!("missing swap field"))?

--- a/crates/core/component/shielded-pool/src/spend/plan.rs
+++ b/crates/core/component/shielded-pool/src/spend/plan.rs
@@ -6,7 +6,7 @@ use penumbra_crypto::{
 };
 use penumbra_proto::{core::transaction::v1alpha1 as pb, DomainType, TypeUrl};
 use penumbra_tct as tct;
-use rand_core::{CryptoRng, OsRng, RngCore};
+use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use super::{Body, Spend};
@@ -99,7 +99,7 @@ impl SpendPlan {
         anchor: tct::Root,
     ) -> SpendProof {
         SpendProof::prove(
-            &mut OsRng,
+            &mut rand_core::OsRng,
             &penumbra_proof_params::SPEND_PROOF_PROVING_KEY,
             state_commitment_proof.clone(),
             self.note.clone(),

--- a/crates/core/crypto/src/memo.rs
+++ b/crates/core/crypto/src/memo.rs
@@ -232,7 +232,6 @@ mod tests {
 
     use super::*;
     use crate::{
-        asset,
         keys::{SeedPhrase, SpendKey},
         Value,
     };


### PR DESCRIPTION
Fixes a couple compiler warnings, usage of `expect` statements, obsolete TODOs.