### PR TITLE
feat: friendlier err msg for pclientd start

### DIFF
--- a/crates/bin/pclientd/src/lib.rs
+++ b/crates/bin/pclientd/src/lib.rs
@@ -219,8 +219,9 @@ impl Opt {
             }
             Command::Start { bind_addr } => {
                 tracing::info!(?opt.home, ?bind_addr, ?opt.node, "starting pclientd");
-
-                let config = PclientdConfig::load(opt.config_path())?;
+                let config = PclientdConfig::load(opt.config_path()).context(
+                    "Failed to load pclientd config file. Have you run `pclientd init` with a FVK?",
+                )?;
                 let storage = opt.load_or_init_sqlite(&config.fvk).await?;
 
                 let proxy_channel = tonic::transport::Channel::from_shared(opt.node.to_string())


### PR DESCRIPTION
Context: When testnets roll over, I clear out my state for pclientd and bounce the service. On 55, I unthinkingly removed the entire "home" directory for pclientd, which also removed the `config.toml` file containing the FVK. When running `pclientd start`, a rather unhelpful message about "No such file or directory" was displayed. Let's be a bit clearer about what we expect to exist.