### PR TITLE
build: don't require a specific protoc version

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -1,10 +1,5 @@
 name: Protobuf
 on: pull_request
-env:
-  # We set the desired protoc version at the workflow level,
-  # so that multiple steps can consume it. N.B. this value must
-  # match the const set in `tools/proto-compiler/src/main.rs`.
-  PROTOC_VERSION: "23.3"
 jobs:
   lint:
     name: Lint protobuf
@@ -52,6 +47,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           lfs: true
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -71,19 +67,21 @@ jobs:
           cd /tmp
           curl -sSfL -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
           unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d $HOME/.local
+        env:
+          PROTOC_VERSION: "23.3"
 
-      # N.B. The freshness check can have false negatives, if `prost` output
-      # is superficially but not substantively different. That's OK for now:
-      # we're aiming to keep the defs in sync, and manual maintenance is required.
+      # We exclude the proto_descriptor file from diff inspection, since
+      # different versions of `protoc` can generate non-substantive changes,
+      # causing noisy CI failures.
       - name: Compile protobuf specs into rust src files
         shell: bash
         run: |
           ./deployments/scripts/protobuf-codegen
+          git checkout crates/proto/src/gen/proto_descriptor.bin
           s="$(git status --porcelain)"
           if [[ -n "$s" ]]; then
               echo "ERROR: protobuf files must be regenerated and committed."
               echo "Run this command locally: ./deployments/scripts/protobuf-codegen"
-              echo "Make sure you're running protoc $(cut -f1 -d. <<< ${PROTOC_VERSION}).x locally."
               echo "These are the files that reported differences:"
               echo "$s"
               exit 1

--- a/tools/proto-compiler/src/main.rs
+++ b/tools/proto-compiler/src/main.rs
@@ -1,35 +1,6 @@
-use anyhow::Context;
 use std::path::PathBuf;
-use std::process::Command;
-
-const PROTOC_TARGET_MAJOR_VERSION: i32 = 23;
-const DEV_DOCS_URL: &str = "https://guide.penumbra.zone/main/dev/protobuf.html";
-
-/// Inspect local version of `protoc` binary and ensure it's compatible
-/// with the supported major version. We do this to ensure that the
-/// binary outputs are generated stably across many workstation setups.
-fn check_protoc_version() -> anyhow::Result<()> {
-    let output = Command::new("protoc")
-        .args(["--version"])
-        .output()
-        .context(format!(
-            "Could not find protoc. Is it installed? See dev docs at {}",
-            DEV_DOCS_URL
-        ))?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stdout_parts = stdout.trim().split(' ').collect::<Vec<&str>>();
-    let version = stdout_parts.last().unwrap();
-    let version_parts = version.split('.').collect::<Vec<&str>>();
-    let major_version: i32 = version_parts.first().unwrap().parse().unwrap();
-    if major_version != PROTOC_TARGET_MAJOR_VERSION {
-        let msg = format!("This tool expects protoc version {PROTOC_TARGET_MAJOR_VERSION}.x, but {version} is installed locally.\nPlease install a compatible version. For more info, see {DEV_DOCS_URL}");
-        anyhow::bail!(msg);
-    }
-    Ok(())
-}
 
 fn main() -> anyhow::Result<()> {
-    check_protoc_version()?;
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     println!("{}", root.display());
     let target_dir = root


### PR DESCRIPTION
 Let's dial down the strictness on the protobuf codegen story. Here we retain the docs changes from #2739, but drop the requirement for a specific major version of `protoc`. Similarly, we remove the CI check that fails if diffs are detected in the generated `proto_descriptor.bin` file, because often those diffs are cosmetic, rather than substantive. We preserve the CI check for ensuring there are no diff elsewhere in the codegen outputs.


Closes #2736.