### PR TITLE
dex: make `put_position` async

### DIFF
--- a/crates/core/component/dex/src/component/action_handler/position/open.rs
+++ b/crates/core/component/dex/src/component/action_handler/position/open.rs
@@ -39,7 +39,7 @@ impl ActionHandler for PositionOpen {
 
     async fn execute<S: StateWrite>(&self, mut state: S) -> Result<()> {
         // Write the newly opened position.
-        state.put_position(self.position.clone());
+        state.put_position(self.position.clone()).await?;
 
         Ok(())
     }

--- a/crates/core/component/dex/src/component/action_handler/position/withdraw.rs
+++ b/crates/core/component/dex/src/component/action_handler/position/withdraw.rs
@@ -66,7 +66,7 @@ impl ActionHandler for PositionWithdraw {
         }
 
         metadata.state = position::State::Withdrawn;
-        state.put_position(metadata);
+        state.put_position(metadata).await?;
 
         Ok(())
     }

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -71,29 +71,6 @@ pub trait PositionRead: StateRead {
         }
     }
 
-    async fn worst_position(
-        &self,
-        pair: &DirectedTradingPair,
-    ) -> Result<Option<position::Position>> {
-        // Since the other direction might not have any positions, we need to
-        // fetch the last one in the index.
-        //
-        // TODO: Maybe we should have a separate index for this?
-        let positions_by_price = self.positions_by_price(pair);
-        let positions = positions_by_price.collect::<Vec<_>>().await;
-
-        let id = match positions.last() {
-            Some(id) => match id {
-                Ok(id) => id.clone(),
-                Err(e) => {
-                    return Err(anyhow::anyhow!("{}", e).context("failed to fetch worst position"));
-                }
-            },
-            None => return Ok(None),
-        };
-        self.position_by_id(&id).await
-    }
-
     /// Fetch the list of pending position closures.
     fn pending_position_closures(&self) -> im::Vector<position::Id> {
         self.object_get(state_key::pending_position_closures())

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -117,10 +117,10 @@ pub trait PositionManager: StateWrite + PositionRead {
         tracing::debug!(?position);
         // Clear any existing indexes of the position, since changes to the
         // reserves or the position state might have invalidated them.
-        self.deindex_position(&position);
+        self.deindex_position_by_price(&position);
         // Only index the position's liquidity if it is active.
         if position.state == position::State::Opened {
-            self.index_position(&position);
+            self.index_position_by_price(&position);
         }
         self.put(state_key::position_by_id(&id), position);
 
@@ -153,7 +153,7 @@ impl<T: StateWrite + ?Sized> PositionManager for T {}
 
 #[async_trait]
 pub(super) trait Inner: StateWrite {
-    fn index_position(&mut self, position: &position::Position) {
+    fn index_position_by_price(&mut self, position: &position::Position) {
         let (pair, phi) = (position.phi.pair, &position.phi);
         let id = position.id();
         if position.reserves.r2 != 0u64.into() {
@@ -185,7 +185,7 @@ pub(super) trait Inner: StateWrite {
         }
     }
 
-    fn deindex_position(&mut self, position: &Position) {
+    fn deindex_position_by_price(&mut self, position: &Position) {
         let id = position.id();
         tracing::debug!("deindexing position");
         let pair12 = DirectedTradingPair {

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -104,7 +104,7 @@ pub trait PositionManager: StateWrite + PositionRead {
             );
 
             position.state = position::State::Closed;
-            self.put_position(position);
+            self.put_position(position).await?;
         }
         self.object_delete(state_key::pending_position_closures());
         Ok(())
@@ -112,7 +112,7 @@ pub trait PositionManager: StateWrite + PositionRead {
 
     /// Writes a position to the state, updating all necessary indexes.
     #[tracing::instrument(level = "debug", skip(self, position), fields(id = ?position.id()))]
-    fn put_position(&mut self, position: position::Position) {
+    async fn put_position(&mut self, position: position::Position) -> Result<()> {
         let id = position.id();
         tracing::debug!(?position);
         // Clear any existing indexes of the position, since changes to the
@@ -123,6 +123,8 @@ pub trait PositionManager: StateWrite + PositionRead {
             self.index_position(&position);
         }
         self.put(state_key::position_by_id(&id), position);
+
+        Ok(())
     }
 
     /// Returns the list of candidate assets to route through for a trade from `from`.

--- a/crates/core/component/dex/src/component/router/path.rs
+++ b/crates/core/component/dex/src/component/router/path.rs
@@ -68,7 +68,7 @@ impl<S: StateRead + 'static> Path<S> {
         // Deindex the position we "consumed" in this and all descendant state forks,
         // ensuring we don't double-count liquidity while traversing cycles.
         use super::super::position_manager::Inner as _;
-        self.state.deindex_position(&best_price_position);
+        self.state.deindex_position_by_price(&best_price_position);
 
         // Compute the effective price of a trade in the direction self.end()=>new_end
         let hop_price = best_price_position

--- a/crates/core/component/dex/src/component/router/tests.rs
+++ b/crates/core/component/dex/src/component/router/tests.rs
@@ -169,7 +169,7 @@ async fn path_extension_basic() {
     // TODO: test synthetic liquidity
 }
 
-fn create_test_positions_basic<S: StateWrite>(s: &mut S, misprice: bool) {
+async fn create_test_positions_basic<S: StateWrite>(s: &mut S, misprice: bool) {
     let gm = asset::Cache::with_known_assets().get_unit("gm").unwrap();
 
     let gn = asset::Cache::with_known_assets().get_unit("gn").unwrap();


### PR DESCRIPTION
This PR makes `put_position` async, allowing it to perform state reads. It also renames `index_position` to `index_position_by_price`. Helpful for #2378 and #2753 