### PR TITLE
dex: canonicalize trading pairs when converting from pb

### DIFF
--- a/crates/core/component/dex/src/trading_pair.rs
+++ b/crates/core/component/dex/src/trading_pair.rs
@@ -205,11 +205,7 @@ impl TryFrom<pb::TradingPair> for TradingPair {
             .ok_or_else(|| anyhow::anyhow!("missing trading pair asset2"))?
             .try_into()?;
         let trading_pair = TradingPair::new(asset_1, asset_2);
-        let result = Self { asset_1, asset_2 };
-        if trading_pair != result {
-            return Err(anyhow::anyhow!("non-canonical trading pair"));
-        }
-        Ok(result)
+        Ok(trading_pair)
     }
 }
 


### PR DESCRIPTION
When we're given a trading pair with non-canonical order, we can rearrange its fields to match the expected internal ordering instead of failing. 