### PR TITLE
events: add or rework events for shielded pool, dex actions

### DIFF
--- a/crates/core/component/dex/src/component/action_handler/position/close.rs
+++ b/crates/core/component/dex/src/component/action_handler/position/close.rs
@@ -5,8 +5,7 @@ use async_trait::async_trait;
 use penumbra_component::ActionHandler;
 use penumbra_storage::{StateRead, StateWrite};
 
-use crate::component::PositionManager;
-use crate::lp::action::PositionClose;
+use crate::{component::PositionManager, event, lp::action::PositionClose};
 
 #[async_trait]
 /// Debits an opened position NFT and credits a closed position NFT.
@@ -29,6 +28,8 @@ impl ActionHandler for PositionClose {
         // transaction opens and closes a position, keeping liquidity live only
         // during that block's batch swap execution.
         state.queue_close_position(self.position_id);
+
+        state.record(event::position_close(&self));
 
         Ok(())
     }

--- a/crates/core/component/dex/src/component/action_handler/position/open.rs
+++ b/crates/core/component/dex/src/component/action_handler/position/open.rs
@@ -7,6 +7,7 @@ use penumbra_storage::{StateRead, StateWrite};
 
 use crate::{
     component::{PositionManager, PositionRead},
+    event,
     lp::action::PositionOpen,
 };
 
@@ -40,6 +41,8 @@ impl ActionHandler for PositionOpen {
     async fn execute<S: StateWrite>(&self, mut state: S) -> Result<()> {
         // Write the newly opened position.
         state.put_position(self.position.clone());
+
+        state.record(event::position_open(&self));
 
         Ok(())
     }

--- a/crates/core/component/dex/src/component/action_handler/position/withdraw.rs
+++ b/crates/core/component/dex/src/component/action_handler/position/withdraw.rs
@@ -8,6 +8,7 @@ use penumbra_storage::{StateRead, StateWrite};
 
 use crate::{
     component::{PositionManager, PositionRead},
+    event,
     lp::{action::PositionWithdraw, position},
 };
 
@@ -64,6 +65,8 @@ impl ActionHandler for PositionWithdraw {
                 metadata.state
             ));
         }
+
+        state.record(event::position_withdraw(&self, &metadata));
 
         metadata.state = position::State::Withdrawn;
         state.put_position(metadata);

--- a/crates/core/component/dex/src/component/action_handler/swap.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap.rs
@@ -9,6 +9,7 @@ use penumbra_storage::{StateRead, StateWrite};
 
 use crate::{
     component::{StateReadExt, StateWriteExt, SwapManager},
+    event,
     swap::Swap,
 };
 
@@ -55,6 +56,8 @@ impl ActionHandler for Swap {
         state
             .add_swap_payload(self.body.payload.clone(), source)
             .await;
+
+        state.record(event::swap(&self));
 
         Ok(())
     }

--- a/crates/core/component/dex/src/component/action_handler/swap_claim.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap_claim.rs
@@ -9,7 +9,7 @@ use penumbra_proof_params::SWAPCLAIM_PROOF_VERIFICATION_KEY;
 use penumbra_shielded_pool::component::{NoteManager, StateReadExt as _};
 use penumbra_storage::{StateRead, StateWrite};
 
-use crate::{component::StateReadExt, swap_claim::SwapClaim};
+use crate::{component::StateReadExt, event, swap_claim::SwapClaim};
 
 #[async_trait]
 impl ActionHandler for SwapClaim {
@@ -79,6 +79,8 @@ impl ActionHandler for SwapClaim {
             .await;
 
         state.spend_nullifier(self.body.nullifier, source).await;
+
+        state.record(event::swap_claim(&self));
 
         Ok(())
     }

--- a/crates/core/component/dex/src/event.rs
+++ b/crates/core/component/dex/src/event.rs
@@ -1,1 +1,84 @@
+use tendermint::abci::{Event, EventAttributeIndexExt};
 
+use crate::{
+    lp::{
+        action::{PositionClose, PositionOpen, PositionWithdraw},
+        position::Position,
+    },
+    swap::Swap,
+    swap_claim::SwapClaim,
+};
+
+pub fn swap(swap: &Swap) -> Event {
+    Event::new(
+        "action_swap",
+        [
+            ("trading_pair", swap.body.trading_pair.to_string()).index(),
+            ("delta_1_i", swap.body.delta_1_i.to_string()).index(),
+            ("delta_2_i", swap.body.delta_2_i.to_string()).index(),
+            ("swap_commitment", swap.body.payload.commitment.to_string()).index(),
+        ],
+    )
+}
+
+pub fn swap_claim(swap_claim: &SwapClaim) -> Event {
+    Event::new(
+        "action_swap_claim",
+        [
+            (
+                "trading_pair",
+                swap_claim.body.output_data.trading_pair.to_string(),
+            )
+                .index(),
+            (
+                "output_1_commitment",
+                swap_claim.body.output_1_commitment.to_string(),
+            )
+                .index(),
+            (
+                "output_2_commitment",
+                swap_claim.body.output_2_commitment.to_string(),
+            )
+                .index(),
+            ("nullifier", swap_claim.body.nullifier.to_string()).index(),
+        ],
+    )
+}
+
+pub fn position_open(action: &PositionOpen) -> Event {
+    Event::new(
+        "action_position_open",
+        [
+            ("position_id", action.position.id().to_string()).index(),
+            ("trading_pair", action.position.phi.pair.to_string()).index(),
+            // TODO: move into position manager and include in a "position updated" event?
+            ("reserves_1", action.position.reserves.r1.to_string()).index(),
+            ("reserves_2", action.position.reserves.r2.to_string()).index(),
+            ("trading_fee", action.position.phi.component.fee.to_string()).index(),
+            ("trading_p1", action.position.phi.component.p.to_string()).index(),
+            ("trading_p2", action.position.phi.component.q.to_string()).index(),
+        ],
+    )
+}
+
+pub fn position_close(action: &PositionClose) -> Event {
+    // TODO: should we have another event triggered by the position manager for when
+    // the position is actually closed?
+    Event::new(
+        "action_position_close",
+        [("position_id", action.position_id.to_string()).index()],
+    )
+}
+
+pub fn position_withdraw(action: &PositionWithdraw, final_position_state: &Position) -> Event {
+    Event::new(
+        "action_position_withdraw",
+        [
+            ("position_id", action.position_id.to_string()).index(),
+            // reserves not included in action so need to be passed in separately
+            ("trading_pair", final_position_state.phi.pair.to_string()).index(),
+            ("reserves_1", final_position_state.reserves.r1.to_string()).index(),
+            ("reserves_2", final_position_state.reserves.r2.to_string()).index(),
+        ],
+    )
+}

--- a/crates/core/component/shielded-pool/src/component/action_handler/output.rs
+++ b/crates/core/component/shielded-pool/src/component/action_handler/output.rs
@@ -6,8 +6,7 @@ use penumbra_component::ActionHandler;
 use penumbra_proof_params::OUTPUT_PROOF_VERIFICATION_KEY;
 use penumbra_storage::{StateRead, StateWrite};
 
-use crate::component::NoteManager;
-use crate::Output;
+use crate::{component::NoteManager, event, Output};
 
 #[async_trait]
 impl ActionHandler for Output {
@@ -34,6 +33,8 @@ impl ActionHandler for Output {
         state
             .add_note_payload(self.body.note_payload.clone(), source)
             .await;
+
+        state.record(event::output(&self.body.note_payload));
 
         Ok(())
     }

--- a/crates/core/component/shielded-pool/src/component/action_handler/spend.rs
+++ b/crates/core/component/shielded-pool/src/component/action_handler/spend.rs
@@ -9,7 +9,7 @@ use penumbra_storage::{StateRead, StateWrite};
 
 use crate::{
     component::{NoteManager, StateReadExt},
-    Spend,
+    event, Spend,
 };
 
 #[async_trait]
@@ -49,6 +49,9 @@ impl ActionHandler for Spend {
         let source = state.object_get("source").unwrap_or_default();
 
         state.spend_nullifier(self.body.nullifier, source).await;
+
+        // Also record an ABCI event for transaction indexing.
+        state.record(event::spend(&self.body.nullifier));
 
         Ok(())
     }

--- a/crates/core/component/shielded-pool/src/component/note_manager.rs
+++ b/crates/core/component/shielded-pool/src/component/note_manager.rs
@@ -9,7 +9,7 @@ use penumbra_tct as tct;
 use tct::Commitment;
 use tracing::instrument;
 
-use crate::{event, state_key};
+use crate::state_key;
 
 use super::SupplyWrite;
 
@@ -131,8 +131,6 @@ pub trait NoteManager: StateWrite {
                 spend_height: self.get_block_height().await.expect("block height is set"),
             },
         );
-        // Also record an ABCI event for transaction indexing.
-        self.record(event::spend(&nullifier));
 
         // Record the nullifier to be inserted into the compact block
         let mut nullifiers: im::Vector<Nullifier> = self

--- a/crates/core/component/shielded-pool/src/event.rs
+++ b/crates/core/component/shielded-pool/src/event.rs
@@ -1,15 +1,16 @@
-use penumbra_crypto::Nullifier;
+use penumbra_crypto::{NotePayload, Nullifier};
 use tendermint::abci::{Event, EventAttributeIndexExt};
 
 pub fn spend(nullifier: &Nullifier) -> Event {
-    Event::new("spend", [("nullifier", nullifier.to_string()).index()])
-}
-
-/*
-pub fn state_payload(payload: &StatePayload) -> Event {
     Event::new(
-        "state_payload",
-        [("commitment", payload.commitment().to_string()).index()],
+        "action_spend",
+        [("nullifier", nullifier.to_string()).index()],
     )
 }
- */
+
+pub fn output(note_payload: &NotePayload) -> Event {
+    Event::new(
+        "action_output",
+        [("note_commitment", note_payload.note_commitment.to_string()).index()],
+    )
+}

--- a/crates/core/component/stake/src/action_handler/delegate.rs
+++ b/crates/core/component/stake/src/action_handler/delegate.rs
@@ -4,9 +4,9 @@ use anyhow::Result;
 use async_trait::async_trait;
 use penumbra_storage::{StateRead, StateWrite};
 
-use crate::Delegate;
 use crate::{
-    action_handler::ActionHandler, component::StateWriteExt as _, validator, StateReadExt as _,
+    action_handler::ActionHandler, component::StateWriteExt as _, event, validator, Delegate,
+    StateReadExt as _,
 };
 
 #[async_trait]
@@ -92,6 +92,8 @@ impl ActionHandler for Delegate {
     async fn execute<S: StateWrite>(&self, mut state: S) -> Result<()> {
         tracing::debug!(?self, "queuing delegation for next epoch");
         state.stub_push_delegation(self.clone());
+
+        state.record(event::delegate(&self));
 
         Ok(())
     }

--- a/crates/core/component/stake/src/action_handler/undelegate.rs
+++ b/crates/core/component/stake/src/action_handler/undelegate.rs
@@ -5,8 +5,10 @@ use async_trait::async_trait;
 use penumbra_shielded_pool::component::SupplyWrite;
 use penumbra_storage::{StateRead, StateWrite};
 
-use crate::Undelegate;
-use crate::{action_handler::ActionHandler, component::StateWriteExt as _, StateReadExt as _};
+use crate::{
+    action_handler::ActionHandler, component::StateWriteExt as _, event, StateReadExt as _,
+    Undelegate,
+};
 
 #[async_trait]
 impl ActionHandler for Undelegate {
@@ -68,6 +70,8 @@ impl ActionHandler for Undelegate {
             .register_denom(&self.unbonding_token().denom())
             .await?;
         // TODO: should we be tracking changes to token supply here or in end_epoch?
+
+        state.record(event::undelegate(&self));
 
         Ok(())
     }

--- a/crates/core/component/stake/src/component.rs
+++ b/crates/core/component/stake/src/component.rs
@@ -40,7 +40,6 @@ use tokio::task::JoinSet;
 use tracing::{instrument, Instrument};
 
 use crate::{
-    event,
     funding_stream::Recipient,
     metrics,
     rate::{BaseRateData, RateData},
@@ -1259,14 +1258,12 @@ pub trait StateWriteExt: StateWrite {
     }
 
     fn stub_push_delegation(&mut self, delegation: Delegate) {
-        self.record(event::delegate(&delegation));
         let mut changes = self.stub_delegation_changes();
         changes.delegations.push(delegation);
         self.put_stub_delegation_changes(changes);
     }
 
     fn stub_push_undelegation(&mut self, undelegation: Undelegate) {
-        self.record(event::undelegate(&undelegation));
         let mut changes = self.stub_delegation_changes();
         changes.undelegations.push(undelegation);
         self.put_stub_delegation_changes(changes);

--- a/crates/core/component/stake/src/event.rs
+++ b/crates/core/component/stake/src/event.rs
@@ -3,7 +3,7 @@ use tendermint::abci::{Event, EventAttributeIndexExt};
 
 pub fn delegate(delegate: &Delegate) -> Event {
     Event::new(
-        "delegate",
+        "action_delegate",
         [
             ("validator", delegate.validator_identity.to_string()).index(),
             ("amount", delegate.unbonded_amount.to_string()).no_index(),
@@ -13,7 +13,7 @@ pub fn delegate(delegate: &Delegate) -> Event {
 
 pub fn undelegate(undelegate: &Undelegate) -> Event {
     Event::new(
-        "undelegate",
+        "action_undelegate",
         [
             ("validator", undelegate.validator_identity.to_string()).index(),
             ("amount", undelegate.unbonded_amount.to_string()).no_index(),


### PR DESCRIPTION
This commit updates the event handling logic to rework existing events and fill in new ones:

- events are generated per transaction action, and action-triggered events are prefixed with `action_`
- added events for outputs, swaps, swap claims, and lp actions

I think it would be useful to also have events fired on position state changes, but I didn't want to do that in this PR in case of conflicts with in-flight changes to position handling.