### PR TITLE
refactor: move penumbra-crypto staking-related types to staking crate 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4954,6 +4954,7 @@ dependencies = [
  "bech32",
  "bitvec",
  "decaf377",
+ "decaf377-rdsa",
  "ed25519-consensus",
  "futures",
  "hex",

--- a/crates/bin/pcli/src/command/query/governance.rs
+++ b/crates/bin/pcli/src/command/query/governance.rs
@@ -7,8 +7,8 @@ use std::{
 use anyhow::{Context, Result};
 use futures::{StreamExt, TryStreamExt};
 use penumbra_app::governance::{self, state_key::*};
-use penumbra_crypto::stake::IdentityKey;
 use penumbra_proto::client::v1alpha1::{PrefixValueRequest, PrefixValueResponse};
+use penumbra_stake::IdentityKey;
 use penumbra_transaction::{
     proposal::{self, Proposal},
     vote::Vote,

--- a/crates/bin/pcli/src/command/query/validator.rs
+++ b/crates/bin/pcli/src/command/query/validator.rs
@@ -3,9 +3,11 @@ use std::{fs::File, io::Write};
 use anyhow::{Context, Result};
 use comfy_table::{presets, Table};
 use futures::TryStreamExt;
-use penumbra_crypto::stake::IdentityKey;
 use penumbra_proto::client::v1alpha1::ValidatorInfoRequest;
-use penumbra_stake::validator::{self, ValidatorToml};
+use penumbra_stake::{
+    validator::{self, ValidatorToml},
+    IdentityKey,
+};
 
 use crate::App;
 

--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -14,7 +14,6 @@ use penumbra_crypto::{
     asset::{self, DenomMetadata},
     keys::AddressIndex,
     memo::MemoPlaintext,
-    stake::{DelegationToken, IdentityKey, Penalty, UnbondingToken},
     Amount, Fee, Value, STAKING_TOKEN_ASSET_ID,
 };
 use penumbra_dex::{lp::position, swap_claim::SwapClaimPlan};
@@ -27,7 +26,7 @@ use penumbra_proto::{
     core::dex::v1alpha1::PositionId,
 };
 use penumbra_stake::rate::RateData;
-use penumbra_stake::UndelegateClaimPlan;
+use penumbra_stake::{DelegationToken, IdentityKey, Penalty, UnbondingToken, UndelegateClaimPlan};
 use penumbra_transaction::{proposal::ProposalToml, vote::Vote};
 use penumbra_view::ViewClient;
 use penumbra_wallet::plan::{self, Planner};

--- a/crates/bin/pcli/src/command/validator.rs
+++ b/crates/bin/pcli/src/command/validator.rs
@@ -4,12 +4,12 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use penumbra_crypto::{keys::AddressIndex, stake::IdentityKey, Fee, GovernanceKey};
+use penumbra_crypto::{keys::AddressIndex, Fee, GovernanceKey};
 use penumbra_proto::{core::stake::v1alpha1::Validator as ProtoValidator, DomainType, Message};
 use penumbra_stake::{
     validator,
     validator::{Validator, ValidatorToml},
-    FundingStream, FundingStreams,
+    FundingStream, FundingStreams, IdentityKey,
 };
 use penumbra_transaction::action::{ValidatorVote, ValidatorVoteBody, Vote};
 use penumbra_wallet::plan;

--- a/crates/bin/pcli/src/command/view/staked.rs
+++ b/crates/bin/pcli/src/command/view/staked.rs
@@ -3,11 +3,11 @@ use std::collections::BTreeMap;
 use anyhow::Result;
 use comfy_table::{presets, Table};
 use futures::TryStreamExt;
-use penumbra_crypto::{stake::DelegationToken, FullViewingKey, Value, STAKING_TOKEN_ASSET_ID};
+use penumbra_crypto::{FullViewingKey, Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_proto::client::v1alpha1::{
     oblivious_query_service_client::ObliviousQueryServiceClient, ValidatorInfoRequest,
 };
-use penumbra_stake::validator;
+use penumbra_stake::{validator, DelegationToken};
 use penumbra_view::ViewClient;
 use tonic::transport::Channel;
 

--- a/crates/bin/pcli/tests/proof.rs
+++ b/crates/bin/pcli/tests/proof.rs
@@ -8,7 +8,6 @@ use penumbra_crypto::{
     keys::{SeedPhrase, SpendKey},
     proofs::groth16::{DelegatorVoteProof, NullifierDerivationProof, OutputProof, SpendProof},
     rdsa::{self, SpendAuth, VerificationKey},
-    stake::{IdentityKey, Penalty, UnbondingToken},
     Amount, Balance, Fee, Fq, Note, Value,
 };
 use penumbra_dex::{
@@ -23,7 +22,7 @@ use penumbra_proof_params::{
     SWAP_PROOF_PROVING_KEY, SWAP_PROOF_VERIFICATION_KEY, UNDELEGATECLAIM_PROOF_PROVING_KEY,
     UNDELEGATECLAIM_PROOF_VERIFICATION_KEY,
 };
-use penumbra_stake::UndelegateClaimProof;
+use penumbra_stake::{IdentityKey, Penalty, UnbondingToken, UndelegateClaimProof};
 use penumbra_tct as tct;
 use rand_core::OsRng;
 

--- a/crates/bin/pd/src/testnet/generate.rs
+++ b/crates/bin/pd/src/testnet/generate.rs
@@ -5,12 +5,10 @@ use crate::testnet::{generate_tm_config, parse_tm_address, write_configs, Valida
 use anyhow::{Context, Result};
 use penumbra_chain::genesis;
 use penumbra_chain::{genesis::Allocation, params::ChainParameters};
-use penumbra_crypto::{
-    keys::SpendKey,
-    stake::{DelegationToken, IdentityKey},
-    Address, GovernanceKey,
+use penumbra_crypto::{keys::SpendKey, Address, GovernanceKey};
+use penumbra_stake::{
+    validator::Validator, DelegationToken, FundingStream, FundingStreams, IdentityKey,
 };
-use penumbra_stake::{validator::Validator, FundingStream, FundingStreams};
 use serde::{de, Deserialize};
 use std::{
     fmt,

--- a/crates/core/app/src/governance/state_key.rs
+++ b/crates/core/app/src/governance/state_key.rs
@@ -1,4 +1,5 @@
-use penumbra_crypto::{stake::IdentityKey, Nullifier};
+use penumbra_crypto::Nullifier;
+use penumbra_stake::IdentityKey;
 
 pub fn next_proposal_id() -> &'static str {
     "governance/next_proposal_id"

--- a/crates/core/app/src/governance/view.rs
+++ b/crates/core/app/src/governance/view.rs
@@ -12,11 +12,11 @@ use penumbra_chain::{
 };
 use penumbra_crypto::{
     asset::{self, Amount},
-    stake::{DelegationToken, IdentityKey},
     GovernanceKey, Nullifier, Value, STAKING_TOKEN_DENOM,
 };
 use penumbra_proto::{StateReadProto, StateWriteProto};
 use penumbra_shielded_pool::component::{StateReadExt as _, SupplyRead};
+use penumbra_stake::{DelegationToken, IdentityKey};
 use penumbra_storage::{StateRead, StateWrite};
 use penumbra_tct as tct;
 use penumbra_transaction::{

--- a/crates/core/component/chain/src/params.rs
+++ b/crates/core/component/chain/src/params.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::Context;
-use penumbra_crypto::{stake::Penalty, Amount};
+use penumbra_crypto::Amount;
 use penumbra_proto::client::v1alpha1 as pb_client;
 use penumbra_proto::core::chain::v1alpha1 as pb_chain;
 
@@ -31,9 +31,9 @@ pub struct ChainParameters {
     /// The base reward rate, expressed in basis points of basis points
     pub base_reward_rate: u64,
     /// The penalty for slashing due to misbehavior, expressed in basis points squared (10^-8)
-    pub slashing_penalty_misbehavior: Penalty,
+    pub slashing_penalty_misbehavior: u64,
     /// The penalty for slashing due to downtime, expressed in basis points squared (10^-8)
-    pub slashing_penalty_downtime: Penalty,
+    pub slashing_penalty_downtime: u64,
     /// The number of blocks in the window to check for downtime.
     pub signed_blocks_window_len: u64,
     /// The maximum number of blocks in the window each validator can miss signing without slashing.
@@ -79,8 +79,8 @@ impl TryFrom<pb_chain::ChainParameters> for ChainParameters {
             epoch_duration: msg.epoch_duration,
             unbonding_epochs: msg.unbonding_epochs,
             active_validator_limit: msg.active_validator_limit,
-            slashing_penalty_downtime: Penalty(msg.slashing_penalty_downtime),
-            slashing_penalty_misbehavior: Penalty(msg.slashing_penalty_misbehavior),
+            slashing_penalty_downtime: msg.slashing_penalty_downtime,
+            slashing_penalty_misbehavior: msg.slashing_penalty_misbehavior,
             base_reward_rate: msg.base_reward_rate,
             missed_blocks_maximum: msg.missed_blocks_maximum,
             signed_blocks_window_len: msg.signed_blocks_window_len,
@@ -140,8 +140,8 @@ impl From<ChainParameters> for pb_chain::ChainParameters {
             active_validator_limit: params.active_validator_limit,
             signed_blocks_window_len: params.signed_blocks_window_len,
             missed_blocks_maximum: params.missed_blocks_maximum,
-            slashing_penalty_downtime: params.slashing_penalty_downtime.0,
-            slashing_penalty_misbehavior: params.slashing_penalty_misbehavior.0,
+            slashing_penalty_downtime: params.slashing_penalty_downtime,
+            slashing_penalty_misbehavior: params.slashing_penalty_misbehavior,
             base_reward_rate: params.base_reward_rate,
             ibc_enabled: params.ibc_enabled,
             inbound_ics20_transfers_enabled: params.inbound_ics20_transfers_enabled,
@@ -169,9 +169,9 @@ impl Default for ChainParameters {
             signed_blocks_window_len: 10000,
             missed_blocks_maximum: 9500,
             // 1000 basis points = 10%
-            slashing_penalty_misbehavior: Penalty(1000_0000),
+            slashing_penalty_misbehavior: 1000_0000,
             // 1 basis point = 0.01%
-            slashing_penalty_downtime: Penalty(1_0000),
+            slashing_penalty_downtime: 1_0000,
             // 3bps -> 11% return over 365 epochs
             base_reward_rate: 3_0000,
             ibc_enabled: true,

--- a/crates/core/component/chain/src/params/change.rs
+++ b/crates/core/component/chain/src/params/change.rs
@@ -2,8 +2,6 @@ use std::fmt::Display;
 
 use anyhow::Result;
 
-use penumbra_crypto::stake::Penalty;
-
 use super::{ChainParameters, Ratio};
 
 // The checks below validate that a parameter change is valid, since some parameter settings or
@@ -114,19 +112,19 @@ impl ChainParameters {
                 "base reward rate must be at least 1 basis point",
             ),
             (
-                *slashing_penalty_misbehavior >= Penalty(1),
+                *slashing_penalty_misbehavior >= 1,
                 "slashing penalty (misbehavior) must be at least 1 basis point",
             ),
             (
-                *slashing_penalty_misbehavior <= Penalty(100_000_000),
+                *slashing_penalty_misbehavior <= 100_000_000,
                 "slashing penalty (misbehavior) must be at most 10,000 basis points^2",
             ),
             (
-                *slashing_penalty_downtime >= Penalty(1),
+                *slashing_penalty_downtime >= 1,
                 "slashing penalty (downtime) must be at least 1 basis point",
             ),
             (
-                *slashing_penalty_downtime <= Penalty(100_000_000),
+                *slashing_penalty_downtime <= 100_000_000,
                 "slashing penalty (downtime) must be at most 10,000 basis points^2",
             ),
             (

--- a/crates/core/component/stake/Cargo.toml
+++ b/crates/core/component/stake/Cargo.toml
@@ -35,6 +35,7 @@ penumbra-chain = { path = "../chain", default-features = false }
 
 # Penumbra dependencies
 decaf377 = {version = "0.4", features = ["r1cs"] }
+decaf377-rdsa = { version = "0.6" }
 ark-r1cs-std = {version = "0.4", default-features = false }
 ark-relations = "0.4"
 ark-ff = { version = "0.4", default_features = false }

--- a/crates/core/component/stake/src/action_handler/undelegate_claim.rs
+++ b/crates/core/component/stake/src/action_handler/undelegate_claim.rs
@@ -3,12 +3,11 @@ use std::sync::Arc;
 use anyhow::{ensure, Result};
 use async_trait::async_trait;
 use penumbra_chain::component::StateReadExt;
-use penumbra_crypto::stake::UnbondingToken;
 use penumbra_proof_params::UNDELEGATECLAIM_PROOF_VERIFICATION_KEY;
 use penumbra_storage::{StateRead, StateWrite};
 
 use crate::UndelegateClaim;
-use crate::{action_handler::ActionHandler, StateReadExt as _};
+use crate::{action_handler::ActionHandler, StateReadExt as _, UnbondingToken};
 
 #[async_trait]
 impl ActionHandler for UndelegateClaim {

--- a/crates/core/component/stake/src/component.rs
+++ b/crates/core/component/stake/src/component.rs
@@ -15,11 +15,7 @@ use penumbra_chain::{
     genesis, Epoch, NoteSource,
 };
 use penumbra_component::Component;
-use penumbra_crypto::stake::Penalty;
-use penumbra_crypto::{
-    stake::{DelegationToken, IdentityKey},
-    Value, STAKING_TOKEN_ASSET_ID,
-};
+use penumbra_crypto::{Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_dao::component::StateWriteExt as _;
 use penumbra_proto::{
     state::future::{DomainFuture, ProtoFuture},
@@ -45,7 +41,7 @@ use crate::{
     rate::{BaseRateData, RateData},
     state_key,
     validator::{self, Validator},
-    CurrentConsensusKeys, DelegationChanges, Uptime,
+    CurrentConsensusKeys, DelegationChanges, Penalty, Uptime, {DelegationToken, IdentityKey},
 };
 use crate::{Delegate, Undelegate};
 
@@ -241,7 +237,8 @@ pub(crate) trait StakingImpl: StateWriteExt {
                 let penalty = self.get_chain_params().await?.slashing_penalty_downtime;
 
                 // Record the slashing penalty on this validator.
-                self.record_slashing_penalty(identity_key, penalty).await?;
+                self.record_slashing_penalty(identity_key, Penalty(penalty))
+                    .await?;
 
                 // The validator's delegation pool begins unbonding.  Jailed
                 // validators are not unbonded immediately, because they need to
@@ -264,7 +261,8 @@ pub(crate) trait StakingImpl: StateWriteExt {
                 let penalty = self.get_chain_params().await?.slashing_penalty_misbehavior;
 
                 // Record the slashing penalty on this validator.
-                self.record_slashing_penalty(identity_key, penalty).await?;
+                self.record_slashing_penalty(identity_key, Penalty(penalty))
+                    .await?;
 
                 // Regardless of its current bonding state, the validator's
                 // delegation pool is unbonded immediately, because the

--- a/crates/core/component/stake/src/delegate.rs
+++ b/crates/core/component/stake/src/delegate.rs
@@ -1,10 +1,8 @@
-use penumbra_crypto::{
-    asset::Amount,
-    stake::{DelegationToken, IdentityKey},
-    Balance, Value, STAKING_TOKEN_ASSET_ID,
-};
+use penumbra_crypto::{asset::Amount, Balance, Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType, TypeUrl};
 use serde::{Deserialize, Serialize};
+
+use crate::{DelegationToken, IdentityKey};
 
 /// A transaction action adding stake to a validator's delegation pool.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/component/stake/src/delegation_token.rs
+++ b/crates/core/component/stake/src/delegation_token.rs
@@ -2,33 +2,37 @@ use std::str::FromStr;
 
 use regex::Regex;
 
-use super::IdentityKey;
-use crate::asset;
+use penumbra_crypto::asset;
 
-/// Unbonding tokens represent staking tokens that are currently unbonding and
-/// subject to slashing.
-///
-/// Unbonding tokens are parameterized by the validator identity, and the epoch at
-/// which unbonding began.
-pub struct UnbondingToken {
+use super::IdentityKey;
+
+/// Delegation tokens represent a share of a particular validator's delegation pool.
+pub struct DelegationToken {
     validator_identity: IdentityKey,
-    start_epoch_index: u64,
     base_denom: asset::DenomMetadata,
 }
 
-impl UnbondingToken {
-    pub fn new(validator_identity: IdentityKey, start_epoch_index: u64) -> Self {
+impl From<IdentityKey> for DelegationToken {
+    fn from(v: IdentityKey) -> Self {
+        DelegationToken::new(v)
+    }
+}
+
+impl From<&IdentityKey> for DelegationToken {
+    fn from(v: &IdentityKey) -> Self {
+        DelegationToken::new(v.clone())
+    }
+}
+
+impl DelegationToken {
+    pub fn new(validator_identity: IdentityKey) -> Self {
         // This format string needs to be in sync with the asset registry
         let base_denom = asset::REGISTRY
-            .parse_denom(&format!(
-                // "uu" is not a typo, these are micro-unbonding tokens
-                "uunbonding_epoch_{start_epoch_index}_{validator_identity}"
-            ))
+            .parse_denom(&format!("udelegation_{validator_identity}"))
             .expect("base denom format is valid");
-        UnbondingToken {
+        DelegationToken {
             validator_identity,
             base_denom,
-            start_epoch_index,
         }
     }
 
@@ -51,53 +55,36 @@ impl UnbondingToken {
     pub fn validator(&self) -> IdentityKey {
         self.validator_identity.clone()
     }
-
-    pub fn start_epoch_index(&self) -> u64 {
-        self.start_epoch_index
-    }
 }
 
-impl TryFrom<asset::DenomMetadata> for UnbondingToken {
+impl TryFrom<asset::DenomMetadata> for DelegationToken {
     type Error = anyhow::Error;
-
     fn try_from(base_denom: asset::DenomMetadata) -> Result<Self, Self::Error> {
-        let base_string = base_denom.to_string();
-
         // Note: this regex must be in sync with both asset::REGISTRY
         // and VALIDATOR_IDENTITY_BECH32_PREFIX
-        // The data capture group is used by asset::REGISTRY
-        let captures =
-            Regex::new("^uunbonding_(?P<data>epoch_(?P<start>[0-9]+)_(?P<validator>penumbravalid1[a-zA-HJ-NP-Z0-9]+))$")
+        let validator_identity =
+            Regex::new("udelegation_(?P<data>penumbravalid1[a-zA-HJ-NP-Z0-9]+)")
                 .expect("regex is valid")
-                .captures(base_string.as_ref())
+                .captures(&base_denom.to_string())
                 .ok_or_else(|| {
                     anyhow::anyhow!(
-                        "base denom {} is not an unbonding token",
+                        "base denom {} is not a delegation token",
                         base_denom.to_string()
                     )
-                })?;
-
-        let validator_identity = captures
-            .name("validator")
-            .expect("validator is a named capture")
-            .as_str()
-            .parse()?;
-
-        let start_epoch_index = captures
-            .name("start")
-            .expect("start is a named capture")
-            .as_str()
-            .parse()?;
+                })?
+                .name("data")
+                .expect("data is a named capture")
+                .as_str()
+                .parse()?;
 
         Ok(Self {
             base_denom,
             validator_identity,
-            start_epoch_index,
         })
     }
 }
 
-impl FromStr for UnbondingToken {
+impl FromStr for DelegationToken {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         asset::REGISTRY
@@ -107,27 +94,27 @@ impl FromStr for UnbondingToken {
     }
 }
 
-impl std::fmt::Display for UnbondingToken {
+impl std::fmt::Display for DelegationToken {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.base_denom.fmt(f)
     }
 }
 
-impl std::fmt::Debug for UnbondingToken {
+impl std::fmt::Debug for DelegationToken {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.base_denom.fmt(f)
     }
 }
 
-impl PartialEq for UnbondingToken {
+impl PartialEq for DelegationToken {
     fn eq(&self, other: &Self) -> bool {
         self.base_denom.eq(&other.base_denom)
     }
 }
 
-impl Eq for UnbondingToken {}
+impl Eq for DelegationToken {}
 
-impl std::hash::Hash for UnbondingToken {
+impl std::hash::Hash for DelegationToken {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.base_denom.hash(state)
     }
@@ -135,22 +122,20 @@ impl std::hash::Hash for UnbondingToken {
 
 #[cfg(test)]
 mod tests {
-    use crate::rdsa::{SigningKey, SpendAuth};
+    use decaf377_rdsa::{SigningKey, SpendAuth};
 
     use super::*;
 
     #[test]
-    fn unbonding_token_denomination_round_trip() {
+    fn delegation_token_denomination_round_trip() {
         use rand_core::OsRng;
 
         let ik = IdentityKey(SigningKey::<SpendAuth>::new(OsRng).into());
-        let start = 782;
 
-        let token = UnbondingToken::new(ik, start);
+        let token = DelegationToken::new(ik);
 
         let denom = token.to_string();
-        println!("denom: {denom}");
-        let token2 = UnbondingToken::from_str(&denom).unwrap();
+        let token2 = DelegationToken::from_str(&denom).unwrap();
         let denom2 = token2.to_string();
 
         assert_eq!(denom, denom2);

--- a/crates/core/component/stake/src/identity_key.rs
+++ b/crates/core/component/stake/src/identity_key.rs
@@ -6,7 +6,7 @@ use penumbra_proto::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::rdsa::{SpendAuth, VerificationKey};
+use decaf377_rdsa::{SpendAuth, VerificationKey};
 
 /// The root of a validator's identity.
 ///

--- a/crates/core/component/stake/src/lib.rs
+++ b/crates/core/component/stake/src/lib.rs
@@ -1,8 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::clone_on_copy)]
 
-use penumbra_crypto::stake::IdentityKey;
-
 mod changes;
 mod current_consensus_keys;
 mod event;
@@ -35,6 +33,16 @@ pub use undelegate_claim::{
     UndelegateClaim, UndelegateClaimBody, UndelegateClaimCircuit, UndelegateClaimPlan,
     UndelegateClaimProof,
 };
+
+mod delegation_token;
+mod identity_key;
+mod penalty;
+mod unbonding_token;
+
+pub use delegation_token::DelegationToken;
+pub use identity_key::IdentityKey;
+pub use penalty::{Penalty, PenaltyVar};
+pub use unbonding_token::UnbondingToken;
 
 pub use self::metrics::register_metrics;
 pub use changes::DelegationChanges;

--- a/crates/core/component/stake/src/penalty.rs
+++ b/crates/core/component/stake/src/penalty.rs
@@ -7,7 +7,7 @@ use decaf377::{r1cs::FqVar, FieldExt, Fq};
 use penumbra_proto::{core::stake::v1alpha1 as pbs, DomainType, TypeUrl};
 use serde::{Deserialize, Serialize};
 
-use crate::{
+use penumbra_crypto::{
     asset::{self, AmountVar, AssetIdVar},
     balance::BalanceVar,
     Amount, Balance, Value, ValueVar, STAKING_TOKEN_ASSET_ID,

--- a/crates/core/component/stake/src/rate.rs
+++ b/crates/core/component/stake/src/rate.rs
@@ -1,6 +1,6 @@
 //! Staking reward and delegation token exchange rates.
 
-use penumbra_crypto::{stake::Penalty, Amount};
+use penumbra_crypto::Amount;
 use penumbra_proto::client::v1alpha1::CurrentValidatorRateResponse;
 use penumbra_proto::{
     client::v1alpha1::NextValidatorRateResponse, core::stake::v1alpha1 as pb, DomainType, TypeUrl,
@@ -8,7 +8,7 @@ use penumbra_proto::{
 use serde::{Deserialize, Serialize};
 
 use crate::{validator::State, FundingStream, IdentityKey};
-use crate::{Delegate, Undelegate};
+use crate::{Delegate, Penalty, Undelegate};
 
 /// Describes a validator's reward rate and voting power in some epoch.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]

--- a/crates/core/component/stake/src/state_key.rs
+++ b/crates/core/component/stake/src/state_key.rs
@@ -1,6 +1,7 @@
-use penumbra_crypto::stake::IdentityKey;
 use std::string::String;
 use tendermint::PublicKey;
+
+use crate::IdentityKey;
 
 pub fn current_base_rate() -> &'static str {
     "staking/base_rate/current"

--- a/crates/core/component/stake/src/undelegate.rs
+++ b/crates/core/component/stake/src/undelegate.rs
@@ -1,10 +1,8 @@
-use penumbra_crypto::{
-    asset::Amount,
-    stake::{DelegationToken, IdentityKey, UnbondingToken},
-    Balance, Value,
-};
+use penumbra_crypto::{asset::Amount, Balance, Value};
 use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType, TypeUrl};
 use serde::{Deserialize, Serialize};
+
+use crate::{DelegationToken, IdentityKey, UnbondingToken};
 
 /// A transaction action withdrawing stake from a validator's delegation pool.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/core/component/stake/src/undelegate_claim/action.rs
+++ b/crates/core/component/stake/src/undelegate_claim/action.rs
@@ -1,11 +1,8 @@
-use penumbra_crypto::{
-    balance,
-    stake::{IdentityKey, Penalty},
-};
+use penumbra_crypto::balance;
 use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType, TypeUrl};
 use serde::{Deserialize, Serialize};
 
-use crate::undelegate_claim::proof::UndelegateClaimProof;
+use crate::{IdentityKey, Penalty, UndelegateClaimProof};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "pb::UndelegateClaimBody", into = "pb::UndelegateClaimBody")]

--- a/crates/core/component/stake/src/undelegate_claim/plan.rs
+++ b/crates/core/component/stake/src/undelegate_claim/plan.rs
@@ -1,14 +1,13 @@
-use penumbra_crypto::{
-    asset, balance,
-    stake::{IdentityKey, Penalty, UnbondingToken},
-    Amount, FieldExt, Fq, Fr,
-};
+use penumbra_crypto::{asset, balance, Amount, FieldExt, Fq, Fr};
 use penumbra_proof_params::UNDELEGATECLAIM_PROOF_PROVING_KEY;
 use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType, TypeUrl};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{UndelegateClaim, UndelegateClaimBody, UndelegateClaimProof};
+use crate::{
+    IdentityKey, Penalty, UnbondingToken, UndelegateClaim, UndelegateClaimBody,
+    UndelegateClaimProof,
+};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(try_from = "pb::UndelegateClaimPlan", into = "pb::UndelegateClaimPlan")]

--- a/crates/core/component/stake/src/undelegate_claim/proof.rs
+++ b/crates/core/component/stake/src/undelegate_claim/proof.rs
@@ -17,9 +17,10 @@ use penumbra_crypto::{
     balance,
     balance::commitment::BalanceCommitmentVar,
     proofs::groth16::{ParameterSetup, VerifyingKeyExt, GROTH16_PROOF_LENGTH_BYTES},
-    stake::{Penalty, PenaltyVar},
     Amount, Balance, FieldExt, Fq, Fr, Value, STAKING_TOKEN_ASSET_ID,
 };
+
+use crate::{Penalty, PenaltyVar};
 
 #[derive(Clone, Debug)]
 pub struct UndelegateClaimCircuit {
@@ -191,13 +192,11 @@ mod tests {
     use super::*;
     use ark_ff::{PrimeField, UniformRand};
     use decaf377::{Fq, Fr};
-    use penumbra_crypto::{
-        rdsa,
-        stake::{IdentityKey, Penalty, UnbondingToken},
-        Amount,
-    };
+    use penumbra_crypto::{rdsa, Amount};
     use proptest::prelude::*;
     use rand_core::OsRng;
+
+    use crate::{IdentityKey, Penalty, UnbondingToken};
 
     fn fr_strategy() -> BoxedStrategy<Fr> {
         any::<[u8; 32]>()

--- a/crates/core/crypto/src/lib.rs
+++ b/crates/core/crypto/src/lib.rs
@@ -20,7 +20,6 @@ mod nullifier;
 mod prf;
 pub mod proofs;
 pub mod rseed;
-pub mod stake;
 pub mod symmetric;
 mod transaction;
 pub mod value;

--- a/crates/core/crypto/src/stake.rs
+++ b/crates/core/crypto/src/stake.rs
@@ -1,9 +1,0 @@
-mod delegation_token;
-mod identity_key;
-mod penalty;
-mod unbonding_token;
-
-pub use delegation_token::DelegationToken;
-pub use identity_key::IdentityKey;
-pub use penalty::{Penalty, PenaltyVar};
-pub use unbonding_token::UnbondingToken;

--- a/crates/core/transaction/src/action/validator_vote.rs
+++ b/crates/core/transaction/src/action/validator_vote.rs
@@ -1,6 +1,7 @@
 use decaf377_rdsa::{Signature, SpendAuth};
-use penumbra_crypto::{stake::IdentityKey, GovernanceKey};
+use penumbra_crypto::GovernanceKey;
 use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType, TypeUrl};
+use penumbra_stake::IdentityKey;
 use serde::{Deserialize, Serialize};
 
 use crate::{vote::Vote, ActionView, IsAction, TransactionPerspective};

--- a/crates/crypto/proof-params/benches/undelegate_claim.rs
+++ b/crates/crypto/proof-params/benches/undelegate_claim.rs
@@ -3,13 +3,11 @@ use ark_relations::r1cs::{
     ConstraintSynthesizer, ConstraintSystem, OptimizationGoal, SynthesisMode,
 };
 use decaf377::Fr;
-use penumbra_crypto::{
-    asset, balance, rdsa,
-    stake::{IdentityKey, Penalty, UnbondingToken},
-    Amount, Fq,
-};
+use penumbra_crypto::{asset, balance, rdsa, Amount, Fq};
 use penumbra_proof_params::UNDELEGATECLAIM_PROOF_PROVING_KEY;
-use penumbra_stake::{UndelegateClaimCircuit, UndelegateClaimProof};
+use penumbra_stake::{
+    IdentityKey, Penalty, UnbondingToken, UndelegateClaimCircuit, UndelegateClaimProof,
+};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand_core::OsRng;

--- a/crates/view/src/client.rs
+++ b/crates/view/src/client.rs
@@ -6,10 +6,11 @@ use penumbra_chain::params::{ChainParameters, FmdParameters};
 use penumbra_crypto::asset::{DenomMetadata, Id};
 use penumbra_crypto::keys::AccountGroupId;
 use penumbra_crypto::{asset, keys::AddressIndex, note, Nullifier};
-use penumbra_crypto::{stake::IdentityKey, Address, Amount};
+use penumbra_crypto::{Address, Amount};
 use penumbra_proto::view::v1alpha1::{
     self as pb, view_protocol_service_client::ViewProtocolServiceClient, WitnessRequest,
 };
+use penumbra_stake::IdentityKey;
 
 use penumbra_transaction::AuthorizationData;
 use penumbra_transaction::{plan::TransactionPlan, Transaction, WitnessData};

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -12,7 +12,6 @@ use penumbra_crypto::{
     asset::DenomMetadata,
     keys::{AccountGroupId, AddressIndex},
     memo::MemoPlaintext,
-    stake::IdentityKey,
     Address, Balance, Fee, Note, Value,
 };
 use penumbra_dao::DaoDeposit;
@@ -29,8 +28,8 @@ use penumbra_dex::{
 use penumbra_ibc::{IbcAction, Ics20Withdrawal};
 use penumbra_proto::view::v1alpha1::{NotesForVotingRequest, NotesRequest};
 use penumbra_shielded_pool::{OutputPlan, SpendPlan};
-use penumbra_stake::UndelegateClaimPlan;
 use penumbra_stake::{rate::RateData, validator};
+use penumbra_stake::{IdentityKey, UndelegateClaimPlan};
 use penumbra_tct as tct;
 use penumbra_transaction::{
     action::{

--- a/crates/view/src/storage.rs
+++ b/crates/view/src/storage.rs
@@ -5,9 +5,7 @@ use parking_lot::Mutex;
 use penumbra_chain::params::{ChainParameters, FmdParameters};
 use penumbra_crypto::{
     asset::{self, DenomMetadata, Id},
-    note,
-    stake::{DelegationToken, IdentityKey},
-    Address, Amount, FieldExt, Fq, FullViewingKey, Note, Nullifier, Rseed, Value,
+    note, Address, Amount, FieldExt, Fq, FullViewingKey, Note, Nullifier, Rseed, Value,
 };
 use penumbra_dex::{
     lp::position::{self, Position, State},
@@ -19,6 +17,7 @@ use penumbra_proto::{
     },
     DomainType,
 };
+use penumbra_stake::{DelegationToken, IdentityKey};
 use penumbra_tct as tct;
 use penumbra_transaction::Transaction;
 use r2d2_sqlite::{

--- a/crates/wasm/src/planner.rs
+++ b/crates/wasm/src/planner.rs
@@ -9,12 +9,12 @@ use anyhow::{anyhow, Result};
 use crate::note_record::SpendableNoteRecord;
 use penumbra_chain::params::{ChainParameters, FmdParameters};
 use penumbra_crypto::{
-    asset::Amount, asset::DenomMetadata, keys::AddressIndex, stake::IdentityKey, Address, Fee,
-    FullViewingKey, Note, Value,
+    asset::Amount, asset::DenomMetadata, keys::AddressIndex, Address, Fee, FullViewingKey, Note,
+    Value,
 };
 use penumbra_dex::{swap::SwapPlaintext, swap::SwapPlan, swap_claim::SwapClaimPlan, TradingPair};
 use penumbra_shielded_pool::{OutputPlan, SpendPlan};
-use penumbra_stake::UndelegateClaimPlan;
+use penumbra_stake::{IdentityKey, UndelegateClaimPlan};
 use penumbra_tct as tct;
 use penumbra_transaction::{
     action::{Proposal, ProposalSubmit, ProposalWithdraw, ValidatorVote, Vote},


### PR DESCRIPTION
Towards #2765

Unfortunately to do this without introducing a cyclic dependency (between `penumbra-stake` and `penumbra-chain`), the `Penalty` struct usage had to be removed from `penumbra-chain`. Please comment if that seems like a bad call!