### PR TITLE
refactor: move governance related items from crypto to governance crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4499,6 +4499,7 @@ dependencies = [
  "penumbra-dao",
  "penumbra-dex",
  "penumbra-distributions",
+ "penumbra-governance",
  "penumbra-ibc",
  "penumbra-proof-params",
  "penumbra-proto",
@@ -4772,6 +4773,34 @@ dependencies = [
  "rand_core 0.6.4",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "penumbra-governance"
+version = "0.55.0"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "async-trait",
+ "blake2b_simd 0.5.11",
+ "bytes",
+ "decaf377-rdsa",
+ "im",
+ "metrics",
+ "penumbra-chain",
+ "penumbra-component",
+ "penumbra-crypto",
+ "penumbra-proof-params",
+ "penumbra-proto",
+ "penumbra-sct",
+ "penumbra-storage",
+ "penumbra-tct",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "regex",
+ "serde",
+ "tendermint",
+ "tracing",
 ]
 
 [[package]]
@@ -5167,6 +5196,7 @@ dependencies = [
  "penumbra-crypto",
  "penumbra-dao",
  "penumbra-dex",
+ "penumbra-governance",
  "penumbra-ibc",
  "penumbra-proof-params",
  "penumbra-proto",

--- a/crates/bin/pcli/src/command/validator.rs
+++ b/crates/bin/pcli/src/command/validator.rs
@@ -4,12 +4,12 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use penumbra_crypto::{keys::AddressIndex, Fee, GovernanceKey};
+use penumbra_crypto::{keys::AddressIndex, Fee};
 use penumbra_proto::{core::stake::v1alpha1::Validator as ProtoValidator, DomainType, Message};
 use penumbra_stake::{
     validator,
     validator::{Validator, ValidatorToml},
-    FundingStream, FundingStreams, IdentityKey,
+    FundingStream, FundingStreams, GovernanceKey, IdentityKey,
 };
 use penumbra_transaction::action::{ValidatorVote, ValidatorVoteBody, Vote};
 use penumbra_wallet::plan;

--- a/crates/bin/pd/src/testnet/generate.rs
+++ b/crates/bin/pd/src/testnet/generate.rs
@@ -5,9 +5,10 @@ use crate::testnet::{generate_tm_config, parse_tm_address, write_configs, Valida
 use anyhow::{Context, Result};
 use penumbra_chain::genesis;
 use penumbra_chain::{genesis::Allocation, params::ChainParameters};
-use penumbra_crypto::{keys::SpendKey, Address, GovernanceKey};
+use penumbra_crypto::{keys::SpendKey, Address};
 use penumbra_stake::{
-    validator::Validator, DelegationToken, FundingStream, FundingStreams, IdentityKey,
+    validator::Validator, DelegationToken, FundingStream, FundingStreams, GovernanceKey,
+    IdentityKey,
 };
 use serde::{de, Deserialize};
 use std::{

--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -16,6 +16,7 @@ penumbra-component = { path = "../component/component" }
 penumbra-chain = { path = "../component/chain", features = ["component"] }
 penumbra-shielded-pool = { path = "../component/shielded-pool", features = ["component"] }
 penumbra-stake = { path = "../component/stake" }
+penumbra-governance = { path = "../component/governance" }
 penumbra-sct = { path = "../component/sct" }
 penumbra-dao = { path = "../component/dao" }
 penumbra-dex = { path = "../component/dex" }

--- a/crates/core/app/src/action_handler/actions/proposal/deposit_claim.rs
+++ b/crates/core/app/src/action_handler/actions/proposal/deposit_claim.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use penumbra_crypto::ProposalNft;
+use penumbra_governance::ProposalNft;
 use penumbra_shielded_pool::component::SupplyWrite;
 use penumbra_storage::{StateRead, StateWrite};
 use penumbra_transaction::action::ProposalDepositClaim;

--- a/crates/core/app/src/action_handler/actions/proposal/submit.rs
+++ b/crates/core/app/src/action_handler/actions/proposal/submit.rs
@@ -6,11 +6,12 @@ use async_trait::async_trait;
 use decaf377::Fq;
 use once_cell::sync::Lazy;
 use penumbra_chain::component::StateReadExt as _;
+use penumbra_crypto::STAKING_TOKEN_DENOM;
 use penumbra_crypto::{
     keys::{FullViewingKey, NullifierKey},
     rdsa::{VerificationKey, VerificationKeyBytes},
 };
-use penumbra_crypto::{ProposalNft, VotingReceiptToken, STAKING_TOKEN_DENOM};
+use penumbra_governance::{ProposalNft, VotingReceiptToken};
 use penumbra_sct::component::StateReadExt as _;
 use penumbra_shielded_pool::component::SupplyWrite;
 use penumbra_storage::{StateDelta, StateRead, StateWrite};

--- a/crates/core/app/src/action_handler/actions/proposal/withdraw.rs
+++ b/crates/core/app/src/action_handler/actions/proposal/withdraw.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use penumbra_crypto::ProposalNft;
+use penumbra_governance::ProposalNft;
 use penumbra_shielded_pool::component::SupplyWrite;
 use penumbra_storage::{StateRead, StateWrite};
 use penumbra_transaction::{action::ProposalWithdraw, proposal};

--- a/crates/core/app/src/governance/view.rs
+++ b/crates/core/app/src/governance/view.rs
@@ -12,11 +12,11 @@ use penumbra_chain::{
 };
 use penumbra_crypto::{
     asset::{self, Amount},
-    GovernanceKey, Nullifier, Value, STAKING_TOKEN_DENOM,
+    Nullifier, Value, STAKING_TOKEN_DENOM,
 };
 use penumbra_proto::{StateReadProto, StateWriteProto};
 use penumbra_shielded_pool::component::{StateReadExt as _, SupplyRead};
-use penumbra_stake::{DelegationToken, IdentityKey};
+use penumbra_stake::{DelegationToken, GovernanceKey, IdentityKey};
 use penumbra_storage::{StateRead, StateWrite};
 use penumbra_tct as tct;
 use penumbra_transaction::{

--- a/crates/core/component/governance/Cargo.toml
+++ b/crates/core/component/governance/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "penumbra-governance"
+version = "0.55.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+component = [
+    "penumbra-component",
+    "penumbra-storage",
+    "penumbra-proto/penumbra-storage",
+    "penumbra-chain/component",
+    "penumbra-sct/component"
+]
+proving-keys = ["penumbra-proof-params/proving-keys"]
+default = ["std", "component", "proving-keys"]
+std = ["ark-ff/std"]
+docsrs = []
+
+[dependencies]
+# Workspace dependencies
+penumbra-proto = { path = "../../../proto", default-features = false }
+penumbra-storage = { path = "../../../storage", optional = true }
+penumbra-tct = { path = "../../../crypto/tct" }
+penumbra-proof-params = { path = "../../../crypto/proof-params", default-features = false }
+penumbra-crypto = { path = "../../crypto", default-features = false }
+penumbra-sct = { path = "../sct", default-features = false }
+penumbra-component = { path = "../component", optional = true }
+penumbra-chain = { path = "../chain", default-features = false }
+
+# Penumbra dependencies
+decaf377-rdsa = { version = "0.6" }
+
+# Crates.io dependencies
+ark-ff = { version = "0.4", default_features = false }
+metrics = "0.19.0"
+serde = { version = "1", features = ["derive"] }
+tracing = "0.1"
+anyhow = "1"
+async-trait = "0.1.52"
+tendermint = "0.32.0"
+blake2b_simd = "0.5"
+bytes = "1"
+rand_core = { version = "0.6.3", features = ["getrandom"] }
+rand = "0.8"
+im = "15.1"
+regex = "1.5"

--- a/crates/core/component/governance/src/lib.rs
+++ b/crates/core/component/governance/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod proposal_nft;
+pub mod voting_receipt_token;
+
+pub use proposal_nft::ProposalNft;
+pub use voting_receipt_token::VotingReceiptToken;

--- a/crates/core/component/governance/src/proposal_nft.rs
+++ b/crates/core/component/governance/src/proposal_nft.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use regex::Regex;
 
-use crate::asset;
+use penumbra_crypto::asset;
 
 /// Unbonding tokens represent staking tokens that are currently unbonding and
 /// subject to slashing.

--- a/crates/core/component/governance/src/voting_receipt_token.rs
+++ b/crates/core/component/governance/src/voting_receipt_token.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use regex::Regex;
 
-use crate::asset;
+use penumbra_crypto::asset;
 
 /// Unbonding tokens represent staking tokens that are currently unbonding and
 /// subject to slashing.

--- a/crates/core/component/stake/src/governance_key.rs
+++ b/crates/core/component/stake/src/governance_key.rs
@@ -5,7 +5,7 @@ use penumbra_proto::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::rdsa::{SpendAuth, VerificationKey};
+use decaf377_rdsa::{SpendAuth, VerificationKey};
 
 /// The root of a validator's governance identity (which may be distinct from its main identity, to
 /// allow cold storage of validator keys).

--- a/crates/core/component/stake/src/lib.rs
+++ b/crates/core/component/stake/src/lib.rs
@@ -35,11 +35,13 @@ pub use undelegate_claim::{
 };
 
 mod delegation_token;
+mod governance_key;
 mod identity_key;
 mod penalty;
 mod unbonding_token;
 
 pub use delegation_token::DelegationToken;
+pub use governance_key::GovernanceKey;
 pub use identity_key::IdentityKey;
 pub use penalty::{Penalty, PenaltyVar};
 pub use unbonding_token::UnbondingToken;

--- a/crates/core/component/stake/src/validator.rs
+++ b/crates/core/component/stake/src/validator.rs
@@ -1,12 +1,12 @@
 //! Penumbra validators and related structures.
 
-use penumbra_crypto::{Address, GovernanceKey};
+use penumbra_crypto::Address;
 use penumbra_proto::{core::stake::v1alpha1 as pb, DomainType, TypeUrl};
 use serde::{Deserialize, Serialize};
 use serde_unit_struct::{Deserialize_unit_struct, Serialize_unit_struct};
 use serde_with::{serde_as, DisplayFromStr};
 
-use crate::{FundingStream, FundingStreams, IdentityKey};
+use crate::{FundingStream, FundingStreams, GovernanceKey, IdentityKey};
 
 mod bonding;
 mod definition;

--- a/crates/core/crypto/src/governance.rs
+++ b/crates/core/crypto/src/governance.rs
@@ -1,3 +1,0 @@
-pub mod key;
-pub mod proposal_nft;
-pub mod voting_receipt_token;

--- a/crates/core/crypto/src/lib.rs
+++ b/crates/core/crypto/src/lib.rs
@@ -11,7 +11,6 @@ pub mod balance;
 mod effect_hash;
 mod fee;
 pub mod fixpoint;
-mod governance;
 pub mod keys;
 pub mod note;
 mod note_payload;
@@ -28,11 +27,6 @@ pub use asset::Amount;
 pub use balance::Balance;
 pub use effect_hash::{EffectHash, EffectingData};
 pub use fee::Fee;
-pub use governance::{
-    key::GovernanceKey,
-    proposal_nft::{self, ProposalNft},
-    voting_receipt_token::{self, VotingReceiptToken},
-};
 pub use keys::FullViewingKey;
 pub use note::{Note, NoteCiphertext, NoteView};
 pub use note_payload::NotePayload;

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -13,6 +13,7 @@ penumbra-tct = { path = "../../crypto/tct" }
 penumbra-proof-params = { path = "../../crypto/proof-params/", features = ["proving-keys"] }
 penumbra-crypto = { path = "../crypto/" }
 penumbra-chain = { path = "../component/chain/", default-features = false }
+penumbra-governance = { path = "../component/governance/", default-features = false }
 penumbra-shielded-pool = { path = "../component/shielded-pool/", default-features = false }
 penumbra-stake = { path = "../component/stake", default-features = false }
 penumbra-ibc = { path = "../component/ibc/", default-features = false }

--- a/crates/core/transaction/src/action/delegator_vote.rs
+++ b/crates/core/transaction/src/action/delegator_vote.rs
@@ -2,9 +2,8 @@ use anyhow::Context;
 use ark_ff::Zero;
 use decaf377::Fr;
 use decaf377_rdsa::{Signature, SpendAuth, VerificationKey};
-use penumbra_crypto::{
-    proofs::groth16::DelegatorVoteProof, Amount, Nullifier, Value, VotingReceiptToken,
-};
+use penumbra_crypto::{proofs::groth16::DelegatorVoteProof, Amount, Nullifier, Value};
+use penumbra_governance::VotingReceiptToken;
 use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType, TypeUrl};
 use penumbra_tct as tct;
 

--- a/crates/core/transaction/src/action/proposal_deposit_claim.rs
+++ b/crates/core/transaction/src/action/proposal_deposit_claim.rs
@@ -3,8 +3,9 @@ use serde::{Deserialize, Serialize};
 
 use penumbra_crypto::{
     asset::{self, Amount, DenomMetadata},
-    balance, Balance, Fr, ProposalNft, Value, STAKING_TOKEN_ASSET_ID,
+    balance, Balance, Fr, Value, STAKING_TOKEN_ASSET_ID,
 };
+use penumbra_governance::ProposalNft;
 use penumbra_proto::core::governance::v1alpha1 as pb;
 
 use crate::{

--- a/crates/core/transaction/src/action/proposal_submit.rs
+++ b/crates/core/transaction/src/action/proposal_submit.rs
@@ -1,7 +1,8 @@
 use ark_ff::Zero;
 use serde::{Deserialize, Serialize};
 
-use penumbra_crypto::{asset::Amount, Balance, Fr, ProposalNft, Value, STAKING_TOKEN_ASSET_ID};
+use penumbra_crypto::{asset::Amount, Balance, Fr, Value, STAKING_TOKEN_ASSET_ID};
+use penumbra_governance::ProposalNft;
 use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType, TypeUrl};
 
 use crate::{proposal::Proposal, ActionView, IsAction, TransactionPerspective};

--- a/crates/core/transaction/src/action/proposal_withdraw.rs
+++ b/crates/core/transaction/src/action/proposal_withdraw.rs
@@ -1,7 +1,8 @@
 use ark_ff::Zero;
 use serde::{Deserialize, Serialize};
 
-use penumbra_crypto::{asset::Amount, Balance, Fr, ProposalNft, Value};
+use penumbra_crypto::{asset::Amount, Balance, Fr, Value};
+use penumbra_governance::ProposalNft;
 use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType, TypeUrl};
 
 use crate::{ActionView, IsAction, TransactionPerspective};

--- a/crates/core/transaction/src/action/validator_vote.rs
+++ b/crates/core/transaction/src/action/validator_vote.rs
@@ -1,7 +1,6 @@
 use decaf377_rdsa::{Signature, SpendAuth};
-use penumbra_crypto::GovernanceKey;
 use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType, TypeUrl};
-use penumbra_stake::IdentityKey;
+use penumbra_stake::{GovernanceKey, IdentityKey};
 use serde::{Deserialize, Serialize};
 
 use crate::{vote::Vote, ActionView, IsAction, TransactionPerspective};

--- a/crates/core/transaction/src/plan/action/delegator_vote.rs
+++ b/crates/core/transaction/src/plan/action/delegator_vote.rs
@@ -3,8 +3,8 @@ use decaf377::{FieldExt, Fq, Fr};
 use decaf377_rdsa::{Signature, SpendAuth};
 use penumbra_crypto::{
     proofs::groth16::DelegatorVoteProof, Amount, FullViewingKey, Note, Nullifier,
-    VotingReceiptToken,
 };
+use penumbra_governance::VotingReceiptToken;
 use penumbra_proof_params::DELEGATOR_VOTE_PROOF_PROVING_KEY;
 use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType, TypeUrl};
 use penumbra_tct as tct;


### PR DESCRIPTION
This is for #2765 - `penumbra-governance` now has the bits from penumbra-crypto related to governance, except for `GovernanceKey` which is together with the validator definition in `penumbra-stake`. 
