### PR TITLE
chore: update poseidon377 to 0.5 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5497,7 +5497,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-wasm"
-version = "0.55.6-indexeddb"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "base64 0.20.0",
@@ -5661,9 +5661,9 @@ dependencies = [
 
 [[package]]
 name = "poseidon-parameters"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a3517328333267b89d5142f1c128909c992d891af70a38e46743592dce8734"
+checksum = "58236ff8bf455c13046c92f041e887c4fd0e64819387a81177d6c70ebeb41711"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5672,9 +5672,9 @@ dependencies = [
 
 [[package]]
 name = "poseidon-paramgen"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f257826633aaa781bfae23a68936b56fd1bfd778409a8c1cdf8cdb05685aeb"
+checksum = "a69506f91189a68bff6c0e4f8c2beaf6b053430be7743059a0110477e9c28fda"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5689,20 +5689,22 @@ dependencies = [
 
 [[package]]
 name = "poseidon-permutation"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84469694c933debead297d95d8132dcd91de300d160eda7ade6047002cc6aa2a"
+checksum = "5f130750ddbff77f3977d3e20fe43ad11e8a13c3e2f2f1c002c6246d294dd392"
 dependencies = [
  "ark-ff",
+ "ark-r1cs-std",
+ "ark-relations",
  "ark-std",
  "poseidon-parameters",
 ]
 
 [[package]]
 name = "poseidon377"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbb3ad52bc19785e6b38fc9cebbdf54755c7b586bbe6ba781d7fea16fb803b1"
+checksum = "3d181575f19bf89d995662200dc515897c0f42a97bc551f8686005367e5594ae"
 dependencies = [
  "ark-ec",
  "ark-ed-on-bls12-377",

--- a/crates/core/asset/Cargo.toml
+++ b/crates/core/asset/Cargo.toml
@@ -16,7 +16,7 @@ penumbra-tct = { path = "../../crypto/tct/", features = ["r1cs"] }
 # Git deps
 decaf377 = {version = "0.4", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.6" }
-poseidon377 = { version = "0.4", features = ["r1cs"] }
+poseidon377 = { version = "0.5", features = ["r1cs"] }
 f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -27,7 +27,7 @@ penumbra-asset = { path = "../../../core/asset", default-features = false  }
 penumbra-num = { path = "../../../core/num", default-features = false  } 
 
 # Penumbra dependencies
-poseidon377 = { version = "0.4", features = ["r1cs"] }
+poseidon377 = { version = "0.5", features = ["r1cs"] }
 decaf377 = {version = "0.4", features = ["r1cs"] }
 
 # Crates.io deps

--- a/crates/core/crypto/Cargo.toml
+++ b/crates/core/crypto/Cargo.toml
@@ -17,7 +17,7 @@ penumbra-num = { path = "../num" }
 # Git deps
 decaf377 = {version = "0.4", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.6" }
-poseidon377 = { version = "0.4", features = ["r1cs"] }
+poseidon377 = { version = "0.5", features = ["r1cs"] }
 f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps

--- a/crates/core/keys/Cargo.toml
+++ b/crates/core/keys/Cargo.toml
@@ -15,7 +15,7 @@ penumbra-tct = { path = "../../crypto/tct/", features = ["r1cs"] }
 # Git deps
 decaf377 = {version = "0.4", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.6" }
-poseidon377 = { version = "0.4", features = ["r1cs"] }
+poseidon377 = { version = "0.5", features = ["r1cs"] }
 f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps

--- a/crates/core/num/Cargo.toml
+++ b/crates/core/num/Cargo.toml
@@ -15,7 +15,7 @@ penumbra-tct = { path = "../../crypto/tct/", features = ["r1cs"] }
 # Git deps
 decaf377 = {version = "0.4", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.6" }
-poseidon377 = { version = "0.4", features = ["r1cs"] }
+poseidon377 = { version = "0.5", features = ["r1cs"] }
 f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -30,7 +30,7 @@ ibc-types2 = { git = "https://github.com/penumbra-zone/ibc-types", branch = "mai
 ibc-proto = { version = "0.31.0", default-features = false }
 decaf377 = "0.4"
 decaf377-rdsa = { version = "0.6" }
-poseidon377 = { version = "0.4", features = ["r1cs"] }
+poseidon377 = { version = "0.5", features = ["r1cs"] }
 base64 = "0.21"
 ark-ff = { version = "0.4", default_features = false }
 ark-serialize = "0.4"

--- a/crates/crypto/tct/Cargo.toml
+++ b/crates/crypto/tct/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 parking_lot = "0.12"
 ark-ff = { version = "0.4", default_features = false }
 ark-serialize = "0.4"
-poseidon377 = { version = "0.4", features = ["r1cs"] }
+poseidon377 = { version = "0.5", features = ["r1cs"] }
 decaf377 = { version = "0.4" }
 tracing = { version = "0.1" }
 async-trait = { version = "0.1" }


### PR DESCRIPTION
Just released the poseidon crates such that our R1CS impl is used