### PR TITLE
chore: bump poseidon377 to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5729,9 +5729,9 @@ dependencies = [
 
 [[package]]
 name = "poseidon-permutation"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f130750ddbff77f3977d3e20fe43ad11e8a13c3e2f2f1c002c6246d294dd392"
+checksum = "a022268b53cec1e99c4bd8c81be249709e971b78a433d9f5556e31f3cd7730b0"
 dependencies = [
  "ark-ff",
  "ark-r1cs-std",
@@ -5742,9 +5742,9 @@ dependencies = [
 
 [[package]]
 name = "poseidon377"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d181575f19bf89d995662200dc515897c0f42a97bc551f8686005367e5594ae"
+checksum = "11dbcae1c9e4624576dd7631a1f2419a18afeaeef104263d70b6f20256ea5b72"
 dependencies = [
  "ark-ec",
  "ark-ed-on-bls12-377",

--- a/crates/core/asset/Cargo.toml
+++ b/crates/core/asset/Cargo.toml
@@ -16,7 +16,7 @@ penumbra-tct = { path = "../../crypto/tct/", features = ["r1cs"] }
 # Git deps
 decaf377 = {version = "0.4", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.6" }
-poseidon377 = { version = "0.5", features = ["r1cs"] }
+poseidon377 = { version = "0.6", features = ["r1cs"] }
 f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -28,7 +28,7 @@ penumbra-num = { path = "../../../core/num", default-features = false  }
 penumbra-keys = { path = "../../../core/keys", default-features = false  } 
 
 # Penumbra dependencies
-poseidon377 = { version = "0.5", features = ["r1cs"] }
+poseidon377 = { version = "0.6", features = ["r1cs"] }
 decaf377 = {version = "0.4", features = ["r1cs"] }
 
 # Crates.io deps

--- a/crates/core/component/shielded-pool/Cargo.toml
+++ b/crates/core/component/shielded-pool/Cargo.toml
@@ -37,7 +37,7 @@ decaf377-fmd = { path = "../../../crypto/decaf377-fmd/" }
 # Penumbra dependencies
 decaf377-rdsa = { version = "0.6" }
 decaf377 = {version = "0.4", features = ["r1cs"] }
-poseidon377 = { version = "0.5", features = ["r1cs"] }
+poseidon377 = { version = "0.6", features = ["r1cs"] }
 
 # Crates.io dependencies
 base64 = "0.20"

--- a/crates/core/crypto/Cargo.toml
+++ b/crates/core/crypto/Cargo.toml
@@ -18,7 +18,7 @@ penumbra-keys = { path = "../keys" }
 # Penumbra deps
 decaf377 = {version = "0.4", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.6" }
-poseidon377 = { version = "0.5", features = ["r1cs"] }
+poseidon377 = { version = "0.6", features = ["r1cs"] }
 
 # Crates.io deps
 base64 = "0.20"

--- a/crates/core/keys/Cargo.toml
+++ b/crates/core/keys/Cargo.toml
@@ -15,7 +15,7 @@ penumbra-tct = { path = "../../crypto/tct/", features = ["r1cs"] }
 # Git deps
 decaf377 = {version = "0.4", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.6" }
-poseidon377 = { version = "0.5", features = ["r1cs"] }
+poseidon377 = { version = "0.6", features = ["r1cs"] }
 f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps

--- a/crates/core/num/Cargo.toml
+++ b/crates/core/num/Cargo.toml
@@ -15,7 +15,7 @@ penumbra-tct = { path = "../../crypto/tct/", features = ["r1cs"] }
 # Git deps
 decaf377 = {version = "0.4", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.6" }
-poseidon377 = { version = "0.5", features = ["r1cs"] }
+poseidon377 = { version = "0.6", features = ["r1cs"] }
 f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -31,7 +31,7 @@ ibc-types2 = { git = "https://github.com/penumbra-zone/ibc-types", branch = "mai
 ibc-proto = { version = "0.31.0", default-features = false }
 decaf377 = "0.4"
 decaf377-rdsa = { version = "0.6" }
-poseidon377 = { version = "0.5", features = ["r1cs"] }
+poseidon377 = { version = "0.6", features = ["r1cs"] }
 base64 = "0.21"
 ark-ff = { version = "0.4", default_features = false }
 ark-serialize = "0.4"

--- a/crates/crypto/tct/Cargo.toml
+++ b/crates/crypto/tct/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 parking_lot = "0.12"
 ark-ff = { version = "0.4", default_features = false }
 ark-serialize = "0.4"
-poseidon377 = { version = "0.5", features = ["r1cs"] }
+poseidon377 = { version = "0.6", features = ["r1cs"] }
 decaf377 = { version = "0.4" }
 tracing = { version = "0.1" }
 async-trait = { version = "0.1" }


### PR DESCRIPTION
Bumping again after https://github.com/penumbra-zone/poseidon377/pull/52