### PR TITLE
add parallel features to component crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4385,6 +4385,7 @@ dependencies = [
  "penumbra-compact-block",
  "penumbra-crypto",
  "penumbra-dex",
+ "penumbra-governance",
  "penumbra-ibc",
  "penumbra-keys",
  "penumbra-proto",

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -16,7 +16,7 @@ default = ["std", "parallel", "download-proving-keys"]
 download-proving-keys = ["penumbra-proof-params/download-proving-keys"]
 sct-divergence-check = ["penumbra-view/sct-divergence-check"]
 std = ["ark-ff/std"]
-parallel = ["penumbra-proof-params/parallel", "decaf377/parallel", "penumbra-crypto/parallel", "penumbra-transaction/parallel", "penumbra-wallet/parallel"]
+parallel = ["penumbra-proof-params/parallel", "decaf377/parallel", "penumbra-shielded-pool/parallel", "penumbra-dex/parallel", "penumbra-governance/parallel", "penumbra-stake/parallel", "penumbra-crypto/parallel", "penumbra-transaction/parallel", "penumbra-wallet/parallel"]
 
 [dependencies]
 # Workspace dependencies

--- a/crates/bin/pclientd/Cargo.toml
+++ b/crates/bin/pclientd/Cargo.toml
@@ -10,7 +10,7 @@ default = ["std"]
 std = ["ibc-types2/std"]
 sct-divergence-check = ["penumbra-view/sct-divergence-check"]
 # Enable to use rayon parallelism for crypto operations
-parallel = ["penumbra-crypto/parallel"]
+parallel = ["penumbra-crypto/parallel", "penumbra-transaction/parallel"]
 
 [dependencies]
 # Workspace dependencies

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -21,10 +21,11 @@ penumbra-storage          = { path = "../../storage" }
 penumbra-asset           = { path = "../../core/asset" }
 penumbra-keys           = { path = "../../core/keys" }
 penumbra-crypto           = { path = "../../core/crypto", features = ["parallel"] }
-penumbra-shielded-pool    = { path = "../../core/component/shielded-pool" }
-penumbra-stake            = { path = "../../core/component/stake" }
+penumbra-shielded-pool    = { path = "../../core/component/shielded-pool", features = ["parallel"] }
+penumbra-stake            = { path = "../../core/component/stake", features = ["parallel"] }
 penumbra-sct              = { path = "../../core/component/sct" }
-penumbra-dex              = { path = "../../core/component/dex" }
+penumbra-dex              = { path = "../../core/component/dex", features = ["parallel"] }
+penumbra-governance       = { path = "../../core/component/governance", features = ["parallel"]}
 penumbra-ibc              = { path = "../../core/component/ibc" }
 penumbra-compact-block    = { path = "../../core/component/compact-block" }
 penumbra-chain            = { path = "../../core/component/chain" }

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -10,6 +10,7 @@ component = ["penumbra-component", "penumbra-storage", "penumbra-proto/penumbra-
 default = ["component", "proving-keys"]
 docsrs = []
 proving-keys = ["penumbra-proof-params/proving-keys"]
+parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "poseidon377/parallel", "decaf377-rdsa/parallel", "ark-groth16/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]
 
 [dependencies]
 # Workspace dependencies

--- a/crates/core/component/governance/Cargo.toml
+++ b/crates/core/component/governance/Cargo.toml
@@ -17,6 +17,7 @@ proving-keys = ["penumbra-proof-params/proving-keys"]
 default = ["std", "component", "proving-keys"]
 std = ["ark-ff/std"]
 docsrs = []
+parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "decaf377-rdsa/parallel", "ark-groth16/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]
 
 [dependencies]
 # Workspace dependencies

--- a/crates/core/component/shielded-pool/Cargo.toml
+++ b/crates/core/component/shielded-pool/Cargo.toml
@@ -17,6 +17,7 @@ proving-keys = ["penumbra-proof-params/proving-keys"]
 default = ["std", "component", "proving-keys"]
 std = ["ark-ff/std"]
 docsrs = []
+parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "poseidon377/parallel", "decaf377-rdsa/parallel", "ark-groth16/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]
 
 [dependencies]
 # Workspace dependencies

--- a/crates/core/component/stake/Cargo.toml
+++ b/crates/core/component/stake/Cargo.toml
@@ -19,6 +19,7 @@ component = [
 proving-keys = ["penumbra-proof-params/proving-keys"]
 default = ["component", "proving-keys"]
 docsrs = []
+parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "decaf377-rdsa/parallel", "ark-groth16/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]
 
 [dependencies]
 # Workspace dependencies

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -67,5 +67,5 @@ serde_json = "1"
 [features]
 default = ["std", "parallel"]
 std = ["ark-ff/std"]
-parallel = ["tokio", "penumbra-crypto/parallel"]
+parallel = ["tokio", "penumbra-crypto/parallel", "penumbra-shielded-pool/parallel", "penumbra-dex/parallel", "penumbra-governance/parallel", "penumbra-stake/parallel"]
 download-proving-keys = ["penumbra-proof-params/download-proving-keys"]


### PR DESCRIPTION
Now that the ZKPs are in the individual component crates, they should have a parallel feature like `penumbra-crypto` to turn on and off parallel proving via rayon