### PR TITLE
relayer: only configure penumbra chains

### DIFF
--- a/deployments/relayer/README.md
+++ b/deployments/relayer/README.md
@@ -34,6 +34,21 @@ Given the rapid pace of development, it's possible that proto definitions
 are out of sync between testnet & preview, in which case there may be errors.
 To debug, consider running a local devnet and linking it with preview.
 
+## Verifying IBC functionality between chains
+
+There are three key stages to working IBC: clients, channels, and connections.
+Use the commands below to evaluate whether each step is correctly configured:
+
+```
+pcli -n http://localhost:8080 q ibc client 07-tendermint-0
+pcli -n http://localhost:8080 q ibc channel transfer channel-0
+pcli -n http://localhost:8080 q ibc connection connection-0
+```
+
+Remember to check the same on the corresponding counterparty chain, e.g. testnet-preview.
+The `client` values may not be the same between chains, so try incrementing the values
+until no results are found as a surrogate for querying via pcli.
+
 ## Updating proto definitions in relayer
 Sometimes the protos between preview & testnet get out of sync. When this happens,
 we must submit a PR upstream to the relayer repo. See [example here](https://github.com/cosmos/relayer/pull/1170),

--- a/deployments/relayer/build-path
+++ b/deployments/relayer/build-path
@@ -22,3 +22,11 @@ done < <(rly paths list --json | jq 'keys | join ("\n")' -r | sort -r)
 
 visible_log "Finished! No errors encountered setting up link. Available paths:"
 rly paths list
+
+visible_log "These commands should all yield results:"
+
+cat <<EOF
+  * pcli -n http://localhost:8080 q ibc client 07-tendermint-0
+  * pcli -n http://localhost:8080 q ibc channel transfer channel-0
+  * pcli -n http://localhost:8080 q ibc connection connection-0
+EOF

--- a/deployments/relayer/configs/babylon-testnet.json
+++ b/deployments/relayer/configs/babylon-testnet.json
@@ -3,7 +3,7 @@
   "value": {
     "key": "default",
     "chain-id": "bbn-test1",
-    "rpc-addr": "http://rpc.testnet.babylonchain.io:26657",
+    "rpc-addr": "https://rpc.testnet.babylonchain.io:443",
     "account-prefix": "bbn",
     "keyring-backend": "test",
     "gas-adjustment": 1.0,

--- a/deployments/relayer/configs/penumbra-preview.json
+++ b/deployments/relayer/configs/penumbra-preview.json
@@ -2,7 +2,7 @@
   "type": "penumbra",
   "value": {
     "key": "default",
-    "chain-id": "penumbra-testnet-amalthe-7ceb20c6",
+    "chain-id": "penumbra-testnet-callisto-7c9d59d6",
     "rpc-addr": "https://rpc.testnet-preview.penumbra.zone:443",
     "account-prefix": "penumbrav2t",
     "keyring-backend": "test",

--- a/deployments/relayer/configure-relayer
+++ b/deployments/relayer/configure-relayer
@@ -21,7 +21,8 @@ rm -rf ~/.relayer
 rly config init --memo "Automatic IBC for Penumbra, via relayer"
 
 >&2 echo "Adding chain specs to relayer config..."
-rly chains add-dir configs/
+find ./configs/ -type f -iname 'penumbra*.json' -exec \
+    rly chains add -f {} \;
 
 # Ideally we wouldn't need to bother with generating keys for the relayer paths,
 # because Penumbra hasn't implemented fees yet, so there's no need for a wallet to pay out of.


### PR DESCRIPTION
We encountered a long (~20s) timeout on all `rly` commands, and traced it to a context timeout on a bad URL for the bablyon testchain. We're still focusing on preview <-> devnet functionality, so let's exclude the external testnet chains from relayer configuration until we're ready.

Also includes some documentation updates so it's a bit easier to understand how test the relayer interactively. Eventually we'll want all this logic bottled up in integration tests, e.g. `interchaintest`, but still working toward that goal.

Refs #2612.