### PR TITLE
docs: don't recommend verbose logs for nodes

### DIFF
--- a/docs/guide/src/dev/devnet-quickstart.md
+++ b/docs/guide/src/dev/devnet-quickstart.md
@@ -17,9 +17,10 @@ This will write configs to `~/.penumbra/testnet_data/`.
 
 ## Running `pd`
 
-You'll probably want to set `RUST_LOG`.  Here's one suggestion:
+You'll probably want to set `RUST_LOG`.  Here's one suggestion that's quite verbose:
 
 ```shell
+# Optional. Expect about 20GB/week of log data for pd with settings below.
 export RUST_LOG="info,pd=debug,penumbra=debug,jmt=debug"
 ```
 

--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -50,12 +50,7 @@ the section above on resetting node state.
 ### Running `pd` and `tendermint`
 
 Next, run `pd` with the `--home` parameter pointed at the correct part of the
-testnet data directory.  It's useful to set the `RUST_LOG` environment variable
-to get information about what it's doing:
-
-```shell
-export RUST_LOG="info,pd=debug,penumbra=debug,jmt=debug" # or some other logging level
-```
+testnet data directory.
 
 ```shell
 cargo run --bin pd --release -- start --home ~/.penumbra/testnet_data/node0/pd


### PR DESCRIPTION
We crank up verbosity on our PL nodes and validators, because we want maximum visibility into application state. We don't need to recommend that everyone running a node does the same, given that log volume is clocking in around 20GB/week per pd instance running in a testnet.