### PR TITLE
ci: add moons of saturn to testnet names

### DIFF
--- a/testnets/names.txt
+++ b/testnets/names.txt
@@ -55,3 +55,10 @@ Europa
 Io
 Callisto
 Ganymede
+Mimas
+Enceladus
+Tethys
+Dione
+Iapetus
+Rhea
+Titan


### PR DESCRIPTION
We're nearly at the end of the list of Jovian moons. We could tack on some recently discovered and lesser-known moons of Jupiter, but they don't have readable names, for the most part, which would defeat the point. So let's use the moons of Saturn to extend the list a bit, allowing us to refer to testnets by a human-readable name and keeping with the theme.