### PR TITLE
fix(pd): use proper nanoseconds in tm proxy

### DIFF
--- a/crates/util/tendermint-proxy/src/tendermint_proxy.rs
+++ b/crates/util/tendermint-proxy/src/tendermint_proxy.rs
@@ -187,7 +187,7 @@ impl TendermintProxyService for TendermintProxy {
                 latest_block_height: res.sync_info.latest_block_height.value(),
                 latest_block_time: Some(pbjson_types::Timestamp {
                     seconds: latest_block_time.timestamp(),
-                    nanos: latest_block_time.timestamp_nanos() as i32,
+                    nanos: latest_block_time.timestamp_subsec_nanos() as i32,
                 }),
                 // These don't exist in tendermint-rpc right now.
                 // earliest_app_hash: res.sync_info.earliest_app_hash.to_string().as_bytes().to_vec(),


### PR DESCRIPTION
The gRPCUI service was throwing an error on `TendermintProxyService.GetBlockByHeight`, with log messages pointing to `ns out of range [0, 1000000000]`. The relevant pbjson type [0] is not well documented, but consulting the associated protobuf type [1] makes it clear that we want subsecond nanos here.

Closes #2673.

[0] https://docs.rs/pbjson-types/0.5.1/pbjson_types/struct.Timestamp.html
[1] https://protobuf.dev/reference/java/api-docs/com/google/protobuf/Timestamp