### PR TITLE
fix packet commitment paths: use `sequences` correctly

### DIFF
--- a/crates/core/component/ibc/src/component/state_key.rs
+++ b/crates/core/component/ibc/src/component/state_key.rs
@@ -75,14 +75,14 @@ pub fn seq_send(channel_id: &ChannelId, port_id: &PortId) -> String {
 
 pub fn packet_receipt(packet: &Packet) -> String {
     format!(
-        "receipts/ports/{}/channels/{}/receipts/{}",
+        "receipts/ports/{}/channels/{}/sequences/{}",
         packet.port_on_b, packet.chan_on_b, packet.sequence
     )
 }
 
 pub fn receipt_by_channel(port_id: &PortId, channel_id: &ChannelId, sequence: u64) -> String {
     format!(
-        "receipts/ports/{port_id}/channels/{channel_id}/receipts/{sequence}",
+        "receipts/ports/{port_id}/channels/{channel_id}/sequences/{sequence}",
         port_id = port_id,
         channel_id = channel_id,
         sequence = sequence
@@ -91,7 +91,7 @@ pub fn receipt_by_channel(port_id: &PortId, channel_id: &ChannelId, sequence: u6
 
 pub fn packet_commitment(packet: &Packet) -> String {
     format!(
-        "commitments/ports/{}/channels/{}/packets/{}",
+        "commitments/ports/{}/channels/{}/sequences/{}",
         packet.port_on_a, packet.chan_on_a, packet.sequence
     )
 }
@@ -108,7 +108,7 @@ pub fn packet_commitment_by_port(
     channel_id: &ChannelId,
     sequence: u64,
 ) -> String {
-    format!("commitments/ports/{port_id}/channels/{channel_id}/packets/{sequence}")
+    format!("commitments/ports/{port_id}/channels/{channel_id}/sequences/{sequence}")
 }
 
 pub fn ics20_value_balance(channel_id: &ChannelId, asset_id: &asset::Id) -> String {


### PR DESCRIPTION
Our packet commitment paths were wrong, because they were modeled on the IBC spec, which contains state commitment paths different than what is currently deployed in `ibc-go`:

https://github.com/cosmos/ibc/blob/854f2e13ccab539dd99d9889dd9367339875f73e/spec/core/ics-004-channel-and-packet-semantics/README.md?plain=1#L231

vs ibc-go:

https://github.com/cosmos/ibc-go/blob/56a519c188ae841818b9ecd11244240941cc5d90/modules/core/24-host/keys.go#L212

this PR brings the penumbra commitment paths inline with `ibc-go`.

Should address #2834, but let's avoid closing that issue until we confirm with testing.