### PR TITLE
Fix unused mut qualifier causing CI to fail

### DIFF
--- a/crates/core/transaction/src/plan/build.rs
+++ b/crates/core/transaction/src/plan/build.rs
@@ -448,7 +448,7 @@ impl UnauthTransaction {
             spend.auth_sig = auth_sig;
         }
 
-        for (mut delegator_vote, auth_sig) in self
+        for (delegator_vote, auth_sig) in self
             .inner
             .transaction_body
             .actions


### PR DESCRIPTION
No more red crosses on our PRs, hopefully.