### PR TITLE
feat(dex): add initial metrics to dex actions

### DIFF
--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -357,6 +357,12 @@ async fn main() -> anyhow::Result<()> {
             // Configure a Prometheus recorder and exporter.
             let (recorder, exporter) = PrometheusBuilder::new()
                 .with_http_listener(metrics_bind)
+                // Set explicit buckets so that Prometheus endpoint emits true histograms, rather
+                // than the default distribution type summaries, for time-series data.
+                .set_buckets_for_metric(
+                    metrics_exporter_prometheus::Matcher::Prefix("penumbra_dex_".to_string()),
+                    penumbra_dex::component::metrics::DEX_BUCKETS,
+                )?
                 .build()
                 .expect("failed to build prometheus recorder");
 

--- a/crates/core/component/dex/src/component/action_handler/swap.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap.rs
@@ -7,7 +7,7 @@ use penumbra_proof_params::SWAP_PROOF_VERIFICATION_KEY;
 use penumbra_storage::{StateRead, StateWrite};
 
 use crate::{
-    component::{StateReadExt, StateWriteExt, SwapManager},
+    component::{metrics, StateReadExt, StateWriteExt, SwapManager},
     event,
     swap::Swap,
 };
@@ -36,6 +36,7 @@ impl ActionHandler for Swap {
     }
 
     async fn execute<S: StateWrite>(&self, mut state: S) -> Result<()> {
+        let swap_start = std::time::Instant::now();
         let swap = self;
 
         // All swaps will be tallied for the block so the
@@ -56,6 +57,10 @@ impl ActionHandler for Swap {
             .add_swap_payload(self.body.payload.clone(), source)
             .await;
 
+        metrics::histogram!(
+            crate::component::metrics::DEX_SWAP_DURATION,
+            swap_start.elapsed()
+        );
         state.record(event::swap(&self));
 
         Ok(())

--- a/crates/core/component/dex/src/component/arb.rs
+++ b/crates/core/component/dex/src/component/arb.rs
@@ -28,6 +28,7 @@ pub trait Arbitrage: StateWrite + Sized {
         Self: 'static,
     {
         tracing::debug!(?arb_token, ?fixed_candidates, "beginning arb search");
+        let arb_start = std::time::Instant::now();
 
         // Work in a new `StateDelta`, so we can transactionally apply any state
         // changes, and roll them back if we fail (e.g., if for some reason we
@@ -118,7 +119,10 @@ pub trait Arbitrage: StateWrite + Sized {
                 },
             },
         );
-
+        metrics::histogram!(
+            crate::component::metrics::DEX_ARB_DURATION,
+            arb_start.elapsed()
+        );
         return Ok(Value {
             amount: arb_profit,
             asset_id: arb_token,

--- a/crates/core/component/dex/src/component/dex.rs
+++ b/crates/core/component/dex/src/component/dex.rs
@@ -45,6 +45,7 @@ impl Component for Dex {
 
         // For each batch swap during the block, calculate clearing prices and set in the JMT.
         for (trading_pair, swap_flows) in state.swap_flows() {
+            let batch_start = std::time::Instant::now();
             state
                 .handle_batch_swaps(
                     trading_pair,
@@ -62,6 +63,10 @@ impl Component for Dex {
                 )
                 .await
                 .expect("handling batch swaps is infaillible");
+            metrics::histogram!(
+                crate::component::metrics::DEX_BATCH_DURATION,
+                batch_start.elapsed()
+            );
         }
 
         // Then, perform arbitrage:

--- a/crates/core/component/dex/src/component/metrics.rs
+++ b/crates/core/component/dex/src/component/metrics.rs
@@ -15,15 +15,46 @@ pub use metrics::*;
 
 /// Registers all metrics used by this crate.
 pub fn register_metrics() {
-    /*
-    // Sample code for reference -- delete when adding the first metric
-    register_counter!(MEMPOOL_CHECKTX_TOTAL);
-    describe_counter!(
-        MEMPOOL_CHECKTX_TOTAL,
-        "The total number of checktx requests made to the mempool"
+    register_histogram!(DEX_ARB_DURATION);
+    describe_histogram!(
+        DEX_ARB_DURATION,
+        Unit::Seconds,
+        "The time spent computing arbitrage during endblock phase"
     );
-     */
+    register_histogram!(DEX_BATCH_DURATION);
+    describe_histogram!(
+        DEX_BATCH_DURATION,
+        Unit::Seconds,
+        "The time spent executing batches within the DEX"
+    );
+    register_histogram!(DEX_PATH_SEARCH_DURATION);
+    describe_histogram!(
+        DEX_PATH_SEARCH_DURATION,
+        Unit::Seconds,
+        "The time spent searching for paths while executing trades within the DEX"
+    );
+    register_histogram!(DEX_ROUTE_FILL_DURATION);
+    describe_histogram!(
+        DEX_ROUTE_FILL_DURATION,
+        Unit::Seconds,
+        "The time spent filling routes while executing trades within the DEX"
+    );
+    register_histogram!(DEX_SWAP_DURATION);
+    describe_histogram!(
+        DEX_SWAP_DURATION,
+        Unit::Seconds,
+        "The time spent processing swaps within the DEX"
+    );
 }
 
-// Sample code for reference -- delete when adding the first metric
-// pub const MEMPOOL_CHECKTX_TOTAL: &str = "penumbra_pd_mempool_checktx_total";
+// We configure buckets for the DEX routing times manually, in order to ensure
+// Prometheus metrics are structed as a Histogram, rather than as a Summary.
+// These values are loosely based on the initial Summary output, and may need to be
+// updated over time.
+pub const DEX_BUCKETS: &[f64; 5] = &[0.00001, 0.0001, 0.001, 0.01, 0.1];
+
+pub const DEX_PATH_SEARCH_DURATION: &str = "penumbra_dex_path_search_duration_seconds";
+pub const DEX_ROUTE_FILL_DURATION: &str = "penumbra_dex_route_fill_duration_seconds";
+pub const DEX_ARB_DURATION: &str = "penumbra_dex_arb_duration_seconds";
+pub const DEX_BATCH_DURATION: &str = "penumbra_dex_batch_duration_seconds";
+pub const DEX_SWAP_DURATION: &str = "penumbra_dex_swap_duration_seconds";

--- a/crates/core/component/dex/src/component/router/route_and_fill.rs
+++ b/crates/core/component/dex/src/component/router/route_and_fill.rs
@@ -149,6 +149,7 @@ pub trait RouteAndFill: StateWrite + Sized {
         // 1. We have no more delta_1 remaining
         // 2. A path can no longer be found
         // 3. We have reached the `RoutingParams` specified price limit
+
         loop {
             // Find the best route between the two assets in the trading pair.
             let (path, spill_price) = self


### PR DESCRIPTION
Shipping some new dex-related metrics. Care has been taken to ensure that we are emitting Histogram, rather than Summary, data types. More info:
    
* https://prometheus.io/docs/practices/histograms/
* https://docs.rs/metrics-exporter-prometheus/0.10.0/metrics_exporter_prometheus/struct.PrometheusBuilder.html#method.set_buckets
    
The buckets themselves were surely need to be tweaked, but for now, I'm eager to get these new metrics onto preview, and will follow up with some visualization work.
    
Refs #2788.

