### PR TITLE
feat(logging) include rust modules in log messages

### DIFF
--- a/crates/bin/pclientd/src/main.rs
+++ b/crates/bin/pclientd/src/main.rs
@@ -8,7 +8,7 @@ use pclientd::Opt;
 async fn main() -> Result<()> {
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_ansi(atty::is(atty::Stream::Stdout))
-        .with_target(false);
+        .with_target(true);
     let filter_layer = EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("info"))?;
     let registry = tracing_subscriber::registry()
         .with(filter_layer)

--- a/crates/bin/pd/src/info/oblivious.rs
+++ b/crates/bin/pd/src/info/oblivious.rs
@@ -68,7 +68,11 @@ impl ObliviousQueryService for Info {
         state
             .check_chain_id(&request.get_ref().chain_id)
             .await
-            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {e}")))?;
+            .map_err(|e| {
+                tonic::Status::unknown(format!(
+                    "failed to validate chain id during chain parameters lookup: {e}"
+                ))
+            })?;
 
         let chain_params = state.get_chain_params().await.map_err(|e| {
             tonic::Status::unavailable(format!("error getting chain parameters: {e}"))
@@ -131,7 +135,11 @@ impl ObliviousQueryService for Info {
         state
             .check_chain_id(&request.get_ref().chain_id)
             .await
-            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {e}")))?;
+            .map_err(|e| {
+                tonic::Status::unknown(format!(
+                    "failed to validate chain id during validator info request: {e}"
+                ))
+            })?;
 
         let validators = state
             .validator_list()
@@ -181,7 +189,11 @@ impl ObliviousQueryService for Info {
         snapshot
             .check_chain_id(&request.get_ref().chain_id)
             .await
-            .map_err(|e| tonic::Status::unknown(format!("chain_id not OK: {e}")))?;
+            .map_err(|e| {
+                tonic::Status::unknown(format!(
+                    "failed to validate chain id during compact_block_range request: {e}"
+                ))
+            })?;
 
         let CompactBlockRangeRequest {
             start_height,

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -196,11 +196,9 @@ async fn main() -> anyhow::Result<()> {
     // The `FmtLayer` is used to print to the console.
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_ansi(atty::is(atty::Stream::Stdout))
-        .with_target(false);
+        .with_target(true);
     // The `EnvFilter` layer is used to filter events based on `RUST_LOG`.
-    let filter_layer = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new("info"))
-        .unwrap();
+    let filter_layer = EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("info"))?;
 
     let opt = Opt::parse();
 

--- a/crates/core/component/chain/src/component/view.rs
+++ b/crates/core/component/chain/src/component/view.rs
@@ -82,7 +82,7 @@ pub trait StateReadExt: StateRead {
         let chain_id = self
             .get_chain_id()
             .await
-            .context(format!("error getting chain id: {provided}"))?;
+            .context(format!("error getting chain id: '{provided}'"))?;
         if provided.is_empty() || provided == chain_id {
             Ok(())
         } else {

--- a/crates/narsil/narsil/src/bin/narsild.rs
+++ b/crates/narsil/narsil/src/bin/narsild.rs
@@ -100,7 +100,7 @@ async fn main() -> anyhow::Result<()> {
     // The `FmtLayer` is used to print to the console.
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_ansi(atty::is(atty::Stream::Stdout))
-        .with_target(false);
+        .with_target(true);
     // The `EnvFilter` layer is used to filter events based on `RUST_LOG`.
     let filter_layer = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("info"))


### PR DESCRIPTION
Ensures that the binaries emit log messages showing which crate generated a specific message. Makes hunting down bugs a lot more straightforward. Also makes a few pd error messages a bit more precise.