### PR TITLE
ibc: pcli transaction withdraw: change source-channel to channel

### DIFF
--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -173,7 +173,7 @@ pub enum TxCmd {
     #[clap(display_order = 250)]
     Withdraw {
         /// Address on the receiving chain,
-        /// e.g. cosmos1grgelyng2v6v3t8z87wu3sxgt9m5s03xvslewd@cosmoshub-4
+        /// e.g. cosmos1grgelyng2v6v3t8z87wu3sxgt9m5s03xvslewd
         #[clap(long)]
         to: String,
 
@@ -183,7 +183,7 @@ pub enum TxCmd {
         /// This channel must already exist, as configured by a relayer client.
         /// You can search for channels via e.g. `pcli query ibc transfer channel-0`.
         #[clap(long)]
-        source_channel: String,
+        channel: String,
 
         #[clap(long, default_value = "0", display_order = 100)]
         timeout_height: u64,
@@ -812,7 +812,7 @@ impl TxCmd {
                 value,
                 timeout_height,
                 timeout_timestamp,
-                source_channel,
+                channel,
                 source,
             } => {
                 let destination_chain_address = to;
@@ -868,7 +868,7 @@ impl TxCmd {
                     timeout_height,
                     timeout_time: timeout_timestamp,
                     return_address: ephemeral_return_address,
-                    source_channel: ChannelId::from_str(source_channel)?,
+                    source_channel: ChannelId::from_str(channel)?,
                     source_port: PortId::from_str("transfer")?,
                 };
 

--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -162,14 +162,10 @@ pub enum TxCmd {
     Sweep,
 
     /// Perform an ICS-20 withdrawal, moving funds from the Penumbra chain
-    /// to a counterparty chain. Destination addresses must be specified as
-    /// 'address@chain-id`, where the `address` is of the appropriate format
-    /// the counterparty chain, and `chain-id` is the current identifier
-    /// for the counterparty chain.
+    /// to a counterparty chain.
     ///
-    /// For a withdrawal to succeed, relayer software must be configured to recognize
-    /// build paths between the two chains. Running a relayer is out of scope
-    /// for the pcli tool.
+    /// For a withdrawal to be processed on the counterparty, IBC packets must be relayed between
+    /// the two chains. Relaying is out of scope for the `pcli` tool.
     #[clap(display_order = 250)]
     Withdraw {
         /// Address on the receiving chain,

--- a/deployments/relayer/configs/penumbra-preview.json
+++ b/deployments/relayer/configs/penumbra-preview.json
@@ -2,7 +2,7 @@
   "type": "penumbra",
   "value": {
     "key": "default",
-    "chain-id": "penumbra-testnet-ganymede-5334ae2e",
+    "chain-id": "penumbra-testnet-ganymede-f721fd94",
     "rpc-addr": "https://rpc.testnet-preview.penumbra.zone:443",
     "account-prefix": "penumbrav2t",
     "keyring-backend": "test",


### PR DESCRIPTION
The `source` semantics isn't relevant to pcli UX, this seems better