### PR TITLE
spec: fix out of date note commitment docs, add closing parentheses

### DIFF
--- a/docs/protocol/src/protocol/action_descriptions/delegator_vote.md
+++ b/docs/protocol/src/protocol/action_descriptions/delegator_vote.md
@@ -38,7 +38,7 @@ The zk-SNARK also certifies that the commitment index of the start position is z
 
 The zk-SNARK certifies that the note commitment $cm$ was derived as:
 
-$cm = hash_5(ds, (rcm, v, ID, B_d, pk_d)$.
+$cm = hash_6(ds, (rcm, v, ID, B_d, pk_d, ck_d))$.
 
 using the above witnessed values and where `ds` is a constant domain separator:
 

--- a/docs/protocol/src/protocol/action_descriptions/outputs.md
+++ b/docs/protocol/src/protocol/action_descriptions/outputs.md
@@ -26,7 +26,7 @@ And the corresponding public inputs:
 
 The zk-SNARK certifies that the public input note commitment $cm$ was derived as:
 
-$cm = hash_5(ds, (rcm, v, ID, B_d, pk_d)$.
+$cm = hash_6(ds, (rcm, v, ID, B_d, pk_d, ck_d))$.
 
 using the above witnessed values and where `ds` is a constant domain separator:
 

--- a/docs/protocol/src/protocol/action_descriptions/spend.md
+++ b/docs/protocol/src/protocol/action_descriptions/spend.md
@@ -32,7 +32,7 @@ We require each one of the following integrity properties to hold only for notes
 
 The zk-SNARK certifies that for non-zero values $v \ne 0$, the note commitment $cm$ was derived as:
 
-$cm = hash_5(ds, (rcm, v, ID, B_d, pk_d)$.
+$cm = hash_6(ds, (rcm, v, ID, B_d, pk_d, ck_d))$.
 
 using the above witnessed values and where `ds` is a constant domain separator:
 

--- a/docs/protocol/src/protocol/action_descriptions/swap.md
+++ b/docs/protocol/src/protocol/action_descriptions/swap.md
@@ -30,7 +30,7 @@ The zk-SNARK certifies that the public input swap commitment $scm$ was derived a
 
 $scm_{inner} = hash_4(ds, (ID_1, ID_2, v_1, v_2))$
 
-$scm = hash_7(ds, (rseed, v_f, ID_{v_f}, B_d, pk_d, \mathsf{ck_d}, scm_{inner})$.
+$scm = hash_7(ds, (rseed, v_f, ID_{v_f}, B_d, pk_d, \mathsf{ck_d}, scm_{inner}))$.
 
 using the above witnessed values and where `ds` is a constant domain separator:
 

--- a/docs/protocol/src/protocol/action_descriptions/swap_claim.md
+++ b/docs/protocol/src/protocol/action_descriptions/swap_claim.md
@@ -44,7 +44,7 @@ The zk-SNARK certifies that the witnessed swap commitment $scm$ was derived as:
 
 $scm_{inner} = hash_4(ds, (ID_1, ID_2, \Delta_1, \Delta_2))$
 
-$scm = hash_7(ds, (rseed, v_f, G_{v_f}, B_d, pk_d, \mathsf{ck_d}, scm_{inner})$.
+$scm = hash_7(ds, (rseed, v_f, G_{v_f}, B_d, pk_d, \mathsf{ck_d}, scm_{inner}))$.
 
 using the above witnessed values and where `ds` is a constant domain separator:
 
@@ -102,9 +102,9 @@ using the correct batch swap output data.
 
 The zk-SNARK certifies that the note commitments $cm_1$ and $cm_2$ were derived as:
 
-$cm_1 = hash_5(ds, (rcm_1, \Lambda_{1i}, ID_1, B_d, pk_d)$
+$cm_1 = hash_6(ds, (rcm_1, \Lambda_{1i}, ID_1, B_d, pk_d, ck_d))$
 
-$cm_2 = hash_5(ds, (rcm_2, \Lambda_{2i}, ID_2, B_d, pk_d)$
+$cm_2 = hash_6(ds, (rcm_2, \Lambda_{2i}, ID_2, B_d, pk_d, ck_d))$
 
 using the above witnessed values and where `ds` is a constant domain separator:
 


### PR DESCRIPTION
Once we started adding the clue key as part of the note commitment, we forgot to update the documentation. This PR fixes that, as well as adds missing closing parentheses for the state commitments.