### PR TITLE
fix(pd): drop unused snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ tools/parameter-setup/Cargo.lock
 # Relayer config referencing local devnet, will always be unique
 # to current host env.
 deployments/relayer/configs/penumbra-local.json
+
+# Memory profiler, via bytehound or otherwise
+*.dat

--- a/crates/bin/pd/src/info/oblivious.rs
+++ b/crates/bin/pd/src/info/oblivious.rs
@@ -207,6 +207,9 @@ impl ObliviousQueryService for Info {
             .await
             .map_err(|e| tonic::Status::unavailable(format!("error getting block height: {e}")))?;
 
+        // Perform housekeeping, so long-lived connections don't cause pd to leak memory.
+        std::mem::drop(snapshot);
+
         // Treat end_height = 0 as end_height = current_height so that if the
         // end_height is unspecified in the proto, it will be treated as a
         // request to sync up to the current height.
@@ -262,7 +265,7 @@ impl ObliviousQueryService for Info {
                     let block = block_fetch
                         .await??
                         .expect("compact block for in-range height must be present");
-                    tx.send(Ok(block.to_proto())).await?;
+                    tx.send(Ok(block.into())).await?;
                     metrics::increment_counter!(
                         metrics::CLIENT_OBLIVIOUS_COMPACT_BLOCK_SERVED_TOTAL
                     );
@@ -292,11 +295,15 @@ impl ObliviousQueryService for Info {
                         .compact_block(height)
                         .await?
                         .expect("compact block for in-range height must be present");
-                    tx.send(Ok(block.to_proto())).await?;
+                    tx.send(Ok(block.into())).await?;
                     metrics::increment_counter!(
                         metrics::CLIENT_OBLIVIOUS_COMPACT_BLOCK_SERVED_TOTAL
                     );
                 }
+
+                // Ensure that we don't hold a reference to the snapshot indefinitely
+                // while we hold open the connection to notify the client of new blocks.
+                std::mem::drop(snapshot);
 
                 // Phase 2: wait on the height notifier and stream blocks as
                 // they're created.
@@ -312,7 +319,7 @@ impl ObliviousQueryService for Info {
                         .compact_block(height)
                         .await?
                         .expect("compact block for in-range height must be present");
-                    tx.send(Ok(block.to_proto())).await?;
+                    tx.send(Ok(block.into())).await?;
                     metrics::increment_counter!(
                         metrics::CLIENT_OBLIVIOUS_COMPACT_BLOCK_SERVED_TOTAL
                     );

--- a/deployments/scripts/pcli-client-sync
+++ b/deployments/scripts/pcli-client-sync
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Simulate a pcli client synchronizing with the network for the first time.
+# Invoke like so:
+#
+#     ./deployments/scripts/pcli-client-sync -n 1000 -p 50
+#
+# which will generate 1000 client identities, performing operations in batches of 50.
+set -euo pipefail
+
+# Use a temporary directory, so we don't clutter up the host with testing data.
+# There's a minor cost to regenerating the key material dynamically every time,
+# but the real blocker if the sync time, which is what we're testing.
+pcli_testdata_pardir="$(mktemp -d)"
+trap 'rm -r "$pcli_testdata_pardir"' EXIT
+
+# user-friendly help
+function usage() {
+    >&2 echo "Usage: $0 [opts]"
+    >&2 printf 'Options:\n'
+    >&2 printf '\t-n : number of pcli client accounts to generate\n'
+    >&2 printf '\t-p : maximum number of requests to run in parallel\n'
+}
+
+# parse opts
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n)
+            NUM_CLIENTS="$2"
+            shift 2
+            ;;
+        -p)
+            MAX_CONCURRENCY="$2"
+            shift 2
+            ;;
+        help)
+            usage
+            exit 0
+            ;;
+        -h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo >&2 "ERROR: Unsupported opt '$1'"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+cat <<EOF
+Running Penumbra pd load test,
+    simulating $NUM_CLIENTS pcli clients,
+    performing at most $MAX_CONCURRENCY sync operations concurrently.
+EOF
+
+
+# export RUST_LOG=pcli=debug
+
+# Generate penumbra keys. We do this in a separate loop so we can rerun
+# subsequent loadtests without regenerating.
+printf "Generating keys... "
+for n in $(seq "$NUM_CLIENTS"); do
+    printf '\rGenerating keys... %d/%d' "$n" "$NUM_CLIENTS"
+    client_dir="${pcli_testdata_pardir}/client${n}"
+    # block on max concurrency
+    # slick trick via https://stackoverflow.com/a/880864
+    while [ "$(jobs -p -r | wc -l)" -ge "$MAX_CONCURRENCY" ]; do
+        sleep 1
+    done
+    pcli -n http://localhost:8080 -d "$client_dir" keys generate > /dev/null &
+done
+wait
+
+printf '\rGenerating keys... %d/%d done!\n' "$n" "$NUM_CLIENTS"
+
+printf "Synchronizing clients..."
+for n in $(seq "$NUM_CLIENTS"); do
+    printf '\rSynchronizing clients... %d/%d' "$n" "$NUM_CLIENTS"
+    client_dir="${pcli_testdata_pardir}/client${n}"
+    pcli -n http://localhost:8080 -d "$client_dir" view sync > /dev/null 2>&1 &
+    # block on max concurrency
+    while [ "$(jobs -p -r | wc -l)" -ge "$MAX_CONCURRENCY" ]; do
+        sleep 1
+    done
+done
+wait
+
+printf '\rSynchronizing clients... %d/%d done!\n' "$n" "$NUM_CLIENTS"


### PR DESCRIPTION
Trying to resolve a memory leak in pd. These manual drops are a first pass, and appear to reduce memory consumption, but there's still a leak, according to bytehound. We'll continue to investigate.

Includes a missed `to_proto` that's a nice to have, but likely doesn't constitute a fix for our problem.

Refs https://github.com/penumbra-zone/penumbra/issues/2867.

Used this script to generate loadtests against a local pd instance, for memory profiling efforts. Steps I used to test:

    pd testnet unsafe-reset-all
    pd testnet join https://rpc.testnet-preview.penumbra.zone
    # start pd & tendermint, wait for genesis to complete
    ./deployments/scripts/pcli-client-test -n 1000 -p 100

Refs #2867.