### PR TITLE
build: update docs version strings during release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_testnet.md
+++ b/.github/ISSUE_TEMPLATE/release_testnet.md
@@ -40,7 +40,6 @@ Following Monday (release day):
 - [ ] Edit the newly created (and published) release object, then click "Generate release notes." Cut and paste the generated text from the bottom to the top of the post, then save it.
 - [ ] You must [manually review](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments) the `Waiting` deployment in the GitHub Action UI before the deployment will begin. Monitor the GitHub action to ensure it completes after it is approved.
 - [ ] Delegate to the Penumbra Labs CI validators; use amounts of ~200k `penumbra` per validator.
-- [ ] Update the User Guide to mention the newly created git tag.
 - [ ] Update Galileo deployment, [following docs](https://github.com/penumbra-zone/galileo).
 - [ ] Make GitHub release object and include the announcement
 - [ ] Make the announcement to Discord! 🎉🎉🎉

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -120,3 +120,11 @@ anyhow = "1"
 
 [package.metadata.dist]
 dist = true
+
+[package.metadata.release]
+# Update the guide docs to use the most recent version, to reduce tedium.
+# Preview the changes with `cargo release replace`.
+pre-release-replacements = [
+    { file="../../../docs/guide/src/pcli/install.md", search="(cd penumbra && git fetch && git checkout) .*", replace="$1 {{tag_name}}", exactly=1 },
+    { file="../../../docs/guide/src/pcli/update.md", search="(cd penumbra && git fetch && git checkout) .*", replace="$1 {{tag_name}}", exactly=1 },
+]


### PR DESCRIPTION
Now that we use `cargo-release` (#2384) we can automate the naive string substitutions for versions in the docs. This will remove precisely one checkbox from the release process checklist.