### PR TITLE
pd: use a range query for client synchronization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,6 +4674,7 @@ dependencies = [
  "blake2b_simd 0.5.11",
  "bytes",
  "decaf377-rdsa",
+ "futures",
  "metrics",
  "penumbra-chain",
  "penumbra-component",

--- a/crates/bin/pd/src/info/oblivious.rs
+++ b/crates/bin/pd/src/info/oblivious.rs
@@ -265,7 +265,7 @@ impl ObliviousQueryService for Info {
                     // Future iterations of this work should start by moving block serialization
                     // outside of the `send_op` future, and investigate if long blocking sends can
                     // happen for benign reasons (i.e not caused by the client).
-                    tx_blocks.send(Ok(block.into())).await?;
+                    tx_blocks.send(Ok(compact_block.into())).await?;
                     metrics::increment_counter!(
                         metrics::CLIENT_OBLIVIOUS_COMPACT_BLOCK_SERVED_TOTAL
                     );

--- a/crates/bin/pd/src/info/oblivious.rs
+++ b/crates/bin/pd/src/info/oblivious.rs
@@ -236,17 +236,8 @@ impl ObliviousQueryService for Info {
                     "catching up from start height to current end height"
                 );
 
-                // We need to send block responses in order, but fetching the
-                // compact block involves disk I/O, so we want to look ahead and
-                // start fetching compact blocks, rather than waiting for each
-                // state query to complete sequentially.
-                //
-                // To do this, we spawn a task that runs ahead and queues block
-                // fetches from the state.  Each block fetch is also spawned as
-                // a new task, so they execute independently, and those tasks'
-                // JoinHandles are sent back to this task using a bounded
-                // channel.  The channel bound prevents the queueing task from
-                // running too far ahead.
+                // We rely on a range query to fetch compact blocks in order and
+                // pipe them to the client sync stream.
                 let storage2 = storage.clone();
                 let latest_snapshot = storage2.latest_snapshot();
                 while let Some(compact_block) = latest_snapshot

--- a/crates/bin/pd/src/info/oblivious.rs
+++ b/crates/bin/pd/src/info/oblivious.rs
@@ -247,26 +247,21 @@ impl ObliviousQueryService for Info {
                 // JoinHandles are sent back to this task using a bounded
                 // channel.  The channel bound prevents the queueing task from
                 // running too far ahead.
-                let (tx_block_fetch, mut rx_block_fetch) = mpsc::channel(8);
-
                 let storage2 = storage.clone();
-                tokio::spawn(async move {
-                    for height in start_height..=end_height {
-                        let state3 = storage2.latest_snapshot();
-                        let _ = tx_block_fetch
-                            .send(tokio::spawn(
-                                async move { state3.compact_block(height).await },
-                            ))
-                            .await;
+                let latest_snapshot = storage2.latest_snapshot();
+                while let Some(compact_block) = latest_snapshot
+                    .stream_compact_block(start_height)
+                    .await
+                    .next()
+                    .await
+                {
+                    let compact_block = compact_block.map_err(|_| {
+                        tonic::Status::internal("error deserializing block from storage")
+                    })?;
+                    if compact_block.height > end_height {
+                        break;
                     }
-                });
 
-                while let Some(block_fetch) = rx_block_fetch.recv().await {
-                    let block = block_fetch
-                        .await
-                        .expect("block fetcher does not fail")
-                        .expect("no error fetching block")
-                        .expect("compact block for in-range height must be present");
                     // Tracked in #2908: we previously added a timeout on `send` targeting
                     // buffered streams staying full for too long. However, in at least a few
                     // "regular usage" instances we observed client streams stopping too eagerly.
@@ -279,27 +274,6 @@ impl ObliviousQueryService for Info {
                     // Future iterations of this work should start by moving block serialization
                     // outside of the `send_op` future, and investigate if long blocking sends can
                     // happen for benign reasons (i.e not caused by the client).
-                    //
-                    // let send_op = async { tx_blocks.send(Ok(block.into())).await };
-                    // match tokio::time::timeout(tokio::time::Duration::from_secs(2), send_op).await {
-                    //     Ok(Ok(_)) => {
-                    //         metrics::increment_counter!(
-                    //             metrics::CLIENT_OBLIVIOUS_COMPACT_BLOCK_SERVED_TOTAL
-                    //         );
-                    //     }
-                    //     Ok(Err(_)) => {
-                    //         return Err(tonic::Status::internal("error while sending block"));
-                    //     }
-                    //     Err(_) => {
-                    //         tracing::debug!(
-                    //             "client did not poll compact block stream for 1s, timing out"
-                    //         );
-                    //         return Err(tonic::Status::deadline_exceeded(
-                    //             "timeout while sending block",
-                    //         ));
-                    //     }
-                    // }
-
                     tx_blocks.send(Ok(block.into())).await?;
                     metrics::increment_counter!(
                         metrics::CLIENT_OBLIVIOUS_COMPACT_BLOCK_SERVED_TOTAL

--- a/crates/core/component/compact-block/Cargo.toml
+++ b/crates/core/component/compact-block/Cargo.toml
@@ -37,5 +37,5 @@ blake2b_simd = "0.5"
 bytes = "1"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand = "0.8"
-
+futures = "0.3.28"
 

--- a/crates/core/component/compact-block/src/component/view.rs
+++ b/crates/core/component/compact-block/src/component/view.rs
@@ -1,4 +1,3 @@
-use crate::state_key::state_key::compact_block;
 use crate::{state_key, CompactBlock};
 use anyhow::Context;
 use anyhow::Error;
@@ -19,18 +18,17 @@ pub trait StateReadExt: StateRead {
         start_height: u64,
     ) -> Pin<Box<dyn Stream<Item = Result<CompactBlock>> + Send + 'static>> {
         self.nonverifiable_range_raw(
-            Some(compact_block::prefix()),
-            compact_block::key_component(start_height).as_bytes()..,
-        );
-        self.nonverifiable_prefix_raw(&state_key::compact_block(start_height).as_bytes())
-            .map(|result| {
-                result.and_then(|(_, v)| {
-                    CompactBlock::decode(&mut v.as_slice())
-                        .map_err(Error::from)
-                        .context("failed to decode compact block")
-                })
+            Some(state_key::prefix().as_bytes()),
+            state_key::height(start_height).as_bytes()..,
+        )
+        .map(|result| {
+            result.and_then(|(_, v)| {
+                CompactBlock::decode(&mut v.as_slice())
+                    .map_err(Error::from)
+                    .context("failed to decode compact block")
             })
-            .boxed()
+        })
+        .boxed()
     }
 
     async fn compact_block(&self, height: u64) -> Result<Option<CompactBlock>> {

--- a/crates/core/component/compact-block/src/component/view.rs
+++ b/crates/core/component/compact-block/src/component/view.rs
@@ -19,8 +19,9 @@ pub trait StateReadExt: StateRead {
     ) -> Pin<Box<dyn Stream<Item = Result<CompactBlock>> + Send + 'static>> {
         self.nonverifiable_range_raw(
             Some(state_key::prefix().as_bytes()),
-            state_key::height(start_height).as_bytes()..,
+            state_key::height(start_height).as_bytes().to_vec()..,
         )
+        .expect("valid range is provided")
         .map(|result| {
             result.and_then(|(_, v)| {
                 CompactBlock::decode(&mut v.as_slice())

--- a/crates/core/component/compact-block/src/component/view.rs
+++ b/crates/core/component/compact-block/src/component/view.rs
@@ -11,9 +11,8 @@ use std::pin::Pin;
 
 #[async_trait]
 pub trait StateReadExt: StateRead {
-    /// Returns a stream of [`CompactBlock`]s starting from `start_height`.A
-    /// If `start_height` is not found, the stream will be empty.
-    async fn stream_compact_block(
+    /// Returns a stream of [`CompactBlock`]s starting from `start_height`.
+    fn stream_compact_block(
         &self,
         start_height: u64,
     ) -> Pin<Box<dyn Stream<Item = Result<CompactBlock>> + Send + 'static>> {

--- a/crates/core/component/compact-block/src/component/view.rs
+++ b/crates/core/component/compact-block/src/component/view.rs
@@ -1,3 +1,4 @@
+use crate::state_key::state_key::compact_block;
 use crate::{state_key, CompactBlock};
 use anyhow::Context;
 use anyhow::Error;
@@ -17,6 +18,10 @@ pub trait StateReadExt: StateRead {
         &self,
         start_height: u64,
     ) -> Pin<Box<dyn Stream<Item = Result<CompactBlock>> + Send + 'static>> {
+        self.nonverifiable_range_raw(
+            Some(compact_block::prefix()),
+            compact_block::key_component(start_height).as_bytes()..,
+        );
         self.nonverifiable_prefix_raw(&state_key::compact_block(start_height).as_bytes())
             .map(|result| {
                 result.and_then(|(_, v)| {

--- a/crates/core/component/compact-block/src/state_key.rs
+++ b/crates/core/component/compact-block/src/state_key.rs
@@ -1,5 +1,9 @@
 pub fn compact_block(height: u64) -> String {
-    format!("compactblock/{height:020}")
+    format!(
+        "{}{}",
+        crate::state_key::prefix(),
+        crate::state_key::height(height)
+    )
 }
 pub fn prefix() -> &'static str {
     "compactblock/"

--- a/crates/core/component/compact-block/src/state_key.rs
+++ b/crates/core/component/compact-block/src/state_key.rs
@@ -1,3 +1,12 @@
-pub fn compact_block(height: u64) -> String {
-    format!("compactblock/{height:020}")
+pub mod state_key {
+    pub fn compact_block(height: u64) -> String {
+        format!("compactblock/{height:020}")
+    }
+    pub fn prefix() -> &'static str {
+        "compactblock/"
+    }
+
+    pub fn key_component(height: u64) -> String {
+        format!("{height:020}", height)
+    }
 }

--- a/crates/core/component/compact-block/src/state_key.rs
+++ b/crates/core/component/compact-block/src/state_key.rs
@@ -1,12 +1,10 @@
-pub mod state_key {
-    pub fn compact_block(height: u64) -> String {
-        format!("compactblock/{height:020}")
-    }
-    pub fn prefix() -> &'static str {
-        "compactblock/"
-    }
+pub fn compact_block(height: u64) -> String {
+    format!("compactblock/{height:020}")
+}
+pub fn prefix() -> &'static str {
+    "compactblock/"
+}
 
-    pub fn key_component(height: u64) -> String {
-        format!("{height:020}", height)
-    }
+pub fn height(height: u64) -> String {
+    format!("{height:020}")
 }


### PR DESCRIPTION
This PR:
- implements a `stream_compact_block` method to `compact_block::StateReadExt` 
- remove the `block_fetcher` tokio tasks in `ObliviousQueryService::compact_block_range`
- use a single range query to catch-up on existing `CompactBlock`s