### PR TITLE
ci: use buildjet cache for less flakiness

### DIFF
--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@nightly
       - name: Load Rust caching
-        uses: Swatinem/rust-cache@v2
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
       - name: Load get-version action to grab version component of deployment path
         uses: battila7/get-version-action@v2
         id: get_version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Load rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
       - name: Run tests with nextest
         run: cargo nextest run --release
         env:
@@ -30,7 +30,7 @@ jobs:
         with:
           components: rustfmt
       - name: Load rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
       - run: cargo fmt --all -- --check
 
   check:
@@ -43,7 +43,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Load rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
       - name: Run cargo check, failing on warnings
         run: cargo check --release
         env:
@@ -65,7 +65,7 @@ jobs:
         # The script for rustdoc build requires nightly toolchain.
         uses: dtolnay/rust-toolchain@nightly
       - name: Load rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
       - name: Build rustdocs
         run: ./deployments/scripts/rust-docs
 
@@ -82,7 +82,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Load rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
 
       - name: build wasm32 target
         run: cargo build --release --target wasm32-unknown-unknown

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -21,7 +21,7 @@ jobs:
           profile: minimal
           toolchain: stable
       - name: Load rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
 
       - name: Install tendermint binary
         run: |


### PR DESCRIPTION
Astria recently started using buildjet runners and ran into caching flakiness with the reliance on github cache, as alluded to [here](https://buildjet.com/for-github-actions/blog/launch-buildjet-cache#the-buildjet-cache-action). Created a fork of the rust cache that is built on top of `buildjet/cache` instead of `action/cache`, it's otherwise identical.

Figured I'd give you all the option to adopt, since I was inspired to use buildjet to speed up our builds by you.