### PR TITLE
spec: fix typo in hash to group documentation

### DIFF
--- a/docs/protocol/src/crypto/decaf377/group_hash.md
+++ b/docs/protocol/src/crypto/decaf377/group_hash.md
@@ -14,7 +14,7 @@ The Elligator map is applied as follows to a field element $r_0$:
 
 4. $m, x =$ `sqrt_ratio_zeta`$(1, u_1 n_1)$ where $m$ is a boolean indicating whether or not a square root exists for the provided input.
 
-5. If a square root for $u_1 n_1$ does not exist, then $q=-1$ and $x = r_0 \zeta x$. Else, $q=1$ and $x$ is unchanged.
+5. If a square root for $u_1 n_1$ does not exist, then $q=-1$ and $x = r_0 x$. Else, $q=1$ and $x$ is unchanged.
 
 6. $s \gets x n_1$.
 


### PR DESCRIPTION
This fixes a small typo in our documentation for decaf377 hash-to-group