### PR TITLE
storage: implement `StateRead::nonverifiable_range`

### DIFF
--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -9,7 +9,7 @@ use crate::{
         CacheFuture, StateDeltaNonconsensusPrefixRawStream, StateDeltaNonconsensusRangeRawStream,
         StateDeltaPrefixKeysStream, StateDeltaPrefixRawStream,
     },
-    Cache, EscapedByteSlice, StateRead, StateWrite,
+    utils, Cache, EscapedByteSlice, StateRead, StateWrite,
 };
 
 /// An arbitrarily-deeply nested stack of delta updates to an underlying state.
@@ -376,19 +376,18 @@ impl<S: StateRead> StateRead for StateDelta<S> {
         }
     }
 
-    fn nonverifiable_range(
+    fn nonverifiable_range_raw(
         &self,
         prefix: Option<&[u8]>,
         range: impl std::ops::RangeBounds<Vec<u8>>,
     ) -> anyhow::Result<Self::NonconsensusRangeRawStream> {
-        let (range, start, end) = crate::convert_bounds(range);
-
+        let (range, (start, end)) = utils::convert_bounds(range)?;
         let underlying = self
             .state
             .read()
             .as_ref()
             .expect("delta must not have been applied")
-            .nonverifiable_range(prefix, range)?
+            .nonverifiable_range_raw(prefix, range)?
             .peekable();
         Ok(StateDeltaNonconsensusRangeRawStream {
             underlying,

--- a/crates/storage/src/future.rs
+++ b/crates/storage/src/future.rs
@@ -560,3 +560,172 @@ where
         }
     }
 }
+
+/// This implementation is a work-in-progress:
+/// MERGEBLOCK(erwan): detail how this implementation difers from
+/// `StateDeltaNonconsensusPrefixRawStream`.
+#[pin_project]
+pub struct StateDeltaNonconsensusRangeRawStream<St>
+where
+    St: Stream<Item = Result<(Vec<u8>, Vec<u8>)>>,
+{
+    #[pin]
+    pub(crate) underlying: Peekable<St>,
+    pub(crate) layers: Vec<Arc<RwLock<Option<Cache>>>>,
+    pub(crate) leaf_cache: Arc<RwLock<Option<Cache>>>,
+    pub(crate) last_key: Option<Vec<u8>>,
+    pub(crate) prefix: Option<Vec<u8>>,
+    pub(crate) range: (Option<Vec<u8>>, Option<Vec<u8>>),
+}
+
+impl<St> Stream for StateDeltaNonconsensusRangeRawStream<St>
+where
+    St: Stream<Item = Result<(Vec<u8>, Vec<u8>)>>,
+{
+    type Item = Result<(Vec<u8>, Vec<u8>)>;
+
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // This implementation interleaves items from the underlying stream with
+        // items in cache layers.  To do this, it tracks the last key it
+        // returned, then, for each item in the underlying stream, searches for
+        // cached keys that lie between the last-returned key and the item's key,
+        // checking whether the cached key represents a deletion requiring further
+        // scanning.  This process is illustrated as follows:
+        //
+        //         ◇ skip                 ◇ skip           ▲ yield          ▲ yield           ▲ yield
+        //         │                      │                │                │                 │
+        //         ░ pick ──────────────▶ ░ pick ────────▶ █ pick ────────▶ █ pick ─────────▶ █ pick
+        //         ▲                      ▲                ▲                ▲                 ▲
+        //      ▲  │                 ▲    │          ▲     │         ▲      │        ▲        │
+        // write│  │                 │    │          │     │         │      │        │        │
+        // layer│  │   █             │    │ █        │     │█        │      █        │      █ │
+        //      │  │ ░               │    ░          │    ░│         │    ░          │    ░   │
+        //      │  ░                 │  ░            │  ░  │         │  ░            │  ░     │
+        //      │    █               │    █          │    █│         │    █          │    █   │
+        //      │  █     █           │  █     █      │  █  │  █      │  █     █      │  █     █
+        //      │     █              │     █         │     █         │     █         │     █
+        //     ─┼(─────]────keys─▶  ─┼──(───]────▶  ─┼────(─]────▶  ─┼─────(]────▶  ─┼──────(──]─▶
+        //      │   ▲  █  █          │      █  █     │      █  █     │      █  █     │      █  █
+        //          │
+        //          │search range of key-value pairs in cache layers that could
+        //          │affect whether to yield the next item in the underlying stream
+
+        /*
+        // Optimization: ensure we have a peekable item in the underlying stream before continuing.
+        let mut this = self.project();
+        ready!(this.underlying.as_mut().poll_peek(cx));
+        // Now that we're ready to interleave the next underlying item with any
+        // cache layers, lock them all for the duration of the method, using a
+        // SmallVec to (hopefully) store all the guards on the stack.
+        let mut layer_guards = SmallVec::<[_; 8]>::new();
+        for layer in this.layers.iter() {
+            layer_guards.push(layer.read());
+        }
+        // Tacking the leaf cache onto the list is important to not miss any values.
+        // It's stored separately so that the contents of the
+        layer_guards.push(this.leaf_cache.read());
+
+        loop {
+            // Obtain a reference to the next key-value pair from the underlying stream.
+            let peeked = match ready!(this.underlying.as_mut().poll_peek(cx)) {
+                // If we get an underlying error, bubble it up immediately.
+                Some(Err(_e)) => return this.underlying.poll_next(cx),
+                // Otherwise, pass through the peeked value.
+                Some(Ok(pair)) => Some(pair),
+                None => None,
+            };
+
+            // To determine whether or not we should return the peeked value, we
+            // need to search the cache layers for keys that are between the last
+            // key we returned (exclusive, so we make forward progress on the
+            // stream) and the peeked key (inclusive, because we need to find out
+            // whether or not there was a covering deletion).
+            let search_range = (
+                this.last_key
+                    .as_ref()
+                    .map(Bound::Excluded)
+                    .unwrap_or(Bound::Included(this.prefix)),
+                peeked
+                    .map(|(k, _)| Bound::Included(k))
+                    .unwrap_or(Bound::Unbounded),
+            );
+
+            // It'd be slightly cleaner to initialize `leftmost_pair` with the
+            // peeked contents, but that would taint `leftmost_pair` with a
+            // `peeked` borrow, and we may need to mutate the underlying stream
+            // later.  Instead, initialize it with `None` to only search the
+            // cache layers, and compare at the end.
+            let mut leftmost_pair = None;
+            for layer in layer_guards.iter() {
+                // Find this layer's leftmost key-value pair in the search range.
+                let found_pair = layer
+                    .as_ref()
+                    .unwrap()
+                    .nonverifiable_changes
+                    .range::<Vec<u8>, _>(search_range)
+                    .take_while(|(k, _v)| k.starts_with(this.prefix))
+                    .next();
+
+                // Check whether the new pair, if any, is the new leftmost pair.
+                match (leftmost_pair, found_pair) {
+                    // We want to replace the pair even when the key is equal,
+                    // so that we always prefer a newer value over an older value.
+                    (Some((leftmost_k, _)), Some((k, v))) if k <= leftmost_k => {
+                        leftmost_pair = Some((k, v));
+                    }
+                    (None, Some((k, v))) => {
+                        leftmost_pair = Some((k, v));
+                    }
+                    _ => {}
+                }
+            }
+
+            // Overwrite a Vec, attempting to reuse its existing allocation.
+            let overwrite_in_place = |dst: &mut Option<Vec<u8>>, src: &[u8]| {
+                if let Some(ref mut dst) = dst {
+                    dst.clear();
+                    dst.extend_from_slice(src);
+                } else {
+                    *dst = Some(src.to_vec());
+                }
+            };
+
+            match (leftmost_pair, peeked) {
+                (Some((k, v)), peeked) => {
+                    // Since we searched for cached keys less than or equal to
+                    // the peeked key, we know that the cached pair takes
+                    // priority over the peeked pair.
+                    //
+                    // If the keys are exactly equal, we advance the underlying stream.
+                    if peeked.map(|(kp, _)| kp) == Some(k) {
+                        let _ = this.underlying.as_mut().poll_next(cx);
+                    }
+                    overwrite_in_place(this.last_key, k);
+                    if let Some(v) = v {
+                        // If the value is Some, we have a key-value pair to yield.
+                        return Poll::Ready(Some(Ok((k.clone(), v.clone()))));
+                    } else {
+                        // If the value is None, this pair represents a deletion,
+                        // so continue looping until we find a non-deleted pair.
+                        continue;
+                    }
+                }
+                (None, Some(_)) => {
+                    // There's no cache hit before the peeked pair, so we want
+                    // to extract and return it from the underlying stream.
+                    let Poll::Ready(Some(Ok((k, v)))) = this.underlying.as_mut().poll_next(cx) else {
+                        unreachable!("peeked stream must yield peeked item");
+                    };
+                    overwrite_in_place(this.last_key, &k);
+                    return Poll::Ready(Some(Ok((k, v))));
+                }
+                (None, None) => {
+                    // Terminate the stream, no more items are available.
+                    return Poll::Ready(None);
+                }
+            }
+        }
+        */
+        todo!()
+    }
+}

--- a/crates/storage/src/future.rs
+++ b/crates/storage/src/future.rs
@@ -584,7 +584,7 @@ where
 {
     type Item = Result<(Vec<u8>, Vec<u8>)>;
 
-    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // This implementation interleaves items from the underlying stream with
         // items in cache layers.  To do this, it tracks the last key it
         // returned, then, for each item in the underlying stream, searches for
@@ -610,7 +610,6 @@ where
         //          │search range of key-value pairs in cache layers that could
         //          │affect whether to yield the next item in the underlying stream
 
-        /*
         // Optimization: ensure we have a peekable item in the underlying stream before continuing.
         let mut this = self.project();
         ready!(this.underlying.as_mut().poll_peek(cx));
@@ -725,7 +724,5 @@ where
                 }
             }
         }
-        */
-        todo!()
     }
 }

--- a/crates/storage/src/future.rs
+++ b/crates/storage/src/future.rs
@@ -561,10 +561,10 @@ where
     }
 }
 
-/// This implementation is a work-in-progress:
-/// MERGEBLOCK(erwan): detail how this implementation difers from
-/// `StateDeltaNonconsensusPrefixRawStream`.
 #[pin_project]
+/// A stream of key-value pairs that interleaves a nonverifiable storage and caching layers.
+// This implementation differs from [`StateDeltaNonconsensusPrefixRawStream`] sin how
+// it specifies the search space for the cache.
 pub struct StateDeltaNonconsensusRangeRawStream<St>
 where
     St: Stream<Item = Result<(Vec<u8>, Vec<u8>)>>,

--- a/crates/storage/src/future.rs
+++ b/crates/storage/src/future.rs
@@ -624,21 +624,18 @@ where
         // It's stored separately so that the contents of the
         layer_guards.push(this.leaf_cache.read());
 
-        let prefix = this.prefix.clone().unwrap_or_default();
-        let start = this.range.0.clone().unwrap_or_default();
-        let end = this.range.1.clone().unwrap_or_default();
+        let (binding_prefix, binding_start, binding_end) = (Vec::new(), Vec::new(), Vec::new());
+        let prefix = this.prefix.as_ref().unwrap_or(&binding_prefix);
+        let start = this.range.0.as_ref().unwrap_or(&binding_start);
+        let end = this.range.1.as_ref().unwrap_or(&binding_end);
 
-        let prefix_start = {
-            let mut prefix_start = prefix.clone();
-            prefix_start.extend_from_slice(&start);
-            prefix_start
-        };
+        let mut prefix_start = Vec::with_capacity(prefix.len() + start.len());
+        let mut prefix_end = Vec::with_capacity(prefix.len() + end.len());
 
-        let prefix_end = {
-            let mut prefix_end = prefix.clone();
-            prefix_end.extend_from_slice(&end);
-            prefix_end
-        };
+        prefix_start.extend(prefix);
+        prefix_start.extend(start);
+        prefix_end.extend(prefix);
+        prefix_end.extend(end);
 
         loop {
             // Obtain a reference to the next key-value pair from the underlying stream.

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -59,3 +59,26 @@ pub use storage::{Storage, TempStorage};
 pub use write::StateWrite;
 
 pub mod future;
+
+// MERGEBLOCK(erwan): move this somewhere more appropriate
+fn convert_bounds(
+    range: impl std::ops::RangeBounds<Vec<u8>>,
+) -> (
+    impl std::ops::RangeBounds<Vec<u8>>,
+    Option<Vec<u8>>,
+    Option<Vec<u8>>,
+) {
+    let start = match range.start_bound() {
+        std::ops::Bound::Included(v) => Some(v.clone()),
+        std::ops::Bound::Excluded(v) => Some(v.clone()),
+        std::ops::Bound::Unbounded => None,
+    };
+
+    let end = match range.end_bound() {
+        std::ops::Bound::Included(v) => Some(v.clone()),
+        std::ops::Bound::Excluded(v) => Some(v.clone()),
+        std::ops::Bound::Unbounded => None,
+    };
+
+    (range, start, end)
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -46,6 +46,7 @@ mod snapshot_cache;
 mod storage;
 #[cfg(test)]
 mod tests;
+mod utils;
 mod write;
 
 pub use crate::metrics::register_metrics;
@@ -59,26 +60,3 @@ pub use storage::{Storage, TempStorage};
 pub use write::StateWrite;
 
 pub mod future;
-
-// MERGEBLOCK(erwan): move this somewhere more appropriate
-fn convert_bounds(
-    range: impl std::ops::RangeBounds<Vec<u8>>,
-) -> (
-    impl std::ops::RangeBounds<Vec<u8>>,
-    Option<Vec<u8>>,
-    Option<Vec<u8>>,
-) {
-    let start = match range.start_bound() {
-        std::ops::Bound::Included(v) => Some(v.clone()),
-        std::ops::Bound::Excluded(v) => Some(v.clone()),
-        std::ops::Bound::Unbounded => None,
-    };
-
-    let end = match range.end_bound() {
-        std::ops::Bound::Included(v) => Some(v.clone()),
-        std::ops::Bound::Excluded(v) => Some(v.clone()),
-        std::ops::Bound::Unbounded => None,
-    };
-
-    (range, start, end)
-}

--- a/crates/storage/src/read.rs
+++ b/crates/storage/src/read.rs
@@ -61,7 +61,7 @@ pub trait StateRead: Send + Sync {
     /// This method does not support inclusive ranges, and will return an error if passed one.
     ///
     /// Users should generally prefer to use wrapper methods in an extension trait.
-    fn nonverifiable_range(
+    fn nonverifiable_range_raw(
         &self,
         prefix: Option<&[u8]>,
         range: impl RangeBounds<Vec<u8>>,
@@ -91,12 +91,12 @@ impl<'a, S: StateRead + Send + Sync> StateRead for &'a S {
         (**self).nonverifiable_prefix_raw(prefix)
     }
 
-    fn nonverifiable_range(
+    fn nonverifiable_range_raw(
         &self,
         prefix: Option<&[u8]>,
-        range: impl RangeBounds<Vec<u8>>,
-    ) -> Result<S::NonconsensusRangeRawStream> {
-        (**self).nonverifiable_range(prefix, range)
+        range: impl std::ops::RangeBounds<Vec<u8>>,
+    ) -> anyhow::Result<Self::NonconsensusRangeRawStream> {
+        (**self).nonverifiable_range_raw(prefix, range)
     }
 
     fn nonverifiable_get_raw(&self, key: &[u8]) -> Self::GetRawFut {
@@ -135,12 +135,12 @@ impl<'a, S: StateRead + Send + Sync> StateRead for &'a mut S {
         (**self).nonverifiable_prefix_raw(prefix)
     }
 
-    fn nonverifiable_range(
+    fn nonverifiable_range_raw(
         &self,
         prefix: Option<&[u8]>,
         range: impl RangeBounds<Vec<u8>>,
     ) -> Result<S::NonconsensusRangeRawStream> {
-        (**self).nonverifiable_range(prefix, range)
+        (**self).nonverifiable_range_raw(prefix, range)
     }
 
     fn nonverifiable_get_raw(&self, key: &[u8]) -> Self::GetRawFut {
@@ -179,12 +179,12 @@ impl<S: StateRead + Send + Sync> StateRead for Arc<S> {
         (**self).nonverifiable_prefix_raw(prefix)
     }
 
-    fn nonverifiable_range(
+    fn nonverifiable_range_raw(
         &self,
         prefix: Option<&[u8]>,
         range: impl RangeBounds<Vec<u8>>,
     ) -> Result<Self::NonconsensusRangeRawStream> {
-        (**self).nonverifiable_range(prefix, range)
+        (**self).nonverifiable_range_raw(prefix, range)
     }
 
     fn nonverifiable_get_raw(&self, key: &[u8]) -> Self::GetRawFut {
@@ -237,7 +237,7 @@ impl StateRead for () {
         futures::stream::iter(std::iter::empty())
     }
 
-    fn nonverifiable_range(
+    fn nonverifiable_range_raw(
         &self,
         _prefix: Option<&[u8]>,
         _range: impl RangeBounds<Vec<u8>>,

--- a/crates/storage/src/snapshot.rs
+++ b/crates/storage/src/snapshot.rs
@@ -321,21 +321,6 @@ impl StateRead for Snapshot {
         tokio_stream::wrappers::ReceiverStream::new(rx)
     }
 
-    /*
-
-    ALT:
-
-        fn nonverifiable_range_raw<T, U>(
-        &self,
-        prefix: Option<&[u8]>,
-        range: T,
-    ) -> anyhow::Result<Self::NonconsensusRangeRawStream>
-    where
-        T: std::ops::RangeBounds<U>,
-        U: Into<Vec<u8>>,
-    {
-
-         */
     fn nonverifiable_range_raw(
         &self,
         prefix: Option<&[u8]>,

--- a/crates/storage/src/snapshot.rs
+++ b/crates/storage/src/snapshot.rs
@@ -349,44 +349,42 @@ impl StateRead for Snapshot {
         let prefix = prefix.unwrap_or_default();
 
         let (start, end) = (start.unwrap_or_default(), end.unwrap_or_default());
+        let end_is_empty = end.is_empty();
 
-        let prefixed_start = {
-            let mut prefixed_start = prefix.to_vec();
-            prefixed_start.extend_from_slice(&start);
-            prefixed_start
-        };
+        let mut prefix_start = Vec::with_capacity(prefix.len() + start.len());
+        let mut prefix_end = Vec::with_capacity(prefix.len() + end.len());
 
-        let prefixed_end = {
-            let mut prefixed_end = prefix.to_vec();
-            prefixed_end.extend_from_slice(&end);
-            prefixed_end
-        };
+        prefix_start.extend(prefix);
+        prefix_start.extend(start);
+        prefix_end.extend(prefix);
+        prefix_end.extend(end);
 
         tracing::debug!(
-            ?prefixed_start,
-            ?prefixed_end,
+            ?prefix_start,
+            ?prefix_end,
             ?prefix,
             "nonverifiable_range_raw"
         );
 
-        options.set_iterate_lower_bound(prefixed_start);
+        options.set_iterate_lower_bound(prefix_start);
 
-        // In the current implementation, range queries only go forward,
-        // so if the upper key is unbounded, we don't set specify it in the
-        // iterator options even if a prefix is specified. Here's an example:
+        // Our range queries implementation relies on forward iteration, which
+        // means that if the upper key is unbounded and a prefix has been set
+        // we cannot set the upper bound to the prefix. This is because the
+        // prefix is used as a lower bound for the iterator, and the upper bound
+        // is used to stop the iteration.
+        // If we set the upper bound to the prefix, we would get a range consisting of:
         // ```
-        //      prefix: "compactblock/"
-        //      start: 001
-        //      end: unbounded
+        // "compactblock/001" to "compactblock/"
         // ```
-        // If we set the upper bound to the prefix, we would get a range consisting
-        // of: "compactblock/001" to "compactblock/" which would not return anything.
-        if !end.is_empty() {
-            options.set_iterate_upper_bound(prefixed_end);
+        // which would not return anything.
+        if !end_is_empty {
+            options.set_iterate_upper_bound(prefix_end);
         }
 
         let mode = rocksdb::IteratorMode::Start;
         let (tx, rx) = mpsc::channel::<Result<(Vec<u8>, Vec<u8>)>>(10);
+        let prefix = prefix.to_vec();
 
         tokio::task::Builder::new()
             .name("Snapshot::nonverifiable_range_raw")
@@ -400,6 +398,14 @@ impl StateRead for Snapshot {
                     let iter = self2.0.snapshot.iterator_cf_opt(keys_cf, options, mode);
                     for i in iter {
                         let (key, value) = i?;
+
+                        // This is a bit of a hack, but RocksDB doesn't let us express the "prefixed range-queries",
+                        // that we want to support. In particular, we want to be able to do a prefix query that starts
+                        // at a particular key, and does not have an upper bound. Since we can't create an iterator that
+                        // cover this range, we have to filter out the keys that don't match the prefix.
+                        if !prefix.is_empty() && !key.starts_with(&prefix) {
+                            break;
+                        }
                         tx.blocking_send(Ok((key.into(), value.into())))?;
                     }
                     Ok::<(), anyhow::Error>(())

--- a/crates/storage/src/snapshot.rs
+++ b/crates/storage/src/snapshot.rs
@@ -145,6 +145,8 @@ impl StateRead for Snapshot {
     type PrefixKeysStream = tokio_stream::wrappers::ReceiverStream<anyhow::Result<String>>;
     type NonconsensusPrefixRawStream =
         tokio_stream::wrappers::ReceiverStream<anyhow::Result<(Vec<u8>, Vec<u8>)>>;
+    type NonconsensusRangeRawStream =
+        tokio_stream::wrappers::ReceiverStream<anyhow::Result<(Vec<u8>, Vec<u8>)>>;
 
     /// Fetch a key from the JMT column family.
     fn get_raw(&self, key: &str) -> Self::GetRawFut {
@@ -317,6 +319,47 @@ impl StateRead for Snapshot {
             .expect("should be able to spawn_blocking");
 
         tokio_stream::wrappers::ReceiverStream::new(rx)
+    }
+
+    fn nonverifiable_range(
+        &self,
+        _prefix: Option<&[u8]>,
+        _range: impl std::ops::RangeBounds<Vec<u8>>,
+    ) -> anyhow::Result<Self::NonconsensusRangeRawStream> {
+        let _span = Span::current();
+        /*
+        let self2 = self.clone();
+
+        let mut options = rocksdb::ReadOptions::default();
+        options.set_iterate_range(rocksdb::PrefixRange(prefix));
+        let mode = rocksdb::IteratorMode::Start;
+
+        let (tx, rx) = mpsc::channel(10);
+
+        // Here we're operating on the nonverifiable data, which is a raw k/v store,
+        // so we just iterate over the keys.
+        tokio::task::Builder::new()
+            .name("Snapshot::nonverifiable_prefix_raw")
+            .spawn_blocking(move || {
+                span.in_scope(|| {
+                    let keys_cf = self2
+                        .0
+                        .db
+                        .cf_handle("nonverifiable")
+                        .expect("nonverifiable column family not found");
+                    let iter = self2.0.snapshot.iterator_cf_opt(keys_cf, options, mode);
+                    for i in iter {
+                        let (key, value) = i?;
+                        tx.blocking_send(Ok((key.into(), value.into())))?;
+                    }
+                    Ok::<(), anyhow::Error>(())
+                })
+            })
+            .expect("should be able to spawn_blocking");
+
+        tokio_stream::wrappers::ReceiverStream::new(rx)
+        */
+        todo!()
     }
 
     fn object_get<T: Any + Send + Sync + Clone>(&self, _key: &str) -> Option<T> {

--- a/crates/storage/src/utils.rs
+++ b/crates/storage/src/utils.rs
@@ -1,0 +1,33 @@
+use anyhow::bail;
+/// Splits a range into a tuple of start and end bounds, ignoring the inclusive/exclusive
+/// nature of the range bounds. And returns a tuple consisting of the range implementation,
+/// and the start and end bounds.
+/// # Errors
+/// This method returns an error when the range is inclusive on the end bound,
+/// and when the lower bound is greater than the upper bound.
+pub(crate) fn convert_bounds(
+    range: impl std::ops::RangeBounds<Vec<u8>>,
+) -> anyhow::Result<(
+    impl std::ops::RangeBounds<Vec<u8>>,
+    (Option<Vec<u8>>, Option<Vec<u8>>),
+)> {
+    let start = match range.start_bound() {
+        std::ops::Bound::Included(v) => Some(v.clone()),
+        std::ops::Bound::Excluded(v) => Some(v.clone()),
+        std::ops::Bound::Unbounded => None,
+    };
+
+    let end = match range.end_bound() {
+        std::ops::Bound::Included(_) => bail!("included end bound not supported"),
+        std::ops::Bound::Excluded(v) => Some(v.clone()),
+        std::ops::Bound::Unbounded => None,
+    };
+
+    if let (Some(k_start), Some(k_end)) = (&start, &end) {
+        if k_start > k_end {
+            bail!("lower bound is greater than upper bound")
+        }
+    }
+
+    Ok((range, (start, end)))
+}


### PR DESCRIPTION
This PR adds support for range queries over the `nonverifiable` storage. It does so by:
- extending the `StateRead` trait with a new method:
```rust
    /// Retrieve all values for keys in a range from the non-verifiable key-value store, as raw bytes.
    /// This method does not support inclusive ranges, and will return an error if passed one.
    ///
    /// Users should generally prefer to use wrapper methods in an extension trait.
    fn nonverifiable_range_raw(
        &self,
        prefix: Option<&[u8]>,
        range: impl RangeBounds<Vec<u8>>,
    ) -> Result<Self::NonconsensusRangeRawStream>;
```
- use a rocksdb range iterator to create an underlying stream of keys and values
- implements a `StateDelta`-level stream that interleaves caching layers and underlying storage.

Example API:

The first intended use of range queries is to fetch a range of `compact_blocks` from an arbitrary height:

```rust
let start_height = compact_block::height(20); // "000000000000000020"
// Return a stream of compact blocks starting at height 20 to the latest one.
let mut compact_block_stream = state.nonverifiable_range_query(Some(compact_block::prefix()), start_height..);
```

Alternative APIs considered:

```rust
        fn nonverifiable_range_raw<T, U>(
        &self,
        prefix: Option<&[u8]>,
        range: T,
    ) -> anyhow::Result<Self::NonconsensusRangeRawStream>
    where
        T: std::ops::RangeBounds<U>,
        U: Into<Vec<u8>>;
```

and

```rust
    fn nonverifiable_range_raw<T, U>(
        &self,
        prefix: Option<&[u8]>,
        range: T,
    ) -> anyhow::Result<Self::NonconsensusRangeRawStream>
    where
        T: std::ops::RangeBounds<U>,
        U: AsRef<[u8]>;
```

either are fine choices, but my preference goes to the simpler signature.