### PR TITLE
pd(oblivious): terminate client sync if it exceeds timeout

### DIFF
--- a/crates/bin/pd/src/info/oblivious.rs
+++ b/crates/bin/pd/src/info/oblivious.rs
@@ -311,7 +311,10 @@ impl ObliviousQueryService for Info {
                         .await
                         .expect("no error fetching block")
                         .expect("compact block for in-range height must be present");
-                    tx_blocks.send(Ok(block.into())).await.expect("TODO(erwan)");
+                    tx_blocks
+                        .send(Ok(block.into()))
+                        .await
+                        .expect("channel should be open");
                     metrics::increment_counter!(
                         metrics::CLIENT_OBLIVIOUS_COMPACT_BLOCK_SERVED_TOTAL
                     );
@@ -330,7 +333,7 @@ impl ObliviousQueryService for Info {
                     rx_state_snapshot
                         .changed()
                         .await
-                        .expect("TODO(erwan): channel should not close");
+                        .expect("channel should be open");
                     let snapshot = rx_state_snapshot.borrow().clone();
                     let height = snapshot.version();
                     tracing::debug!(?height, "notifying client of new block");
@@ -339,7 +342,10 @@ impl ObliviousQueryService for Info {
                         .await
                         .map_err(|e| tonic::Status::internal(e.to_string()))?
                         .expect("compact block for in-range height must be present");
-                    tx_blocks.send(Ok(block.into())).await.expect("TODO(erwan)");
+                    tx_blocks
+                        .send(Ok(block.into()))
+                        .await
+                        .expect("channel should be open");
                     metrics::increment_counter!(
                         metrics::CLIENT_OBLIVIOUS_COMPACT_BLOCK_SERVED_TOTAL
                     );

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -298,6 +298,7 @@ async fn main() -> anyhow::Result<()> {
                 })
                 // Allow HTTP/1, which will be used by grpc-web connections.
                 .accept_http1(true)
+                .timeout(std::time::Duration::from_secs(7))
                 // Wrap each of the gRPC services in a tonic-web proxy:
                 .add_service(tonic_web::enable(ObliviousQueryServiceServer::new(
                     info.clone(),

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -298,6 +298,10 @@ async fn main() -> anyhow::Result<()> {
                 })
                 // Allow HTTP/1, which will be used by grpc-web connections.
                 .accept_http1(true)
+                // Sets a timeout for all gRPC requests, but note that in the case of streaming
+                // requests, the timeout is only applied to the initial request. This means that
+                // this does not prevent long lived streams, for example to allow clients to obtain
+                // new blocks.
                 .timeout(std::time::Duration::from_secs(7))
                 // Wrap each of the gRPC services in a tonic-web proxy:
                 .add_service(tonic_web::enable(ObliviousQueryServiceServer::new(


### PR DESCRIPTION
This PR is part of a series of performance improvements that we are making to `pd`. This PR specifically:
- terminate  the `compact_block_range` streams  if the outbound queue is full for more than `1s`.
- adds a servel-level timeout of `7s` to all request handlers 