### PR TITLE
chore: use `anyhow::{bail, Ok, Result}` consistently

### DIFF
--- a/crates/bin/pcli/src/command/keys.rs
+++ b/crates/bin/pcli/src/command/keys.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 use std::str::FromStr;
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use directories::ProjectDirs;
 use penumbra_keys::keys::SeedPhrase;
 use rand_core::OsRng;
@@ -113,15 +113,15 @@ impl KeysCmd {
                     std::fs::remove_file(&wallet_path)?;
                     println!("Deleted wallet file at {wallet_path}");
                 } else if wallet_path.exists() {
-                    return Err(anyhow!(
-                            "Expected wallet file at {} but found something that is not a file; refusing to delete it",
-                            wallet_path
-                        ));
+                    anyhow::bail!(
+                        "Expected wallet file at {} but found something that is not a file; refusing to delete it",
+                        wallet_path
+                    );
                 } else {
-                    return Err(anyhow!(
+                    anyhow::bail!(
                         "No wallet exists at {}, so it cannot be deleted",
                         wallet_path
-                    ));
+                    );
                 }
             }
         };

--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -6,7 +6,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use ark_ff::UniformRand;
 use decaf377::{Fq, Fr};
 use ibc_types::core::channel::ChannelId;
@@ -436,7 +436,7 @@ impl TxCmd {
                 let unbonded_amount = {
                     let Value { amount, asset_id } = amount.parse::<Value>()?;
                     if asset_id != *STAKING_TOKEN_ASSET_ID {
-                        return Err(anyhow!("staking can only be done with the staking token"));
+                        anyhow::bail!("staking can only be done with the staking token");
                     }
                     amount
                 };

--- a/crates/bin/pcli/src/command/view.rs
+++ b/crates/bin/pcli/src/command/view.rs
@@ -101,15 +101,15 @@ impl Reset {
             std::fs::remove_file(&view_path)?;
             println!("Deleted view data at {view_path}");
         } else if view_path.exists() {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "Expected view data at {} but found something that is not a file; refusing to delete it",
                 view_path
-            ));
+            );
         } else {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "No view data exists at {}, so it cannot be deleted",
                 view_path
-            ));
+            );
         }
 
         Ok(())

--- a/crates/bin/pcli/src/legacy.rs
+++ b/crates/bin/pcli/src/legacy.rs
@@ -26,7 +26,7 @@ pub fn migrate(
     // Load the new wallet, to check we really did save it:
     let new_wallet_2 = crate::KeyStore::load(custody_path)?;
     if new_wallet_2.spend_key.to_bytes().0 != new_wallet.spend_key.to_bytes().0 {
-        return Err(anyhow::anyhow!("Failed to save wallet"));
+        anyhow::bail!("Failed to save wallet");
     } else {
         tracing::info!("Removing legacy wallet file");
         std::fs::remove_file(legacy_wallet_path)?;

--- a/crates/bin/pcli/src/network.rs
+++ b/crates/bin/pcli/src/network.rs
@@ -57,7 +57,7 @@ impl App {
     pub async fn submit_transaction(
         &mut self,
         transaction: Transaction,
-    ) -> Result<TransactionId, anyhow::Error> {
+    ) -> anyhow::Result<TransactionId> {
         println!("broadcasting transaction and awaiting confirmation...");
         let (id, detection_height) = self.view().broadcast_transaction(transaction, true).await?;
         if detection_height != 0 {
@@ -77,7 +77,7 @@ impl App {
     pub async fn submit_transaction_unconfirmed(
         &mut self,
         transaction: Transaction,
-    ) -> Result<(), anyhow::Error> {
+    ) -> anyhow::Result<()> {
         println!("broadcasting transaction without confirmation...");
         self.view()
             .broadcast_transaction(transaction, false)
@@ -100,23 +100,19 @@ impl App {
         }
     }
 
-    pub async fn specific_client(
-        &self,
-    ) -> Result<SpecificQueryServiceClient<Channel>, anyhow::Error> {
+    pub async fn specific_client(&self) -> anyhow::Result<SpecificQueryServiceClient<Channel>> {
         let channel = self.pd_channel().await?;
         Ok(SpecificQueryServiceClient::new(channel))
     }
 
-    pub async fn oblivious_client(
-        &self,
-    ) -> Result<ObliviousQueryServiceClient<Channel>, anyhow::Error> {
+    pub async fn oblivious_client(&self) -> anyhow::Result<ObliviousQueryServiceClient<Channel>> {
         let channel = self.pd_channel().await?;
         Ok(ObliviousQueryServiceClient::new(channel))
     }
 
     pub async fn tendermint_proxy_client(
         &self,
-    ) -> Result<TendermintProxyServiceClient<Channel>, anyhow::Error> {
+    ) -> anyhow::Result<TendermintProxyServiceClient<Channel>> {
         let channel = self.pd_channel().await?;
         Ok(TendermintProxyServiceClient::new(channel))
     }

--- a/crates/bin/pclientd/tests/network_integration.rs
+++ b/crates/bin/pclientd/tests/network_integration.rs
@@ -63,7 +63,7 @@ async fn transaction_send_flow() -> anyhow::Result<()> {
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     if let Some(status) = pclientd.try_wait()? {
         // An error occurred during startup, probably.
-        return Err(anyhow::anyhow!("pclientd exited early: {status:?}"));
+        anyhow::bail!("pclientd exited early: {status:?}");
     }
 
     // 3. Build a client for the daemon we just started.
@@ -163,7 +163,7 @@ async fn transaction_send_flow() -> anyhow::Result<()> {
     // Last, check that we didn't have any errors:
     if let Some(status) = pclientd.try_wait()? {
         // An error occurred during startup, probably.
-        return Err(anyhow::anyhow!("pclientd errored: {status:?}"));
+        anyhow::bail!("pclientd errored: {status:?}");
     }
     pclientd.kill().await?;
 

--- a/crates/bin/pd/src/consensus.rs
+++ b/crates/bin/pd/src/consensus.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use penumbra_chain::genesis;
 use penumbra_storage::Storage;
@@ -103,7 +103,7 @@ impl Consensus {
 
         // Check that we haven't got a duplicated InitChain message for some reason:
         if self.storage.latest_version() != u64::MAX {
-            return Err(anyhow!("database already initialized"));
+            anyhow::bail!("database already initialized");
         }
         self.app.init_chain(&app_state).await;
 

--- a/crates/bin/pd/src/info.rs
+++ b/crates/bin/pd/src/info.rs
@@ -61,7 +61,7 @@ impl Info {
         Self { storage }
     }
 
-    async fn info(&self, info: abci::request::Info) -> Result<abci::response::Info, anyhow::Error> {
+    async fn info(&self, info: abci::request::Info) -> anyhow::Result<abci::response::Info> {
         let state = self.storage.latest_snapshot();
         tracing::info!(?info, version = ?state.version());
 
@@ -118,10 +118,7 @@ impl Info {
         }
     }
 
-    async fn query(
-        &self,
-        query: abci::request::Query,
-    ) -> Result<abci::response::Query, anyhow::Error> {
+    async fn query(&self, query: abci::request::Query) -> anyhow::Result<abci::response::Query> {
         tracing::info!(?query);
 
         match query.path.as_str() {
@@ -468,7 +465,7 @@ impl Info {
 
                 for seq in request.packet_commitment_sequences {
                     if seq == 0 {
-                        return Err(anyhow::anyhow!("packet sequence {} cannot be 0", seq));
+                        anyhow::bail!("packet sequence {} cannot be 0", seq);
                     }
 
                     if !snapshot
@@ -515,7 +512,7 @@ impl Info {
 
                 for seq in request.packet_ack_sequences {
                     if seq == 0 {
-                        return Err(anyhow::anyhow!("packet sequence {} cannot be 0", seq));
+                        anyhow::bail!("packet sequence {} cannot be 0", seq);
                     }
 
                     if snapshot

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -417,10 +417,10 @@ async fn main() -> anyhow::Result<()> {
 
             // If the output directory already exists, bail out, rather than overwriting.
             if output_dir.exists() {
-                return Err(anyhow::anyhow!(
+                anyhow::bail!(
                     "output directory {:?} already exists, refusing to overwrite it",
                     output_dir
-                ));
+                );
             }
 
             // Check whether an external address was set, and parse as TendermintAddress.
@@ -485,10 +485,10 @@ async fn main() -> anyhow::Result<()> {
             let output_dir = get_testnet_dir(testnet_dir);
             // If the output directory already exists, bail out, rather than overwriting.
             if output_dir.exists() {
-                return Err(anyhow::anyhow!(
+                anyhow::bail!(
                     "output directory {:?} already exists, refusing to overwrite it",
                     output_dir
-                ));
+                );
             }
 
             // Build and write local configs based on input flags.

--- a/crates/bin/pd/src/testnet.rs
+++ b/crates/bin/pd/src/testnet.rs
@@ -71,10 +71,7 @@ pub fn parse_tm_address(
     let hostname = match node_address.host() {
         Some(h) => h,
         None => {
-            return Err(anyhow::anyhow!(format!(
-                "Could not find hostname in URL: {}",
-                node_address
-            )))
+            anyhow::bail!(format!("Could not find hostname in URL: {}", node_address))
         }
     };
     // Default to 26656 for Tendermint port, if not specified.

--- a/crates/bin/pd/src/testnet/generate.rs
+++ b/crates/bin/pd/src/testnet/generate.rs
@@ -147,13 +147,13 @@ pub fn testnet_generate(
                                 rate_bps: fs.rate_bps,
                             })
                         })
-                        .collect::<Result<Vec<FundingStream>, anyhow::Error>>()?,
+                        .collect::<anyhow::Result<Vec<FundingStream>>>()?,
                 )
                 .context("unable to construct funding streams from validators.json")?,
                 sequence_number: v.sequence_number,
             })
         })
-        .collect::<Result<Vec<Validator>, anyhow::Error>>()?;
+        .collect::<anyhow::Result<Vec<Validator>>>()?;
 
     let default_params = ChainParameters::default();
     let active_validator_limit =

--- a/crates/core/app/src/action_handler/actions.rs
+++ b/crates/core/app/src/action_handler/actions.rs
@@ -69,9 +69,7 @@ impl ActionHandler for Action {
             Action::Output(action) => action.check_stateful(state).await,
             Action::IbcAction(action) => {
                 if !state.get_chain_params().await?.ibc_enabled {
-                    return Err(anyhow::anyhow!(
-                        "transaction contains IBC actions, but IBC is not enabled"
-                    ));
+                    anyhow::bail!("transaction contains IBC actions, but IBC is not enabled");
                 }
 
                 action.check_stateful(state).await

--- a/crates/core/app/src/action_handler/actions/proposal/submit.rs
+++ b/crates/core/app/src/action_handler/actions/proposal/submit.rs
@@ -51,15 +51,13 @@ impl ActionHandler for ProposalSubmit {
         } = proposal;
 
         if title.len() > PROPOSAL_TITLE_LIMIT {
-            return Err(anyhow::anyhow!(
-                "proposal title must fit within {PROPOSAL_TITLE_LIMIT} characters"
-            ));
+            anyhow::bail!("proposal title must fit within {PROPOSAL_TITLE_LIMIT} characters");
         }
 
         if description.len() > PROPOSAL_DESCRIPTION_LIMIT {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "proposal description must fit within {PROPOSAL_DESCRIPTION_LIMIT} characters"
-            ));
+            );
         }
 
         use penumbra_transaction::action::ProposalPayload::*;

--- a/crates/core/app/src/action_handler/actions/proposal/withdraw.rs
+++ b/crates/core/app/src/action_handler/actions/proposal/withdraw.rs
@@ -20,9 +20,9 @@ impl ActionHandler for ProposalWithdraw {
         const PROPOSAL_WITHDRAWAL_REASON_LIMIT: usize = 80;
 
         if self.reason.len() > PROPOSAL_WITHDRAWAL_REASON_LIMIT {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "proposal withdrawal reason must fit within {PROPOSAL_WITHDRAWAL_REASON_LIMIT} characters"
-            ));
+            );
         }
 
         Ok(())

--- a/crates/core/app/src/action_handler/transaction/stateful.rs
+++ b/crates/core/app/src/action_handler/transaction/stateful.rs
@@ -56,9 +56,7 @@ pub fn fmd_precision_within_grace_period(
         {
             continue;
         } else {
-            return Err(anyhow::anyhow!(
-                "consensus rule violated: invalid clue precision",
-            ));
+            anyhow::bail!("consensus rule violated: invalid clue precision");
         }
     }
     Ok(())

--- a/crates/core/app/src/action_handler/transaction/stateless.rs
+++ b/crates/core/app/src/action_handler/transaction/stateless.rs
@@ -23,10 +23,7 @@ pub(super) fn no_duplicate_nullifiers(tx: &Transaction) -> Result<()> {
     let mut spent_nullifiers = BTreeSet::new();
     for nf in tx.spent_nullifiers() {
         if let Some(duplicate) = spent_nullifiers.replace(nf) {
-            return Err(anyhow::anyhow!(
-                "Duplicate nullifier in transaction: {}",
-                duplicate
-            ));
+            anyhow::bail!("Duplicate nullifier in transaction: {}", duplicate);
         }
     }
 

--- a/crates/core/app/src/governance/view.rs
+++ b/crates/core/app/src/governance/view.rs
@@ -137,9 +137,9 @@ pub trait StateReadExt: StateRead + penumbra_stake::StateReadExt {
             .await?
         {
             // If the nullifier was already voted with, error:
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "nullifier {nullifier} was already used for voting on proposal {proposal_id} at height {height}",
-            ));
+            );
         }
 
         Ok(())
@@ -229,10 +229,10 @@ pub trait StateReadExt: StateRead + penumbra_stake::StateReadExt {
     async fn validator_by_delegation_asset(&self, asset_id: asset::Id) -> Result<IdentityKey> {
         // Attempt to find the denom for the asset ID of the specified value
         let Some(denom) = self.denom_by_asset(&asset_id).await? else {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "asset ID {} does not correspond to a known denom",
                 asset_id
-            ));
+            );
         };
 
         // Attempt to find the validator identity for the specified denom, failing if it is not a
@@ -516,7 +516,7 @@ pub trait StateReadExt: StateRead + penumbra_stake::StateReadExt {
         let prefix = state_key::deliver_dao_transactions_at_height(self.get_block_height().await?);
         let proposals: Vec<u64> = self
             .prefix_proto::<u64>(&prefix)
-            .map(|result| Ok::<_, anyhow::Error>(result?.1))
+            .map(|result| anyhow::Ok(result?.1))
             .try_collect()
             .await?;
 
@@ -572,11 +572,11 @@ pub trait StateWriteExt: StateWrite {
     async fn new_proposal(&mut self, proposal: &Proposal) -> Result<u64> {
         let proposal_id = self.next_proposal_id().await?;
         if proposal_id != proposal.id {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "proposal id {} does not match next proposal id {}",
                 proposal.id,
                 proposal_id
-            ));
+            );
         }
 
         // Snapshot the rate data and voting power for all active validators at this height
@@ -602,7 +602,7 @@ pub trait StateWriteExt: StateWrite {
                     None
                 };
                 // Return the pair, to be written to the state
-                Ok::<_, anyhow::Error>(per_validator)
+                anyhow::Ok(per_validator)
             });
         }
         // Iterate over all the futures and insert them into the state (this can be done in

--- a/crates/core/app/src/mock_client.rs
+++ b/crates/core/app/src/mock_client.rs
@@ -60,11 +60,11 @@ impl MockClient {
         use penumbra_tct::Witness::*;
 
         if self.latest_height.wrapping_add(1) != block.height {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "wrong block height {} for latest height {}",
                 block.height,
                 self.latest_height
-            ));
+            );
         }
 
         for payload in block.state_payloads {

--- a/crates/core/app/src/temp_storage_ext.rs
+++ b/crates/core/app/src/temp_storage_ext.rs
@@ -17,7 +17,7 @@ impl TempStorageExt for TempStorage {
     async fn apply_genesis(self, genesis: genesis::AppState) -> anyhow::Result<Self> {
         // Check that we haven't already applied a genesis state:
         if self.latest_version() != u64::MAX {
-            return Err(anyhow::anyhow!("database already initialized"));
+            anyhow::bail!("database already initialized");
         }
 
         // Apply the genesis state to the storage

--- a/crates/core/asset/src/asset/cache.rs
+++ b/crates/core/asset/src/asset/cache.rs
@@ -221,20 +221,17 @@ impl TryFrom<BTreeMap<Id, DenomMetadata>> for Cache {
             if let Some(denom) = REGISTRY.parse_denom(&denom.base_denom().denom) {
                 let id = denom.id();
                 if provided_id != id {
-                    return Err(anyhow::anyhow!(
+                    anyhow::bail!(
                         "provided id {} for denom {} does not match computed id {}",
                         provided_id,
                         denom,
                         id
-                    ));
+                    );
                 }
                 cache.insert(id, denom.clone());
                 units.insert(denom.base_denom().denom, denom.base_unit());
             } else {
-                return Err(anyhow::anyhow!(
-                    "invalid base denom {}",
-                    denom.base_denom().denom
-                ));
+                anyhow::bail!("invalid base denom {}", denom.base_denom().denom);
             }
         }
         Ok(Self { cache, units })

--- a/crates/core/asset/src/asset/denom_metadata.rs
+++ b/crates/core/asset/src/asset/denom_metadata.rs
@@ -437,10 +437,10 @@ impl Unit {
         }
     }
 
-    pub fn parse_value(&self, value: &str) -> Result<Amount, anyhow::Error> {
+    pub fn parse_value(&self, value: &str) -> anyhow::Result<Amount> {
         let split: Vec<&str> = value.split('.').collect();
         if split.len() > 2 {
-            Err(anyhow::anyhow!("expected only one decimal point"))
+            anyhow::bail!("expected only one decimal point")
         } else {
             let left = split[0];
 
@@ -456,7 +456,7 @@ impl Unit {
                 // This stanza means that the value is the base unit. Simply return v1.
                 return Ok(v1.into());
             } else if right.len() > self.exponent().into() {
-                return Err(anyhow::anyhow!("cannot represent this value"));
+                anyhow::bail!("cannot represent this value");
             }
 
             let v2_power_of_ten = 10u128.pow((self.exponent() - right.len() as u8).into());
@@ -469,7 +469,7 @@ impl Unit {
             if let Some(value) = v {
                 Ok(value.into())
             } else {
-                Err(anyhow::anyhow!("overflow!"))
+                anyhow::bail!("overflow!")
             }
         }
     }

--- a/crates/core/asset/src/asset/id.rs
+++ b/crates/core/asset/src/asset/id.rs
@@ -47,9 +47,9 @@ impl TryFrom<pb::AssetId> for Id {
     fn try_from(value: pb::AssetId) -> Result<Self, Self::Error> {
         if !value.inner.is_empty() {
             if !value.alt_base_denom.is_empty() || !value.alt_bech32m.is_empty() {
-                return Err(anyhow::anyhow!(
+                anyhow::bail!(
                     "AssetId proto has both inner and alt_bech32m or alt_base_denom fields set"
-                ));
+                );
             }
             value.inner.as_slice().try_into()
         } else if !value.alt_bech32m.is_empty() {

--- a/crates/core/component/chain/src/component/app_hash.rs
+++ b/crates/core/component/chain/src/component/app_hash.rs
@@ -71,14 +71,14 @@ pub trait AppHashRead {
     async fn get_with_proof_to_apphash(
         &self,
         key: Vec<u8>,
-    ) -> Result<(Option<Vec<u8>>, MerkleProof), anyhow::Error>;
+    ) -> anyhow::Result<(Option<Vec<u8>>, MerkleProof)>;
 
     async fn get_with_proof_to_apphash_tm(
         &self,
         key: Vec<u8>,
-    ) -> Result<Option<(Vec<u8>, tendermint::merkle::proof::ProofOps)>, anyhow::Error>;
+    ) -> anyhow::Result<Option<(Vec<u8>, tendermint::merkle::proof::ProofOps)>>;
 
-    async fn app_hash(&self) -> Result<AppHash, anyhow::Error>;
+    async fn app_hash(&self) -> anyhow::Result<AppHash>;
 }
 
 #[async_trait]

--- a/crates/core/component/chain/src/params.rs
+++ b/crates/core/component/chain/src/params.rs
@@ -266,7 +266,7 @@ impl FromStr for Ratio {
             .ok_or_else(|| anyhow::anyhow!("missing denominator"))?
             .parse()?;
         if parts.next().is_some() {
-            return Err(anyhow::anyhow!("too many parts"));
+            anyhow::bail!("too many parts");
         }
         Ok(Ratio {
             numerator,

--- a/crates/core/component/dex/src/component/action_handler/position/withdraw.rs
+++ b/crates/core/component/dex/src/component/action_handler/position/withdraw.rs
@@ -36,11 +36,11 @@ impl ActionHandler for PositionWithdraw {
             .commit(Fr::zero());
 
         if self.reserves_commitment != expected_reserves_commitment {
-            return Err(anyhow!(
+            anyhow::bail!(
                 "reserves commitment {:?} is incorrect, expected {:?}",
                 self.reserves_commitment,
                 expected_reserves_commitment
-            ));
+            );
         }
 
         // We don't check that the position state is Closed here, because all
@@ -60,11 +60,11 @@ impl ActionHandler for PositionWithdraw {
             .ok_or_else(|| anyhow!("withdrew from unknown position {}", self.position_id))?;
 
         if metadata.state != position::State::Closed {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "attempted to withdraw position {} with state {}, expected Closed",
                 self.position_id,
                 metadata.state
-            ));
+            );
         }
 
         state.record(event::position_withdraw(&self, &metadata));

--- a/crates/core/component/dex/src/component/action_handler/swap.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap.rs
@@ -18,7 +18,7 @@ impl ActionHandler for Swap {
     async fn check_stateless(&self, _context: ()) -> Result<()> {
         // Check that the trading pair is distinct.
         if self.body.trading_pair.asset_1() == self.body.trading_pair.asset_2() {
-            return Err(anyhow::anyhow!("Trading pair must be distinct"));
+            anyhow::bail!("Trading pair must be distinct");
         }
 
         self.proof.verify(

--- a/crates/core/component/dex/src/component/action_handler/swap_claim.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap_claim.rs
@@ -39,9 +39,7 @@ impl ActionHandler for SwapClaim {
         let epoch_duration = state.get_epoch_duration().await?;
         let provided_epoch_duration = swap_claim.epoch_duration;
         if epoch_duration != provided_epoch_duration {
-            return Err(anyhow::anyhow!(
-                "provided epoch duration does not match chain epoch duration"
-            ));
+            anyhow::bail!("provided epoch duration does not match chain epoch duration");
         }
 
         // 2. The stateful check *must* validate that the clearing
@@ -56,9 +54,7 @@ impl ActionHandler for SwapClaim {
             .ok_or_else(|| anyhow::anyhow!("output data not found"))?;
 
         if output_data != swap_claim.body.output_data {
-            return Err(anyhow::anyhow!(
-                "provided output data does not match chain output data"
-            ));
+            anyhow::bail!("provided output data does not match chain output data");
         }
 
         // 3. Check that the nullifier hasn't been spent before.

--- a/crates/core/component/dex/src/lp/order.rs
+++ b/crates/core/component/dex/src/lp/order.rs
@@ -37,12 +37,12 @@ fn parse_parts(input: &str) -> Result<(&str, &str, u32)> {
     };
 
     let Some((val1, val2)) = trade_part.split_once('@') else {
-        return Err(anyhow!("could not parse trade string {}", input));
+        anyhow::bail!("could not parse trade string {}", input);
     };
 
     let fee = match fee_part.strip_suffix("bps") {
         Some(fee) => fee.parse::<u32>()?,
-        None => return Err(anyhow!("could not parse fee string {}", fee_part)),
+        None => anyhow::bail!("could not parse fee string {}", fee_part),
     };
 
     Ok((val1, val2, fee))

--- a/crates/core/component/dex/src/lp/position.rs
+++ b/crates/core/component/dex/src/lp/position.rs
@@ -312,7 +312,7 @@ impl TryFrom<pb::PositionState> for State {
     fn try_from(v: pb::PositionState) -> Result<Self, Self::Error> {
         let Some(position_state) = pb::position_state::PositionStateEnum::from_i32(v.state) else {
             // maps to an invalid position state
-            return Err(anyhow!("invalid position state!"))
+            anyhow::bail!("invalid position state!")
         };
 
         match position_state {

--- a/crates/core/component/dex/src/lp/reserves.rs
+++ b/crates/core/component/dex/src/lp/reserves.rs
@@ -23,15 +23,13 @@ impl Reserves {
         if self.r1.value() as u128 > MAX_RESERVE_AMOUNT
             || self.r2.value() as u128 > MAX_RESERVE_AMOUNT
         {
-            Err(anyhow::anyhow!(format!(
+            anyhow::bail!(format!(
                 "Reserve amounts are out-of-bounds (limit: {MAX_RESERVE_AMOUNT})"
-            )))
+            ))
         } else {
             // Both reserves cannot be empty.
             if self.r1.value() == 0 && self.r2.value() == 0 {
-                return Err(anyhow::anyhow!(
-                    "initial reserves must provision some amount of either asset",
-                ));
+                anyhow::bail!("initial reserves must provision some amount of either asset",);
             }
 
             Ok(())

--- a/crates/core/component/dex/src/swap/plaintext.rs
+++ b/crates/core/component/dex/src/swap/plaintext.rs
@@ -352,7 +352,7 @@ impl TryFrom<&[u8]> for SwapPlaintext {
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         if bytes.len() != SWAP_LEN_BYTES {
-            return Err(anyhow!("incorrect length for serialized swap plaintext"));
+            anyhow::bail!("incorrect length for serialized swap plaintext");
         }
 
         let tp_bytes: [u8; 64] = bytes[0..64]

--- a/crates/core/component/dex/src/trading_pair.rs
+++ b/crates/core/component/dex/src/trading_pair.rs
@@ -126,7 +126,7 @@ impl TryFrom<[u8; 64]> for TradingPair {
         let trading_pair = TradingPair::new(asset_1, asset_2);
         let result = Self { asset_1, asset_2 };
         if trading_pair != result {
-            return Err(anyhow::anyhow!("non-canonical trading pair"));
+            anyhow::bail!("non-canonical trading pair");
         }
         Ok(result)
     }

--- a/crates/core/component/ibc/src/component/action_handler/ibc_action.rs
+++ b/crates/core/component/ibc/src/component/action_handler/ibc_action.rs
@@ -28,10 +28,7 @@ impl ActionHandler for IbcAction {
             IbcAction::Acknowledgement(msg) => msg.check_stateless().await?,
             IbcAction::Timeout(msg) => msg.check_stateless().await?,
             IbcAction::Unknown(msg) => {
-                return Err(anyhow::anyhow!(
-                    "unknown IBC message type: {}",
-                    msg.type_url
-                ))
+                anyhow::bail!("unknown IBC message type: {}", msg.type_url)
             }
         }
 
@@ -61,10 +58,7 @@ impl ActionHandler for IbcAction {
             IbcAction::Acknowledgement(msg) => msg.try_execute(state).await?,
             IbcAction::Timeout(msg) => msg.try_execute(state).await?,
             IbcAction::Unknown(msg) => {
-                return Err(anyhow::anyhow!(
-                    "unknown IBC message type: {}",
-                    msg.type_url
-                ))
+                anyhow::bail!("unknown IBC message type: {}", msg.type_url)
             }
         }
 

--- a/crates/core/component/ibc/src/component/msg_handler/channel_close_confirm.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/channel_close_confirm.rs
@@ -38,7 +38,7 @@ impl MsgHandler for MsgChannelCloseConfirm {
             .await?
             .ok_or_else(|| anyhow::anyhow!("channel not found"))?;
         if channel.state_matches(&ChannelState::Closed) {
-            return Err(anyhow::anyhow!("channel is already closed"));
+            anyhow::bail!("channel is already closed");
         }
 
         let connection = state
@@ -46,7 +46,7 @@ impl MsgHandler for MsgChannelCloseConfirm {
             .await?
             .ok_or_else(|| anyhow::anyhow!("connection not found for channel"))?;
         if !connection.state_matches(&ConnectionState::Open) {
-            return Err(anyhow::anyhow!("connection for channel is not open"));
+            anyhow::bail!("connection for channel is not open");
         }
 
         let expected_connection_hops = vec![connection
@@ -85,7 +85,7 @@ impl MsgHandler for MsgChannelCloseConfirm {
         if self.port_id_on_b == transfer {
             Ics20Transfer::chan_close_confirm_check(&mut state, self).await?;
         } else {
-            return Err(anyhow::anyhow!("invalid port id"));
+            anyhow::bail!("invalid port id");
         }
         channel.set_state(ChannelState::Closed);
         state.put_channel(&self.chan_id_on_b, &self.port_id_on_b, channel.clone());
@@ -109,7 +109,7 @@ impl MsgHandler for MsgChannelCloseConfirm {
         if self.port_id_on_b == transfer {
             Ics20Transfer::chan_close_confirm_execute(state, self).await;
         } else {
-            return Err(anyhow::anyhow!("invalid port id"));
+            anyhow::bail!("invalid port id");
         }
 
         Ok(())

--- a/crates/core/component/ibc/src/component/msg_handler/channel_close_init.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/channel_close_init.rs
@@ -34,7 +34,7 @@ impl MsgHandler for MsgChannelCloseInit {
             .await?
             .ok_or_else(|| anyhow::anyhow!("channel not found"))?;
         if channel.state_matches(&ChannelState::Closed) {
-            return Err(anyhow::anyhow!("channel is already closed"));
+            anyhow::bail!("channel is already closed");
         }
 
         let connection = state
@@ -42,13 +42,13 @@ impl MsgHandler for MsgChannelCloseInit {
             .await?
             .ok_or_else(|| anyhow::anyhow!("connection not found for channel"))?;
         if !connection.state_matches(&ConnectionState::Open) {
-            return Err(anyhow::anyhow!("connection for channel is not open"));
+            anyhow::bail!("connection for channel is not open");
         }
         let transfer = PortId::transfer();
         if self.port_id_on_a == transfer {
             Ics20Transfer::chan_close_init_check(&mut state, self).await?;
         } else {
-            return Err(anyhow::anyhow!("invalid port id"));
+            anyhow::bail!("invalid port id");
         }
 
         channel.set_state(ChannelState::Closed);
@@ -73,7 +73,7 @@ impl MsgHandler for MsgChannelCloseInit {
         if self.port_id_on_a == transfer {
             Ics20Transfer::chan_close_init_execute(state, self).await;
         } else {
-            return Err(anyhow::anyhow!("invalid port id"));
+            anyhow::bail!("invalid port id");
         }
 
         Ok(())

--- a/crates/core/component/ibc/src/component/msg_handler/channel_open_ack.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/channel_open_ack.rs
@@ -69,7 +69,7 @@ impl MsgHandler for MsgChannelOpenAck {
         if self.port_id_on_a == transfer {
             Ics20Transfer::chan_open_ack_check(&mut state, self).await?;
         } else {
-            return Err(anyhow::anyhow!("invalid port id"));
+            anyhow::bail!("invalid port id");
         }
 
         channel.set_state(ChannelState::Open);
@@ -96,7 +96,7 @@ impl MsgHandler for MsgChannelOpenAck {
         if self.port_id_on_a == transfer {
             Ics20Transfer::chan_open_ack_execute(state, self).await;
         } else {
-            return Err(anyhow::anyhow!("invalid port id"));
+            anyhow::bail!("invalid port id");
         }
 
         Ok(())

--- a/crates/core/component/ibc/src/component/msg_handler/channel_open_confirm.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/channel_open_confirm.rs
@@ -31,7 +31,7 @@ impl MsgHandler for MsgChannelOpenConfirm {
             .await?
             .ok_or_else(|| anyhow::anyhow!("channel not found"))?;
         if !channel.state_matches(&ChannelState::TryOpen) {
-            return Err(anyhow::anyhow!("channel is not in the correct state"));
+            anyhow::bail!("channel is not in the correct state");
         }
 
         // TODO: capability authentication?
@@ -41,7 +41,7 @@ impl MsgHandler for MsgChannelOpenConfirm {
             .await?
             .ok_or_else(|| anyhow::anyhow!("connection not found for channel"))?;
         if !connection.state_matches(&ConnectionState::Open) {
-            return Err(anyhow::anyhow!("connection for channel is not open"));
+            anyhow::bail!("connection for channel is not open");
         }
 
         let expected_connection_hops = vec![connection
@@ -80,7 +80,7 @@ impl MsgHandler for MsgChannelOpenConfirm {
         if self.port_id_on_b == transfer {
             Ics20Transfer::chan_open_confirm_check(&mut state, self).await?;
         } else {
-            return Err(anyhow::anyhow!("invalid port id"));
+            anyhow::bail!("invalid port id");
         }
 
         channel.set_state(ChannelState::Open);
@@ -105,7 +105,7 @@ impl MsgHandler for MsgChannelOpenConfirm {
         if self.port_id_on_b == transfer {
             Ics20Transfer::chan_open_confirm_execute(state, self).await;
         } else {
-            return Err(anyhow::anyhow!("invalid port id"));
+            anyhow::bail!("invalid port id");
         }
 
         Ok(())

--- a/crates/core/component/ibc/src/component/msg_handler/channel_open_init.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/channel_open_init.rs
@@ -38,7 +38,7 @@ impl MsgHandler for MsgChannelOpenInit {
         if self.port_id_on_a == transfer {
             Ics20Transfer::chan_open_init_check(&mut state, self).await?;
         } else {
-            return Err(anyhow::anyhow!("invalid port id"));
+            anyhow::bail!("invalid port id");
         }
         let channel_id = state.next_channel_id().await.unwrap();
         let new_channel = ChannelEnd {
@@ -69,18 +69,16 @@ impl MsgHandler for MsgChannelOpenInit {
         if self.port_id_on_a == transfer {
             Ics20Transfer::chan_open_init_execute(state, self).await;
         } else {
-            return Err(anyhow::anyhow!("invalid port id"));
+            anyhow::bail!("invalid port id");
         }
 
         Ok(())
     }
 }
 
-fn connection_hops_eq_1(msg: &MsgChannelOpenInit) -> Result<(), anyhow::Error> {
+fn connection_hops_eq_1(msg: &MsgChannelOpenInit) -> anyhow::Result<()> {
     if msg.connection_hops_on_a.len() != 1 {
-        return Err(anyhow::anyhow!(
-            "currently only channels with one connection hop are supported"
-        ));
+        anyhow::bail!("currently only channels with one connection hop are supported");
     }
     Ok(())
 }
@@ -108,7 +106,7 @@ async fn verify_channel_does_not_exist<S: StateRead>(
 ) -> anyhow::Result<()> {
     let channel = state.get_channel(channel_id, port_id).await?;
     if channel.is_some() {
-        return Err(anyhow::anyhow!("channel already exists"));
+        anyhow::bail!("channel already exists");
     }
     Ok(())
 }

--- a/crates/core/component/ibc/src/component/msg_handler/channel_open_try.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/channel_open_try.rs
@@ -62,7 +62,7 @@ impl MsgHandler for MsgChannelOpenTry {
         if self.port_id_on_b == transfer {
             Ics20Transfer::chan_open_try_check(&mut state, self).await?;
         } else {
-            return Err(anyhow::anyhow!("invalid port id"));
+            anyhow::bail!("invalid port id");
         }
 
         let channel_id = state.next_channel_id().await.unwrap();
@@ -99,7 +99,7 @@ impl MsgHandler for MsgChannelOpenTry {
         if self.port_id_on_b == transfer {
             Ics20Transfer::chan_open_try_execute(state, self).await;
         } else {
-            return Err(anyhow::anyhow!("invalid port id"));
+            anyhow::bail!("invalid port id");
         }
 
         Ok(())
@@ -108,9 +108,7 @@ impl MsgHandler for MsgChannelOpenTry {
 
 pub fn connection_hops_eq_1(msg: &MsgChannelOpenTry) -> anyhow::Result<()> {
     if msg.connection_hops_on_b.len() != 1 {
-        return Err(anyhow::anyhow!(
-            "currently only channels with one connection hop are supported"
-        ));
+        anyhow::bail!("currently only channels with one connection hop are supported");
     }
     Ok(())
 }

--- a/crates/core/component/ibc/src/component/msg_handler/connection_open_ack.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/connection_open_ack.rs
@@ -71,7 +71,7 @@ impl MsgHandler for MsgConnectionOpenAck {
         // check if the client is frozen
         // TODO: should we also check if the client is expired here?
         if trusted_client_state.is_frozen() {
-            return Err(anyhow::anyhow!("client is frozen"));
+            anyhow::bail!("client is frozen");
         }
 
         // get the stored consensus state for the counterparty
@@ -196,9 +196,7 @@ async fn consensus_height_is_correct<S: StateRead>(
 ) -> anyhow::Result<()> {
     let current_height = Height::new(0, state.get_block_height().await?)?;
     if msg.consensus_height_of_a_on_b > current_height {
-        return Err(anyhow::anyhow!(
-            "consensus height is greater than the current block height",
-        ));
+        anyhow::bail!("consensus height is greater than the current block height",);
     }
 
     Ok(())
@@ -237,7 +235,7 @@ async fn verify_previous_connection<S: StateRead>(
             && connection.versions.get(0).eq(&Some(&msg.version));
 
     if !state_is_consistent {
-        return Err(anyhow::anyhow!("connection is not in the correct state"));
+        anyhow::bail!("connection is not in the correct state");
     } else {
         Ok(connection)
     }

--- a/crates/core/component/ibc/src/component/msg_handler/connection_open_confirm.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/connection_open_confirm.rs
@@ -60,7 +60,7 @@ impl MsgHandler for MsgConnectionOpenConfirm {
         // check if the client is frozen
         // TODO: should we also check if the client is expired here?
         if trusted_client_state.is_frozen() {
-            return Err(anyhow::anyhow!("client is frozen"));
+            anyhow::bail!("client is frozen");
         }
 
         // get the stored consensus state for the counterparty

--- a/crates/core/component/ibc/src/component/msg_handler/connection_open_try.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/connection_open_try.rs
@@ -89,7 +89,7 @@ impl MsgHandler for MsgConnectionOpenTry {
         // check if the client is frozen
         // TODO: should we also check if the client is expired here?
         if trusted_client_state.is_frozen() {
-            return Err(anyhow::anyhow!("client is frozen"));
+            anyhow::bail!("client is frozen");
         }
 
         // get the stored consensus state for the counterparty
@@ -199,9 +199,7 @@ async fn consensus_height_is_correct<S: StateRead>(
 ) -> anyhow::Result<()> {
     let current_height = IBCHeight::new(0, state.get_block_height().await?)?;
     if msg.consensus_height_of_b_on_a > current_height {
-        return Err(anyhow::anyhow!(
-            "consensus height is greater than the current block height",
-        ));
+        anyhow::bail!("consensus height is greater than the current block height",);
     }
 
     Ok(())

--- a/crates/core/component/ibc/src/component/proof_verification.rs
+++ b/crates/core/component/ibc/src/component/proof_verification.rs
@@ -120,7 +120,7 @@ pub trait ChannelProofVerifier: StateReadExt {
         // check if the client is frozen
         // TODO: should we also check if the client is expired here?
         if trusted_client_state.is_frozen() {
-            return Err(anyhow::anyhow!("client is frozen"));
+            anyhow::bail!("client is frozen");
         }
 
         // get the stored consensus state for the counterparty
@@ -369,7 +369,7 @@ mod inner {
 
             // TODO: should we also check if the client is expired here?
             if trusted_client_state.is_frozen() {
-                return Err(anyhow::anyhow!("client is frozen"));
+                anyhow::bail!("client is frozen");
             }
 
             let trusted_consensus_state = self

--- a/crates/core/component/ibc/src/component/transfer.rs
+++ b/crates/core/component/ibc/src/component/transfer.rs
@@ -112,15 +112,11 @@ impl<T: StateWrite + ?Sized> Ics20TransferWriteExt for T {}
 impl AppHandlerCheck for Ics20Transfer {
     async fn chan_open_init_check<S: StateRead>(_state: S, msg: &MsgChannelOpenInit) -> Result<()> {
         if msg.ordering != ChannelOrder::Unordered {
-            return Err(anyhow::anyhow!(
-                "channel order must be unordered for Ics20 transfer"
-            ));
+            anyhow::bail!("channel order must be unordered for Ics20 transfer");
         }
         let ics20_version = Version::new("ics20-1".to_string());
         if msg.version_proposal != ics20_version {
-            return Err(anyhow::anyhow!(
-                "channel version must be ics20 for Ics20 transfer"
-            ));
+            anyhow::bail!("channel version must be ics20 for Ics20 transfer");
         }
 
         Ok(())
@@ -128,16 +124,12 @@ impl AppHandlerCheck for Ics20Transfer {
 
     async fn chan_open_try_check<S: StateRead>(_state: S, msg: &MsgChannelOpenTry) -> Result<()> {
         if msg.ordering != ChannelOrder::Unordered {
-            return Err(anyhow::anyhow!(
-                "channel order must be unordered for Ics20 transfer"
-            ));
+            anyhow::bail!("channel order must be unordered for Ics20 transfer");
         }
         let ics20_version = Version::new("ics20-1".to_string());
 
         if msg.version_supported_on_a != ics20_version {
-            return Err(anyhow::anyhow!(
-                "counterparty version must be ics20-1 for Ics20 transfer"
-            ));
+            anyhow::bail!("counterparty version must be ics20-1 for Ics20 transfer");
         }
 
         Ok(())
@@ -146,9 +138,7 @@ impl AppHandlerCheck for Ics20Transfer {
     async fn chan_open_ack_check<S: StateRead>(_state: S, msg: &MsgChannelOpenAck) -> Result<()> {
         let ics20_version = Version::new("ics20-1".to_string());
         if msg.version_on_b != ics20_version {
-            return Err(anyhow::anyhow!(
-                "counterparty version must be ics20-1 for Ics20 transfer"
-            ));
+            anyhow::bail!("counterparty version must be ics20-1 for Ics20 transfer");
         }
 
         Ok(())
@@ -175,7 +165,7 @@ impl AppHandlerCheck for Ics20Transfer {
         _msg: &MsgChannelCloseInit,
     ) -> Result<()> {
         // always abort transaction
-        return Err(anyhow::anyhow!("ics20 always aborts on close init"));
+        anyhow::bail!("ics20 always aborts on close init");
     }
 
     async fn recv_packet_check<S: StateRead>(_state: S, _msg: &MsgRecvPacket) -> Result<()> {
@@ -199,9 +189,7 @@ impl AppHandlerCheck for Ics20Transfer {
 
             let amount_penumbra: Amount = packet_data.amount.try_into()?;
             if value_balance < amount_penumbra {
-                return Err(anyhow::anyhow!(
-                    "insufficient balance to refund tokens to sender"
-                ));
+                anyhow::bail!("insufficient balance to refund tokens to sender");
             }
         }
 
@@ -275,7 +263,7 @@ async fn recv_transfer_packet_inner<S: StateWrite>(
 
         if value_balance < receiver_amount {
             // error text here is from the ics20 spec
-            return Err(anyhow::anyhow!("transfer coins failed"));
+            anyhow::bail!("transfer coins failed");
         }
 
         state
@@ -369,9 +357,7 @@ async fn timeout_packet_inner<S: StateWrite>(mut state: S, msg: &MsgTimeout) -> 
             .unwrap_or_else(Amount::zero);
 
         if value_balance < amount {
-            return Err(anyhow::anyhow!(
-                "couldn't return coins in timeout: not enough value balance"
-            ));
+            anyhow::bail!("couldn't return coins in timeout: not enough value balance");
         }
 
         state

--- a/crates/core/component/ibc/src/version.rs
+++ b/crates/core/component/ibc/src/version.rs
@@ -13,7 +13,7 @@ pub fn pick_connection_version(
             }
             for feature in c.features.iter() {
                 if feature.trim().is_empty() {
-                    return Err(anyhow::anyhow!("freatures cannot be empty"));
+                    anyhow::bail!("freatures cannot be empty");
                 }
             }
             intersection.append(&mut vec![s.clone()]);
@@ -21,7 +21,7 @@ pub fn pick_connection_version(
     }
     intersection.sort_by(|a, b| a.identifier.cmp(&b.identifier));
     if intersection.is_empty() {
-        return Err(anyhow::anyhow!("no common version"));
+        anyhow::bail!("no common version");
     }
     Ok(intersection[0].clone())
 }

--- a/crates/core/component/sct/src/nullifier.rs
+++ b/crates/core/component/sct/src/nullifier.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 pub struct Nullifier(pub Fq);
 
 impl Nullifier {
-    pub fn parse_hex(str: &str) -> Result<Nullifier, anyhow::Error> {
+    pub fn parse_hex(str: &str) -> anyhow::Result<Nullifier> {
         let bytes = hex::decode(str)?;
         Nullifier::try_from(&bytes[..])
     }

--- a/crates/core/component/shielded-pool/src/component/shielded_pool.rs
+++ b/crates/core/component/shielded-pool/src/component/shielded_pool.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use anyhow::anyhow;
 use anyhow::Result;
 use async_trait::async_trait;
 use penumbra_asset::{asset, Value};
@@ -79,11 +78,11 @@ pub trait StateReadExt: StateRead {
             .get::<SpendInfo>(&state_key::spent_nullifier_lookup(&nullifier))
             .await?
         {
-            return Err(anyhow!(
+            anyhow::bail!(
                 "nullifier {} was already spent in {:?}",
                 nullifier,
                 info.note_source,
-            ));
+            );
         }
         Ok(())
     }

--- a/crates/core/component/shielded-pool/src/note.rs
+++ b/crates/core/component/shielded-pool/src/note.rs
@@ -118,7 +118,7 @@ impl Note {
     ///
     /// Note: to ensure determinism, this uses a zero rseed when
     /// creating the note.
-    pub fn from_allocation(allocation: Allocation) -> Result<Note, anyhow::Error> {
+    pub fn from_allocation(allocation: Allocation) -> anyhow::Result<Note> {
         Note::from_parts(
             allocation.address,
             Value {

--- a/crates/core/component/stake/src/action_handler/delegate.rs
+++ b/crates/core/component/stake/src/action_handler/delegate.rs
@@ -28,11 +28,11 @@ impl ActionHandler for Delegate {
         // Check whether the epoch is correct first, to give a more helpful
         // error message if it's wrong.
         if d.epoch_index != next_rate_data.epoch_index {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "delegation was prepared for epoch {} but the next epoch is {}",
                 d.epoch_index,
                 next_rate_data.epoch_index
-            ));
+            );
         }
 
         // Check whether the delegation is allowed
@@ -47,17 +47,17 @@ impl ActionHandler for Delegate {
 
         use validator::State::*;
         if !validator.enabled {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "delegations are only allowed to enabled validators, but {} is disabled",
                 d.validator_identity,
-            ));
+            );
         }
         if !matches!(validator_state, Inactive | Active) {
-            return Err(anyhow::anyhow!(
-                    "delegations are only allowed to active or inactive validators, but {} is in state {:?}",
-                    d.validator_identity,
-                    validator_state,
-                ));
+            anyhow::bail!(
+                "delegations are only allowed to active or inactive validators, but {} is in state {:?}",
+                d.validator_identity,
+                validator_state,
+            );
         }
 
         // For delegations, we enforce correct computation (with rounding)
@@ -78,12 +78,12 @@ impl ActionHandler for Delegate {
             next_rate_data.delegation_amount(d.unbonded_amount.value());
 
         if expected_delegation_amount != d.delegation_amount.value() {
-            return Err(anyhow::anyhow!(
-                    "given {} unbonded stake, expected {} delegation tokens but description produces {}",
-                    d.unbonded_amount,
-                    expected_delegation_amount,
-                    d.delegation_amount
-                ));
+            anyhow::bail!(
+                "given {} unbonded stake, expected {} delegation tokens but description produces {}",
+                d.unbonded_amount,
+                expected_delegation_amount,
+                d.delegation_amount
+            );
         }
 
         Ok(())

--- a/crates/core/component/stake/src/action_handler/undelegate.rs
+++ b/crates/core/component/stake/src/action_handler/undelegate.rs
@@ -29,11 +29,11 @@ impl ActionHandler for Undelegate {
         // Check whether the start epoch is correct first, to give a more helpful
         // error message if it's wrong.
         if u.start_epoch_index != rate_data.epoch_index {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "undelegation was prepared for next epoch {} but the next epoch is {}",
                 u.start_epoch_index,
                 rate_data.epoch_index
-            ));
+            );
         }
 
         // For undelegations, we enforce correct computation (with rounding)

--- a/crates/core/component/stake/src/action_handler/validator_definition.rs
+++ b/crates/core/component/stake/src/action_handler/validator_definition.rs
@@ -34,10 +34,10 @@ impl ActionHandler for validator::Definition {
             .sum::<u64>();
 
         if total_funding_bps > 10000 {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "validator defined {} bps of funding streams, greater than 10000bps = 100%",
                 total_funding_bps
-            ));
+            );
         }
 
         Ok(())
@@ -53,10 +53,10 @@ impl ActionHandler for validator::Definition {
             // the new sequence number.
             let current_seq = existing_v.sequence_number;
             if v.validator.sequence_number <= current_seq {
-                return Err(anyhow::anyhow!(
+                anyhow::bail!(
                     "expected sequence numbers to be increasing: current sequence number is {}",
                     current_seq
-                ));
+                );
             }
         }
 
@@ -78,11 +78,11 @@ impl ActionHandler for validator::Definition {
                 // 2. If we submit a validator update to Tendermint that
                 // includes duplicate consensus keys, Tendermint gets confused
                 // and hangs.
-                return Err(anyhow::anyhow!(
+                anyhow::bail!(
                     "consensus key {:?} is already in use by validator {}",
                     v.validator.consensus_key,
                     existing_v.identity_key,
-                ));
+                );
             }
         }
 

--- a/crates/core/component/stake/src/component.rs
+++ b/crates/core/component/stake/src/component.rs
@@ -1282,7 +1282,7 @@ pub trait StateWriteExt: StateWrite {
     ) -> Result<()> {
         tracing::debug!("setting validator power");
         if voting_power as i64 > MAX_VOTING_POWER || (voting_power as i64) < 0 {
-            return Err(anyhow::anyhow!("invalid voting power"));
+            anyhow::bail!("invalid voting power");
         }
 
         self.put_proto(state_key::power_by_validator(identity_key), voting_power);

--- a/crates/core/component/stake/src/funding_stream.rs
+++ b/crates/core/component/stake/src/funding_stream.rs
@@ -114,9 +114,7 @@ impl TryFrom<pb::FundingStream> for FundingStream {
                     .try_into()
                     .map_err(|e| anyhow::anyhow!("invalid funding stream rate: {}", e))?;
                 if rate_bps > 10_000 {
-                    return Err(anyhow::anyhow!(
-                        "funding stream rate exceeds 100% (10,000bps)"
-                    ));
+                    anyhow::bail!("funding stream rate exceeds 100% (10,000bps)");
                 }
                 Ok(FundingStream::ToAddress { address, rate_bps })
             }
@@ -126,9 +124,7 @@ impl TryFrom<pb::FundingStream> for FundingStream {
                     .try_into()
                     .map_err(|e| anyhow::anyhow!("invalid funding stream rate: {}", e))?;
                 if rate_bps > 10_000 {
-                    return Err(anyhow::anyhow!(
-                        "funding stream rate exceeds 100% (10,000bps)"
-                    ));
+                    anyhow::bail!("funding stream rate exceeds 100% (10,000bps)");
                 }
                 Ok(FundingStream::ToDao { rate_bps })
             }
@@ -164,9 +160,7 @@ impl TryFrom<Vec<FundingStream>> for FundingStreams {
 
     fn try_from(funding_streams: Vec<FundingStream>) -> Result<Self, Self::Error> {
         if funding_streams.iter().map(|fs| fs.rate_bps()).sum::<u16>() > 10_000 {
-            return Err(anyhow::anyhow!(
-                "sum of funding rates exceeds 100% (10,000bps)"
-            ));
+            anyhow::bail!("sum of funding rates exceeds 100% (10,000bps)");
         }
 
         Ok(Self { funding_streams })

--- a/crates/core/component/stake/src/uptime.rs
+++ b/crates/core/component/stake/src/uptime.rs
@@ -56,17 +56,13 @@ impl Uptime {
     /// the current block height.  This should not happen in normal use (i.e.,
     /// it's probably reasonable to `expect` on the error), but the method
     /// takes an explicit height and checks it to flag misuse and detect bugs.
-    pub fn mark_height_as_signed(
-        &mut self,
-        height: u64,
-        signed: bool,
-    ) -> Result<(), anyhow::Error> {
+    pub fn mark_height_as_signed(&mut self, height: u64, signed: bool) -> anyhow::Result<()> {
         if height != self.as_of_block_height + 1 {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "Last block height was {} but next block height is {}",
                 self.as_of_block_height,
                 height
-            ));
+            );
         }
 
         // Use the bit vector as a ring buffer, overwriting the record for N blocks ago with this one.
@@ -110,7 +106,7 @@ impl TryFrom<pb::Uptime> for Uptime {
     fn try_from(msg: pb::Uptime) -> Result<Uptime, Self::Error> {
         let mut signatures = BitVec::from_vec(msg.bitvec);
         if signatures.len() < msg.window_len as usize {
-            return Err(anyhow::anyhow!("not enough data in bitvec buffer"));
+            anyhow::bail!("not enough data in bitvec buffer");
         }
         signatures.truncate(msg.window_len as usize);
         Ok(Uptime {

--- a/crates/core/component/stake/src/validator/bonding.rs
+++ b/crates/core/component/stake/src/validator/bonding.rs
@@ -64,7 +64,7 @@ impl TryFrom<pb::BondingState> for State {
     type Error = anyhow::Error;
     fn try_from(v: pb::BondingState) -> Result<Self, Self::Error> {
         let Some(bonding_state) = pb::bonding_state::BondingStateEnum::from_i32(v.state) else {
-            return Err(anyhow::anyhow!("invalid bonding state!"))
+            anyhow::bail!("invalid bonding state!")
         };
 
         match bonding_state {
@@ -72,8 +72,8 @@ impl TryFrom<pb::BondingState> for State {
             pb::bonding_state::BondingStateEnum::Unbonded => Ok(State::Unbonded),
             pb::bonding_state::BondingStateEnum::Unbonding => {
                 let Some(unbonding_epoch) = v.unbonding_epoch else {
-            return Err(anyhow::anyhow!("unbonding epoch should be set for unbonding state"))
-        };
+                    anyhow::bail!("unbonding epoch should be set for unbonding state")
+                };
                 Ok(State::Unbonding { unbonding_epoch })
             }
             pb::bonding_state::BondingStateEnum::Unspecified => {

--- a/crates/core/component/stake/src/validator/state.rs
+++ b/crates/core/component/stake/src/validator/state.rs
@@ -60,8 +60,8 @@ impl TryFrom<pb::ValidatorState> for State {
     type Error = anyhow::Error;
     fn try_from(v: pb::ValidatorState) -> Result<Self, Self::Error> {
         let Some(validator_state) = pb::validator_state::ValidatorStateEnum::from_i32(v.state) else {
-            return Err(anyhow!("invalid validator state!"))
-            };
+            anyhow::bail!("invalid validator state!")
+        };
         match validator_state {
             pb::validator_state::ValidatorStateEnum::Inactive => Ok(State::Inactive),
             pb::validator_state::ValidatorStateEnum::Active => Ok(State::Active),

--- a/crates/core/keys/src/address.rs
+++ b/crates/core/keys/src/address.rs
@@ -229,7 +229,7 @@ impl TryFrom<&[u8]> for Address {
 
     fn try_from(jumbled_bytes: &[u8]) -> Result<Self, Self::Error> {
         if jumbled_bytes.len() != ADDRESS_LEN_BYTES {
-            return Err(anyhow::anyhow!("address malformed"));
+            anyhow::bail!("address malformed");
         }
 
         let unjumbled_bytes =

--- a/crates/core/keys/src/keys/diversifier.rs
+++ b/crates/core/keys/src/keys/diversifier.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use aes::cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt, KeyInit};
 use aes::Aes128;
 
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use ark_ff::PrimeField;
 use derivative::Derivative;
 use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType, TypeUrl};
@@ -45,10 +45,7 @@ impl TryFrom<&[u8]> for Diversifier {
 
     fn try_from(slice: &[u8]) -> Result<Diversifier, Self::Error> {
         if slice.len() != DIVERSIFIER_LEN_BYTES {
-            return Err(anyhow!(
-                "diversifier must be 16 bytes, got {:?}",
-                slice.len()
-            ));
+            anyhow::bail!("diversifier must be 16 bytes, got {:?}", slice.len());
         }
 
         let mut bytes = [0u8; DIVERSIFIER_LEN_BYTES];
@@ -219,10 +216,7 @@ impl TryFrom<&[u8]> for AddressIndex {
 
     fn try_from(slice: &[u8]) -> Result<AddressIndex, Self::Error> {
         if slice.len() != DIVERSIFIER_LEN_BYTES {
-            return Err(anyhow!(
-                "address index must be 16 bytes, got {:?}",
-                slice.len()
-            ));
+            anyhow::bail!("address index must be 16 bytes, got {:?}", slice.len());
         }
 
         Ok(AddressIndex {

--- a/crates/core/keys/src/keys/fvk.rs
+++ b/crates/core/keys/src/keys/fvk.rs
@@ -153,10 +153,10 @@ impl TryFrom<pb::FullViewingKey> for FullViewingKey {
 
     fn try_from(value: pb::FullViewingKey) -> Result<Self, Self::Error> {
         if value.inner.len() != 64 {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "Wrong byte length, expected 64 but found {}",
                 value.inner.len()
-            ));
+            );
         }
 
         let ak_bytes: [u8; 32] = value.inner[0..32].try_into().unwrap();

--- a/crates/core/keys/src/keys/seed_phrase.rs
+++ b/crates/core/keys/src/keys/seed_phrase.rs
@@ -53,11 +53,11 @@ impl SeedPhrase {
     }
 
     /// Verify the checksum of this [`SeedPhrase`].
-    fn verify_checksum(&self) -> Result<(), anyhow::Error> {
+    fn verify_checksum(&self) -> anyhow::Result<()> {
         let mut bits = [false; NUM_TOTAL_BITS];
         for (i, word) in self.0.iter().enumerate() {
             if !BIP39_WORDS.contains(&word.as_str()) {
-                return Err(anyhow::anyhow!("invalid word in BIP39 seed phrase"));
+                anyhow::bail!("invalid word in BIP39 seed phrase");
             }
 
             let word_index = BIP39_WORDS.iter().position(|&x| x == word).unwrap();
@@ -109,10 +109,7 @@ impl std::str::FromStr for SeedPhrase {
             .collect::<Vec<String>>();
 
         if words.len() != NUM_WORDS {
-            return Err(anyhow::anyhow!(
-                "seed phrases should have {} words",
-                NUM_WORDS
-            ));
+            anyhow::bail!("seed phrases should have {} words", NUM_WORDS);
         }
 
         let seed_phrase = SeedPhrase(words.try_into().expect("can convert vec to arr"));

--- a/crates/core/keys/src/keys/spend.rs
+++ b/crates/core/keys/src/keys/spend.rs
@@ -134,10 +134,7 @@ impl TryFrom<&[u8]> for SpendKeyBytes {
     type Error = anyhow::Error;
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
         if slice.len() != SPENDKEY_LEN_BYTES {
-            return Err(anyhow::anyhow!(
-                "spendseed must be 32 bytes, got {:?}",
-                slice.len()
-            ));
+            anyhow::bail!("spendseed must be 32 bytes, got {:?}", slice.len());
         }
 
         let mut bytes = [0u8; SPENDKEY_LEN_BYTES];

--- a/crates/core/transaction/src/action.rs
+++ b/crates/core/transaction/src/action.rs
@@ -243,7 +243,7 @@ impl TryFrom<pb::Action> for Action {
     type Error = anyhow::Error;
     fn try_from(proto: pb::Action) -> anyhow::Result<Self, Self::Error> {
         if proto.action.is_none() {
-            return Err(anyhow::anyhow!("missing action content"));
+            anyhow::bail!("missing action content");
         }
         match proto.action.unwrap() {
             pb::action::Action::Output(inner) => Ok(Action::Output(inner.try_into()?)),

--- a/crates/core/transaction/src/id.rs
+++ b/crates/core/transaction/src/id.rs
@@ -32,7 +32,7 @@ impl FromStr for Id {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let bytes = hex::decode(s)?;
         if bytes.len() != 32 {
-            return Err(anyhow::anyhow!("invalid transaction ID length"));
+            anyhow::bail!("invalid transaction ID length");
         }
         let mut id = [0u8; 32];
         id.copy_from_slice(&bytes);
@@ -59,10 +59,10 @@ impl From<Id> for pb::Id {
 impl TryFrom<pb::Id> for Id {
     type Error = anyhow::Error;
 
-    fn try_from(proto: pb::Id) -> Result<Id, anyhow::Error> {
+    fn try_from(proto: pb::Id) -> anyhow::Result<Id> {
         let hash = proto.hash;
         if hash.len() != 32 {
-            return Err(anyhow::anyhow!("invalid transaction ID length"));
+            anyhow::bail!("invalid transaction ID length");
         }
         let mut id = [0u8; 32];
         id.copy_from_slice(&hash);

--- a/crates/core/transaction/src/plan/action.rs
+++ b/crates/core/transaction/src/plan/action.rs
@@ -293,7 +293,7 @@ impl TryFrom<pb_t::ActionPlan> for ActionPlan {
 
     fn try_from(proto: pb_t::ActionPlan) -> anyhow::Result<Self, Self::Error> {
         if proto.action.is_none() {
-            return Err(anyhow::anyhow!("missing action content"));
+            anyhow::bail!("missing action content");
         }
 
         match proto.action.unwrap() {

--- a/crates/core/transaction/src/plan/build.rs
+++ b/crates/core/transaction/src/plan/build.rs
@@ -439,11 +439,11 @@ impl UnauthTransaction {
         // Do some basic input sanity-checking.
         let spend_count = self.inner.spends().count();
         if auth_data.spend_auths.len() != spend_count {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "expected {} spend auths but got {}",
                 spend_count,
                 auth_data.spend_auths.len()
-            ));
+            );
         }
         // Overwrite the placeholder auth sigs with the real ones from `auth_data`
 

--- a/crates/core/transaction/src/plan/memo.rs
+++ b/crates/core/transaction/src/plan/memo.rs
@@ -17,13 +17,13 @@ impl MemoPlan {
     pub fn new<R: CryptoRng + RngCore>(
         rng: &mut R,
         plaintext: MemoPlaintext,
-    ) -> Result<MemoPlan, anyhow::Error> {
+    ) -> anyhow::Result<MemoPlan> {
         let key = PayloadKey::random_key(rng);
         Ok(MemoPlan { plaintext, key })
     }
 
     /// Create a [`MemoCiphertext`] from the [`MemoPlan`].
-    pub fn memo(&self) -> Result<MemoCiphertext, anyhow::Error> {
+    pub fn memo(&self) -> anyhow::Result<MemoCiphertext> {
         MemoCiphertext::encrypt(self.key.clone(), &self.plaintext)
     }
 }

--- a/crates/core/transaction/src/proposal.rs
+++ b/crates/core/transaction/src/proposal.rs
@@ -143,9 +143,7 @@ impl TryFrom<pb::Proposal> for Proposal {
                     },
                 }
             } else {
-                return Err(anyhow::anyhow!(
-                    "missing proposal payload or unknown proposal type"
-                ));
+                anyhow::bail!("missing proposal payload or unknown proposal type");
             },
         })
     }

--- a/crates/core/transaction/src/vote.rs
+++ b/crates/core/transaction/src/vote.rs
@@ -73,7 +73,7 @@ impl TryFrom<pb::Vote> for Vote {
 
     fn try_from(msg: pb::Vote) -> Result<Self, Self::Error> {
         let Some(vote_state) = pb::vote::Vote::from_i32(msg.vote) else {
-            return Err(anyhow!("invalid vote state"))
+            anyhow::bail!("invalid vote state")
         };
         match vote_state {
             pb::vote::Vote::Abstain => Ok(Vote::Abstain),

--- a/crates/crypto/eddy/src/decryption_share.rs
+++ b/crates/crypto/eddy/src/decryption_share.rs
@@ -79,11 +79,11 @@ impl DecryptionShare<Unverified> {
         // key share, the transcript won't match anyways, but it's a helpful
         // check against misuse.
         if self.participant_index != pub_key_share.participant_index {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "decryption share participant index {} does not match public key share index {}",
                 self.participant_index,
                 pub_key_share.participant_index
-            ));
+            );
         }
 
         transcript.begin_decryption();

--- a/crates/crypto/eddy/src/proofs.rs
+++ b/crates/crypto/eddy/src/proofs.rs
@@ -30,9 +30,7 @@ impl TransparentEncryptionProof {
                 blinding * encryption_key.0 + decaf377::Fr::from(limb.0) * decaf377::basepoint();
 
             if c1 != ctxt.c1 || c2 != ctxt.c2 {
-                return Err(anyhow::anyhow!(
-                    "TransparentEncryptionProof: verification failed"
-                ));
+                anyhow::bail!("TransparentEncryptionProof: verification failed");
             }
         }
 

--- a/crates/crypto/proof-params/build.rs
+++ b/crates/crypto/proof-params/build.rs
@@ -76,9 +76,9 @@ pub fn check_proving_key(file: &str) -> anyhow::Result<()> {
         }
         #[cfg(not(feature = "download-proving-keys"))]
         {
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "proving key is too small; please enable the download-proving-keys feature"
-            ));
+            );
         }
     }
 

--- a/crates/custody/src/pre_auth.rs
+++ b/crates/custody/src/pre_auth.rs
@@ -50,7 +50,7 @@ impl TryFrom<pb::PreAuthorization> for PreAuthorization {
                 Self::Ed25519(ed.try_into()?)
             }
             None => {
-                return Err(anyhow::anyhow!("missing pre-authorization"));
+                anyhow::bail!("missing pre-authorization");
             }
         })
     }

--- a/crates/misc/measure/src/main.rs
+++ b/crates/misc/measure/src/main.rs
@@ -260,7 +260,7 @@ impl Opt {
     }
 
     #[instrument(skip(self))]
-    pub async fn latest_known_block_height(&self) -> Result<(u64, bool), anyhow::Error> {
+    pub async fn latest_known_block_height(&self) -> anyhow::Result<(u64, bool)> {
         let mut client = get_tendermint_proxy_client(self.node.clone()).await?;
         let rsp = client.get_status(GetStatusRequest {}).await?.into_inner();
         let sync_info = rsp
@@ -276,7 +276,7 @@ impl Opt {
 // This code is ripped from the pcli code, and could be split out into something common.
 async fn get_tendermint_proxy_client(
     pd_url: Url,
-) -> Result<TendermintProxyServiceClient<Channel>, anyhow::Error> {
+) -> anyhow::Result<TendermintProxyServiceClient<Channel>> {
     let pd_channel: Channel = match pd_url.scheme() {
         "http" => Channel::from_shared(pd_url.to_string())?.connect().await?,
         "https" => {

--- a/crates/misc/tct-visualize/src/bin/tct-visualize.rs
+++ b/crates/misc/tct-visualize/src/bin/tct-visualize.rs
@@ -293,7 +293,7 @@ fn write_svg<W: Write>(dot: &[u8], writer: &mut W) -> Result<()> {
         });
         std::io::copy(&mut stdout, writer)?;
         render_thread.join().unwrap()?;
-        Ok::<_, anyhow::Error>(())
+        anyhow::Ok(())
     })?;
     Ok(())
 }
@@ -308,7 +308,7 @@ fn write_svg_direct<W: Write>(tree: &Tree, writer: &mut W) -> Result<()> {
         });
         std::io::copy(&mut stdout, writer)?;
         render_thread.join().unwrap()?;
-        Ok::<_, anyhow::Error>(())
+        anyhow::Ok(())
     })?;
     Ok(())
 }

--- a/crates/narsil/narsil/src/ledger/consensus.rs
+++ b/crates/narsil/narsil/src/ledger/consensus.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use penumbra_chain::genesis;
 use penumbra_storage::Storage;
@@ -103,7 +103,7 @@ impl Consensus {
 
         // Check that we haven't got a duplicated InitChain message for some reason:
         if self.storage.latest_version() != u64::MAX {
-            return Err(anyhow!("database already initialized"));
+            anyhow::bail!("database already initialized");
         }
         self.app.init_chain(&app_state).await;
 

--- a/crates/narsil/narsil/src/ledger/info.rs
+++ b/crates/narsil/narsil/src/ledger/info.rs
@@ -32,10 +32,7 @@ impl Info {
         Self { storage }
     }
 
-    pub async fn info(
-        &self,
-        info: abci::request::Info,
-    ) -> Result<abci::response::Info, anyhow::Error> {
+    pub async fn info(&self, info: abci::request::Info) -> anyhow::Result<abci::response::Info> {
         let state = self.storage.latest_snapshot();
         tracing::info!(?info, version = ?state.version());
 

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -34,7 +34,7 @@ Check that you have git-lfs installed, then run:
 and retry the build."
         );
 
-        return Err(anyhow::anyhow!(msg));
+        anyhow::bail!(msg);
     }
     return Ok(());
 }

--- a/crates/proto/src/protobuf.rs
+++ b/crates/proto/src/protobuf.rs
@@ -25,7 +25,7 @@ where
     }
 
     /// Decode this domain type from a byte buffer, via proto type `P`.
-    fn decode<B: bytes::Buf>(buf: B) -> Result<Self, anyhow::Error> {
+    fn decode<B: bytes::Buf>(buf: B) -> anyhow::Result<Self> {
         <Self::Proto as prost::Message>::decode(buf)?
             .try_into()
             .map_err(Into::into)
@@ -134,7 +134,7 @@ impl From<Clue> for ProtoClue {
 impl TryFrom<ProtoClue> for Clue {
     type Error = anyhow::Error;
 
-    fn try_from(proto: ProtoClue) -> anyhow::Result<Self, Self::Error> {
+    fn try_from(proto: ProtoClue) -> Result<Self, Self::Error> {
         let clue: [u8; 68] = proto.inner[..]
             .try_into()
             .map_err(|_| anyhow::anyhow!("expected 68-byte clue"))?;

--- a/crates/proto/src/serializers/bech32str.rs
+++ b/crates/proto/src/serializers/bech32str.rs
@@ -19,18 +19,18 @@ pub fn decode(
     let (hrp, data, variant) = bech32::decode(string)?;
 
     if variant != expected_variant {
-        return Err(anyhow::anyhow!(
+        anyhow::bail!(
             "wrong bech32 variant {:?}, expected {:?}",
             variant,
             expected_variant
-        ));
+        );
     }
     if hrp != expected_hrp {
-        return Err(anyhow::anyhow!(
+        anyhow::bail!(
             "wrong bech32 human readable part {}, expected {}",
             hrp,
             expected_hrp
-        ));
+        );
     }
 
     Ok(Vec::from_base32(&data).expect("bech32 decoding produces valid base32"))

--- a/crates/storage/src/delta.rs
+++ b/crates/storage/src/delta.rs
@@ -145,7 +145,7 @@ impl<S: StateRead + StateWrite> StateDelta<S> {
 }
 
 impl<S: StateRead + StateWrite> StateDelta<Arc<S>> {
-    pub fn try_apply(self) -> Result<(S, Vec<abci::Event>), anyhow::Error> {
+    pub fn try_apply(self) -> anyhow::Result<(S, Vec<abci::Event>)> {
         let (arc_state, mut changes) = self.flatten();
         let events = std::mem::take(&mut changes.events);
 

--- a/crates/storage/src/snapshot.rs
+++ b/crates/storage/src/snapshot.rs
@@ -239,7 +239,7 @@ impl StateRead for Snapshot {
 
                         tx.blocking_send(Ok((k, v)))?;
                     }
-                    Ok::<(), anyhow::Error>(())
+                    anyhow::Ok(())
                 })
             })
             .expect("should be able to spawn_blocking");
@@ -277,7 +277,7 @@ impl StateRead for Snapshot {
                             .to_string();
                         tx.blocking_send(Ok(k))?;
                     }
-                    Ok::<(), anyhow::Error>(())
+                    anyhow::Ok(())
                 })
             })
             .expect("should be able to spawn_blocking");
@@ -311,7 +311,7 @@ impl StateRead for Snapshot {
                         let (key, value) = i?;
                         tx.blocking_send(Ok((key.into(), value.into())))?;
                     }
-                    Ok::<(), anyhow::Error>(())
+                    anyhow::Ok(())
                 })
             })
             .expect("should be able to spawn_blocking");

--- a/crates/storage/src/snapshot_cache.rs
+++ b/crates/storage/src/snapshot_cache.rs
@@ -1,8 +1,6 @@
 use crate::Snapshot;
 use std::{cmp, collections::VecDeque};
 
-use anyhow::anyhow;
-
 /// A circular cache for storing [`Snapshot`]s.
 ///
 /// # Usage
@@ -49,7 +47,7 @@ impl SnapshotCache {
     pub fn try_push(&mut self, snapshot: Snapshot) -> anyhow::Result<()> {
         let latest_version = self.latest().version();
         if latest_version.wrapping_add(1) != snapshot.version() {
-            return Err(anyhow!("snapshot_cache: trying to insert stale snapshots."));
+            anyhow::bail!("snapshot_cache: trying to insert stale snapshots.");
         }
 
         if self.cache.len() >= self.max_size {

--- a/crates/storage/src/storage.rs
+++ b/crates/storage/src/storage.rs
@@ -238,7 +238,7 @@ impl Storage {
         let new_version = old_version.wrapping_add(1);
         tracing::trace!(old_version, new_version);
         if old_version != snapshot.version() {
-            return Err(anyhow::anyhow!("version mismatch in commit: expected state forked from version {} but found state forked from version {}", old_version, snapshot.version()));
+            anyhow::bail!("version mismatch in commit: expected state forked from version {} but found state forked from version {}", old_version, snapshot.version());
         }
 
         self.commit_inner(changes, new_version).await

--- a/crates/storage/src/storage/temp.rs
+++ b/crates/storage/src/storage/temp.rs
@@ -19,7 +19,7 @@ impl Deref for TempStorage {
 }
 
 impl TempStorage {
-    pub async fn new() -> Result<Self, anyhow::Error> {
+    pub async fn new() -> anyhow::Result<Self> {
         let dir = tempfile::tempdir()?;
         let db_filepath = dir.path().join("storage.db");
         let inner = Storage::load(db_filepath.clone()).await?;

--- a/crates/view/src/client.rs
+++ b/crates/view/src/client.rs
@@ -650,7 +650,7 @@ where
             let assets = pb_assets
                 .into_iter()
                 .map(DenomMetadata::try_from)
-                .collect::<Result<Vec<DenomMetadata>, anyhow::Error>>()?;
+                .collect::<anyhow::Result<Vec<DenomMetadata>>>()?;
 
             Ok(assets.into_iter().collect())
         }
@@ -686,7 +686,7 @@ where
                         anyhow::anyhow!("empty OwnedPositionsIdsResponse message")
                     })?)
                 })
-                .collect::<Result<Vec<position::Id>, anyhow::Error>>()?;
+                .collect::<anyhow::Result<Vec<position::Id>>>()?;
 
             Ok(position_ids)
         }

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -4,7 +4,7 @@ use std::{
     mem,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use penumbra_asset::{asset::DenomMetadata, Balance, Value};
 use penumbra_chain::params::{ChainParameters, FmdParameters};
@@ -230,7 +230,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
 
         // If there is no input, then there is no swap.
         if delta_1 == Amount::zero() && delta_2 == Amount::zero() {
-            return Err(anyhow!("No input value for swap"));
+            anyhow::bail!("No input value for swap");
         }
 
         // Create the `SwapPlaintext` representing the swap to be performed:
@@ -547,10 +547,10 @@ impl<R: RngCore + CryptoRng> Planner<R> {
                 // If there are no notes to vote with, return an error, because otherwise the user
                 // would compose a transaction that would not satisfy their intention, and would
                 // silently eat the fee.
-                return Err(anyhow!(
+                anyhow::bail!(
                     "can't vote on proposal {} because no delegation notes were staked to an active validator when voting started",
                     proposal
-                ));
+                );
             }
         }
 

--- a/crates/view/src/storage/sct.rs
+++ b/crates/view/src/storage/sct.rs
@@ -99,7 +99,7 @@ impl Read for TreeStore<'_, '_> {
                         let hash = <[u8; 32]>::try_from(hash)
                             .map_err(|_| anyhow::anyhow!("hash was of incorrect length"))
                             .and_then(move |array| Hash::from_bytes(array).map_err(Into::into))?;
-                        Ok::<_, anyhow::Error>((Position::from(position as u64), height, hash))
+                        anyhow::Ok((Position::from(position as u64), height, hash))
                     })
                     .context("couldn't query database")
                 {
@@ -171,7 +171,7 @@ impl Read for TreeStore<'_, '_> {
                             .and_then(|array| {
                                 StateCommitment::try_from(array).map_err(Into::into)
                             })?;
-                        Ok::<_, anyhow::Error>((Position::from(position as u64), commitment))
+                        anyhow::Ok((Position::from(position as u64), commitment))
                     })
                     .context("couldn't query database")
                 {

--- a/crates/view/src/worker.rs
+++ b/crates/view/src/worker.rs
@@ -146,7 +146,7 @@ impl Worker {
         Ok(transactions)
     }
 
-    pub async fn sync(&mut self) -> Result<(), anyhow::Error> {
+    pub async fn sync(&mut self) -> anyhow::Result<()> {
         // Do a single sync run, up to whatever the latest block height is
         tracing::info!("starting client sync");
 
@@ -342,7 +342,7 @@ impl Worker {
         Ok(())
     }
 
-    pub async fn run(mut self) -> Result<(), anyhow::Error> {
+    pub async fn run(mut self) -> anyhow::Result<()> {
         self.run_inner().await.map_err(|e| {
             tracing::info!(?e, "view worker error");
             self.error_slot.lock().unwrap().replace(e);
@@ -350,7 +350,7 @@ impl Worker {
         })
     }
 
-    async fn run_inner(&mut self) -> Result<(), anyhow::Error> {
+    async fn run_inner(&mut self) -> anyhow::Result<()> {
         // For now, this can be outside of the loop, because assets are only
         // created at genesis. In the future, we'll want to have a way for
         // clients to learn about assets as they're created.
@@ -362,7 +362,7 @@ impl Worker {
 async fn fetch_block(
     client: &mut TendermintProxyServiceClient<Channel>,
     height: i64,
-) -> Result<proto::tendermint::types::Block, anyhow::Error> {
+) -> anyhow::Result<proto::tendermint::types::Block> {
     Ok(client
         .get_block_by_height(GetBlockByHeightRequest { height })
         .await?

--- a/crates/wallet/src/key_store.rs
+++ b/crates/wallet/src/key_store.rs
@@ -16,10 +16,10 @@ impl KeyStore {
     pub fn save(&self, path: impl AsRef<std::path::Path>) -> anyhow::Result<()> {
         if path.as_ref().exists() {
             let p = path.as_ref().to_string_lossy();
-            return Err(anyhow::anyhow!(
+            anyhow::bail!(
                 "Wallet file already exists, refusing to overwrite it: {}",
                 &p
-            ));
+            );
         }
         use std::io::Write;
         let path = path.as_ref();

--- a/crates/wallet/src/plan.rs
+++ b/crates/wallet/src/plan.rs
@@ -118,7 +118,7 @@ pub async fn send<V, R>(
     dest_address: Address,
     source_address: AddressIndex,
     tx_memo: Option<MemoPlaintext>,
-) -> Result<TransactionPlan, anyhow::Error>
+) -> anyhow::Result<TransactionPlan>
 where
     V: ViewClient,
     R: RngCore + CryptoRng,
@@ -142,7 +142,7 @@ pub async fn sweep<V, R>(
     view: &mut V,
     mut rng: R,
     specific_client: SpecificQueryServiceClient<Channel>,
-) -> Result<Vec<TransactionPlan>, anyhow::Error>
+) -> anyhow::Result<Vec<TransactionPlan>>
 where
     V: ViewClient,
     R: RngCore + CryptoRng,
@@ -166,7 +166,7 @@ pub async fn claim_unclaimed_swaps<V, R>(
     _view: &mut V,
     mut _rng: R,
     mut _specific_client: SpecificQueryServiceClient<Channel>,
-) -> Result<Vec<TransactionPlan>, anyhow::Error>
+) -> anyhow::Result<Vec<TransactionPlan>>
 where
     V: ViewClient,
     R: RngCore + CryptoRng,
@@ -256,7 +256,7 @@ pub async fn sweep_notes<V, R>(
     account_group_id: AccountGroupId,
     view: &mut V,
     mut rng: R,
-) -> Result<Vec<TransactionPlan>, anyhow::Error>
+) -> anyhow::Result<Vec<TransactionPlan>>
 where
     V: ViewClient,
     R: RngCore + CryptoRng,

--- a/crates/wasm/src/planner.rs
+++ b/crates/wasm/src/planner.rs
@@ -4,7 +4,7 @@ use std::{
     mem,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use crate::note_record::SpendableNoteRecord;
 use penumbra_asset::{asset::DenomMetadata, Balance, Value};
@@ -174,7 +174,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
 
         // If there is no input, then there is no swap.
         if delta_1 == Amount::zero() && delta_2 == Amount::zero() {
-            return Err(anyhow!("No input value for swap"));
+            anyhow::bail!("No input value for swap");
         }
 
         // Create the `SwapPlaintext` representing the swap to be performed:
@@ -386,10 +386,10 @@ impl<R: RngCore + CryptoRng> Planner<R> {
         //         // If there are no notes to vote with, return an error, because otherwise the user
         //         // would compose a transaction that would not satisfy their intention, and would
         //         // silently eat the fee.
-        //         return Err(anyhow!(
+        //         anyhow::bail!(
         //             "can't vote on proposal {} because no delegation notes were staked when voting started",
         //             proposal
-        //         ));
+        //         );
         //     }
         //
         //     for (record, identity_key) in records {


### PR DESCRIPTION
There are no functionality changes, and all resulting code should be shorter than before.