### PR TITLE
feat(metrics): add dex path search histogram

### DIFF
--- a/deployments/compose/justfile
+++ b/deployments/compose/justfile
@@ -1,0 +1,3 @@
+# Run a grafana/prometheus sidecar deployment, attaching to local node.
+metrics:
+    docker-compose -f metrics.yml up --build --abort-on-container-exit --force-recreate

--- a/deployments/compose/metrics.yml
+++ b/deployments/compose/metrics.yml
@@ -1,0 +1,23 @@
+---
+# docker-compose file for running a sidecar metrics deployment.
+# Requires a running fullnode, exposing metrics on http://localhost:8080
+# on the host machine.
+
+version: "3.7"
+services:
+  # The Grafana service, which pulls data from Prometheus and serves a web UI.
+  grafana:
+    image: penumbra-grafana
+    build:
+      context: ../../
+      dockerfile: deployments/containerfiles/Dockerfile-grafana
+    network_mode: host
+    user: "${UID:-1000}"
+
+  # The Prometheus service, for scraping metrics from Penumbra's pd metrics port.
+  prom:
+    image: "docker.io/prom/prometheus"
+    network_mode: host
+    volumes:
+      # TODO: this path is not accurate
+      - /home/conor/src/penumbra/deployments/config/prometheus.yml:/etc/prometheus/prometheus.yml:ro

--- a/deployments/config/grafana/dashboards/Transactions.json
+++ b/deployments/config/grafana/dashboards/Transactions.json
@@ -1,35 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": [],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "8.5.2"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -55,10 +24,146 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Time spent searching for paths between two assets, while processing Swaps in the DEX engine.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "bucketOffset": 0,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(penumbra_dex_path_search_duration_seconds_bucket[$__rate_interval])))",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DEX path search duration",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "The total number of path-search operations. Only shows for val-0, as we expect the number to be the same across all nodes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "penumbra_dex_path_search_duration_seconds_count{instance=\"penumbra-testnet-preview-val-0-metrics:9000\"}",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DEX path search count",
+      "type": "stat"
+    },
     {
       "datasource": {
         "type": "prometheus",
@@ -70,6 +175,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -118,14 +225,15 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 8
       },
       "id": 2,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -149,19 +257,28 @@
       "type": "timeseries"
     }
   ],
-  "schemaVersion": 36,
+  "refresh": "",
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
         "hide": 0,
+        "includeAll": false,
         "label": "datasource",
+        "multi": false,
         "name": "DS_PROMETHEUS",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       }
     ]

--- a/deployments/config/grafana/provisioning/datasources/all.yml
+++ b/deployments/config/grafana/provisioning/datasources/all.yml
@@ -2,6 +2,6 @@ datasources:
 - name: 'Prometheus'
   type: 'prometheus'
   access: 'browser'
-  url: 'http://prometheus:9090'
+  url: 'http://127.0.0.1:9090'
   is_default: true
   editable: false

--- a/deployments/config/prometheus.yml
+++ b/deployments/config/prometheus.yml
@@ -4,13 +4,11 @@ scrape_configs:
     scheme: http
     metrics_path: metrics
     static_configs:
-      # TODO: The hostname isn't working here, but the IP is hardcoded in docker-compose.yml so this works for now
-      - targets: ['192.167.10.11:26660']
-  # NOTE: `pd` doesn't actually expose metrics yet, so this doesn't actually do
-  # anything interesting...
+      # Using localhost for scrape targets requires `--network=host` on container run args.
+      - targets: ['127.0.0.1:26660']
   - job_name: 'Penumbra Daemon'
     scrape_interval: 10s
     scheme: http
     metrics_path: metrics
     static_configs:
-      - targets: ['192.167.10.10:9000']
+      - targets: ['127.0.0.1:9000']

--- a/docs/guide/src/dev/metrics.md
+++ b/docs/guide/src/dev/metrics.md
@@ -1,13 +1,16 @@
 # Metrics
 
 Metrics are an important part of observability, allowing us to understand what
-the Penumbra software is doing.
+the Penumbra software is doing. Penumbra Labs runs Grafana instances for the public deployments:
+
+  * https://grafana.testnet.penumbra.zone
+  * https://grafana.testnet-preview.penumbra.zone
 
 ## Viewing Metrics
 
 TODO: add details on how to use Grafana:
 
-- [ ] link to <https://grafana.testnet.penumbra.zone> for dashboard on current testnet;
+- [x] link to <https://grafana.testnet.penumbra.zone> for dashboard on current testnet;
 - [ ] instructions on how to run Grafana + Prometheus for local dev setup (ideally this could work without requiring that `pd` itself is Dockerized, since local development is often more convenient outside of docker);
 - [x] instructions on how to commit dashboards back to the repo.
 
@@ -62,4 +65,18 @@ we use for maintaining our dashboards.
 
 1. Export the dashboard as JSON with the default settings
 2. Rename the JSON file and copy into the repo (`config/grafana/dashboards/`)
-3. Use the import function in the UI to update all deployments
+3. PR the changes into main, and confirm on preview post-deploy that it works as expected.
+
+
+## Editing metrics locally
+
+To facilitate working with metrics locally, first run a `pd` node on your machine with the metrics endpoint
+exposed. Then, you can spin up a metrics sidecar deployment:
+
+```bash
+cd deployments/compose
+just metrics
+```
+
+To add new Grafana visualizations, open http://localhost:3000 and edit the existing dashboards.
+When you're happy with what you've got, follow the "Backing up Grafana" instructions above to save your work.


### PR DESCRIPTION
Adds a visual histogram showing how long DEX path search takes. Also includes some overdue updates to the metrics docs, and some tooling I used locally to put the changes together.

Refs #2788.