### PR TITLE
Add log verification / searching for setup ceremony

### DIFF
--- a/crates/crypto/proof-setup/src/group.rs
+++ b/crates/crypto/proof-setup/src/group.rs
@@ -6,7 +6,6 @@ use ark_ec::pairing::{Pairing, PairingOutput};
 use ark_ec::scalar_mul::{variable_base::VariableBaseMSM, ScalarMul};
 use ark_ff::fields::PrimeField;
 use ark_serialize::CanonicalSerialize;
-use blake2b_simd;
 use decaf377::Bls12_377;
 use rand_core::CryptoRngCore;
 

--- a/crates/crypto/proof-setup/src/lib.rs
+++ b/crates/crypto/proof-setup/src/lib.rs
@@ -1,6 +1,6 @@
 // Todo: prune public interface once we know exactly what's needed.
 mod dlog;
 mod group;
+pub mod log;
 pub mod phase1;
 pub mod phase2;
-mod log;

--- a/crates/crypto/proof-setup/src/lib.rs
+++ b/crates/crypto/proof-setup/src/lib.rs
@@ -3,3 +3,4 @@ mod dlog;
 mod group;
 pub mod phase1;
 pub mod phase2;
+mod log;

--- a/crates/crypto/proof-setup/src/log.rs
+++ b/crates/crypto/proof-setup/src/log.rs
@@ -23,7 +23,7 @@ pub trait Phase {
     /// with respect to other contributions.
     type CRSElements: Hashable;
     /// The type of a contribution before any kind of validation.
-    type RawContribution;
+    type RawContribution: Hashable;
     /// A contribution after having been validated.
     type Contribution: Hashable;
 
@@ -68,15 +68,35 @@ impl<P: Phase> ContributionLog<P> {
     /// This requires the root elements which these contributions all build upon.
     ///
     /// This might fail to find any good contributions, in which case None will be returned.
-    pub fn last_good_contribution(&self, root: &P::CRSElements) -> Option<P::Contribution> {
+    pub fn last_good_contribution(
+        &self,
+        root: &P::CRSElements,
+        checkpoint: Option<ContributionHash>,
+    ) -> Option<P::Contribution> {
         // We start by assuming that the root is correct, and the first good elements
         // the log should start building on. From there, we keep considering new contributions,
         // each of which can become the most recent good contribution if all conditions are met.
         // By the end, we'll have the last good contribution for the log as a whole.
         let root_hash = root.hash();
+        // By default, we start with 0, and no last known good contribution
+        let mut start = 0;
         let mut last_good: Option<P::Contribution> = None;
+        // If we have a checkpoint, we might want to start at a different place, however:
+        if let Some(checkpoint) = checkpoint {
+            if let Some((i, matching)) = self
+                .contributions
+                .iter()
+                .enumerate()
+                .find(|(_, c)| c.hash() == checkpoint)
+            {
+                if let Some(valid) = P::validate(root, matching) {
+                    start = i + 1;
+                    last_good = Some(valid);
+                }
+            }
+        }
 
-        for contribution in &self.contributions {
+        for contribution in &self.contributions[start..] {
             // 1. Check if the parent we're building off of is the last good contribution.
             let expected_parent_hash = last_good.as_ref().map(|c| c.hash()).unwrap_or(root_hash);
             if P::parent_hash(contribution) != expected_parent_hash {
@@ -190,7 +210,7 @@ mod test {
     fn test_empty_log_search_returns_none() {
         let log: ContributionLog<DummyPhase> = ContributionLog::new(vec![]);
         assert!(log
-            .last_good_contribution(&DummyElements { id: 0 })
+            .last_good_contribution(&DummyElements { id: 0 }, None)
             .is_none());
     }
 
@@ -199,7 +219,7 @@ mod test {
         let log: ContributionLog<DummyPhase> =
             ContributionLog::new(vec![contribution!(0, 1, true, true)]);
         assert_eq!(
-            log.last_good_contribution(&DummyElements { id: 0 }),
+            log.last_good_contribution(&DummyElements { id: 0 }, None),
             Some(log.contributions[0])
         );
     }
@@ -211,7 +231,7 @@ mod test {
             contribution!(1, 2, true, true),
         ]);
         assert_eq!(
-            log.last_good_contribution(&DummyElements { id: 0 }),
+            log.last_good_contribution(&DummyElements { id: 0 }, None),
             Some(log.contributions[1])
         );
     }
@@ -222,7 +242,10 @@ mod test {
             contribution!(0, 1, true, true),
             contribution!(1, 2, true, true),
         ]);
-        assert_eq!(log.last_good_contribution(&DummyElements { id: 2 }), None);
+        assert_eq!(
+            log.last_good_contribution(&DummyElements { id: 2 }, None),
+            None
+        );
     }
 
     #[test]
@@ -243,8 +266,59 @@ mod test {
             contribution!(5, 7, true, true),
         ]);
         assert_eq!(
-            log.last_good_contribution(&DummyElements { id: 0 }),
+            log.last_good_contribution(&DummyElements { id: 0 }, None),
             Some(log.contributions[6])
+        );
+    }
+
+    #[test]
+    fn test_multi_log_with_skips_and_resuming_search() {
+        let log: ContributionLog<DummyPhase> = ContributionLog::new(vec![
+            contribution!(0, 1, true, true),
+            // Invalid
+            contribution!(1, 2, false, true),
+            // Valid
+            contribution!(1, 3, true, true),
+            // Valid, but wrong parent
+            contribution!(1, 4, true, true),
+            // Valid
+            contribution!(3, 5, true, true),
+            // Bad linking
+            contribution!(5, 6, true, false),
+            // Valid
+            contribution!(5, 7, true, true),
+        ]);
+        assert_eq!(
+            log.last_good_contribution(&DummyElements { id: 0 }, Some(hash_from_u8(5))),
+            Some(log.contributions[6]),
+        );
+    }
+
+    #[test]
+    fn test_multi_log_with_skips_and_bad_checkpoint() {
+        let log: ContributionLog<DummyPhase> = ContributionLog::new(vec![
+            contribution!(0, 1, true, true),
+            // Invalid
+            contribution!(1, 2, false, true),
+            // Valid
+            contribution!(1, 3, true, true),
+            // Valid, but wrong parent
+            contribution!(1, 4, true, true),
+            // Valid
+            contribution!(3, 5, true, true),
+            // Bad linking
+            contribution!(5, 6, true, false),
+            // Valid
+            contribution!(5, 7, true, true),
+        ]);
+        assert_eq!(
+            log.last_good_contribution(&DummyElements { id: 0 }, Some(hash_from_u8(100))),
+            Some(log.contributions[6]),
+        );
+        // Should work because we validate internal consistency
+        assert_eq!(
+            log.last_good_contribution(&DummyElements { id: 0 }, Some(hash_from_u8(2))),
+            Some(log.contributions[6]),
         );
     }
 }

--- a/crates/crypto/proof-setup/src/log.rs
+++ b/crates/crypto/proof-setup/src/log.rs
@@ -5,7 +5,13 @@ pub const CONTRIBUTION_HASH_SIZE: usize = 32;
 ///
 /// This is also used as the output of hashing CRS elements.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct ContributionHash([u8; CONTRIBUTION_HASH_SIZE]);
+pub struct ContributionHash(pub [u8; CONTRIBUTION_HASH_SIZE]);
+
+impl AsRef<[u8]> for ContributionHash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
 
 /// Represents an item that can be hashed.
 pub trait Hashable {

--- a/crates/crypto/proof-setup/src/log.rs
+++ b/crates/crypto/proof-setup/src/log.rs
@@ -185,7 +185,7 @@ mod test {
         }
 
         fn validate(
-            root: &Self::CRSElements,
+            _root: &Self::CRSElements,
             contribution: &Self::RawContribution,
         ) -> Option<Self::Contribution> {
             if contribution.valid {
@@ -195,7 +195,7 @@ mod test {
             }
         }
 
-        fn is_linked_to(contribution: &Self::Contribution, elements: &Self::CRSElements) -> bool {
+        fn is_linked_to(contribution: &Self::Contribution, _elements: &Self::CRSElements) -> bool {
             contribution.linked
         }
     }

--- a/crates/crypto/proof-setup/src/log.rs
+++ b/crates/crypto/proof-setup/src/log.rs
@@ -1,0 +1,104 @@
+/// The number of bytes in a contribution hash.
+pub const CONTRIBUTION_HASH_SIZE: usize = 32;
+
+/// Represents the hash of a contribution.
+///
+/// This is also used as the output of hashing CRS elements.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ContributionHash([u8; CONTRIBUTION_HASH_SIZE]);
+
+/// Represents an item that can be hashed.
+pub trait Hashable {
+    fn hash(&self) -> ContributionHash;
+}
+
+/// A trait abstracting common behavior between both setup phases.
+///
+/// This trait provides us with enough functionality to verify the contribution
+/// logs produced by both phases.
+pub trait Phase {
+    /// The type of the elements constituting this phase.
+    ///
+    /// This elements will be internally valid, although possibly not correctly linked
+    /// with respect to other contributions.
+    type CRSElements: Hashable;
+    /// The type of a contribution before any kind of validation.
+    type RawContribution;
+    /// A contribution after having been validated.
+    type Contribution: Hashable;
+
+    /// The hash of the parent element for a raw contribution.
+    fn parent_hash(contribution: &Self::RawContribution) -> ContributionHash;
+
+    /// The elements in a contribution.
+    fn elements(contribution: &Self::Contribution) -> Self::CRSElements;
+
+    /// Validate a contribution relative to some root elements.
+    ///
+    /// This might fail, hence the Option.
+    fn validate(
+        root: &Self::CRSElements,
+        contribution: &Self::RawContribution,
+    ) -> Option<Self::Contribution>;
+
+    /// Check if a contribution is linked to some parent elements.
+    ///
+    /// If a contribution is linked to those elements, then it builds upon those elements
+    /// correctly.
+    fn is_linked_to(contribution: &Self::Contribution, elements: &Self::CRSElements) -> bool;
+}
+
+/// A log of contributions.
+///
+/// This is just an ordered list of contributions, which should usually
+/// contain all contributions, starting from some root elements.
+pub struct ContributionLog<P: Phase> {
+    contributions: Vec<P::RawContribution>,
+}
+
+impl<P: Phase> ContributionLog<P> {
+    pub fn new(contributions: impl IntoIterator<Item = P::RawContribution>) -> Self {
+        Self {
+            contributions: contributions.into_iter().collect(),
+        }
+    }
+
+    /// Scan this log for the most recent valid contribution.
+    ///
+    /// This requires the root elements which these contributions all build upon.
+    ///
+    /// This might fail to find any good contributions, in which case None will be returned.
+    pub fn last_good_contribution(&self, root: &P::CRSElements) -> Option<P::Contribution> {
+        // We start by assuming that the root is correct, and the first good elements
+        // the log should start building on. From there, we keep considering new contributions,
+        // each of which can become the most recent good contribution if all conditions are met.
+        // By the end, we'll have the last good contribution for the log as a whole.
+        let root_hash = root.hash();
+        let mut last_good: Option<P::Contribution> = None;
+
+        for contribution in &self.contributions {
+            // 1. Check if the parent we're building off of is the last good contribution.
+            let expected_parent_hash = last_good.as_ref().map(|c| c.hash()).unwrap_or(root_hash);
+            if P::parent_hash(contribution) != expected_parent_hash {
+                continue;
+            }
+            // 2. Check if this contribution is internally valid.
+            let contribution = match P::validate(root, contribution) {
+                None => continue,
+                Some(c) => c,
+            };
+            // 3. Check if we're linked to the parent elements.
+            let linked = match last_good.as_ref() {
+                None => P::is_linked_to(&contribution, root),
+                Some(c) => P::is_linked_to(c, root),
+            };
+            if !linked {
+                continue;
+            }
+            // 4. At this point, this is the next good contribution
+            last_good = Some(contribution)
+        }
+
+        last_good
+    }
+}

--- a/crates/crypto/proof-setup/src/phase1.rs
+++ b/crates/crypto/proof-setup/src/phase1.rs
@@ -254,6 +254,16 @@ impl Hashable for RawContribution {
     }
 }
 
+impl From<Contribution> for RawContribution {
+    fn from(value: Contribution) -> Self {
+        Self {
+            parent: value.parent,
+            new_elements: value.new_elements.raw,
+            linking_proof: value.linking_proof
+        }
+    }
+}
+
 /// Represents a contribution to phase1 of the ceremony.
 ///
 /// This contribution is linked to a previous contribution, which it builds upon.
@@ -267,19 +277,9 @@ pub struct Contribution {
     linking_proof: LinkingProof,
 }
 
-impl Contribution {
-    fn to_raw(self) -> RawContribution {
-        RawContribution {
-            parent: self.parent,
-            new_elements: self.new_elements.raw,
-            linking_proof: self.linking_proof,
-        }
-    }
-}
-
 impl Hashable for Contribution {
     fn hash(&self) -> ContributionHash {
-        self.to_owned().to_raw().hash()
+        RawContribution::from(self.to_owned()).hash()
     }
 }
 

--- a/crates/crypto/proof-setup/src/phase1.rs
+++ b/crates/crypto/proof-setup/src/phase1.rs
@@ -4,9 +4,9 @@ use rand_core::{CryptoRngCore, OsRng};
 
 use crate::dlog;
 use crate::group::{
-    pairing, BatchedPairingChecker11, BatchedPairingChecker12, GroupHasher, Hash, F, G1, G2,
+    pairing, BatchedPairingChecker11, BatchedPairingChecker12, GroupHasher, F, G1, G2,
 };
-use crate::log::{ContributionHash, Hashable, Phase, CONTRIBUTION_HASH_SIZE};
+use crate::log::{ContributionHash, Hashable, Phase};
 
 /// Check that a given degree is high enough.
 ///
@@ -62,7 +62,7 @@ impl RawCRSElements {
         if self.x_1.len() != long_len(d) {
             return None;
         }
-        return Some(d);
+        Some(d)
     }
 
     /// Validate the internal consistency of these elements, producing a validated struct.
@@ -234,7 +234,7 @@ impl RawContribution {
             .map(|new_elements| Contribution {
                 parent: self.parent,
                 new_elements,
-                linking_proof: self.linking_proof.clone(),
+                linking_proof: self.linking_proof,
             })
     }
 }
@@ -259,7 +259,7 @@ impl From<Contribution> for RawContribution {
         Self {
             parent: value.parent,
             new_elements: value.new_elements.raw,
-            linking_proof: value.linking_proof
+            linking_proof: value.linking_proof,
         }
     }
 }
@@ -447,6 +447,7 @@ mod test {
     use rand_core::OsRng;
 
     use crate::group::F;
+    use crate::log::CONTRIBUTION_HASH_SIZE;
 
     /// The degree we use for tests.
     ///

--- a/crates/crypto/proof-setup/src/phase2.rs
+++ b/crates/crypto/proof-setup/src/phase2.rs
@@ -1,14 +1,13 @@
 //! This module is very similar to the one for phase1, so reading that one might be useful.
-use std::hash;
 
 use ark_ec::Group;
 use ark_ff::{fields::Field, UniformRand, Zero};
 use rand_core::{CryptoRngCore, OsRng};
 
-use crate::log::{ContributionHash, Hashable, Phase, CONTRIBUTION_HASH_SIZE};
+use crate::log::{ContributionHash, Hashable, Phase};
 use crate::{
     dlog,
-    group::{BatchedPairingChecker11, GroupHasher, Hash, F, G1, G2},
+    group::{BatchedPairingChecker11, GroupHasher, F, G1, G2},
 };
 
 /// Raw CRS elements, not yet validated for consistency.
@@ -66,12 +65,12 @@ impl Hashable for RawCRSElements {
 
         hasher.eat_usize(self.inv_delta_p_1.len());
         for v in &self.inv_delta_p_1 {
-            hasher.eat_g1(&v);
+            hasher.eat_g1(v);
         }
 
         hasher.eat_usize(self.inv_delta_t_1.len());
         for v in &self.inv_delta_t_1 {
-            hasher.eat_g1(&v);
+            hasher.eat_g1(v);
         }
 
         ContributionHash(hasher.finalize_bytes())
@@ -252,6 +251,8 @@ impl Phase for Phase2 {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    use crate::log::CONTRIBUTION_HASH_SIZE;
 
     use rand_core::OsRng;
 

--- a/crates/crypto/proof-setup/src/phase2.rs
+++ b/crates/crypto/proof-setup/src/phase2.rs
@@ -1,4 +1,6 @@
 //! This module is very similar to the one for phase1, so reading that one might be useful.
+use std::hash;
+
 use ark_ec::Group;
 use ark_ff::{fields::Field, UniformRand, Zero};
 use rand_core::CryptoRngCore;
@@ -92,7 +94,7 @@ pub const CONTRIBUTION_HASH_SIZE: usize = 32;
 // Note: Don't need constant time equality because we're hashing public data: contributions.
 
 /// The hash of a contribution, providing a unique string for each contribution.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, hash::Hash)]
 pub struct ContributionHash(pub [u8; CONTRIBUTION_HASH_SIZE]);
 
 impl AsRef<[u8]> for ContributionHash {


### PR DESCRIPTION
Fixes #2870.

This also adds an abstraction over the two phases, which was need to consolidate the common behavior they share for log verification.