### PR TITLE
build: simplify container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,17 @@
-docs/
-.github/
-target/**
+# exclude everything by default from container images,
+# re-add directories explicitly.
+**/
+!crates/
+!Cargo.toml
+!Cargo.lock
+!.cargo/
+# git directory for vergen. unfortunately, breaks cache
+# on every commit.
+!.git/
 
-# We'll generate relayer configs dynamically for now
-deployments/relayer/configs/*
+# testnets for 'pd testnet generate' defaults
+!testnets/
+# metrics containers
+!deployments/config/
+# relayer container
+!deployments/relayer/

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,5 +1,5 @@
 ---
-name: Create and publish container image
+name: Create and publish container images
 # Build strategy: we want to build new containers immediately
 # prior to deploying testnets using those containers. We don't
 # trigger the container-build workflow on merge or tag events;
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-push-penumbra:
+  penumbra:
     runs-on: buildjet-16vcpu-ubuntu-2004
     permissions:
       contents: read
@@ -51,14 +51,15 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           file: deployments/containerfiles/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  build-and-push-grafana:
-    runs-on: buildjet-16vcpu-ubuntu-2004
+  grafana:
+    # No need for a heavy runner, we're just copying in a few files, not compiling.
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -96,7 +97,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  build-and-push-relayer:
+  relayer:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/deployments/containerfiles/Dockerfile
+++ b/deployments/containerfiles/Dockerfile
@@ -1,167 +1,49 @@
-FROM --platform=$BUILDPLATFORM rust:1.65.0-bullseye AS build-env
+ARG RUST_VERSION=1.71.1
+FROM docker.io/rust:${RUST_VERSION}-slim-bookworm AS build-env
 
-RUN rustup component add rustfmt
+# Install build dependencies. These packages should match what's recommended on
+# https://guide.penumbra.zone/main/pcli/install.html
+# We don't install git-lfs, because the git artifacts are copied in from the build host.
+RUN apt-get update && apt-get install -y \
+        build-essential \
+        pkg-config \
+        libssl-dev \
+        clang
 
-ARG TARGETARCH
-ARG BUILDARCH
+WORKDIR /usr/src/penumbra
+# Add rust dependency lockfiles first, to cache downloads.
+COPY Cargo.lock Cargo.toml .
+COPY crates ./crates
+RUN cargo fetch
+# Unfortunately, container layer cache is busted copying in the .git
+# dir, which is required for using vergen, so we rebuild the rust
+# code from source fresh.
+COPY . .
+RUN cargo build --release
 
-RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-      rustup target add aarch64-unknown-linux-gnu; \
-      if [ "${BUILDARCH}" != "arm64" ]; then \
-        dpkg --add-architecture arm64; \
-        apt update && apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu; \
-        ln -s /usr/aarch64-linux-gnu/include/bits /usr/include/bits; \
-        ln -s /usr/aarch64-linux-gnu/include/sys /usr/include/sys; \
-        ln -s /usr/aarch64-linux-gnu/include/gnu /usr/include/gnu; \
-      else \
-        apt update; \
-      fi; \
-      apt install -y libssl1.1:arm64 libssl-dev:arm64 openssl:arm64 libclang-dev clang; \
-    elif [ "${TARGETARCH}" = "amd64" ]; then \
-      rustup target add x86_64-unknown-linux-gnu; \
-      if [ "${BUILDARCH}" != "amd64" ]; then \
-        dpkg --add-architecture amd64; apt update; \
-        apt update && apt install -y gcc-x86_64-linux-gnu g++-x86_64-linux-gnu; \
-        ln -s /usr/x86_64-linux-gnu/include/bits /usr/include/bits; \
-        ln -s /usr/x86_64-linux-gnu/include/sys /usr/include/sys; \
-        ln -s /usr/x86_64-linux-gnu/include/gnu /usr/include/gnu; \
-      else \
-        apt update; \
-      fi; \
-      apt install -y libssl1.1:amd64 libssl-dev:amd64 openssl:amd64 libclang-dev clang; \
-    fi
+# Runtime image.
+FROM docker.io/debian:bookworm-slim
+ARG USERNAME=penumbra
+ARG UID=1000
+ARG GID=1000
+# We add curl & jq so we can munge JSON during init steps for deployment.
+RUN apt-get update && apt-get install -y \
+        curl \
+        jq \
+        libssl-dev
 
-WORKDIR /usr/src
-
-ADD . .
-
-RUN if [ "$TARGETARCH" = "arm64" ] && [ "$BUILDARCH" != "arm64" ]; then \
-      cargo fetch --target aarch64-unknown-linux-gnu; \
-    elif [ "$TARGETARCH" = "amd64" ] && [ "$BUILDARCH" != "amd64" ]; then \
-      cargo fetch --target x86_64-unknown-linux-gnu; \
-    else \
-      cargo fetch --target $(uname -m)-unknown-linux-gnu; \
-    fi;
-
-RUN if [ "$TARGETARCH" = "arm64" ] && [ "$BUILDARCH" != "arm64" ]; then \
-      export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-        CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
-        CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
-        PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu; \
-      cargo build --release --target aarch64-unknown-linux-gnu; \
-    elif [ "$TARGETARCH" = "amd64" ] && [ "$BUILDARCH" != "amd64" ]; then \
-      export CARGO_TARGET_x86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc \
-        CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc \
-        CXX_x86_64_unknown_linux_gnu=x86_64-linux-gnu-g++ \
-        PKG_CONFIG_SYSROOT_DIR=/usr/x86_64-linux-gnu; \
-      cargo build --release --target x86_64-unknown-linux-gnu; \
-    else \
-      cargo build --release --target $(uname -m)-unknown-linux-gnu;\
-    fi;
-
-# Copy all binaries to /root/bin, for a single place to copy into final image.
-RUN mkdir /root/bin
-RUN if [ "${TARGETARCH}" = "arm64" ]; then ARCH=aarch64; \
-    elif [ "${TARGETARCH}" = "amd64" ]; then ARCH=x86_64; fi; \
-    cp /usr/src/target/${ARCH}-unknown-linux-gnu/release/pcli \
-      /usr/src/target/${ARCH}-unknown-linux-gnu/release/pd \
-      /usr/src/target/${ARCH}-unknown-linux-gnu/release/pclientd \
-      /usr/src/target/${ARCH}-unknown-linux-gnu/release/tct-live-edit \
-      /root/bin
-
-# Use minimal busybox from Strangelove infra-toolkit image for final scratch image
-FROM ghcr.io/strangelove-ventures/infra-toolkit:v0.0.6 AS busybox-min
-RUN addgroup --gid 1000 -S penumbra && adduser --uid 1000 -S penumbra -G penumbra
-
-# Use ln and rm from full featured busybox for assembling final image
-FROM busybox:1.34.1-musl AS busybox-full
-
-# Use TARGETARCH image for determining necessary libs
-FROM rust:1.65.0-bullseye as target-arch-libs
-RUN apt update && apt install -y clang libssl1.1 openssl
-
-# Determine library dependencies of built binaries and copy to indexed path in /root/lib_abs for copying to final image.
-# Absolute path of each library is appended to /root/lib_abs.list for restoring in final image.
-COPY --from=build-env /root/bin /root/bin
-RUN mkdir -p /root/lib_abs && touch /root/lib_abs.list
-RUN bash -ec \
-  'readarray -t LIBS < <( for b in $(ls -1 /root/bin/* | sort -u) ; do ldd $b | awk "{print \$1, \$2, \$3 }" | sort -u; done | sort -u ; ) ; \
-    i=0; for LIB in "${LIBS[@]}"; do \
-      PATH1=$(echo $LIB | awk "{print \$1}") ; \
-      if [ "$PATH1" = "linux-vdso.so.1" ]; then continue; fi; \
-      if [ "$PATH1" = "/lib/ld-linux-aarch64.so.1" ]; then continue; fi; \
-      PATH2=$(echo $LIB | awk "{print \$3}") ; \
-      if [ -n "$PATH2" ]; then \
-        cp $PATH2 /root/lib_abs/$i ; \
-        echo $PATH2 >> /root/lib_abs.list; \
-      else \
-        cp $PATH1 /root/lib_abs/$i ; \
-        echo $PATH1 >> /root/lib_abs.list; \
-      fi; \
-      ((i = i + 1)) ;\
-  done; \
-  ARCH=$(uname -m) ; \
-  for l in libnss_dns.so.2 libresolv.so.2 ; do \
-        p="/lib/${ARCH}-linux-gnu/$l"; \
-        cp $p /root/lib_abs/$i; \
-        echo $p >> /root/lib_abs.list; \
-        ((i = i + 1)) ; \
-  done'
-
-# Build final image from scratch
-FROM scratch
-
-WORKDIR /bin
-
-# Install ln (for making hard links), rm (for cleanup), mv, mkdir, and dirname from full busybox image (will be deleted, only needed for image assembly)
-COPY --from=busybox-full /bin/ln /bin/rm /bin/mv /bin/mkdir /bin/dirname ./
-
-# Install minimal busybox image as shell binary (will create hardlinks for the rest of the binaries to this data)
-COPY --from=busybox-min /busybox/busybox /bin/sh
-
-# Add hard links for read-only utils, then remove ln and rm
-# Will then only have one copy of the busybox minimal binary file with all utils pointing to the same underlying inode
-RUN ln sh pwd && \
-    ln sh ls && \
-    ln sh cat && \
-    ln sh less && \
-    ln sh grep && \
-    ln sh sleep && \
-    ln sh env && \
-    ln sh tar && \
-    ln sh tee && \
-    ln sh du
+# Add normal user account
+RUN groupadd --gid ${GID} ${USERNAME} \
+        && useradd -m -d /home/${USERNAME} -g ${GID} -u ${UID} ${USERNAME}
 
 # Install chain binaries
-COPY --from=build-env /root/bin /bin
+COPY --from=build-env \
+            /usr/src/penumbra/target/release/pcli \
+            /usr/src/penumbra/target/release/pclientd \
+            /usr/src/penumbra/target/release/pd \
+            /usr/src/penumbra/target/release/tct-live-edit \
+            /usr/bin/
 
-# Copy over libraries
-COPY --from=target-arch-libs /root/lib_abs /root/lib_abs
-COPY --from=target-arch-libs /root/lib_abs.list /root/lib_abs.list
-
-# Move libraries to their absolute locations.
-RUN sh -ec 'i=0; while read FILE; do \
-      echo "$i: $FILE"; \
-      DIR="$(dirname "$FILE")"; \
-      mkdir -p "$DIR"; \
-      mv /root/lib_abs/$i $FILE; \
-      i=$((i+1)); \
-    done < /root/lib_abs.list'
-
-# Remove write utils used to construct image and tmp dir/file for lib copy.
-RUN rm -rf ln rm mv mkdir dirname /root/lib_abs /root/lib_abs.list
-
-# Install trusted CA certificates
-COPY --from=busybox-min /etc/ssl/cert.pem /etc/ssl/cert.pem
-
-# Install penumbra user
-COPY --from=busybox-min /etc/passwd /etc/passwd
-COPY --from=busybox-min --chown=1000:1000 /home/penumbra /home/penumbra
-
-WORKDIR /home/penumbra
-USER penumbra
-
-ARG DATABASE_URL
-ENV DATABASE_URL=$DATABASE_URL
-ENV RUST_LOG=warn,pd=info,penumbra=info
-CMD [ "/bin/pd" ]
+WORKDIR /home/${USERNAME}
+USER ${USERNAME}
+CMD [ "/usr/bin/pd" ]

--- a/deployments/containerfiles/Dockerfile-relayer
+++ b/deployments/containerfiles/Dockerfile-relayer
@@ -20,9 +20,8 @@ COPY --from=upstream /bin/rly /bin/rly
 RUN groupadd -g ${GID} ${USERNAME} && useradd -m -d /home/${USERNAME} -g ${GID} -u ${UID} ${USERNAME}
 
 # Prepare custom config script
-RUN mkdir -p /usr/src/penumbra-relayer
-COPY deployments/relayer/ /usr/src/penumbra-relayer/
 WORKDIR /usr/src/penumbra-relayer
+COPY deployments/relayer/ /usr/src/penumbra-relayer/
 RUN chown -R ${USERNAME}:${USERNAME} /usr/src/penumbra-relayer
 USER ${USERNAME}
 ENTRYPOINT ["/usr/src/penumbra-relayer/entrypoint.sh"]


### PR DESCRIPTION
Removes several of the multi-stage build targets, and drops ostensible support for arm64, which wasn't working anyway (#2857). We now use a bog-standard Debian slim container for the runtime, with no manual wrangling of shared object files.

Closes #2858.