### PR TITLE
fix: make `U128x128::round_up` fallible

### DIFF
--- a/crates/core/component/dex/src/lp/order.rs
+++ b/crates/core/component/dex/src/lp/order.rs
@@ -78,7 +78,7 @@ impl BuyOrder {
         let desired_unit_amount = U128x128::from(desired_unit.unit_amount()); // e.g., 1_000
 
         let offered_amount = ((price_amount * desired_amount) / desired_unit_amount)?
-            .round_up()
+            .round_up()?
             .try_into()
             .expect("rounded to integer");
 
@@ -117,7 +117,7 @@ impl BuyOrder {
 
         let price_amount: Amount = ((offered_amount * desired_unit_amount) / desired_amount)?
             // TODO: Is this the correct rounding behavior? Should we expect this to round-trip exactly?
-            .round_up()
+            .round_up()?
             .try_into()
             .expect("rounded to integer");
 
@@ -163,7 +163,7 @@ impl SellOrder {
         let offered_unit_amount = U128x128::from(offered_unit.unit_amount()); // e.g., 1_000
 
         let desired_amount = ((price_amount * offered_amount) / offered_unit_amount)?
-            .round_up()
+            .round_up()?
             .try_into()
             .expect("rounded to integer");
 
@@ -202,7 +202,7 @@ impl SellOrder {
 
         let price_amount: Amount = ((desired_amount * offered_unit_amount) / offered_amount)?
             // TODO: Is this the correct rounding behavior? Should we expect this to round-trip exactly?
-            .round_up()
+            .round_up()?
             .try_into()
             .expect("rounded to integer");
 

--- a/crates/core/component/dex/src/lp/trading_function.rs
+++ b/crates/core/component/dex/src/lp/trading_function.rs
@@ -261,8 +261,10 @@ impl BareTradingFunction {
         // We burn the rouding error by apply `ceil` to delta_1:
         //
         // delta_1_star = Ceil(delta_1)
+        // TODO: round_up is now fallible
         let fillable_delta_1_exact: Amount = fillable_delta_1
             .round_up()
+            .expect("no overflow")
             .try_into()
             .expect("rounded up to integral value");
 
@@ -355,7 +357,12 @@ impl BareTradingFunction {
             // We burn the rouding error by apply `ceil` to delta_1:
             //
             // delta_1_star = Ceil(delta_1)
-            let fillable_delta_1_exact: Amount = fillable_delta_1.round_up().try_into().unwrap();
+            // TODO: round_up is now fallible
+            let fillable_delta_1_exact: Amount = fillable_delta_1
+                .round_up()
+                .expect("no overflow")
+                .try_into()
+                .unwrap();
 
             // How to show that: `unfilled_amount >= 0`:
             // In this branch, we have:

--- a/crates/core/num/src/fixpoint.rs
+++ b/crates/core/num/src/fixpoint.rs
@@ -103,12 +103,13 @@ impl U128x128 {
     }
 
     /// Rounds the number up to the nearest integer.
-    pub fn round_up(&self) -> Self {
+    pub fn round_up(&self) -> Result<Self, Error> {
         let (integral, fractional) = self.0.into_words();
         if fractional == 0 {
-            *self
+            Ok(*self)
         } else {
-            Self(U256::from_words(integral + 1, 0u128))
+            let integral = integral.checked_add(1).ok_or(Error::Overflow)?;
+            Ok(Self(U256::from_words(integral, 0u128)))
         }
     }
 


### PR DESCRIPTION
Followup from one of the audits. 

Inside the DEX logic for the infallible methods that call `U128x128::round_up`, what should happen? (cc @erwanor)