### PR TITLE
docs(protos): clarify memo in tx planner

### DIFF
--- a/crates/proto/src/gen/penumbra.view.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.view.v1alpha1.rs
@@ -53,7 +53,8 @@ pub struct TransactionPlannerRequest {
     /// The fee for the requested TransactionPlan, if any.
     #[prost(message, optional, tag = "2")]
     pub fee: ::core::option::Option<super::super::core::crypto::v1alpha1::Fee>,
-    /// The memo for the requested TransactionPlan
+    /// The memo for the requested TransactionPlan.
+    /// The memo must be unspecified unless `outputs` is nonempty.
     #[prost(message, optional, tag = "3")]
     pub memo: ::core::option::Option<
         super::super::core::transaction::v1alpha1::MemoPlaintext,

--- a/crates/proto/src/gen/proto_descriptor.bin
+++ b/crates/proto/src/gen/proto_descriptor.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6286081a94479fc796bd0f8cdca3b11447d0e08a93b66eceb2038abd283c9db0
-size 330419
+oid sha256:ece94822c180b88829886efe0f88e9baa2b90c9bd7bd9d86e607d412f27af671
+size 330480

--- a/proto/go/gen/penumbra/view/v1alpha1/view.pb.go
+++ b/proto/go/gen/penumbra/view/v1alpha1/view.pb.go
@@ -255,7 +255,8 @@ type TransactionPlannerRequest struct {
 	ExpiryHeight uint64 `protobuf:"varint,1,opt,name=expiry_height,json=expiryHeight,proto3" json:"expiry_height,omitempty"`
 	// The fee for the requested TransactionPlan, if any.
 	Fee *v1alpha11.Fee `protobuf:"bytes,2,opt,name=fee,proto3" json:"fee,omitempty"`
-	// The memo for the requested TransactionPlan
+	// The memo for the requested TransactionPlan.
+	// The memo must be unspecified unless `outputs` is nonempty.
 	Memo *v1alpha1.MemoPlaintext `protobuf:"bytes,3,opt,name=memo,proto3" json:"memo,omitempty"`
 	// Identifies the account group to query.
 	AccountGroupId *v1alpha11.AccountGroupId `protobuf:"bytes,14,opt,name=account_group_id,json=accountGroupId,proto3,oneof" json:"account_group_id,omitempty"`

--- a/proto/penumbra/penumbra/view/v1alpha1/view.proto
+++ b/proto/penumbra/penumbra/view/v1alpha1/view.proto
@@ -125,7 +125,8 @@ message TransactionPlannerRequest {
     uint64 expiry_height = 1;
     // The fee for the requested TransactionPlan, if any.
     core.crypto.v1alpha1.Fee fee = 2;
-    // The memo for the requested TransactionPlan
+    // The memo for the requested TransactionPlan.
+    // The memo must be unspecified unless `outputs` is nonempty.
     core.transaction.v1alpha1.MemoPlaintext memo = 3;
     // Identifies the account group to query.
     optional core.crypto.v1alpha1.AccountGroupId account_group_id = 14;


### PR DESCRIPTION
We had a request from Zpoken to clarify whether we should support memos on swap actions. We should not! But that wasn't clear from the interfaces docs, so adding a note for future implementors.