### PR TITLE
fix: delegator vote nullifier handling

### DIFF
--- a/crates/core/app/src/action_handler/transaction.rs
+++ b/crates/core/app/src/action_handler/transaction.rs
@@ -15,7 +15,7 @@ mod stateless;
 
 use self::stateful::{claimed_anchor_is_valid, fmd_parameters_valid};
 use stateless::{
-    check_memo_exists_if_outputs_absent_if_not, no_duplicate_nullifiers,
+    check_memo_exists_if_outputs_absent_if_not, no_duplicate_nullifiers, no_duplicate_votes,
     num_clues_equal_to_num_outputs, valid_binding_signature,
 };
 
@@ -31,6 +31,7 @@ impl ActionHandler for Transaction {
         // TODO: unify code organization
         valid_binding_signature(self)?;
         no_duplicate_nullifiers(self)?;
+        no_duplicate_votes(self)?;
         num_clues_equal_to_num_outputs(self)?;
         check_memo_exists_if_outputs_absent_if_not(self)?;
 

--- a/crates/core/app/src/action_handler/transaction.rs
+++ b/crates/core/app/src/action_handler/transaction.rs
@@ -15,7 +15,7 @@ mod stateless;
 
 use self::stateful::{claimed_anchor_is_valid, fmd_parameters_valid};
 use stateless::{
-    check_memo_exists_if_outputs_absent_if_not, no_duplicate_nullifiers, no_duplicate_votes,
+    check_memo_exists_if_outputs_absent_if_not, no_duplicate_spends, no_duplicate_votes,
     num_clues_equal_to_num_outputs, valid_binding_signature,
 };
 
@@ -30,7 +30,7 @@ impl ActionHandler for Transaction {
 
         // TODO: unify code organization
         valid_binding_signature(self)?;
-        no_duplicate_nullifiers(self)?;
+        no_duplicate_spends(self)?;
         no_duplicate_votes(self)?;
         num_clues_equal_to_num_outputs(self)?;
         check_memo_exists_if_outputs_absent_if_not(self)?;

--- a/crates/core/app/src/mock_client.rs
+++ b/crates/core/app/src/mock_client.rs
@@ -12,9 +12,9 @@ use penumbra_tct as tct;
 pub struct MockClient {
     latest_height: u64,
     fvk: FullViewingKey,
-    notes: BTreeMap<note::StateCommitment, Note>,
+    pub notes: BTreeMap<note::StateCommitment, Note>,
     swaps: BTreeMap<tct::StateCommitment, SwapPlaintext>,
-    sct: penumbra_tct::Tree,
+    pub sct: penumbra_tct::Tree,
 }
 
 impl MockClient {

--- a/crates/core/app/src/tests/mod.rs
+++ b/crates/core/app/src/tests/mod.rs
@@ -1,1 +1,2 @@
+mod spend;
 mod swap_and_swap_claim;

--- a/crates/core/app/src/tests/spend.rs
+++ b/crates/core/app/src/tests/spend.rs
@@ -10,7 +10,7 @@ use penumbra_keys::PayloadKey;
 use penumbra_num::Amount;
 use penumbra_shielded_pool::{component::ShieldedPool, SpendPlan};
 use penumbra_storage::{ArcStateDeltaExt, StateDelta, TempStorage};
-use penumbra_transaction::{AuthorizingData, Transaction, TransactionBody};
+use penumbra_transaction::{AuthorizingData, Transaction, TransactionBody, TransactionParameters};
 use rand_core::SeedableRng;
 use tendermint::abci;
 
@@ -237,17 +237,15 @@ async fn spend_duplicate_nullifier_same_transaction() {
     synthetic_blinding_factor += output_plan.value_blinding;
 
     // 5. Construct a transaction with both spends that use the same note/nullifier.
-    let chain_id = "test-chain-id".to_string();
     let transaction_body = TransactionBody {
         actions: vec![
             penumbra_transaction::Action::Spend(spend_1),
             penumbra_transaction::Action::Spend(spend_2),
             penumbra_transaction::Action::Output(output),
         ],
-        expiry_height: 1000,
-        chain_id,
+        transaction_parameters: TransactionParameters::default(),
         fee: Fee::from_staking_token_amount(0u64.into()),
-        fmd_clues: vec![],
+        detection_data: None,
         memo: None,
     };
     let binding_signing_key = SigningKey::from(synthetic_blinding_factor);

--- a/crates/core/app/src/tests/spend.rs
+++ b/crates/core/app/src/tests/spend.rs
@@ -1,0 +1,83 @@
+use std::{ops::Deref, sync::Arc};
+
+use crate::{app::App, MockClient, TempStorageExt};
+use penumbra_asset::{Value, STAKING_TOKEN_ASSET_ID};
+use penumbra_chain::{
+    component::{StateReadExt, StateWriteExt},
+    test_keys, EffectHash, TransactionContext,
+};
+use penumbra_component::{ActionHandler, Component};
+use penumbra_fee::Fee;
+use penumbra_keys::Address;
+use penumbra_num::Amount;
+use penumbra_sct::component::{SctManager, StateReadExt as _};
+use penumbra_shielded_pool::{component::ShieldedPool, Note, SpendPlan};
+use penumbra_storage::{ArcStateDeltaExt, StateDelta, TempStorage};
+use penumbra_transaction::Transaction;
+use rand_core::SeedableRng;
+use tendermint::abci;
+
+#[tokio::test]
+async fn spend_happy_path() -> anyhow::Result<()> {
+    let mut rng = rand_chacha::ChaChaRng::seed_from_u64(1312);
+
+    let storage = TempStorage::new().await?.apply_default_genesis().await?;
+    let mut state = Arc::new(StateDelta::new(storage.latest_snapshot()));
+
+    let height = 1;
+
+    // Precondition: This test uses the default genesis which has existing notes for the test keys.
+    let mut client = MockClient::new(test_keys::FULL_VIEWING_KEY.clone());
+    let sk = test_keys::SPEND_KEY.clone();
+    client.sync_to(0, state.deref()).await?;
+    let note = client.notes.values().next().unwrap().clone();
+    let note_commitment = note.commit();
+    let proof = client.sct.witness(note_commitment).unwrap();
+    let root = client.sct.root();
+    let tct_position = proof.position();
+
+    // 1. Simulate BeginBlock
+    let mut state_tx = state.try_begin_transaction().unwrap();
+    state_tx.put_block_height(height);
+    state_tx.put_epoch_by_height(
+        height,
+        penumbra_chain::Epoch {
+            index: 0,
+            start_height: 0,
+        },
+    );
+    state_tx.apply();
+
+    // 2. Create a Spend action
+    let spend_plan = SpendPlan::new(&mut rng, note, tct_position);
+    let dummy_effect_hash = [0u8; 64];
+    let rsk = sk.spend_auth_key().randomize(&spend_plan.randomizer);
+    let auth_sig = rsk.sign(&mut rng, dummy_effect_hash.as_ref());
+    let spend = spend_plan.spend(&test_keys::FULL_VIEWING_KEY, auth_sig, proof, root);
+    let transaction_context = TransactionContext {
+        anchor: root,
+        effect_hash: EffectHash(dummy_effect_hash),
+    };
+
+    // 3. Simulate execution of the Spend action
+    spend.check_stateless(transaction_context).await?;
+    spend.check_stateful(state.clone()).await?;
+    let mut state_tx = state.try_begin_transaction().unwrap();
+    spend.execute(&mut state_tx).await?;
+    state_tx.apply();
+
+    // 4. Execute EndBlock
+
+    let end_block = abci::request::EndBlock {
+        height: height.try_into().unwrap(),
+    };
+    ShieldedPool::end_block(&mut state, &end_block).await;
+
+    let mut state_tx = state.try_begin_transaction().unwrap();
+    // ... and for the App, call `finish_block` to correctly write out the SCT with the data we'll use next.
+    App::finish_block(&mut state_tx).await;
+
+    state_tx.apply();
+
+    Ok(())
+}

--- a/crates/core/app/src/tests/spend.rs
+++ b/crates/core/app/src/tests/spend.rs
@@ -1,19 +1,16 @@
 use std::{ops::Deref, sync::Arc};
 
-use crate::{app::App, MockClient, TempStorageExt};
-use penumbra_asset::{Value, STAKING_TOKEN_ASSET_ID};
-use penumbra_chain::{
-    component::{StateReadExt, StateWriteExt},
-    test_keys, EffectHash, TransactionContext,
-};
-use penumbra_component::{ActionHandler, Component};
+use crate::{app::App, ActionHandler, MockClient, TempStorageExt};
+use decaf377_rdsa::SigningKey;
+use penumbra_asset::Value;
+use penumbra_chain::{component::StateWriteExt, test_keys, EffectHash, TransactionContext};
+use penumbra_component::{ActionHandler as _, Component};
 use penumbra_fee::Fee;
-use penumbra_keys::Address;
+use penumbra_keys::PayloadKey;
 use penumbra_num::Amount;
-use penumbra_sct::component::{SctManager, StateReadExt as _};
-use penumbra_shielded_pool::{component::ShieldedPool, Note, SpendPlan};
+use penumbra_shielded_pool::{component::ShieldedPool, SpendPlan};
 use penumbra_storage::{ArcStateDeltaExt, StateDelta, TempStorage};
-use penumbra_transaction::Transaction;
+use penumbra_transaction::{AuthorizingData, Transaction, TransactionBody};
 use rand_core::SeedableRng;
 use tendermint::abci;
 
@@ -80,4 +77,188 @@ async fn spend_happy_path() -> anyhow::Result<()> {
     state_tx.apply();
 
     Ok(())
+}
+
+#[tokio::test]
+#[should_panic(expected = "was already spent")]
+async fn spend_duplicate_nullifier_previous_transaction() {
+    let mut rng = rand_chacha::ChaChaRng::seed_from_u64(1312);
+
+    let storage = TempStorage::new()
+        .await
+        .expect("can start new temp storage")
+        .apply_default_genesis()
+        .await
+        .expect("can apply default genesis");
+    let mut state = Arc::new(StateDelta::new(storage.latest_snapshot()));
+
+    let height = 1;
+
+    // Precondition: This test uses the default genesis which has existing notes for the test keys.
+    let mut client = MockClient::new(test_keys::FULL_VIEWING_KEY.clone());
+    let sk = test_keys::SPEND_KEY.clone();
+    client
+        .sync_to(0, state.deref())
+        .await
+        .expect("can sync to genesis");
+    let note = client.notes.values().next().unwrap().clone();
+    let note_commitment = note.commit();
+    let proof = client.sct.witness(note_commitment).unwrap();
+    let root = client.sct.root();
+    let tct_position = proof.position();
+
+    // 1. Simulate BeginBlock
+    let mut state_tx = state.try_begin_transaction().unwrap();
+    state_tx.put_block_height(height);
+    state_tx.put_epoch_by_height(
+        height,
+        penumbra_chain::Epoch {
+            index: 0,
+            start_height: 0,
+        },
+    );
+    state_tx.apply();
+
+    // 2. Create a Spend action - This is the first spend of this note.
+    let spend_plan = SpendPlan::new(&mut rng, note.clone(), tct_position);
+    let dummy_effect_hash = [0u8; 64];
+    let rsk = sk.spend_auth_key().randomize(&spend_plan.randomizer);
+    let auth_sig = rsk.sign(&mut rng, dummy_effect_hash.as_ref());
+    let spend = spend_plan.spend(&test_keys::FULL_VIEWING_KEY, auth_sig, proof.clone(), root);
+    let transaction_context = TransactionContext {
+        anchor: root,
+        effect_hash: EffectHash(dummy_effect_hash),
+    };
+
+    // 3. Simulate execution of the Spend action
+    spend
+        .check_stateless(transaction_context)
+        .await
+        .expect("can apply first spend");
+    spend
+        .check_stateful(state.clone())
+        .await
+        .expect("can apply first spend");
+    let mut state_tx = state.try_begin_transaction().unwrap();
+    spend
+        .execute(&mut state_tx)
+        .await
+        .expect("should be able to apply first spend");
+    state_tx.apply();
+
+    // 4. Create a second Spend action of the same note - This is a double spend.
+    let spend_plan = SpendPlan::new(&mut rng, note, tct_position);
+    let dummy_effect_hash = [0u8; 64];
+    let rsk = sk.spend_auth_key().randomize(&spend_plan.randomizer);
+    let auth_sig = rsk.sign(&mut rng, dummy_effect_hash.as_ref());
+    let spend = spend_plan.spend(&test_keys::FULL_VIEWING_KEY, auth_sig, proof, root);
+    let transaction_context = TransactionContext {
+        anchor: root,
+        effect_hash: EffectHash(dummy_effect_hash),
+    };
+
+    // 5. Simulate execution of the double spend - the test should panic here
+    spend
+        .check_stateless(transaction_context)
+        .await
+        .expect("check stateless should succeed");
+    spend.check_stateful(state.clone()).await.unwrap();
+    let mut state_tx = state.try_begin_transaction().unwrap();
+    spend.execute(&mut state_tx).await.unwrap();
+    state_tx.apply();
+}
+
+#[tokio::test]
+#[should_panic(expected = "Duplicate nullifier in transaction")]
+async fn spend_duplicate_nullifier_same_transaction() {
+    let mut rng = rand_chacha::ChaChaRng::seed_from_u64(1312);
+
+    let storage = TempStorage::new()
+        .await
+        .expect("can start new temp storage")
+        .apply_default_genesis()
+        .await
+        .expect("can apply default genesis");
+    let mut state = Arc::new(StateDelta::new(storage.latest_snapshot()));
+
+    let height = 1;
+
+    // Precondition: This test uses the default genesis which has existing notes for the test keys.
+    let mut client = MockClient::new(test_keys::FULL_VIEWING_KEY.clone());
+    let sk = test_keys::SPEND_KEY.clone();
+    client
+        .sync_to(0, state.deref())
+        .await
+        .expect("can sync to genesis");
+    let note = client.notes.values().next().unwrap().clone();
+    let note_commitment = note.commit();
+    let proof = client.sct.witness(note_commitment).unwrap();
+    let root = client.sct.root();
+    let tct_position = proof.position();
+
+    // 1. Simulate BeginBlock
+    let mut state_tx = state.try_begin_transaction().unwrap();
+    state_tx.put_block_height(height);
+    state_tx.put_epoch_by_height(
+        height,
+        penumbra_chain::Epoch {
+            index: 0,
+            start_height: 0,
+        },
+    );
+    state_tx.apply();
+
+    // 2. Create a Spend action - This is the first spend of this note.
+    let spend_plan = SpendPlan::new(&mut rng, note.clone(), tct_position);
+    let dummy_effect_hash = [0u8; 64];
+    let rsk = sk.spend_auth_key().randomize(&spend_plan.randomizer);
+    let auth_sig = rsk.sign(&mut rng, dummy_effect_hash.as_ref());
+    let spend_1 = spend_plan.spend(&test_keys::FULL_VIEWING_KEY, auth_sig, proof.clone(), root);
+    let mut synthetic_blinding_factor = spend_plan.value_blinding;
+
+    // 3. Create a second Spend action of the same note - This is a double spend.
+    let spend_plan = SpendPlan::new(&mut rng, note.clone(), tct_position);
+    let dummy_effect_hash = [0u8; 64];
+    let rsk = sk.spend_auth_key().randomize(&spend_plan.randomizer);
+    let auth_sig = rsk.sign(&mut rng, dummy_effect_hash.as_ref());
+    let spend_2 = spend_plan.spend(&test_keys::FULL_VIEWING_KEY, auth_sig, proof, root);
+    synthetic_blinding_factor += spend_plan.value_blinding;
+
+    // 4. We need to create an output to balance the transaction.
+    let value = Value {
+        amount: Amount::from(2u64) * note.amount(),
+        asset_id: note.asset_id(),
+    };
+    let output_plan =
+        penumbra_shielded_pool::OutputPlan::new(&mut rng, value, *test_keys::ADDRESS_1);
+    let fvk = &test_keys::FULL_VIEWING_KEY;
+    let memo_key = PayloadKey::random_key(&mut rng);
+    let output = output_plan.output(fvk.outgoing(), &memo_key);
+    synthetic_blinding_factor += output_plan.value_blinding;
+
+    // 5. Construct a transaction with both spends that use the same note/nullifier.
+    let chain_id = "test-chain-id".to_string();
+    let transaction_body = TransactionBody {
+        actions: vec![
+            penumbra_transaction::Action::Spend(spend_1),
+            penumbra_transaction::Action::Spend(spend_2),
+            penumbra_transaction::Action::Output(output),
+        ],
+        expiry_height: 1000,
+        chain_id,
+        fee: Fee::from_staking_token_amount(0u64.into()),
+        fmd_clues: vec![],
+        memo: None,
+    };
+    let binding_signing_key = SigningKey::from(synthetic_blinding_factor);
+    let auth_hash = transaction_body.auth_hash();
+    let binding_sig = binding_signing_key.sign(rng, auth_hash.as_bytes());
+    let transaction = Transaction {
+        transaction_body,
+        binding_sig,
+        anchor: root,
+    };
+
+    // 6. Simulate execution of the transaction - the test should panic here
+    transaction.check_stateless(()).await.unwrap();
 }

--- a/crates/core/app/src/tests/swap_and_swap_claim.rs
+++ b/crates/core/app/src/tests/swap_and_swap_claim.rs
@@ -134,6 +134,130 @@ async fn swap_and_swap_claim() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+#[should_panic(expected = "was already spent")]
+async fn swap_claim_duplicate_nullifier_previous_transaction() {
+    let mut rng = rand_chacha::ChaChaRng::seed_from_u64(1312);
+
+    let storage = TempStorage::new()
+        .await
+        .unwrap()
+        .apply_default_genesis()
+        .await
+        .unwrap();
+    let mut state = Arc::new(StateDelta::new(storage.latest_snapshot()));
+
+    let height = 1;
+
+    // 1. Simulate BeginBlock
+
+    let mut state_tx = state.try_begin_transaction().unwrap();
+    state_tx.put_epoch_by_height(
+        height,
+        penumbra_chain::Epoch {
+            index: 0,
+            start_height: 0,
+        },
+    );
+    state_tx.put_block_height(height);
+    state_tx.apply();
+
+    // 2. Create a Swap action
+
+    let gm = asset::Cache::with_known_assets().get_unit("gm").unwrap();
+    let gn = asset::Cache::with_known_assets().get_unit("gn").unwrap();
+    let trading_pair = TradingPair::new(gm.id(), gn.id());
+
+    let delta_1 = Amount::from(100_000u64);
+    let delta_2 = Amount::from(0u64);
+    let fee = Fee::default();
+    let claim_address: Address = *test_keys::ADDRESS_0;
+
+    let plaintext =
+        SwapPlaintext::new(&mut rng, trading_pair, delta_1, delta_2, fee, claim_address);
+
+    let swap_plan = SwapPlan::new(&mut rng, plaintext.clone());
+    let swap = swap_plan.swap(&test_keys::FULL_VIEWING_KEY);
+
+    // 3. Simulate execution of the Swap action
+
+    swap.check_stateless(()).await.unwrap();
+    swap.check_stateful(state.clone()).await.unwrap();
+    let mut state_tx = state.try_begin_transaction().unwrap();
+    swap.execute(&mut state_tx).await.unwrap();
+    state_tx.apply();
+
+    // 4. Execute EndBlock (where the swap is actually executed)
+
+    let end_block = abci::request::EndBlock {
+        height: height.try_into().unwrap(),
+    };
+    // Execute EndBlock for the Dex, to actually execute the swaps...
+    Dex::end_block(&mut state, &end_block).await;
+    ShieldedPool::end_block(&mut state, &end_block).await;
+
+    let mut state_tx = state.try_begin_transaction().unwrap();
+    // ... and for the App, call `finish_block` to correctly write out the SCT with the data we'll use next.
+    App::finish_block(&mut state_tx).await;
+
+    state_tx.apply();
+
+    // 6. Create a SwapClaim action
+    let epoch_duration = state.get_epoch_duration().await.unwrap();
+    let mut client = MockClient::new(test_keys::FULL_VIEWING_KEY.clone());
+    client.sync_to(1, state.deref()).await.unwrap();
+
+    let output_data = state
+        .output_data(height, trading_pair)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let commitment = swap.body.payload.commitment;
+    let swap_auth_path = client.witness(commitment).unwrap();
+    let detected_plaintext = client.swap_by_commitment(&commitment).unwrap();
+    assert_eq!(plaintext, detected_plaintext);
+
+    let claim_plan = SwapClaimPlan {
+        swap_plaintext: plaintext.clone(),
+        position: swap_auth_path.position(),
+        output_data,
+        epoch_duration,
+        proof_blinding_r: Fq::rand(&mut rng),
+        proof_blinding_s: Fq::rand(&mut rng),
+    };
+    let claim = claim_plan.swap_claim(&test_keys::FULL_VIEWING_KEY, &swap_auth_path);
+
+    // 7. Execute the SwapClaim action
+
+    // The SwapClaim ActionHandler uses the transaction's anchor to check proofs:
+    let context = &Transaction {
+        anchor: client.latest_height_and_sct_root().1,
+        ..Default::default()
+    }
+    .context();
+
+    claim.check_stateless(context.clone()).await.unwrap();
+    claim.check_stateful(state.clone()).await.unwrap();
+    let mut state_tx = state.try_begin_transaction().unwrap();
+    claim.execute(&mut state_tx).await.unwrap();
+    state_tx.apply();
+
+    // 8. Now form a second SwapClaim action attempting to claim the outputs again.
+    let claim_plan = SwapClaimPlan {
+        swap_plaintext: plaintext,
+        position: swap_auth_path.position(),
+        output_data,
+        epoch_duration,
+        proof_blinding_r: Fq::rand(&mut rng),
+        proof_blinding_s: Fq::rand(&mut rng),
+    };
+    let claim = claim_plan.swap_claim(&test_keys::FULL_VIEWING_KEY, &swap_auth_path);
+
+    // 9. Execute the second SwapClaim action - the test should panic here
+    claim.check_stateful(state.clone()).await.unwrap();
+}
+
+#[tokio::test]
 async fn swap_with_nonzero_fee() -> anyhow::Result<()> {
     let mut rng = rand_chacha::ChaChaRng::seed_from_u64(1312);
 

--- a/crates/core/transaction/src/lib.rs
+++ b/crates/core/transaction/src/lib.rs
@@ -37,7 +37,7 @@ pub use effect_hash::EffectingData;
 pub use error::Error;
 pub use id::Id;
 pub use is_action::IsAction;
-pub use transaction::{Transaction, TransactionBody};
+pub use transaction::{Transaction, TransactionBody, TransactionParameters};
 pub use view::{ActionView, MemoView, TransactionPerspective, TransactionView};
 pub use witness_data::WitnessData;
 


### PR DESCRIPTION
This PR fixes an issue found in one of the audits wherein one can vote for the same proposal ID multiple times using the same note if the delegator votes are in a single transaction (case 2 below). Noting for posterity: this was already reviewed in a private repository.

## Test coverage

Some additional tests are added in this PR for the possible double spend cases. 

Cases attempting to double spend/vote in a single transaction:

1. We check for duplicate nullifiers across the same tx in `Transaction::check_stateless` for `Spends` and `SwapClaims` only - *a test is added in this PR for double spends in the same tx* (`spend_duplicate_nullifier_same_transaction`)
2. We were _not_ checking for duplicate nullifiers in the same tx for delegator votes (the bug) -  followup issue #2927 for tests

Cases double spending/voting across two transactions:

3. For swap claims in `SwapClaim::check_stateful` we check for duplicate nullifiers - *a test is added in this PR for double swap claims across two tx* (`swap_claim_duplicate_nullifier_previous_transaction`)
4. For spends in `Spend::check_stateful` we check for duplicate nullifiers - *a test is added in this PR for double spends across two tx* (`spend_duplicate_nullifier_previous_transaction`)
5. For delegator votes in `DelegatorVote::check_stateful` we check the nullifier has not already been used to vote for that proposal ID - followup issue #2927 for tests

