### PR TITLE
crypto: rework action-level `EffectingData` implementations

### DIFF
--- a/crates/core/component/dao/src/action/dao_deposit.rs
+++ b/crates/core/component/dao/src/action/dao_deposit.rs
@@ -1,29 +1,14 @@
 use anyhow::{Context, Error};
-use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 
 use penumbra_asset::{Balance, Value};
-use penumbra_chain::{EffectHash, EffectingData};
 use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType, TypeUrl};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(try_from = "pb::DaoDeposit", into = "pb::DaoDeposit")]
 pub struct DaoDeposit {
     pub value: Value,
-}
-
-impl EffectingData for DaoDeposit {
-    fn effect_hash(&self) -> EffectHash {
-        let effecting_data: pb::DaoDeposit = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:daodeposit")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
-    }
 }
 
 impl DaoDeposit {

--- a/crates/core/component/dao/src/action/dao_output.rs
+++ b/crates/core/component/dao/src/action/dao_output.rs
@@ -1,10 +1,8 @@
 use anyhow::{Context, Error};
-use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 
 use penumbra_asset::{Balance, Value};
-use penumbra_chain::{EffectHash, EffectingData};
 use penumbra_keys::Address;
 use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType, TypeUrl};
 
@@ -13,19 +11,6 @@ use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType, TypeUrl};
 pub struct DaoOutput {
     pub value: Value,
     pub address: Address,
-}
-
-impl EffectingData for DaoOutput {
-    fn effect_hash(&self) -> EffectHash {
-        let effecting_data: pb::DaoOutput = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:daooutput")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
-    }
 }
 
 impl DaoOutput {

--- a/crates/core/component/dao/src/action/dao_spend.rs
+++ b/crates/core/component/dao/src/action/dao_spend.rs
@@ -1,10 +1,8 @@
 use anyhow::{Context, Error};
-use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 
 use penumbra_asset::{Balance, Value};
-use penumbra_chain::{EffectHash, EffectingData};
 use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType, TypeUrl};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/core/component/dao/src/action/dao_spend.rs
+++ b/crates/core/component/dao/src/action/dao_spend.rs
@@ -13,19 +13,6 @@ pub struct DaoSpend {
     pub value: Value,
 }
 
-impl EffectingData for DaoSpend {
-    fn effect_hash(&self) -> EffectHash {
-        let effecting_data: pb::DaoSpend = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:daospend")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
-    }
-}
-
 impl DaoSpend {
     pub fn balance(&self) -> Balance {
         // Spends from the DAO produce value

--- a/crates/core/component/dao/src/action/dao_spend.rs
+++ b/crates/core/component/dao/src/action/dao_spend.rs
@@ -1,25 +1,28 @@
+use anyhow::{Context, Error};
+use prost::Message;
+use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 
-use anyhow::{Context, Error};
 use penumbra_asset::{Balance, Value};
 use penumbra_chain::{EffectHash, EffectingData};
 use penumbra_proto::{core::governance::v1alpha1 as pb, DomainType, TypeUrl};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(try_from = "pb::DaoSpend", into = "pb::DaoSpend")]
 pub struct DaoSpend {
     pub value: Value,
 }
 
 impl EffectingData for DaoSpend {
     fn effect_hash(&self) -> EffectHash {
+        let effecting_data: pb::DaoSpend = self.clone().into();
+
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:daospend")
             .to_state();
+        state.update(&effecting_data.encode_to_vec());
 
-        state.update(&self.value.amount.to_le_bytes());
-        state.update(&self.value.asset_id.to_bytes());
-
-        EffectHash(state.finalize().as_array().clone())
+        EffectHash(*state.finalize().as_array())
     }
 }
 

--- a/crates/core/component/dex/src/swap/action.rs
+++ b/crates/core/component/dex/src/swap/action.rs
@@ -6,6 +6,7 @@ use penumbra_num::Amount;
 use penumbra_proto::{
     core::crypto::v1alpha1 as pbc, core::dex::v1alpha1 as pb, DomainType, TypeUrl,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::TradingPair;
 
@@ -73,7 +74,8 @@ impl TryFrom<pb::Swap> for Swap {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "pb::SwapBody", into = "pb::SwapBody")]
 pub struct Body {
     pub trading_pair: TradingPair,
     pub delta_1_i: Amount,

--- a/crates/core/component/dex/src/swap_claim/action.rs
+++ b/crates/core/component/dex/src/swap_claim/action.rs
@@ -5,6 +5,7 @@ use penumbra_proof_params::GROTH16_PROOF_LENGTH_BYTES;
 use penumbra_proto::{core::dex::v1alpha1 as pb, DomainType, TypeUrl};
 use penumbra_sct::Nullifier;
 use penumbra_tct as tct;
+use serde::{Deserialize, Serialize};
 
 use crate::BatchSwapOutputData;
 
@@ -61,7 +62,8 @@ impl TryFrom<pb::SwapClaim> for SwapClaim {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "pb::SwapClaimBody", into = "pb::SwapClaimBody")]
 pub struct Body {
     pub nullifier: Nullifier,
     pub fee: Fee,

--- a/crates/core/component/ibc/src/ics20_withdrawal.rs
+++ b/crates/core/component/ibc/src/ics20_withdrawal.rs
@@ -3,7 +3,6 @@ use penumbra_asset::{
     asset::{self, DenomMetadata},
     Balance, Value,
 };
-use penumbra_chain::{EffectHash, EffectingData};
 use penumbra_keys::Address;
 use penumbra_num::Amount;
 use penumbra_proto::{
@@ -66,19 +65,6 @@ impl Ics20Withdrawal {
         // addresses, but this would preclude sending to chains that don't use bech32 addresses.
 
         Ok(())
-    }
-}
-
-impl EffectingData for Ics20Withdrawal {
-    fn effect_hash(&self) -> EffectHash {
-        let effecting_data: pb::Ics20Withdrawal = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:ics20wthdrwl")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
     }
 }
 

--- a/crates/core/component/ibc/src/ics20_withdrawal.rs
+++ b/crates/core/component/ibc/src/ics20_withdrawal.rs
@@ -71,22 +71,13 @@ impl Ics20Withdrawal {
 
 impl EffectingData for Ics20Withdrawal {
     fn effect_hash(&self) -> EffectHash {
+        let effecting_data: pb::Ics20Withdrawal = self.clone().into();
+
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:ics20wthdrwl")
             .to_state();
+        state.update(&effecting_data.encode_to_vec());
 
-        let destination_chain_address_hash =
-            blake2b_simd::Params::default().hash(self.destination_chain_address.as_bytes());
-        let return_address = blake2b_simd::Params::default().hash(&self.return_address.to_vec());
-
-        state.update(&self.amount.to_le_bytes());
-        state.update(&self.denom.id().to_bytes());
-        state.update(&self.source_channel.as_bytes());
-
-        state.update(destination_chain_address_hash.as_bytes());
-        state.update(return_address.as_bytes());
-        state.update(&self.timeout_height.to_le_bytes());
-        state.update(&self.timeout_time.to_le_bytes());
         EffectHash(*state.finalize().as_array())
     }
 }

--- a/crates/core/component/shielded-pool/src/output/action.rs
+++ b/crates/core/component/shielded-pool/src/output/action.rs
@@ -3,7 +3,6 @@ use std::convert::{TryFrom, TryInto};
 use anyhow::{Context, Error};
 use bytes::Bytes;
 use penumbra_asset::balance;
-use penumbra_chain::{EffectHash, EffectingData};
 use penumbra_keys::symmetric::{OvkWrappedKey, WrappedMemoKey};
 use penumbra_proto::{
     core::crypto::v1alpha1 as pbc, core::transaction::v1alpha1 as pb, DomainType, Message, TypeUrl,
@@ -25,22 +24,6 @@ pub struct Body {
     pub balance_commitment: balance::Commitment,
     pub ovk_wrapped_key: OvkWrappedKey,
     pub wrapped_memo_key: WrappedMemoKey,
-}
-
-impl EffectingData for Body {
-    fn effect_hash(&self) -> EffectHash {
-        // The effecting data is in the body of the output, so we can
-        // just use hash the proto-encoding of the body.
-        let body: pb::OutputBody = self.clone().into();
-        let body_data = body.encode_to_vec();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:output_body")
-            .to_state();
-        state.update(&body_data);
-
-        EffectHash(*state.finalize().as_array())
-    }
 }
 
 impl TypeUrl for Output {

--- a/crates/core/component/shielded-pool/src/output/action.rs
+++ b/crates/core/component/shielded-pool/src/output/action.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use penumbra_asset::balance;
 use penumbra_keys::symmetric::{OvkWrappedKey, WrappedMemoKey};
 use penumbra_proto::{
-    core::crypto::v1alpha1 as pbc, core::transaction::v1alpha1 as pb, DomainType, Message, TypeUrl,
+    core::crypto::v1alpha1 as pbc, core::transaction::v1alpha1 as pb, DomainType, TypeUrl,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/core/component/shielded-pool/src/output/action.rs
+++ b/crates/core/component/shielded-pool/src/output/action.rs
@@ -2,13 +2,13 @@ use std::convert::{TryFrom, TryInto};
 
 use anyhow::{Context, Error};
 use bytes::Bytes;
-use decaf377::FieldExt;
 use penumbra_asset::balance;
 use penumbra_chain::{EffectHash, EffectingData};
 use penumbra_keys::symmetric::{OvkWrappedKey, WrappedMemoKey};
 use penumbra_proto::{
-    core::crypto::v1alpha1 as pbc, core::transaction::v1alpha1 as pb, DomainType, TypeUrl,
+    core::crypto::v1alpha1 as pbc, core::transaction::v1alpha1 as pb, DomainType, Message, TypeUrl,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{NotePayload, OutputProof};
 
@@ -18,7 +18,8 @@ pub struct Output {
     pub proof: OutputProof,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(try_from = "pb::OutputBody", into = "pb::OutputBody")]
 pub struct Body {
     pub note_payload: NotePayload,
     pub balance_commitment: balance::Commitment,
@@ -28,20 +29,17 @@ pub struct Body {
 
 impl EffectingData for Body {
     fn effect_hash(&self) -> EffectHash {
+        // The effecting data is in the body of the output, so we can
+        // just use hash the proto-encoding of the body.
+        let body: pb::OutputBody = self.clone().into();
+        let body_data = body.encode_to_vec();
+
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:output_body")
             .to_state();
+        state.update(&body_data);
 
-        // All of these fields are fixed-length, so we can just throw them
-        // in the hash one after the other.
-        state.update(&self.note_payload.note_commitment.0.to_bytes());
-        state.update(&self.note_payload.ephemeral_key.0);
-        state.update(&self.note_payload.encrypted_note.0);
-        state.update(&self.balance_commitment.to_bytes());
-        state.update(&self.wrapped_memo_key.0);
-        state.update(&self.ovk_wrapped_key.0);
-
-        EffectHash(state.finalize().as_array().clone())
+        EffectHash(*state.finalize().as_array())
     }
 }
 

--- a/crates/core/component/shielded-pool/src/spend/action.rs
+++ b/crates/core/component/shielded-pool/src/spend/action.rs
@@ -26,22 +26,6 @@ pub struct Body {
     pub rk: VerificationKey<SpendAuth>,
 }
 
-impl EffectingData for Body {
-    fn effect_hash(&self) -> EffectHash {
-        // The effecting data is in the body of the spend, so we can
-        // just use hash the proto-encoding of the body.
-        let body: transaction::SpendBody = self.clone().into();
-        let body_data = body.encode_to_vec();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:spend_body")
-            .to_state();
-        state.update(&body_data);
-
-        EffectHash(*state.finalize().as_array())
-    }
-}
-
 impl TypeUrl for Spend {
     const TYPE_URL: &'static str = "/penumbra.core.transaction.v1alpha1.Spend";
 }

--- a/crates/core/component/shielded-pool/src/spend/action.rs
+++ b/crates/core/component/shielded-pool/src/spend/action.rs
@@ -2,12 +2,12 @@ use std::convert::{TryFrom, TryInto};
 
 use anyhow::{Context, Error};
 use bytes::Bytes;
-use decaf377::FieldExt;
 use decaf377_rdsa::{Signature, SpendAuth, VerificationKey};
 use penumbra_asset::balance;
 use penumbra_chain::{EffectHash, EffectingData};
-use penumbra_proto::{core::transaction::v1alpha1 as transaction, DomainType, TypeUrl};
+use penumbra_proto::{core::transaction::v1alpha1 as transaction, DomainType, Message, TypeUrl};
 use penumbra_sct::Nullifier;
+use serde::{Deserialize, Serialize};
 
 use crate::SpendProof;
 
@@ -18,7 +18,8 @@ pub struct Spend {
     pub proof: SpendProof,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(try_from = "transaction::SpendBody", into = "transaction::SpendBody")]
 pub struct Body {
     pub balance_commitment: balance::Commitment,
     pub nullifier: Nullifier,
@@ -27,17 +28,17 @@ pub struct Body {
 
 impl EffectingData for Body {
     fn effect_hash(&self) -> EffectHash {
+        // The effecting data is in the body of the spend, so we can
+        // just use hash the proto-encoding of the body.
+        let body: transaction::SpendBody = self.clone().into();
+        let body_data = body.encode_to_vec();
+
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:spend_body")
             .to_state();
+        state.update(&body_data);
 
-        // All of these fields are fixed-length, so we can just throw them
-        // in the hash one after the other.
-        state.update(&self.balance_commitment.to_bytes());
-        state.update(&self.nullifier.0.to_bytes());
-        state.update(&self.rk.to_bytes());
-
-        EffectHash(state.finalize().as_array().clone())
+        EffectHash(*state.finalize().as_array())
     }
 }
 

--- a/crates/core/component/shielded-pool/src/spend/action.rs
+++ b/crates/core/component/shielded-pool/src/spend/action.rs
@@ -4,8 +4,7 @@ use anyhow::{Context, Error};
 use bytes::Bytes;
 use decaf377_rdsa::{Signature, SpendAuth, VerificationKey};
 use penumbra_asset::balance;
-use penumbra_chain::{EffectHash, EffectingData};
-use penumbra_proto::{core::transaction::v1alpha1 as transaction, DomainType, Message, TypeUrl};
+use penumbra_proto::{core::transaction::v1alpha1 as transaction, DomainType, TypeUrl};
 use penumbra_sct::Nullifier;
 use serde::{Deserialize, Serialize};
 

--- a/crates/core/transaction/src/action/proposal_deposit_claim.rs
+++ b/crates/core/transaction/src/action/proposal_deposit_claim.rs
@@ -8,7 +8,7 @@ use penumbra_asset::{
 };
 use penumbra_governance::ProposalNft;
 use penumbra_num::Amount;
-use penumbra_proto::core::governance::v1alpha1 as pb;
+use penumbra_proto::{core::governance::v1alpha1 as pb, TypeUrl};
 
 use crate::{
     proposal::{Outcome, Withdrawn},
@@ -56,6 +56,10 @@ impl TryFrom<pb::ProposalDepositClaim> for ProposalDepositClaim {
                 .try_into()?,
         })
     }
+}
+
+impl TypeUrl for ProposalDepositClaim {
+    const TYPE_URL: &'static str = "/penumbra.core.governance.v1alpha1.ProposalDepositClaim";
 }
 
 impl IsAction for ProposalDepositClaim {

--- a/crates/core/transaction/src/effect_hash.rs
+++ b/crates/core/transaction/src/effect_hash.rs
@@ -547,55 +547,55 @@ impl EffectingData for proposal::Withdrawn<()> {
 
 impl EffectingData for PositionOpen {
     fn effect_hash(&self) -> EffectHash {
+        // The position open action consists only of the position, which
+        // we consider effecting data.
+        let effecting_data: pbd::PositionOpen = self.clone().into();
+
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:pos_open")
             .to_state();
+        state.update(&effecting_data.encode_to_vec());
 
-        // All of these fields are fixed-length, so we can just throw them in the hash one after the
-        // other.
-        state.update(&self.position.id().0);
-        state.update(&self.position.reserves.r1.to_le_bytes());
-        state.update(&self.position.reserves.r2.to_le_bytes());
-
-        EffectHash(state.finalize().as_array().clone())
+        EffectHash(*state.finalize().as_array())
     }
 }
 
 impl EffectingData for PositionClose {
     fn effect_hash(&self) -> EffectHash {
+        let effecting_data: pbd::PositionClose = self.clone().into();
+
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:pos_close")
             .to_state();
+        state.update(&effecting_data.encode_to_vec());
 
-        state.update(&self.position_id.0);
-
-        EffectHash(state.finalize().as_array().clone())
+        EffectHash(*state.finalize().as_array())
     }
 }
 
 impl EffectingData for PositionWithdraw {
     fn effect_hash(&self) -> EffectHash {
+        let effecting_data: pbd::PositionWithdraw = self.clone().into();
+
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:pos_withdraw")
             .to_state();
+        state.update(&effecting_data.encode_to_vec());
 
-        state.update(&self.position_id.0);
-        state.update(&self.reserves_commitment.to_bytes());
-
-        EffectHash(state.finalize().as_array().clone())
+        EffectHash(*state.finalize().as_array())
     }
 }
 
 impl EffectingData for PositionRewardClaim {
     fn effect_hash(&self) -> EffectHash {
+        let effecting_data: pbd::PositionRewardClaim = self.clone().into();
+
         let mut state = blake2b_simd::Params::default()
             .personal(b"PAH:pos_rewrdclm")
             .to_state();
+        state.update(&effecting_data.encode_to_vec());
 
-        state.update(&self.position_id.0);
-        state.update(&self.rewards_commitment.to_bytes());
-
-        EffectHash(state.finalize().as_array().clone())
+        EffectHash(*state.finalize().as_array())
     }
 }
 

--- a/crates/core/transaction/src/effect_hash.rs
+++ b/crates/core/transaction/src/effect_hash.rs
@@ -275,18 +275,22 @@ impl EffectingData for Action {
     }
 }
 
+/// A helper function to hash the data of a proto-encoded message.
+fn hash_proto_effecting_data<M: Message>(personalization: &[u8], message: &M) -> EffectHash {
+    let mut state = blake2b_simd::Params::default()
+        .personal(personalization)
+        .to_state();
+    state.update(&message.encode_to_vec());
+
+    EffectHash(*state.finalize().as_array())
+}
+
 impl EffectingData for swap::Body {
     fn effect_hash(&self) -> EffectHash {
         // The effecting data is in the body of the swap, so we can
         // just use hash the proto-encoding of the body.
         let effecting_data: pbd::SwapBody = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:swap_body")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:swap_body", &effecting_data)
     }
 }
 
@@ -295,13 +299,7 @@ impl EffectingData for swap_claim::Body {
         // The effecting data is in the body of the swap claim, so we can
         // just use hash the proto-encoding of the body.
         let effecting_data: pbd::SwapClaimBody = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:swapclaimbdy")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:swapclaimbdy", &effecting_data)
     }
 }
 
@@ -309,13 +307,7 @@ impl EffectingData for Delegate {
     fn effect_hash(&self) -> EffectHash {
         // For delegations, the entire action is considered effecting data.
         let effecting_data: pbs::Delegate = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:delegate")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:delegate", &effecting_data)
     }
 }
 
@@ -323,13 +315,7 @@ impl EffectingData for Undelegate {
     fn effect_hash(&self) -> EffectHash {
         // For undelegations, the entire action is considered effecting data.
         let effecting_data: pbs::Undelegate = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:undelegate")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:undelegate", &effecting_data)
     }
 }
 
@@ -338,52 +324,28 @@ impl EffectingData for UndelegateClaimBody {
         // The effecting data is in the body of the undelegate claim, so we can
         // just use hash the proto-encoding of the body.
         let effecting_data: pbs::UndelegateClaimBody = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:udlgclm_body")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:udlgclm_body", &effecting_data)
     }
 }
 
 impl EffectingData for Proposal {
     fn effect_hash(&self) -> EffectHash {
         let effecting_data: pbg::Proposal = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:proposal")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:proposal", &effecting_data)
     }
 }
 
 impl EffectingData for ProposalSubmit {
     fn effect_hash(&self) -> EffectHash {
         let effecting_data: pbg::ProposalSubmit = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:prop_submit")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:prop_submit", &effecting_data)
     }
 }
 
 impl EffectingData for ProposalWithdraw {
     fn effect_hash(&self) -> EffectHash {
         let effecting_data: pbg::ProposalWithdraw = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:prop_withdrw")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:prop_withdrw", &effecting_data)
     }
 }
 
@@ -402,52 +364,28 @@ impl EffectingData for DelegatorVote {
 impl EffectingData for Vote {
     fn effect_hash(&self) -> EffectHash {
         let effecting_data: pbg::Vote = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:vote")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:vote", &effecting_data)
     }
 }
 
 impl EffectingData for ValidatorVoteBody {
     fn effect_hash(&self) -> EffectHash {
         let effecting_data: pbg::ValidatorVoteBody = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:val_vote")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:val_vote", &effecting_data)
     }
 }
 
 impl EffectingData for DelegatorVoteBody {
     fn effect_hash(&self) -> EffectHash {
         let effecting_data: pbg::DelegatorVoteBody = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:del_vote")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:del_vote", &effecting_data)
     }
 }
 
 impl EffectingData for ProposalDepositClaim {
     fn effect_hash(&self) -> EffectHash {
         let effecting_data: pbg::ProposalDepositClaim = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:prop_dep_clm")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:prop_dep_clm", &effecting_data)
     }
 }
 
@@ -456,52 +394,28 @@ impl EffectingData for PositionOpen {
         // The position open action consists only of the position, which
         // we consider effecting data.
         let effecting_data: pbd::PositionOpen = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:pos_open")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:pos_open", &effecting_data)
     }
 }
 
 impl EffectingData for PositionClose {
     fn effect_hash(&self) -> EffectHash {
         let effecting_data: pbd::PositionClose = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:pos_close")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:pos_close", &effecting_data)
     }
 }
 
 impl EffectingData for PositionWithdraw {
     fn effect_hash(&self) -> EffectHash {
         let effecting_data: pbd::PositionWithdraw = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:pos_withdraw")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:pos_withdraw", &effecting_data)
     }
 }
 
 impl EffectingData for PositionRewardClaim {
     fn effect_hash(&self) -> EffectHash {
         let effecting_data: pbd::PositionRewardClaim = self.clone().into();
-
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:pos_rewrdclm")
-            .to_state();
-        state.update(&effecting_data.encode_to_vec());
-
-        EffectHash(*state.finalize().as_array())
+        hash_proto_effecting_data(b"PAH:pos_rewrdclm", &effecting_data)
     }
 }
 
@@ -519,12 +433,7 @@ impl EffectingData for Clue {
 impl EffectingData for Fee {
     fn effect_hash(&self) -> EffectHash {
         let proto_encoded_fee: pbc::Fee = self.clone().into();
-        let mut state = blake2b_simd::Params::default()
-            .personal(b"PAH:fee")
-            .to_state();
-        state.update(&proto_encoded_fee.encode_to_vec());
-
-        EffectHash(state.finalize().as_array().clone())
+        hash_proto_effecting_data(b"PAH:fee", &proto_encoded_fee)
     }
 }
 


### PR DESCRIPTION
Towards one of the checkboxes in #2808
Closes #2000

The scope of this PR is to in each `EffectingData` implementation hash a single proto that represents the effecting data of that transaction action. 