### PR TITLE
pd: remove client sync timeouts

### DIFF
--- a/crates/bin/pcli/tests/network_integration.rs
+++ b/crates/bin/pcli/tests/network_integration.rs
@@ -597,7 +597,11 @@ fn swap() {
         // Address 0 has 100gm.
         .stdout(predicate::str::is_match(format!(r"0\s*100gm")).unwrap())
         // Address 1 has no gm.
-        .stdout(predicate::str::is_match(format!(r"1\s.*gm")).unwrap().not())
+        .stdout(
+            predicate::str::is_match(format!(r"1\s[0-9]*\.?[0-9]gm"))
+                .unwrap()
+                .not(),
+        )
         // Address 0 has some penumbra.
         .stdout(predicate::str::is_match(format!(r"0\s*.*penumbra")).unwrap())
         // Address 1 has 1001penumbra.
@@ -625,7 +629,11 @@ fn swap() {
         // Address 0 has 100gm.
         .stdout(predicate::str::is_match(format!(r"0\s*100gm")).unwrap())
         // Address 1 has no gm.
-        .stdout(predicate::str::is_match(format!(r"1\s.*gm")).unwrap().not())
+        .stdout(
+            predicate::str::is_match(format!(r"1\s[0-9]*\.?[0-9]gm"))
+                .unwrap()
+                .not(),
+        )
         // Address 0 has some penumbra.
         .stdout(predicate::str::is_match(format!(r"0\s*.*penumbra")).unwrap())
         // Address 1 has 1000penumbra.
@@ -665,7 +673,11 @@ fn swap() {
         // Address 0 has 100gm.
         .stdout(predicate::str::is_match(format!(r"0\s*99gm")).unwrap())
         // Address 1 has no gm.
-        .stdout(predicate::str::is_match(format!(r"1\s.*gm")).unwrap().not())
+        .stdout(
+            predicate::str::is_match(format!(r"1\s[0-9]*\.?[0-9]gm"))
+                .unwrap()
+                .not(),
+        )
         // Address 0 has some penumbra.
         .stdout(predicate::str::is_match(format!(r"0\s*.*penumbra")).unwrap())
         // Address 1 has 1000penumbra.

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -298,6 +298,8 @@ async fn main() -> anyhow::Result<()> {
                 })
                 // Allow HTTP/1, which will be used by grpc-web connections.
                 .accept_http1(true)
+                // As part of #2932, we are disabling all timeouts until we circle back to our
+                // performance story.
                 // Sets a timeout for all gRPC requests, but note that in the case of streaming
                 // requests, the timeout is only applied to the initial request. This means that
                 // this does not prevent long lived streams, for example to allow clients to obtain


### PR DESCRIPTION
Part of #2918 (cc @conorsch ). We have isolated that the stream terminates because of the timeout on polling compact blocks. This PR reenable the req-resp timeout and increase the polling timeout to `2s`.