### PR TITLE
ibc-types: stop tracking main and use `rev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,7 +2916,7 @@ dependencies = [
 [[package]]
 name = "ibc-types"
 version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/ibc-types#99d1484398f13aa35578948d34537bb8bb9848d9"
+source = "git+https://github.com/penumbra-zone/ibc-types?rev=99d1484398f13aa35578948d34537bb8bb9848d9#99d1484398f13aa35578948d34537bb8bb9848d9"
 dependencies = [
  "ibc-types-core-channel",
  "ibc-types-core-client",
@@ -2933,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "ibc-types-core-channel"
 version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/ibc-types#99d1484398f13aa35578948d34537bb8bb9848d9"
+source = "git+https://github.com/penumbra-zone/ibc-types?rev=99d1484398f13aa35578948d34537bb8bb9848d9#99d1484398f13aa35578948d34537bb8bb9848d9"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "ibc-types-core-client"
 version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/ibc-types#99d1484398f13aa35578948d34537bb8bb9848d9"
+source = "git+https://github.com/penumbra-zone/ibc-types?rev=99d1484398f13aa35578948d34537bb8bb9848d9#99d1484398f13aa35578948d34537bb8bb9848d9"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "ibc-types-core-commitment"
 version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/ibc-types#99d1484398f13aa35578948d34537bb8bb9848d9"
+source = "git+https://github.com/penumbra-zone/ibc-types?rev=99d1484398f13aa35578948d34537bb8bb9848d9#99d1484398f13aa35578948d34537bb8bb9848d9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3021,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "ibc-types-core-connection"
 version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/ibc-types#99d1484398f13aa35578948d34537bb8bb9848d9"
+source = "git+https://github.com/penumbra-zone/ibc-types?rev=99d1484398f13aa35578948d34537bb8bb9848d9#99d1484398f13aa35578948d34537bb8bb9848d9"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "ibc-types-domain-type"
 version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/ibc-types#99d1484398f13aa35578948d34537bb8bb9848d9"
+source = "git+https://github.com/penumbra-zone/ibc-types?rev=99d1484398f13aa35578948d34537bb8bb9848d9#99d1484398f13aa35578948d34537bb8bb9848d9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "ibc-types-identifier"
 version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/ibc-types#99d1484398f13aa35578948d34537bb8bb9848d9"
+source = "git+https://github.com/penumbra-zone/ibc-types?rev=99d1484398f13aa35578948d34537bb8bb9848d9#99d1484398f13aa35578948d34537bb8bb9848d9"
 dependencies = [
  "displaydoc",
  "serde",
@@ -3068,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "ibc-types-lightclients-tendermint"
 version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/ibc-types#99d1484398f13aa35578948d34537bb8bb9848d9"
+source = "git+https://github.com/penumbra-zone/ibc-types?rev=99d1484398f13aa35578948d34537bb8bb9848d9#99d1484398f13aa35578948d34537bb8bb9848d9"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "ibc-types-path"
 version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/ibc-types#99d1484398f13aa35578948d34537bb8bb9848d9"
+source = "git+https://github.com/penumbra-zone/ibc-types?rev=99d1484398f13aa35578948d34537bb8bb9848d9#99d1484398f13aa35578948d34537bb8bb9848d9"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "ibc-types-timestamp"
 version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/ibc-types#99d1484398f13aa35578948d34537bb8bb9848d9"
+source = "git+https://github.com/penumbra-zone/ibc-types?rev=99d1484398f13aa35578948d34537bb8bb9848d9#99d1484398f13aa35578948d34537bb8bb9848d9"
 dependencies = [
  "bytes",
  "displaydoc",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "ibc-types-transfer"
 version = "0.3.0"
-source = "git+https://github.com/penumbra-zone/ibc-types#99d1484398f13aa35578948d34537bb8bb9848d9"
+source = "git+https://github.com/penumbra-zone/ibc-types?rev=99d1484398f13aa35578948d34537bb8bb9848d9#99d1484398f13aa35578948d34537bb8bb9848d9"
 dependencies = [
  "displaydoc",
  "serde",

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -47,7 +47,7 @@ tendermint = { version = "0.32.0", features = ["rust-crypto"] }
 jmt = "0.6"
 
 # External dependencies
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", version = "0.3.0", default-features = false }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", rev = "99d1484398f13aa35578948d34537bb8bb9848d9", default-features = false }
 
 ibc-proto = { version = "0.31.0" }
 ark-ff = { version = "0.4", default-features = false }

--- a/crates/bin/pclientd/Cargo.toml
+++ b/crates/bin/pclientd/Cargo.toml
@@ -61,7 +61,7 @@ atty = "0.2"
 tempfile = "3.3.0"
 assert_cmd = "2.0"
 base64 = "0.20"
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", version = "0.3.0" }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", rev = "99d1484398f13aa35578948d34537bb8bb9848d9" }
 
 ibc-proto = "0.31.0"
 

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -49,7 +49,7 @@ tendermint-config = "0.32.0"
 tendermint-proto = "0.32.0"
 tendermint = "0.32.0"
 tendermint-light-client-verifier = "0.32.0"
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", version = "0.3.0" }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", rev = "99d1484398f13aa35578948d34537bb8bb9848d9" }
 
 ibc-proto = { version = "0.31.0", default-features = false, features = ["server"] }
 prost = "0.11"

--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -62,7 +62,7 @@ parking_lot = "0.12"
 tendermint = "0.32.0"
 tendermint-proto = "0.32.0"
 tendermint-light-client-verifier = "0.32.0"
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", version = "0.3.0", default-features = false }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", rev = "99d1484398f13aa35578948d34537bb8bb9848d9", default-features = false }
 ibc-proto = { version = "0.31.0" }
 
 [dev-dependencies]

--- a/crates/core/component/chain/Cargo.toml
+++ b/crates/core/component/chain/Cargo.toml
@@ -17,7 +17,7 @@ penumbra-num = { path = "../../../core/num", default-features = false  }
 decaf377 = "0.5"
 
 tendermint = "0.32.0"
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", version = "0.3.0", default-features = false }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", rev = "99d1484398f13aa35578948d34537bb8bb9848d9", default-features = false }
 ics23 = "0.10.1"
 
 # Crates.io deps

--- a/crates/core/component/ibc/Cargo.toml
+++ b/crates/core/component/ibc/Cargo.toml
@@ -23,7 +23,7 @@ penumbra-num = { path = "../../../core/num", default-features = false  }
 penumbra-keys = { path = "../../../core/keys", default-features = false  } 
 
 # Penumbra dependencies
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", version = "0.3.0", default-features = false }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", rev = "99d1484398f13aa35578948d34537bb8bb9848d9", default-features = false }
 ibc-proto = { version = "0.31.0", default-features = false }
 
 # Crates.io deps

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -24,7 +24,7 @@ penumbra-asset = { path = "../asset", default-features = false }
 penumbra-keys = { path = "../keys", default-features = false }
 
 # Git deps
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", version = "0.3.0", default-features = false }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", rev = "99d1484398f13aa35578948d34537bb8bb9848d9", default-features = false }
 
 # Crates.io deps
 ibc-proto = { version = "0.31.0", default-features = false }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 subtle-encoding = "0.5"
 bech32 = "0.8"
 penumbra-storage = { path = "../storage", optional = true }
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", version = "0.3.0", features = ["std"]}
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", rev = "99d1484398f13aa35578948d34537bb8bb9848d9", features = ["std"]}
 pin-project = "1"
 async-trait = "0.1.52"
 async-stream = "0.2.0"

--- a/crates/view/Cargo.toml
+++ b/crates/view/Cargo.toml
@@ -36,7 +36,7 @@ penumbra-compact-block = { path = "../core/component/compact-block", default-fea
 penumbra-app           = { path = "../core/app" }
 penumbra-transaction   = { path = "../core/transaction" }
 
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", version = "0.3.0", default-features = false }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types", rev = "99d1484398f13aa35578948d34537bb8bb9848d9", default-features = false }
 
 decaf377 = {version = "0.5", features = ["r1cs"] }
 tokio = { version = "1.22", features = ["full"] }


### PR DESCRIPTION
We are switching to published crates later today. But to avoid any breakage, we need to point to this specific revision.