### PR TITLE
chain: implement upgrade halts

### DIFF
--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -415,11 +415,15 @@ impl App {
             .expect("we have exclusive ownership of the State at commit()");
 
         // Check if someone has signaled that we should halt.
-        // TODO(erwan): manage upgrade halt and epoch regen
         let should_halt = state
             .is_chain_halted(TOTAL_HALT_COUNT)
             .await
             .expect("must be able to read halt flag");
+
+        let is_upgrade_height = state
+            .is_upgrade_height()
+            .await
+            .expect("must be able to read upgrade height");
 
         // Commit the pending writes, clearing the state.
         let jmt_root = storage
@@ -430,6 +434,11 @@ impl App {
         // If we should halt, we should end the process here.
         if should_halt {
             tracing::info!("committed block when a chain halt was signaled; exiting now");
+            std::process::exit(0);
+        }
+
+        if is_upgrade_height {
+            tracing::info!("committed block at upgrade height; exiting now");
             std::process::exit(0);
         }
 

--- a/crates/core/app/src/governance/view.rs
+++ b/crates/core/app/src/governance/view.rs
@@ -884,8 +884,9 @@ pub trait StateWriteExt: StateWrite {
                 // be slotted in at the end of the block:
                 self.deliver_dao_transaction(proposal_id).await?;
             }
-            ProposalPayload::UpgradePlan { .. } => {
-                tracing::info!("upgrade plan proposal passed, nothing to do for now");
+            ProposalPayload::UpgradePlan { height } => {
+                tracing::info!(target_height = height, "upgrade plan proposal passed");
+                self.signal_upgrade(*height).await?;
             }
         }
 

--- a/crates/core/component/chain/src/component/view.rs
+++ b/crates/core/component/chain/src/component/view.rs
@@ -126,8 +126,9 @@ pub trait StateReadExt: StateRead {
             .is_some())
     }
 
-    /// Returns true if the next height is an upgrade height. We do this because we want to
-    /// decide whether to upgrade before we commit the block.
+    /// Returns true if the next height is an upgrade height.
+    /// We look-ahead to the next height because we want to halt the chain immediately after
+    /// committing the block.
     async fn is_upgrade_height(&self) -> Result<bool> {
         let Some(next_upgrade_height) = self
             .nonverifiable_get_raw(state_key::next_upgrade().as_bytes())
@@ -227,6 +228,9 @@ pub trait StateWriteExt: StateWrite {
         Ok(())
     }
 
+    /// Record the next upgrade height.
+    /// Right after committing the state for this height, the chain will halt and wait for an upgrade.
+    /// It uses the same mechanism as emergency halting to prevent the chain from restarting.
     async fn signal_upgrade(&mut self, height: u64) -> Result<()> {
         self.nonverifiable_put_raw(
             state_key::next_upgrade().into(),

--- a/crates/core/component/chain/src/state_key.rs
+++ b/crates/core/component/chain/src/state_key.rs
@@ -31,6 +31,10 @@ pub fn halted(total_halt_count: u64) -> Vec<u8> {
     key
 }
 
+pub fn next_upgrade() -> &'static str {
+    "chain/next_upgrade"
+}
+
 // These are used for the object store:
 pub fn chain_params_changed() -> &'static str {
     "chain_params_changed"

--- a/crates/core/transaction/src/proposal.rs
+++ b/crates/core/transaction/src/proposal.rs
@@ -204,7 +204,7 @@ impl FromStr for ProposalKind {
             "emergency" => Ok(ProposalKind::Emergency),
             "parameterchange" => Ok(ProposalKind::ParameterChange),
             "daospend" => Ok(ProposalKind::DaoSpend),
-            "upgradeplan" => Ok(ProposalKind::UpgradePlan),
+            "upgrade_plan" => Ok(ProposalKind::UpgradePlan),
             _ => Err(anyhow::anyhow!("invalid proposal kind: {}", s)),
         }
     }

--- a/crates/core/transaction/src/proposal.rs
+++ b/crates/core/transaction/src/proposal.rs
@@ -155,6 +155,10 @@ impl TryFrom<pb::Proposal> for Proposal {
                         TransactionPlan::decode(transaction_plan.value)?
                     },
                 }
+            } else if let Some(upgrade_plan) = inner.upgrade_plan {
+                ProposalPayload::UpgradePlan {
+                    height: upgrade_plan.height,
+                }
             } else {
                 anyhow::bail!("missing proposal payload or unknown proposal type");
             },

--- a/crates/view/src/storage.rs
+++ b/crates/view/src/storage.rs
@@ -931,6 +931,7 @@ impl Storage {
                 .query_and_then((), |row| row.try_into())?
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
+
             // TODO: this could be internalized into the SQL query in principle, but it's easier to
             // do it this way; if it becomes slow, we can do it better
             let mut results = Vec::new();
@@ -939,7 +940,7 @@ impl Storage {
                 let denom: String = dbtx.query_row_and_then(
                     "SELECT denom FROM assets WHERE asset_id = ?1",
                     [asset_id],
-                    |row| row.get("asset_id")
+                    |row| row.get("denom")
                 )?;
 
                 let identity_key = DelegationToken::from_str(&denom)


### PR DESCRIPTION
This PR implement chain halts when the upgrade height specified in an `UpgradePlan` has been reached. It does this in three steps:
- when an `UpgradePlan` is enacted, we write the scheduled upgrade height in nonverifiable storage at key `chain/next_upgrade_height`
- when the target height is reached:
    - trigger an early epoch change so that the upgraded chain starts at a clean epoch boundary
    - after committing, shutdown gracefully