### PR TITLE
crypto: allow 12 or 24 words mnemonic seed phrases

### DIFF
--- a/crates/core/component/dex/src/swap_claim/proof.rs
+++ b/crates/core/component/dex/src/swap_claim/proof.rs
@@ -217,7 +217,7 @@ impl ParameterSetup for SwapClaimCircuit {
                 .id(),
         };
 
-        let seed_phrase = SeedPhrase::from_randomness([b'f'; 32]);
+        let seed_phrase = SeedPhrase::from_randomness(&[b'f'; 32]);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
@@ -416,7 +416,7 @@ mod tests {
 
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+        let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
         let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();

--- a/crates/core/component/governance/src/delegator_vote/proof.rs
+++ b/crates/core/component/governance/src/delegator_vote/proof.rs
@@ -186,7 +186,7 @@ impl ConstraintSynthesizer<Fq> for DelegatorVoteCircuit {
 
 impl ParameterSetup for DelegatorVoteCircuit {
     fn generate_test_parameters() -> (ProvingKey<Bls12_377>, VerifyingKey<Bls12_377>) {
-        let seed_phrase = SeedPhrase::from_randomness([b'f'; 32]);
+        let seed_phrase = SeedPhrase::from_randomness(&[b'f'; 32]);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
@@ -367,7 +367,7 @@ mod tests {
         let (pk, vk) = DelegatorVoteCircuit::generate_prepared_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+        let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
@@ -438,7 +438,7 @@ mod tests {
         let (pk, vk) = DelegatorVoteCircuit::generate_prepared_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+        let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();

--- a/crates/core/component/shielded-pool/src/nullifier_derivation.rs
+++ b/crates/core/component/shielded-pool/src/nullifier_derivation.rs
@@ -75,7 +75,7 @@ impl ConstraintSynthesizer<Fq> for NullifierDerivationCircuit {
 
 impl ParameterSetup for NullifierDerivationCircuit {
     fn generate_test_parameters() -> (ProvingKey<Bls12_377>, VerifyingKey<Bls12_377>) {
-        let seed_phrase = SeedPhrase::from_randomness([b'f'; 32]);
+        let seed_phrase = SeedPhrase::from_randomness(&[b'f'; 32]);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
@@ -211,7 +211,7 @@ mod tests {
 
             let mut rng = OsRng;
 
-            let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+            let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();

--- a/crates/core/component/shielded-pool/src/output/proof.rs
+++ b/crates/core/component/shielded-pool/src/output/proof.rs
@@ -253,7 +253,7 @@ mod tests {
 
             let mut rng = OsRng;
 
-            let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+            let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
             let fvk_recipient = sk_recipient.full_viewing_key();
             let ivk_recipient = fvk_recipient.incoming();
@@ -296,7 +296,7 @@ mod tests {
         let (pk, vk) = OutputCircuit::generate_prepared_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+        let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
         let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
@@ -345,7 +345,7 @@ mod tests {
         let (pk, vk) = OutputCircuit::generate_prepared_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+        let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
         let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();

--- a/crates/core/component/shielded-pool/src/spend/proof.rs
+++ b/crates/core/component/shielded-pool/src/spend/proof.rs
@@ -171,7 +171,7 @@ impl ConstraintSynthesizer<Fq> for SpendCircuit {
 
 impl ParameterSetup for SpendCircuit {
     fn generate_test_parameters() -> (ProvingKey<Bls12_377>, VerifyingKey<Bls12_377>) {
-        let seed_phrase = SeedPhrase::from_randomness([b'f'; 32]);
+        let seed_phrase = SeedPhrase::from_randomness(&[b'f'; 32]);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
@@ -358,7 +358,7 @@ mod tests {
         let (pk, vk) = SpendCircuit::generate_prepared_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+        let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
@@ -423,7 +423,7 @@ mod tests {
         let (pk, vk) = SpendCircuit::generate_prepared_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+        let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
@@ -481,10 +481,10 @@ mod tests {
             let (pk, vk) = SpendCircuit::generate_prepared_test_parameters();
             let mut rng = OsRng;
 
-            let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+            let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
 
-            let wrong_seed_phrase = SeedPhrase::from_randomness(incorrect_seed_phrase_randomness);
+            let wrong_seed_phrase = SeedPhrase::from_randomness(&incorrect_seed_phrase_randomness);
             let wrong_sk_sender = SpendKey::from_seed_phrase(wrong_seed_phrase, 0);
             let wrong_fvk_sender = wrong_sk_sender.full_viewing_key();
             let wrong_ivk_sender = wrong_fvk_sender.incoming();
@@ -543,7 +543,7 @@ mod tests {
             let (pk, vk) = SpendCircuit::generate_prepared_test_parameters();
             let mut rng = OsRng;
 
-            let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+            let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();
@@ -602,7 +602,7 @@ mod tests {
         let (pk, vk) = SpendCircuit::generate_prepared_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+        let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
@@ -660,7 +660,7 @@ mod tests {
             let (pk, vk) = SpendCircuit::generate_prepared_test_parameters();
             let mut rng = OsRng;
 
-            let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+            let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();
@@ -721,7 +721,7 @@ mod tests {
             let (pk, vk) = SpendCircuit::generate_prepared_test_parameters();
             let mut rng = OsRng;
 
-            let seed_phrase = SeedPhrase::from_randomness(seed_phrase_randomness);
+            let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();
@@ -825,7 +825,7 @@ mod tests {
 
     impl ParameterSetup for MerkleProofCircuit {
         fn generate_test_parameters() -> (ProvingKey<Bls12_377>, VerifyingKey<Bls12_377>) {
-            let seed_phrase = SeedPhrase::from_randomness([b'f'; 32]);
+            let seed_phrase = SeedPhrase::from_randomness(&[b'f'; 32]);
             let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();
@@ -876,7 +876,7 @@ mod tests {
         let (pk, vk) = MerkleProofCircuit::generate_prepared_test_parameters();
         let mut rng = OsRng;
 
-        let seed_phrase = SeedPhrase::from_randomness([b'f'; 32]);
+        let seed_phrase = SeedPhrase::from_randomness(&[b'f'; 32]);
         let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();

--- a/crates/core/keys/src/keys/seed_phrase.rs
+++ b/crates/core/keys/src/keys/seed_phrase.rs
@@ -175,8 +175,15 @@ mod tests {
     #[test]
     fn bip39_mnemonic_derivation() {
         // These test vectors are taken from: https://github.com/trezor/python-mnemonic/blob/master/vectors.json
-        let randomness_arr: [&str; 9] = [
+        let randomness_arr: [&str; 16] = [
             "00000000000000000000000000000000",
+            "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+            "80808080808080808080808080808080",
+            "ffffffffffffffffffffffffffffffff",
+            "9e885d952ad362caeb4efe34a8e91bd2",
+            "c0ba5a8e914111210f2bd131f3d5e08d",
+            "23db8160a31d3e0dca3688ed941adbf3",
+            "f30f8c1da665478f49b001d94c5fc452",
             "0000000000000000000000000000000000000000000000000000000000000000",
             "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
             "8080808080808080808080808080808080808080808080808080808080808080",
@@ -186,8 +193,15 @@ mod tests {
             "066dca1a2bb7e8a1db2832148ce9933eea0f3ac9548d793112d9a95c9407efad",
             "f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f",
         ];
-        let expected_phrase_arr: [&str; 9] = [
+        let expected_phrase_arr: [&str; 16] = [
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            "legal winner thank year wave sausage worth useful legal winner thank yellow",
+            "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+            "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+            "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
+            "scheme spot photo card baby mountain device kick cradle pact join borrow",
+            "cat swing flag economy stadium alone churn speed unique patch report train",
+            "vessel ladder alter error federal sibling chat ability sun glass valve picture",
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
             "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
             "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
@@ -205,6 +219,9 @@ mod tests {
             let randomness = hex::decode(hex_randomness).expect("can decode test vector");
             let actual_phrase = SeedPhrase::from_randomness(&randomness[..], length);
             assert_eq!(actual_phrase.to_string(), *expected_phrase);
+            actual_phrase
+                .verify_checksum()
+                .expect("checksum should validate");
         }
     }
 


### PR DESCRIPTION
This enables one to generate a 12- or 24 word seed phrase, instead of having a hardcoded 24 word seed phrase. 
Also adds test vectors referenced in the BIP39 spec for the 12-word phrases, in  https://github.com/trezor/python-mnemonic/blob/master/vectors.json. 