### PR TITLE
crypto: BIP44 derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,17 +368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-secp256k1"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02e954eaeb4ddb29613fee20840c2bbc85ca4396d53e33837e11905363c5f2"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
-]
-
-[[package]]
 name = "ark-serialize"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +938,24 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.28",
+]
+
+[[package]]
+name = "bip32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e141fb0f8be1c7b45887af94c88b182472b57c96b56773250ae00cd6a14a164"
+dependencies = [
+ "bs58",
+ "hmac 0.12.1",
+ "k256",
+ "once_cell",
+ "pbkdf2",
+ "rand_core 0.6.4",
+ "ripemd",
+ "sha2 0.10.7",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1108,7 +1121,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
- "tinyvec",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -1681,6 +1694,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,6 +2032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -2061,6 +2087,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "304e6508efa593091e97a9abbc10f90aa7ca635b6d2784feff3c89d41dd12272"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,6 +2129,24 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -2224,6 +2281,16 @@ name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fixed-hash"
@@ -2481,6 +2548,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2564,6 +2632,17 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3481,6 +3560,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -5002,14 +5093,13 @@ dependencies = [
  "ark-groth16",
  "ark-r1cs-std",
  "ark-relations",
- "ark-secp256k1",
  "ark-serialize",
  "ark-snark",
  "ark-std",
  "base64 0.20.0",
  "bech32",
+ "bip32",
  "blake2b_simd 0.5.11",
- "bs58",
  "bytes",
  "chacha20poly1305",
  "decaf377 0.5.0",
@@ -6446,6 +6536,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6830,6 +6930,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7164,6 +7277,10 @@ name = "signature"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "simple-mutex"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5000,6 +5009,7 @@ dependencies = [
  "base64 0.20.0",
  "bech32",
  "blake2b_simd 0.5.11",
+ "bs58",
  "bytes",
  "chacha20poly1305",
  "decaf377 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-secp256k1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c02e954eaeb4ddb29613fee20840c2bbc85ca4396d53e33837e11905363c5f2"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4982,6 +4993,7 @@ dependencies = [
  "ark-groth16",
  "ark-r1cs-std",
  "ark-relations",
+ "ark-secp256k1",
  "ark-serialize",
  "ark-snark",
  "ark-std",

--- a/crates/bin/pcli/src/command/keys.rs
+++ b/crates/bin/pcli/src/command/keys.rs
@@ -83,7 +83,7 @@ impl KeysCmd {
                 println!("YOUR PRIVATE SEED PHRASE: {seed_phrase}\nDO NOT SHARE WITH ANYONE!");
 
                 if *bip44_derivation {
-                    let path = Bip44Path::new(0, 0, 0);
+                    let path = Bip44Path::new(0, Some(0), Some(0));
                     let wallet = KeyStore::from_seed_phrase_bip44(seed_phrase, &path);
                     wallet.save(data_dir.join(crate::CUSTODY_FILE_NAME))?;
                     self.archive_wallet(&wallet)?;
@@ -111,7 +111,7 @@ impl KeysCmd {
                 }
 
                 if *bip44_derivation {
-                    let path = Bip44Path::new(0, 0, 0);
+                    let path = Bip44Path::new(0, Some(0), Some(0));
                     let wallet = KeyStore::from_seed_phrase_bip44(
                         SeedPhrase::from_str(&seed_phrase)?,
                         &path,

--- a/crates/bin/pcli/src/command/keys.rs
+++ b/crates/bin/pcli/src/command/keys.rs
@@ -82,16 +82,14 @@ impl KeysCmd {
                 // shared by users accidentally in log output.
                 println!("YOUR PRIVATE SEED PHRASE: {seed_phrase}\nDO NOT SHARE WITH ANYONE!");
 
-                if *bip44_derivation {
+                let wallet = if *bip44_derivation {
                     let path = Bip44Path::new(0);
-                    let wallet = KeyStore::from_seed_phrase_bip44(seed_phrase, &path);
-                    wallet.save(data_dir.join(crate::CUSTODY_FILE_NAME))?;
-                    self.archive_wallet(&wallet)?;
+                    KeyStore::from_seed_phrase_bip44(seed_phrase, &path)
                 } else {
-                    let wallet = KeyStore::from_seed_phrase_bip39(seed_phrase);
-                    wallet.save(data_dir.join(crate::CUSTODY_FILE_NAME))?;
-                    self.archive_wallet(&wallet)?;
-                }
+                    KeyStore::from_seed_phrase_bip39(seed_phrase)
+                };
+                wallet.save(data_dir.join(crate::CUSTODY_FILE_NAME))?;
+                self.archive_wallet(&wallet)?;
             }
             KeysCmd::Import(ImportCmd::Phrase { bip44_derivation }) => {
                 let mut seed_phrase = String::new();
@@ -110,20 +108,15 @@ impl KeysCmd {
                     }
                 }
 
-                if *bip44_derivation {
+                let seed_phrase = SeedPhrase::from_str(&seed_phrase)?;
+                let wallet = if *bip44_derivation {
                     let path = Bip44Path::new(0);
-                    let wallet = KeyStore::from_seed_phrase_bip44(
-                        SeedPhrase::from_str(&seed_phrase)?,
-                        &path,
-                    );
-                    wallet.save(data_dir.join(crate::CUSTODY_FILE_NAME))?;
-                    self.archive_wallet(&wallet)?;
+                    KeyStore::from_seed_phrase_bip44(seed_phrase, &path)
                 } else {
-                    let wallet =
-                        KeyStore::from_seed_phrase_bip39(SeedPhrase::from_str(&seed_phrase)?);
-                    wallet.save(data_dir.join(crate::CUSTODY_FILE_NAME))?;
-                    self.archive_wallet(&wallet)?;
-                }
+                    KeyStore::from_seed_phrase_bip39(seed_phrase)
+                };
+                wallet.save(data_dir.join(crate::CUSTODY_FILE_NAME))?;
+                self.archive_wallet(&wallet)?;
             }
             KeysCmd::Export(ExportCmd::FullViewingKey) => {
                 let wallet = KeyStore::load(data_dir.join(crate::CUSTODY_FILE_NAME))?;

--- a/crates/bin/pcli/src/command/keys.rs
+++ b/crates/bin/pcli/src/command/keys.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use directories::ProjectDirs;
-use penumbra_keys::keys::SeedPhrase;
+use penumbra_keys::keys::{Bip44Path, SeedPhrase};
 use rand_core::OsRng;
 use sha2::{Digest, Sha256};
 
@@ -83,7 +83,10 @@ impl KeysCmd {
                 println!("YOUR PRIVATE SEED PHRASE: {seed_phrase}\nDO NOT SHARE WITH ANYONE!");
 
                 if *bip44_derivation {
-                    unimplemented!();
+                    let path = Bip44Path::new(0, 0, 0);
+                    let wallet = KeyStore::from_seed_phrase_bip44(seed_phrase, &path);
+                    wallet.save(data_dir.join(crate::CUSTODY_FILE_NAME))?;
+                    self.archive_wallet(&wallet)?;
                 } else {
                     let wallet = KeyStore::from_seed_phrase_bip39(seed_phrase);
                     wallet.save(data_dir.join(crate::CUSTODY_FILE_NAME))?;
@@ -108,7 +111,13 @@ impl KeysCmd {
                 }
 
                 if *bip44_derivation {
-                    unimplemented!();
+                    let path = Bip44Path::new(0, 0, 0);
+                    let wallet = KeyStore::from_seed_phrase_bip44(
+                        SeedPhrase::from_str(&seed_phrase)?,
+                        &path,
+                    );
+                    wallet.save(data_dir.join(crate::CUSTODY_FILE_NAME))?;
+                    self.archive_wallet(&wallet)?;
                 } else {
                     let wallet =
                         KeyStore::from_seed_phrase_bip39(SeedPhrase::from_str(&seed_phrase)?);

--- a/crates/bin/pcli/src/command/keys.rs
+++ b/crates/bin/pcli/src/command/keys.rs
@@ -19,8 +19,8 @@ pub enum KeysCmd {
     Export(ExportCmd),
     /// Generate a new seed phrase and import its corresponding key.
     Generate {
-        /// If true, will use experimental BIP44 derivation.
-        #[clap(long, default_missing_value = "true", default_value = "false")]
+        /// If set, will use experimental BIP44 derivation.
+        #[clap(long, action)]
         bip44_derivation: bool,
     },
     /// Delete the entire wallet permanently.
@@ -32,8 +32,8 @@ pub enum ImportCmd {
     /// Import wallet from an existing 24-word seed phrase. Will prompt for input interactively.
     /// Also accepts input from stdin, for use with pipes.
     Phrase {
-        /// If true, will use experimental BIP44 derivation.
-        #[clap(long, default_missing_value = "true", default_value = "false")]
+        /// If set, will use experimental BIP44 derivation.
+        #[clap(long, action)]
         bip44_derivation: bool,
     },
 }

--- a/crates/bin/pcli/src/command/keys.rs
+++ b/crates/bin/pcli/src/command/keys.rs
@@ -83,7 +83,7 @@ impl KeysCmd {
                 println!("YOUR PRIVATE SEED PHRASE: {seed_phrase}\nDO NOT SHARE WITH ANYONE!");
 
                 if *bip44_derivation {
-                    let path = Bip44Path::new(0, Some(0), Some(0));
+                    let path = Bip44Path::new(0);
                     let wallet = KeyStore::from_seed_phrase_bip44(seed_phrase, &path);
                     wallet.save(data_dir.join(crate::CUSTODY_FILE_NAME))?;
                     self.archive_wallet(&wallet)?;
@@ -111,7 +111,7 @@ impl KeysCmd {
                 }
 
                 if *bip44_derivation {
-                    let path = Bip44Path::new(0, Some(0), Some(0));
+                    let path = Bip44Path::new(0);
                     let wallet = KeyStore::from_seed_phrase_bip44(
                         SeedPhrase::from_str(&seed_phrase)?,
                         &path,

--- a/crates/bin/pcli/tests/proof.rs
+++ b/crates/bin/pcli/tests/proof.rs
@@ -34,7 +34,7 @@ fn spend_proof_parameters_vs_current_spend_circuit() {
     let vk = &*SPEND_PROOF_VERIFICATION_KEY;
 
     let seed_phrase = SeedPhrase::generate(OsRng);
-    let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+    let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
     let fvk_sender = sk_sender.full_viewing_key();
     let ivk_sender = fvk_sender.incoming();
     let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -92,7 +92,7 @@ fn delegator_vote_proof_parameters_vs_current_delegator_vote_circuit() {
     let vk = &*DELEGATOR_VOTE_PROOF_VERIFICATION_KEY;
 
     let seed_phrase = SeedPhrase::generate(OsRng);
-    let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+    let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
     let fvk_sender = sk_sender.full_viewing_key();
     let ivk_sender = fvk_sender.incoming();
     let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -159,7 +159,7 @@ fn swap_proof_parameters_vs_current_swap_circuit() {
     let mut rng = OsRng;
 
     let seed_phrase = SeedPhrase::generate(OsRng);
-    let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
+    let sk_recipient = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
     let fvk_recipient = sk_recipient.full_viewing_key();
     let ivk_recipient = fvk_recipient.incoming();
     let (claim_address, _dtk_d) = ivk_recipient.payment_address(0u32.into());
@@ -224,7 +224,7 @@ fn swap_claim_parameters_vs_current_swap_claim_circuit() {
     let mut rng = OsRng;
 
     let seed_phrase = SeedPhrase::generate(OsRng);
-    let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
+    let sk_recipient = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
     let fvk_recipient = sk_recipient.full_viewing_key();
     let ivk_recipient = fvk_recipient.incoming();
     let (claim_address, _dtk_d) = ivk_recipient.payment_address(0u32.into());
@@ -320,7 +320,7 @@ fn output_proof_parameters_vs_current_output_circuit() {
     let mut rng = OsRng;
 
     let seed_phrase = SeedPhrase::generate(OsRng);
-    let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
+    let sk_recipient = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
     let fvk_recipient = sk_recipient.full_viewing_key();
     let ivk_recipient = fvk_recipient.incoming();
     let (dest, _dtk_d) = ivk_recipient.payment_address(0u32.into());
@@ -364,7 +364,7 @@ fn nullifier_derivation_parameters_vs_current_nullifier_derivation_circuit() {
     let mut rng = OsRng;
 
     let seed_phrase = SeedPhrase::generate(OsRng);
-    let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+    let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
     let fvk_sender = sk_sender.full_viewing_key();
     let ivk_sender = fvk_sender.incoming();
     let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());

--- a/crates/bin/pclientd/src/lib.rs
+++ b/crates/bin/pclientd/src/lib.rs
@@ -201,7 +201,7 @@ impl Opt {
 
                 let (spend_key, full_viewing_key) = match (seed_phrase, view) {
                     (Some(seed_phrase), None) => {
-                        let spend_key = SpendKey::from_seed_phrase(
+                        let spend_key = SpendKey::from_seed_phrase_bip39(
                             SeedPhrase::from_str(seed_phrase.as_str())?,
                             0,
                         );

--- a/crates/core/component/chain/src/lib.rs
+++ b/crates/core/component/chain/src/lib.rs
@@ -45,8 +45,9 @@ pub mod test_keys {
             .expect("hardcoded test addresses should be valid")
     });
 
-    pub static SPEND_KEY: Lazy<SpendKey> =
-        Lazy::new(|| SpendKey::from_seed_phrase_bip39(SEED_PHRASE.parse().unwrap(), 0));
+    pub static SPEND_KEY: Lazy<SpendKey> = Lazy::new(|| {
+        SpendKey::from_seed_phrase_bip39(SEED_PHRASE.parse().expect("seed phrase is valids"), 0)
+    });
 
     pub static FULL_VIEWING_KEY: Lazy<FullViewingKey> =
         Lazy::new(|| SPEND_KEY.full_viewing_key().clone());

--- a/crates/core/component/chain/src/lib.rs
+++ b/crates/core/component/chain/src/lib.rs
@@ -45,14 +45,8 @@ pub mod test_keys {
             .expect("hardcoded test addresses should be valid")
     });
 
-    pub static SPEND_KEY: Lazy<SpendKey> = Lazy::new(|| {
-        SpendKey::from_seed_phrase(
-            SEED_PHRASE
-                .parse()
-                .expect("hardcoded test seed phrase should be valid"),
-            0,
-        )
-    });
+    pub static SPEND_KEY: Lazy<SpendKey> =
+        Lazy::new(|| SpendKey::from_seed_phrase_bip39(SEED_PHRASE.parse().unwrap(), 0));
 
     pub static FULL_VIEWING_KEY: Lazy<FullViewingKey> =
         Lazy::new(|| SPEND_KEY.full_viewing_key().clone());

--- a/crates/core/component/chain/src/lib.rs
+++ b/crates/core/component/chain/src/lib.rs
@@ -46,7 +46,12 @@ pub mod test_keys {
     });
 
     pub static SPEND_KEY: Lazy<SpendKey> = Lazy::new(|| {
-        SpendKey::from_seed_phrase_bip39(SEED_PHRASE.parse().expect("seed phrase is valids"), 0)
+        SpendKey::from_seed_phrase_bip39(
+            SEED_PHRASE
+                .parse()
+                .expect("hardcoded test seed phrase should be valid"),
+            0,
+        )
     });
 
     pub static FULL_VIEWING_KEY: Lazy<FullViewingKey> =

--- a/crates/core/component/dex/src/swap/plaintext.rs
+++ b/crates/core/component/dex/src/swap/plaintext.rs
@@ -420,7 +420,7 @@ mod tests {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let ivk = fvk.incoming();
         let ovk = fvk.outgoing();

--- a/crates/core/component/dex/src/swap/proof.rs
+++ b/crates/core/component/dex/src/swap/proof.rs
@@ -283,7 +283,7 @@ mod tests {
 
 
         let seed_phrase = SeedPhrase::generate(&mut rng);
-        let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_recipient = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
         let (claim_address, _dtk_d) = ivk_recipient.payment_address(0u32.into());

--- a/crates/core/component/dex/src/swap_claim/proof.rs
+++ b/crates/core/component/dex/src/swap_claim/proof.rs
@@ -217,7 +217,7 @@ impl DummyWitness for SwapClaimCircuit {
         };
 
         let seed_phrase = SeedPhrase::from_randomness(&[b'f'; 32]);
-        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (address, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -450,7 +450,7 @@ mod tests {
 
 
         let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-        let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_recipient = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
         let (claim_address, _dtk_d) = ivk_recipient.payment_address(0u32.into());
@@ -537,7 +537,7 @@ mod tests {
         let (pk, vk) = generate_prepared_test_parameters::<SwapClaimCircuit>(&mut rng);
 
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_recipient = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
         let (claim_address, _dtk_d) = ivk_recipient.payment_address(0u32.into());

--- a/crates/core/component/governance/src/delegator_vote/proof.rs
+++ b/crates/core/component/governance/src/delegator_vote/proof.rs
@@ -186,7 +186,7 @@ impl ConstraintSynthesizer<Fq> for DelegatorVoteCircuit {
 impl DummyWitness for DelegatorVoteCircuit {
     fn with_dummy_witness() -> Self {
         let seed_phrase = SeedPhrase::from_randomness(&[b'f'; 32]);
-        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (address, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -399,7 +399,7 @@ mod tests {
         let (pk, vk) = generate_prepared_test_parameters::<DelegatorVoteCircuit>(&mut rng);
 
         let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -470,7 +470,7 @@ mod tests {
         let (pk, vk) = generate_prepared_test_parameters::<DelegatorVoteCircuit>(&mut rng);
 
         let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());

--- a/crates/core/component/shielded-pool/src/note.rs
+++ b/crates/core/component/shielded-pool/src/note.rs
@@ -566,7 +566,7 @@ mod tests {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let ivk = fvk.incoming();
         let (dest, _dtk_d) = ivk.payment_address(0u32.into());
@@ -589,7 +589,7 @@ mod tests {
         assert_eq!(plaintext, note);
 
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk2 = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk2 = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk2 = sk2.full_viewing_key();
         let ivk2 = fvk2.incoming();
 
@@ -601,7 +601,7 @@ mod tests {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let ivk = fvk.incoming();
         let ovk = fvk.outgoing();
@@ -636,7 +636,7 @@ mod tests {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let ivk = fvk.incoming();
         let (dest, _dtk_d) = ivk.payment_address(0u32.into());

--- a/crates/core/component/shielded-pool/src/nullifier_derivation.rs
+++ b/crates/core/component/shielded-pool/src/nullifier_derivation.rs
@@ -74,7 +74,7 @@ impl ConstraintSynthesizer<Fq> for NullifierDerivationCircuit {
 impl DummyWitness for NullifierDerivationCircuit {
     fn with_dummy_witness() -> Self {
         let seed_phrase = SeedPhrase::from_randomness(&[b'f'; 32]);
-        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (address, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -221,7 +221,7 @@ mod tests {
 
 
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-            let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+            let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();
             let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());

--- a/crates/core/component/shielded-pool/src/output/plan.rs
+++ b/crates/core/component/shielded-pool/src/output/plan.rs
@@ -189,7 +189,7 @@ mod test {
     fn check_output_proof_verification() {
         let mut rng = OsRng;
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let ovk = sk.full_viewing_key().outgoing();
         let dummy_memo_key: PayloadKey = [0; 32].into();
 

--- a/crates/core/component/shielded-pool/src/output/proof.rs
+++ b/crates/core/component/shielded-pool/src/output/proof.rs
@@ -259,7 +259,7 @@ mod tests {
 
 
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-            let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
+            let sk_recipient = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
             let fvk_recipient = sk_recipient.full_viewing_key();
             let ivk_recipient = fvk_recipient.incoming();
             let (dest, _dtk_d) = ivk_recipient.payment_address(0u32.into());
@@ -302,7 +302,7 @@ mod tests {
         let (pk, vk) = generate_prepared_test_parameters::<OutputCircuit>(&mut rng);
 
         let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-        let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_recipient = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
         let (dest, _dtk_d) = ivk_recipient.payment_address(0u32.into());
@@ -351,7 +351,7 @@ mod tests {
         let (pk, vk) = generate_prepared_test_parameters::<OutputCircuit>(&mut rng);
 
         let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-        let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_recipient = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_recipient = sk_recipient.full_viewing_key();
         let ivk_recipient = fvk_recipient.incoming();
         let (dest, _dtk_d) = ivk_recipient.payment_address(0u32.into());

--- a/crates/core/component/shielded-pool/src/spend/proof.rs
+++ b/crates/core/component/shielded-pool/src/spend/proof.rs
@@ -171,7 +171,7 @@ impl ConstraintSynthesizer<Fq> for SpendCircuit {
 impl DummyWitness for SpendCircuit {
     fn with_dummy_witness() -> Self {
         let seed_phrase = SeedPhrase::from_randomness(&[b'f'; 32]);
-        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (address, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -372,7 +372,7 @@ mod tests {
         let (pk, vk) = generate_prepared_test_parameters::<SpendCircuit>(&mut rng);
 
         let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -437,7 +437,7 @@ mod tests {
         let (pk, vk) = generate_prepared_test_parameters::<SpendCircuit>(&mut rng);
 
         let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -495,10 +495,10 @@ mod tests {
             let (pk, vk) = generate_prepared_test_parameters::<SpendCircuit>(&mut rng);
 
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-            let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+            let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
 
             let wrong_seed_phrase = SeedPhrase::from_randomness(&incorrect_seed_phrase_randomness);
-            let wrong_sk_sender = SpendKey::from_seed_phrase(wrong_seed_phrase, 0);
+            let wrong_sk_sender = SpendKey::from_seed_phrase_bip39(wrong_seed_phrase, 0);
             let wrong_fvk_sender = wrong_sk_sender.full_viewing_key();
             let wrong_ivk_sender = wrong_fvk_sender.incoming();
             let (wrong_sender, _dtk_d) = wrong_ivk_sender.payment_address(1u32.into());
@@ -557,7 +557,7 @@ mod tests {
             let (pk, vk) = generate_prepared_test_parameters::<SpendCircuit>(&mut rng);
 
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-            let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+            let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();
             let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -616,7 +616,7 @@ mod tests {
         let (pk, vk) = generate_prepared_test_parameters::<SpendCircuit>(&mut rng);
 
         let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -674,7 +674,7 @@ mod tests {
             let (pk, vk) = generate_prepared_test_parameters::<SpendCircuit>(&mut rng);
 
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-            let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+            let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();
             let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -735,7 +735,7 @@ mod tests {
             let (pk, vk) = generate_prepared_test_parameters::<SpendCircuit>(&mut rng);
 
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-            let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+            let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();
             let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -839,7 +839,7 @@ mod tests {
     impl DummyWitness for MerkleProofCircuit {
         fn with_dummy_witness() -> Self {
             let seed_phrase = SeedPhrase::from_randomness(&[b'f'; 32]);
-            let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+            let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();
             let (address, _dtk_d) = ivk_sender.payment_address(0u32.into());
@@ -889,7 +889,7 @@ mod tests {
         let (pk, vk) = generate_prepared_test_parameters::<MerkleProofCircuit>(&mut rng);
 
         let seed_phrase = SeedPhrase::from_randomness(&[b'f'; 32]);
-        let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk_sender = sk_sender.full_viewing_key();
         let ivk_sender = fvk_sender.incoming();
         let (address, _dtk_d) = ivk_sender.payment_address(0u32.into());

--- a/crates/core/keys/Cargo.toml
+++ b/crates/core/keys/Cargo.toml
@@ -22,6 +22,7 @@ f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e
 # Crates.io deps
 base64 = "0.20"
 ark-ff = { version = "0.4", default_features = false }
+ark-secp256k1 = { version = "0.4", default_features = false }
 ark-std = { version = "0.4", default_features = false }
 ark-serialize = "0.4"
 regex = "1.5"

--- a/crates/core/keys/Cargo.toml
+++ b/crates/core/keys/Cargo.toml
@@ -62,6 +62,7 @@ proptest = "1"
 serde_json = "1"
 frost377 = { version = "0.2", default-features=false }
 num-traits = "0.2"
+bs58 = "0.5"
 
 [features]
 default = []

--- a/crates/core/keys/Cargo.toml
+++ b/crates/core/keys/Cargo.toml
@@ -21,8 +21,8 @@ f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e
 
 # Crates.io deps
 base64 = "0.20"
+bip32 = "0.5"
 ark-ff = { version = "0.4", default_features = false }
-ark-secp256k1 = { version = "0.4", default_features = false }
 ark-std = { version = "0.4", default_features = false }
 ark-serialize = "0.4"
 regex = "1.5"
@@ -62,7 +62,6 @@ proptest = "1"
 serde_json = "1"
 frost377 = { version = "0.2", default-features=false }
 num-traits = "0.2"
-bs58 = "0.5"
 
 [features]
 default = []

--- a/crates/core/keys/src/address.rs
+++ b/crates/core/keys/src/address.rs
@@ -275,7 +275,7 @@ mod tests {
     fn test_address_encoding() {
         let rng = OsRng;
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let ivk = fvk.incoming();
         let (dest, _dtk_d) = ivk.payment_address(0u32.into());
@@ -310,7 +310,7 @@ mod tests {
     fn test_bytes_roundtrip() {
         let rng = OsRng;
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let ivk = fvk.incoming();
         let (dest, _dtk_d) = ivk.payment_address(0u32.into());
@@ -325,7 +325,7 @@ mod tests {
     fn test_address_keys_are_diversified() {
         let rng = OsRng;
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let ivk = fvk.incoming();
         let (dest1, dtk_d1) = ivk.payment_address(0u32.into());

--- a/crates/core/keys/src/address/view.rs
+++ b/crates/core/keys/src/address/view.rs
@@ -112,8 +112,8 @@ mod tests {
 
     #[test]
     fn address_view_basic() {
-        let sk1 = SpendKey::from_seed_phrase(SeedPhrase::generate(OsRng), 0);
-        let sk2 = SpendKey::from_seed_phrase(SeedPhrase::generate(OsRng), 0);
+        let sk1 = SpendKey::from_seed_phrase_bip39(SeedPhrase::generate(OsRng), 0);
+        let sk2 = SpendKey::from_seed_phrase_bip39(SeedPhrase::generate(OsRng), 0);
 
         let fvk1 = sk1.full_viewing_key();
         let fvk2 = sk2.full_viewing_key();

--- a/crates/core/keys/src/keys.rs
+++ b/crates/core/keys/src/keys.rs
@@ -10,6 +10,7 @@ pub use seed_phrase::SeedPhrase;
 mod spend;
 pub use spend::{SpendKey, SpendKeyBytes, SPENDKEY_LEN_BYTES};
 
+mod bip44;
 mod fvk;
 mod ivk;
 mod ovk;

--- a/crates/core/keys/src/keys.rs
+++ b/crates/core/keys/src/keys.rs
@@ -11,6 +11,8 @@ mod spend;
 pub use spend::{SpendKey, SpendKeyBytes, SPENDKEY_LEN_BYTES};
 
 mod bip44;
+pub use bip44::Bip44Path;
+
 mod fvk;
 mod ivk;
 mod ovk;

--- a/crates/core/keys/src/keys/bip44.rs
+++ b/crates/core/keys/src/keys/bip44.rs
@@ -16,13 +16,13 @@ const PENUMBRA_COIN_TYPE: u32 = 0x0001984;
 pub struct Bip44Path {
     coin_type: u32,
     account: u32,
-    change: bool,
+    change: u32,
     address_index: u32,
 }
 
 impl Bip44Path {
     /// Create a new BIP44 path for Penumbra.
-    pub fn new(account: u32, change: bool, address_index: u32) -> Self {
+    pub fn new(account: u32, change: u32, address_index: u32) -> Self {
         Self {
             coin_type: PENUMBRA_COIN_TYPE,
             account,
@@ -47,7 +47,7 @@ impl Bip44Path {
     }
 
     /// Change is set to 1 to denote change addresses.
-    pub fn change(&self) -> bool {
+    pub fn change(&self) -> u32 {
         self.change
     }
 
@@ -61,7 +61,7 @@ impl Bip44Path {
             "m/44'/{}'/{}'/{}/{}",
             self.coin_type(),
             self.account(),
-            if self.change() { 1 } else { 0 },
+            self.change(),
             self.address_index()
         )
     }
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn test_bip44_path() {
-        let path = Bip44Path::new(0, false, 0);
+        let path = Bip44Path::new(0, 0, 0);
         assert_eq!(path.path(), "m/44'/6532'/0'/0/0");
     }
 }

--- a/crates/core/keys/src/keys/bip44.rs
+++ b/crates/core/keys/src/keys/bip44.rs
@@ -14,6 +14,7 @@ const PENUMBRA_COIN_TYPE: u32 = 0x0001984;
 /// BIP43: https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki
 /// BIP44: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
 pub struct Bip44Path {
+    purpose: u32,
     coin_type: u32,
     account: u32,
     change: u32,
@@ -24,6 +25,7 @@ impl Bip44Path {
     /// Create a new BIP44 path for Penumbra.
     pub fn new(account: u32, change: u32, address_index: u32) -> Self {
         Self {
+            purpose: 0x8000002C,
             coin_type: PENUMBRA_COIN_TYPE,
             account,
             change,
@@ -31,9 +33,26 @@ impl Bip44Path {
         }
     }
 
-    /// Per BIP43, purpose is a constant set to 44' or 0x8000002C.
+    /// Create a new generic BIP44 path.
+    pub fn new_generic(
+        purpose: u32,
+        coin_type: u32,
+        account: u32,
+        change: u32,
+        address_index: u32,
+    ) -> Self {
+        Self {
+            purpose,
+            coin_type,
+            account,
+            change,
+            address_index,
+        }
+    }
+
+    /// Per BIP43, purpose is typically a constant set to 44' or 0x8000002C.
     pub fn purpose(&self) -> u32 {
-        0x8000002C
+        self.purpose
     }
 
     /// Per BIP44, coin type is a constant set for each currency.
@@ -64,17 +83,6 @@ impl Bip44Path {
             self.change(),
             self.address_index()
         )
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_bip44_path() {
-        let path = Bip44Path::new(0, 0, 0);
-        assert_eq!(path.path(), "m/44'/6532'/0'/0/0");
     }
 }
 
@@ -122,6 +130,10 @@ pub fn ckd_priv(k_par: [u8; 32], c_par: [u8; 32], i: u32) -> ([u8; 32], [u8; 32]
     // Finally, we need to check if i_L ≥ n or k_i = 0, as the resulting key is invalid
     if k_i == Fsecp256k1::zero() || i_L_mod_n_bytes != i_L.to_vec() {
         // Key is invalid, proceed with the next value for i
+        dbg!("this should only occur with w/ low probability");
+        dbg!(k_i);
+        dbg!(i_L_mod_n_bytes);
+        dbg!(i_L.to_vec());
         return ckd_priv(k_par, c_par, i + 1);
     }
 
@@ -129,4 +141,56 @@ pub fn ckd_priv(k_par: [u8; 32], c_par: [u8; 32], i: u32) -> ([u8; 32], [u8; 32]
     k_i.serialize_with_mode(&mut k_i_bytes, Compress::Yes)
         .expect("can serialize");
     (k_i_bytes.try_into().expect("result fits in 32 bytes"), c_i)
+}
+
+#[cfg(test)]
+mod tests {
+    use bs58;
+
+    use super::*;
+
+    #[test]
+    fn test_bip44_path() {
+        let path = Bip44Path::new(0, 0, 0);
+        assert_eq!(path.path(), "m/44'/6532'/0'/0/0");
+    }
+
+    /// The below test vectors are from: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#test-vector-1
+    #[test]
+    fn bip44_child_derivation() {
+        // Test vector 1
+        let hex_seed = "000102030405060708090a0b0c0d0e0f".to_string();
+        let seed = hex::decode(hex_seed).expect("can decode test vector");
+        let mut seed_arr = [0u8; 32];
+        seed_arr[0..16].copy_from_slice(&seed[..]);
+
+        let path = Bip44Path::new_generic(0, 1, 2, 2, 1000000000);
+
+        // Chain m
+        let data = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi".to_string();
+        let decoded_bytes = bs58::decode(data)
+            .into_vec()
+            .expect("all test vectors should be valid base58");
+
+        // Per BIP43, each address has the prefix 0x0488B21E for public and 0x0488ADE4 for private nodes.
+        // All our test vectors are private nodes since we only implemented the private key derivation:
+        assert_eq!(decoded_bytes[0..4], [0x04, 0x88, 0xAD, 0xE4]);
+
+        // Extended keys are 82 bytes long, the final 4 bytes being a checksum, and the preceding 33 bytes being the
+        // actual key material. Public keys are 33 bytes, and private keys get a 0x00 appended since they are 32 bytes.
+        let priv_key_material = &decoded_bytes[46..78];
+
+        // First level is hardened derivation in test vector 1.
+        let i = 2147483648u32; // 2^31
+        let mut purpose_bytes = [0u8; 32];
+        let purpose = path.purpose();
+        let purpose_arr = path.purpose().to_le_bytes();
+        purpose_bytes[0..4].copy_from_slice(&purpose_arr[..]);
+        let (k_1, _) = ckd_priv(seed_arr, purpose_bytes, i);
+
+        assert_eq!(
+            k_1, priv_key_material,
+            "first level derivation should match"
+        );
+    }
 }

--- a/crates/core/keys/src/keys/bip44.rs
+++ b/crates/core/keys/src/keys/bip44.rs
@@ -38,12 +38,12 @@ impl Bip44Path {
 
     /// Per BIP44, coin type is a constant set for each currency.
     pub fn coin_type(&self) -> u32 {
-        self.coin_type
+        self.coin_type | 0x80000000
     }
 
     /// Per BIP44, account splits the key space into independent user identities.
     pub fn account(&self) -> u32 {
-        self.account
+        self.account | 0x80000000
     }
 
     /// Change is set to 1 to denote change addresses.

--- a/crates/core/keys/src/keys/bip44.rs
+++ b/crates/core/keys/src/keys/bip44.rs
@@ -17,14 +17,14 @@ pub struct Bip44Path {
 }
 
 impl Bip44Path {
-    /// Create a new BIP44 path for Penumbra.
-    pub fn new(account: u32, change: Option<u32>, address_index: Option<u32>) -> Self {
+    /// Create a new BIP44 path for a Penumbra account group.
+    pub fn new(account: u32) -> Self {
         Self {
             purpose: 44,
             coin_type: PENUMBRA_COIN_TYPE,
             account,
-            change,
-            address_index,
+            change: None,
+            address_index: None,
         }
     }
 
@@ -73,10 +73,14 @@ impl Bip44Path {
     pub fn path(&self) -> String {
         let mut path = format!("m/44'/{}'/{}'", self.coin_type(), self.account());
         if self.change().is_some() {
-            path = format!("{}/{}'", path, self.change().unwrap());
+            path = format!("{}/{}", path, self.change().expect("change will exist"));
         }
         if self.address_index().is_some() {
-            path = format!("{}/{}", path, self.address_index().unwrap());
+            path = format!(
+                "{}/{}",
+                path,
+                self.address_index().expect("address index will exist")
+            );
         }
         path
     }
@@ -87,8 +91,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_bip44_path() {
-        let path = Bip44Path::new(0, Some(0), Some(0));
+    fn test_bip44_path_full() {
+        let path = Bip44Path::new_generic(44, 6532, 0, Some(0), Some(0));
         assert_eq!(path.path(), "m/44'/6532'/0'/0/0");
+    }
+
+    #[test]
+    fn test_bip44_path_account_level() {
+        let path = Bip44Path::new(0);
+        assert_eq!(path.path(), "m/44'/6532'/0'");
     }
 }

--- a/crates/core/keys/src/keys/bip44.rs
+++ b/crates/core/keys/src/keys/bip44.rs
@@ -12,13 +12,13 @@ pub struct Bip44Path {
     purpose: u32,
     coin_type: u32,
     account: u32,
-    change: u32,
-    address_index: u32,
+    change: Option<u32>,
+    address_index: Option<u32>,
 }
 
 impl Bip44Path {
     /// Create a new BIP44 path for Penumbra.
-    pub fn new(account: u32, change: u32, address_index: u32) -> Self {
+    pub fn new(account: u32, change: Option<u32>, address_index: Option<u32>) -> Self {
         Self {
             purpose: 44,
             coin_type: PENUMBRA_COIN_TYPE,
@@ -33,8 +33,8 @@ impl Bip44Path {
         purpose: u32,
         coin_type: u32,
         account: u32,
-        change: u32,
-        address_index: u32,
+        change: Option<u32>,
+        address_index: Option<u32>,
     ) -> Self {
         Self {
             purpose,
@@ -60,24 +60,25 @@ impl Bip44Path {
         self.account
     }
 
-    /// Change is set to 1 to denote change addresses.
-    pub fn change(&self) -> u32 {
+    /// Change is set to 1 to denote change addresses. None if unset.
+    pub fn change(&self) -> Option<u32> {
         self.change
     }
 
-    /// Addresses are numbered starting from index 0.
-    pub fn address_index(&self) -> u32 {
+    /// Addresses are numbered starting from index 0. None if unset.
+    pub fn address_index(&self) -> Option<u32> {
         self.address_index
     }
 
     pub fn path(&self) -> String {
-        format!(
-            "m/44'/{}'/{}'/{}/{}",
-            self.coin_type(),
-            self.account(),
-            self.change(),
-            self.address_index()
-        )
+        let mut path = format!("m/44'/{}'/{}'", self.coin_type(), self.account());
+        if self.change().is_some() {
+            path = format!("{}/{}'", path, self.change().unwrap());
+        }
+        if self.address_index().is_some() {
+            path = format!("{}/{}", path, self.address_index().unwrap());
+        }
+        path
     }
 }
 
@@ -87,7 +88,7 @@ mod tests {
 
     #[test]
     fn test_bip44_path() {
-        let path = Bip44Path::new(0, 0, 0);
+        let path = Bip44Path::new(0, Some(0), Some(0));
         assert_eq!(path.path(), "m/44'/6532'/0'/0/0");
     }
 }

--- a/crates/core/keys/src/keys/bip44.rs
+++ b/crates/core/keys/src/keys/bip44.rs
@@ -1,0 +1,74 @@
+/// Penumbra's registered coin type.
+/// See: https://github.com/satoshilabs/slips/pull/1592
+const PENUMBRA_COIN_TYPE: u32 = 0x0001984;
+
+/// Represents a BIP44 derivation path.
+///
+/// BIP43 defines the purpose constant used for BIP44 derivation.
+///
+/// BIP43: https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki
+/// BIP44: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+struct Bip44Path {
+    coin_type: u32,
+    account: u32,
+    change: bool,
+    address_index: u32,
+}
+
+impl Bip44Path {
+    /// Create a new BIP44 path for Penumbra.
+    pub fn new(account: u32, change: bool, address_index: u32) -> Self {
+        Self {
+            coin_type: PENUMBRA_COIN_TYPE,
+            account,
+            change,
+            address_index,
+        }
+    }
+
+    /// Per BIP43, purpose is a constant set to 44' or 0x8000002C.
+    pub fn purpose(&self) -> u32 {
+        0x8000002C
+    }
+
+    /// Per BIP44, coin type is a constant set for each currency.
+    pub fn coin_type(&self) -> u32 {
+        self.coin_type
+    }
+
+    /// Per BIP44, account splits the key space into independent user identities.
+    pub fn account(&self) -> u32 {
+        self.account
+    }
+
+    /// Change is set to 1 to denote change addresses.
+    pub fn change(&self) -> bool {
+        self.change
+    }
+
+    /// Addresses are numbered starting from index 0.
+    pub fn address_index(&self) -> u32 {
+        self.address_index
+    }
+
+    pub fn path(&self) -> String {
+        format!(
+            "m/44'/{}'/{}'/{}/{}",
+            self.coin_type(),
+            self.account(),
+            if self.change() { 1 } else { 0 },
+            self.address_index()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bip44_path() {
+        let path = Bip44Path::new(0, false, 0);
+        assert_eq!(path.path(), "m/44'/6532'/0'/0/0");
+    }
+}

--- a/crates/core/keys/src/keys/bip44.rs
+++ b/crates/core/keys/src/keys/bip44.rs
@@ -8,7 +8,7 @@ const PENUMBRA_COIN_TYPE: u32 = 0x0001984;
 ///
 /// BIP43: https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki
 /// BIP44: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
-struct Bip44Path {
+pub struct Bip44Path {
     coin_type: u32,
     account: u32,
     change: bool,

--- a/crates/core/keys/src/keys/bip44.rs
+++ b/crates/core/keys/src/keys/bip44.rs
@@ -1,11 +1,6 @@
-use ark_ff::Zero;
-use ark_secp256k1::Fr as Fsecp256k1;
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress};
-use hmac::{Hmac, Mac};
-
 /// Penumbra's registered coin type.
 /// See: https://github.com/satoshilabs/slips/pull/1592
-const PENUMBRA_COIN_TYPE: u32 = 0x0001984;
+const PENUMBRA_COIN_TYPE: u32 = 6532;
 
 /// Represents a BIP44 derivation path.
 ///
@@ -25,7 +20,7 @@ impl Bip44Path {
     /// Create a new BIP44 path for Penumbra.
     pub fn new(account: u32, change: u32, address_index: u32) -> Self {
         Self {
-            purpose: 0x8000002C,
+            purpose: 44,
             coin_type: PENUMBRA_COIN_TYPE,
             account,
             change,
@@ -57,12 +52,12 @@ impl Bip44Path {
 
     /// Per BIP44, coin type is a constant set for each currency.
     pub fn coin_type(&self) -> u32 {
-        self.coin_type | 0x80000000
+        self.coin_type
     }
 
     /// Per BIP44, account splits the key space into independent user identities.
     pub fn account(&self) -> u32 {
-        self.account | 0x80000000
+        self.account
     }
 
     /// Change is set to 1 to denote change addresses.
@@ -86,111 +81,13 @@ impl Bip44Path {
     }
 }
 
-#[allow(non_snake_case)]
-pub fn ckd_priv(k_par: [u8; 32], c_par: [u8; 32], i: u32) -> ([u8; 32], [u8; 32]) {
-    let mut hmac = Hmac::<sha2::Sha512>::new_from_slice(&c_par).expect("can create hmac");
-    if i >= 0x80000000 {
-        // Hardened derivation
-        hmac.update(&[0u8]);
-        hmac.update(&k_par);
-    } else {
-        hmac.update(&k_par);
-    }
-    hmac.update(&i.to_be_bytes());
-
-    // The output of the above hash is 64 bytes, and we split it into two 32 byte chunks, i_L and i_R.
-    let result = hmac.finalize().into_bytes();
-    let mut i_L = [0u8; 32];
-    i_L.copy_from_slice(&result[..32]);
-    let mut i_R = [0u8; 32];
-    i_R.copy_from_slice(&result[32..]);
-
-    // The result of the above is the child key k_i and the chain code c_i.
-    let c_i = i_R;
-
-    // k_i is derived as (k_par + i_L) % n
-    // where n is the order of the secp256k1 curve:
-    //
-    // n = FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141
-    //
-    // which in the Arkworks crate is the scalar field modulus, in decimal:
-    //
-    // 115792089237316195423570985008687907852837564279074904382605163141518161494337
-    //
-    // See:
-    // https://en.bitcoin.it/wiki/Secp256k1
-    // https://en.bitcoin.it/wiki/BIP_0032#Child_key_derivation_.28CKD.29_functions
-    let i_L_field = Fsecp256k1::deserialize_compressed(&i_L[..]).expect("valid Fr");
-    let k_i = Fsecp256k1::deserialize_compressed(&k_par[..]).expect("valid Fr") + i_L_field;
-
-    let mut i_L_mod_n_bytes = Vec::new();
-    i_L_field
-        .serialize_with_mode(&mut i_L_mod_n_bytes, Compress::Yes)
-        .expect("can serialize");
-    // Finally, we need to check if i_L ≥ n or k_i = 0, as the resulting key is invalid
-    if k_i == Fsecp256k1::zero() || i_L_mod_n_bytes != i_L.to_vec() {
-        // Key is invalid, proceed with the next value for i
-        dbg!("this should only occur with w/ low probability");
-        dbg!(k_i);
-        dbg!(i_L_mod_n_bytes);
-        dbg!(i_L.to_vec());
-        return ckd_priv(k_par, c_par, i + 1);
-    }
-
-    let mut k_i_bytes = Vec::new();
-    k_i.serialize_with_mode(&mut k_i_bytes, Compress::Yes)
-        .expect("can serialize");
-    (k_i_bytes.try_into().expect("result fits in 32 bytes"), c_i)
-}
-
 #[cfg(test)]
 mod tests {
-    use bs58;
-
     use super::*;
 
     #[test]
     fn test_bip44_path() {
         let path = Bip44Path::new(0, 0, 0);
         assert_eq!(path.path(), "m/44'/6532'/0'/0/0");
-    }
-
-    /// The below test vectors are from: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#test-vector-1
-    #[test]
-    fn bip44_child_derivation() {
-        // Test vector 1
-        let hex_seed = "000102030405060708090a0b0c0d0e0f".to_string();
-        let seed = hex::decode(hex_seed).expect("can decode test vector");
-        let mut seed_arr = [0u8; 32];
-        seed_arr[0..16].copy_from_slice(&seed[..]);
-
-        let path = Bip44Path::new_generic(0, 1, 2, 2, 1000000000);
-
-        // Chain m
-        let data = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi".to_string();
-        let decoded_bytes = bs58::decode(data)
-            .into_vec()
-            .expect("all test vectors should be valid base58");
-
-        // Per BIP43, each address has the prefix 0x0488B21E for public and 0x0488ADE4 for private nodes.
-        // All our test vectors are private nodes since we only implemented the private key derivation:
-        assert_eq!(decoded_bytes[0..4], [0x04, 0x88, 0xAD, 0xE4]);
-
-        // Extended keys are 82 bytes long, the final 4 bytes being a checksum, and the preceding 33 bytes being the
-        // actual key material. Public keys are 33 bytes, and private keys get a 0x00 appended since they are 32 bytes.
-        let priv_key_material = &decoded_bytes[46..78];
-
-        // First level is hardened derivation in test vector 1.
-        let i = 2147483648u32; // 2^31
-        let mut purpose_bytes = [0u8; 32];
-        let purpose = path.purpose();
-        let purpose_arr = path.purpose().to_le_bytes();
-        purpose_bytes[0..4].copy_from_slice(&purpose_arr[..]);
-        let (k_1, _) = ckd_priv(seed_arr, purpose_bytes, i);
-
-        assert_eq!(
-            k_1, priv_key_material,
-            "first level derivation should match"
-        );
     }
 }

--- a/crates/core/keys/src/keys/ivk.rs
+++ b/crates/core/keys/src/keys/ivk.rs
@@ -171,7 +171,7 @@ mod test {
     #[test]
     fn views_address_succeeds_on_own_address() {
         let rng = rand::rngs::OsRng;
-        let spend_key = SpendKey::from_seed_phrase(SeedPhrase::generate(rng), 0);
+        let spend_key = SpendKey::from_seed_phrase_bip39(SeedPhrase::generate(rng), 0);
         let ivk = spend_key.full_viewing_key().incoming();
         let own_address = ivk.payment_address(AddressIndex::from(0u32)).0;
         assert!(ivk.views_address(&own_address));
@@ -181,7 +181,7 @@ mod test {
         #[test]
         fn views_address_succeeds_on_own_ephemeral_address(address_index in any::<u32>()) {
             let rng = rand::rngs::OsRng;
-            let spend_key = SpendKey::from_seed_phrase(SeedPhrase::generate(rng), 0);
+            let spend_key = SpendKey::from_seed_phrase_bip39(SeedPhrase::generate(rng), 0);
             let fvk = spend_key.full_viewing_key();
             let (own_address, _) = fvk.ephemeral_address(rng, AddressIndex::from(address_index));
             let ivk = fvk.incoming();
@@ -195,10 +195,10 @@ mod test {
     #[test]
     fn views_address_fails_on_other_address() {
         let rng = rand::rngs::OsRng;
-        let spend_key = SpendKey::from_seed_phrase(SeedPhrase::generate(rng), 0);
+        let spend_key = SpendKey::from_seed_phrase_bip39(SeedPhrase::generate(rng), 0);
         let ivk = spend_key.full_viewing_key().incoming();
 
-        let other_address = SpendKey::from_seed_phrase(SeedPhrase::generate(rng), 0)
+        let other_address = SpendKey::from_seed_phrase_bip39(SeedPhrase::generate(rng), 0)
             .full_viewing_key()
             .incoming()
             .payment_address(AddressIndex::from(0u32))

--- a/crates/core/keys/src/keys/seed_phrase.rs
+++ b/crates/core/keys/src/keys/seed_phrase.rs
@@ -217,6 +217,8 @@ fn convert_bits_to_usize(bits: &[bool]) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use hmac::Hmac;
+    use pbkdf2::pbkdf2;
     use std::str::FromStr;
 
     use super::*;
@@ -224,7 +226,7 @@ mod tests {
     #[test]
     fn bip39_mnemonic_derivation() {
         // These test vectors are taken from: https://github.com/trezor/python-mnemonic/blob/master/vectors.json
-        let randomness_arr: [&str; 16] = [
+        let randomness_arr = [
             "00000000000000000000000000000000",
             "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
             "80808080808080808080808080808080",
@@ -242,7 +244,7 @@ mod tests {
             "066dca1a2bb7e8a1db2832148ce9933eea0f3ac9548d793112d9a95c9407efad",
             "f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f",
         ];
-        let expected_phrase_arr: [&str; 16] = [
+        let expected_phrase_arr = [
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
             "legal winner thank year wave sausage worth useful legal winner thank yellow",
             "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
@@ -260,9 +262,29 @@ mod tests {
             "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
             "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
         ];
+        let seed_result_arr = [
+            "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04",
+            "2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607",
+            "d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8",
+            "ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069",
+            "274ddc525802f7c828d8ef7ddbcdc5304e87ac3535913611fbbfa986d0c9e5476c91689f9c8a54fd55bd38606aa6a8595ad213d4c9c9f9aca3fb217069a41028",
+            "ea725895aaae8d4c1cf682c1bfd2d358d52ed9f0f0591131b559e2724bb234fca05aa9c02c57407e04ee9dc3b454aa63fbff483a8b11de949624b9f1831a9612",
+            "deb5f45449e615feff5640f2e49f933ff51895de3b4381832b3139941c57b59205a42480c52175b6efcffaa58a2503887c1e8b363a707256bdd2b587b46541f5",
+            "2aaa9242daafcee6aa9d7269f17d4efe271e1b9a529178d7dc139cd18747090bf9d60295d0ce74309a78852a9caadf0af48aae1c6253839624076224374bc63f",
+            "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8",
+            "bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87",
+            "c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f",
+            "dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad",
+            "64c87cde7e12ecf6704ab95bb1408bef047c22db4cc7491c4271d170a1b213d20b385bc1588d9c7b38f1b39d415665b8a9030c9ec653d75e65f847d8fc1fc440",
+            "72be8e052fc4919d2adf28d5306b5474b0069df35b02303de8c1729c9538dbb6fc2d731d5f832193cd9fb6aeecbc469594a70e3dd50811b5067f3b88b28c3e8d",
+            "26e975ec644423f4a4c4f4215ef09b4bd7ef924e85d1d17c4cf3f136c2863cf6df0a475045652c57eb5fb41513ca2a2d67722b77e954b4b3fc11f7590449191d",
+            "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998",
+        ];
 
-        for (hex_randomness, expected_phrase) in
-            randomness_arr.iter().zip(expected_phrase_arr.iter())
+        for (i, (hex_randomness, expected_phrase)) in randomness_arr
+            .iter()
+            .zip(expected_phrase_arr.iter())
+            .enumerate()
         {
             let randomness = hex::decode(hex_randomness).expect("can decode test vector");
             let actual_phrase = SeedPhrase::from_randomness(&randomness[..]);
@@ -270,6 +292,18 @@ mod tests {
             actual_phrase
                 .verify_checksum()
                 .expect("checksum should validate");
+
+            let password = format!("{actual_phrase}");
+            let mut seed_bytes = [0u8; 64];
+            pbkdf2::<Hmac<sha2::Sha512>>(
+                password.as_bytes(),
+                "mnemonicTREZOR".as_bytes(),
+                NUM_PBKDF2_ROUNDS,
+                &mut seed_bytes,
+            )
+            .expect("seed phrase hash always succeeds");
+            let seed_result = hex::encode(seed_bytes);
+            assert_eq!(seed_result, seed_result_arr[i]);
         }
     }
 

--- a/crates/core/keys/src/keys/seed_phrase.rs
+++ b/crates/core/keys/src/keys/seed_phrase.rs
@@ -68,6 +68,7 @@ impl SeedPhraseType {
 }
 
 /// A mnemonic seed phrase. Used to generate [`SpendSeed`]s.
+#[derive(Clone, Debug)]
 pub struct SeedPhrase(pub Vec<String>);
 
 impl SeedPhrase {

--- a/crates/core/keys/src/keys/spend.rs
+++ b/crates/core/keys/src/keys/spend.rs
@@ -6,6 +6,7 @@ use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType, TypeUrl};
 use serde::{Deserialize, Serialize};
 
 use super::{
+    bip44,
     seed_phrase::{SeedPhrase, NUM_PBKDF2_ROUNDS},
     FullViewingKey, IncomingViewingKey, NullifierKey, OutgoingViewingKey,
 };

--- a/crates/core/keys/src/keys/spend.rs
+++ b/crates/core/keys/src/keys/spend.rs
@@ -92,7 +92,7 @@ impl SpendKey {
     /// authorities from a single seed phrase.
     ///
     /// [`BIP39`]: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
-    pub fn from_seed_phrase(seed_phrase: SeedPhrase, index: u64) -> Self {
+    pub fn from_seed_phrase_bip39(seed_phrase: SeedPhrase, index: u64) -> Self {
         let password = format!("{seed_phrase}");
         let salt = format!("mnemonic{index}");
         let mut spend_seed_bytes = [0u8; 32];

--- a/crates/core/keys/src/keys/spend.rs
+++ b/crates/core/keys/src/keys/spend.rs
@@ -110,6 +110,7 @@ impl SpendKey {
     pub fn from_seed_phrase_bip44(seed_phrase: SeedPhrase, path: &Bip44Path) -> Self {
         // First derive the HD wallet master key.
         let password = format!("{seed_phrase}");
+        // The salt used for deriving the master key is defined in BIP32.
         let salt = "Bitcoin seed";
         let mut m_bytes = [0u8; 32];
         pbkdf2::<Hmac<sha2::Sha512>>(

--- a/crates/core/keys/src/keys/spend.rs
+++ b/crates/core/keys/src/keys/spend.rs
@@ -199,7 +199,7 @@ mod tests {
                 .expect("valid");
         let expected_spendkey = SpendKeyBytes(expected_bytes.try_into().expect("fits in 32 bytes"));
 
-        let derivation_path = Bip44Path::new(0, 0, 0);
+        let derivation_path = Bip44Path::new(0, None, None);
         dbg!(derivation_path.path());
         let software_spendkey = SpendKey::from_seed_phrase_bip44(seed.clone(), &derivation_path);
 

--- a/crates/core/keys/src/keys/spend.rs
+++ b/crates/core/keys/src/keys/spend.rs
@@ -6,7 +6,7 @@ use penumbra_proto::{core::crypto::v1alpha1 as pb, DomainType, TypeUrl};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    bip44,
+    bip44::Bip44Path,
     seed_phrase::{SeedPhrase, NUM_PBKDF2_ROUNDS},
     FullViewingKey, IncomingViewingKey, NullifierKey, OutgoingViewingKey,
 };
@@ -105,6 +105,23 @@ impl SpendKey {
         )
         .expect("seed phrase hash always succeeds");
         SpendKeyBytes(spend_seed_bytes).into()
+    }
+
+    pub fn from_seed_phrase_bip44(seed_phrase: SeedPhrase, path: &Bip44Path) -> Self {
+        // First derive the HD wallet master key.
+        let password = format!("{seed_phrase}");
+        let salt = "Bitcoin seed";
+        let mut m_bytes = [0u8; 32];
+        pbkdf2::<Hmac<sha2::Sha512>>(
+            password.as_bytes(),
+            salt.as_bytes(),
+            NUM_PBKDF2_ROUNDS,
+            &mut m_bytes,
+        )
+        .expect("seed phrase hash always succeeds");
+
+        // Now we derive the child keys from the BIP44 path.
+        todo!("impl CKDpriv function")
     }
 
     // XXX how many of these do we need? leave them for now

--- a/crates/core/keys/src/keys/spend.rs
+++ b/crates/core/keys/src/keys/spend.rs
@@ -1,3 +1,4 @@
+use bip32::XPrv;
 use std::convert::TryFrom;
 
 use hmac::Hmac;
@@ -11,7 +12,6 @@ use super::{
     FullViewingKey, IncomingViewingKey, NullifierKey, OutgoingViewingKey,
 };
 use crate::{
-    keys::bip44::ckd_priv,
     prf,
     rdsa::{SigningKey, SpendAuth},
 };
@@ -109,54 +109,18 @@ impl SpendKey {
     }
 
     pub fn from_seed_phrase_bip44(seed_phrase: SeedPhrase, path: &Bip44Path) -> Self {
-        // First derive the HD wallet master node.
-        let password = format!("{seed_phrase}");
-        // The salt used for deriving the master key is defined in BIP32.
-        let salt = "Bitcoin seed";
-        let mut m_bytes = [0u8; 32];
-        pbkdf2::<Hmac<sha2::Sha512>>(
-            password.as_bytes(),
-            salt.as_bytes(),
-            NUM_PBKDF2_ROUNDS,
-            &mut m_bytes,
-        )
-        .expect("seed phrase hash always succeeds");
+        let seed_bytes = seed_phrase.randomness().expect("valid seed phrase");
 
         // Now we derive the child keys from the BIP44 path. There are five levels
         // in the BIP44 path: purpose, coin type, account, change, and address index.
+        let child_key = XPrv::derive_from_path(
+            &seed_bytes[..],
+            &path.path().parse().expect("valid BIP44 path"),
+        )
+        .expect("can derive child key");
+        let child_key_bytes = child_key.to_bytes();
 
-        // The first key is derived from the master key and the purpose constant.
-        // i is set to 2^31 to indicate that hardened derivation should be used
-        // for the first three levels.
-        let i = 2u32.pow(31);
-        let mut purpose_bytes = [0u8; 32];
-        purpose_bytes.copy_from_slice(&path.purpose().to_le_bytes());
-        let (k_1, _) = ckd_priv(m_bytes, purpose_bytes, i);
-
-        // The second key is derived from the first key and the coin type constant.
-        let mut coin_type_bytes = [0u8; 32];
-        coin_type_bytes.copy_from_slice(&path.coin_type().to_le_bytes());
-        let (k_2, _) = ckd_priv(k_1, coin_type_bytes, i);
-
-        // The third key is derived from the second key and the account constant.
-        let mut account_bytes = [0u8; 32];
-        account_bytes.copy_from_slice(&path.account().to_le_bytes());
-        let (k_3, _) = ckd_priv(k_2, account_bytes, i);
-
-        // The fourth key is derived from the third key and the change constant.
-        // Starting here, we set i=0 to indicate that public derivation should be used
-        // for the change and address index levels.
-        let i = 0;
-        let mut change_bytes = [0u8; 32];
-        change_bytes.copy_from_slice(&path.change().to_le_bytes());
-        let (k_4, _) = ckd_priv(k_3, change_bytes, i);
-
-        // The fifth key is derived from the fourth key and the address index.
-        let mut address_index_bytes = [0u8; 32];
-        address_index_bytes.copy_from_slice(&path.address_index().to_le_bytes());
-        let (k_5, _) = ckd_priv(k_4, address_index_bytes, i);
-
-        SpendKeyBytes(k_5).into()
+        SpendKeyBytes(child_key_bytes).into()
     }
 
     // XXX how many of these do we need? leave them for now
@@ -217,5 +181,28 @@ impl std::str::FromStr for SpendKey {
             inner: bech32str::decode(s, bech32str::spend_key::BECH32_PREFIX, bech32str::Bech32m)?,
         }
         .try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn bip44_test_ledger() {
+        let seed = SeedPhrase::from_str("comfort ten front cycle churn burger oak absent rice ice urge result art couple benefit cabbage frequent obscure hurry trick segment cool job debate").unwrap();
+
+        let expected_bytes =
+            hex::decode("1b8113fad04f5db00e6acf541949950f85eca3e02e70254838b750b42a2caa51")
+                .expect("valid");
+        let expected_spendkey = SpendKeyBytes(expected_bytes.try_into().expect("fits in 32 bytes"));
+
+        let derivation_path = Bip44Path::new(0, 0, 0);
+        dbg!(derivation_path.path());
+        let software_spendkey = SpendKey::from_seed_phrase_bip44(seed.clone(), &derivation_path);
+
+        assert_eq!(software_spendkey.to_bytes(), expected_spendkey);
     }
 }

--- a/crates/core/transaction/src/effect_hash.rs
+++ b/crates/core/transaction/src/effect_hash.rs
@@ -551,7 +551,7 @@ mod tests {
     fn plan_effect_hash_matches_transaction_effect_hash() {
         let rng = OsRng;
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let (addr, _dtk) = fvk.incoming().payment_address(0u32.into());
 

--- a/crates/core/transaction/src/memo.rs
+++ b/crates/core/transaction/src/memo.rs
@@ -242,7 +242,7 @@ mod tests {
     fn test_memo_encryption_and_decryption() {
         let mut rng = OsRng;
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let ivk = fvk.incoming();
         let (dest, _dtk_d) = ivk.payment_address(0u32.into());
@@ -282,7 +282,7 @@ mod tests {
         let mut rng = OsRng;
 
         let seed_phrase = SeedPhrase::generate(rng);
-        let sk = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let sk = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
         let fvk = sk.full_viewing_key();
         let ivk = fvk.incoming();
         let ovk = fvk.outgoing();

--- a/crates/crypto/proof-params/benches/delegator_vote.rs
+++ b/crates/crypto/proof-params/benches/delegator_vote.rs
@@ -54,7 +54,7 @@ fn delegator_vote_proving_time(c: &mut Criterion) {
     let value_to_send = Value::from_str("1upenumbra").expect("valid value");
 
     let seed_phrase = SeedPhrase::generate(OsRng);
-    let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+    let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
     let fvk_sender = sk_sender.full_viewing_key();
     let ivk_sender = fvk_sender.incoming();
     let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());

--- a/crates/crypto/proof-params/benches/nullifier_derivation.rs
+++ b/crates/crypto/proof-params/benches/nullifier_derivation.rs
@@ -29,7 +29,7 @@ fn prove(position: tct::Position, note: Note, nk: NullifierKey, nullifier: Nulli
 
 fn nullifier_derivation_proving_time(c: &mut Criterion) {
     let seed_phrase = SeedPhrase::generate(OsRng);
-    let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+    let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
     let fvk_sender = sk_sender.full_viewing_key();
     let ivk_sender = fvk_sender.incoming();
     let (address, _dtk_d) = ivk_sender.payment_address(0u32.into());

--- a/crates/crypto/proof-params/benches/spend.rs
+++ b/crates/crypto/proof-params/benches/spend.rs
@@ -52,7 +52,7 @@ fn spend_proving_time(c: &mut Criterion) {
     let value_to_send = Value::from_str("1upenumbra").expect("valid value");
 
     let seed_phrase = SeedPhrase::generate(OsRng);
-    let sk_sender = SpendKey::from_seed_phrase(seed_phrase, 0);
+    let sk_sender = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
     let fvk_sender = sk_sender.full_viewing_key();
     let ivk_sender = fvk_sender.incoming();
     let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());

--- a/crates/crypto/proof-params/benches/swap.rs
+++ b/crates/crypto/proof-params/benches/swap.rs
@@ -42,7 +42,7 @@ fn prove(
 
 fn swap_proving_time(c: &mut Criterion) {
     let seed_phrase = SeedPhrase::generate(OsRng);
-    let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
+    let sk_recipient = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
     let fvk_recipient = sk_recipient.full_viewing_key();
     let ivk_recipient = fvk_recipient.incoming();
     let (claim_address, _dtk_d) = ivk_recipient.payment_address(0u32.into());

--- a/crates/crypto/proof-params/benches/swap_claim.rs
+++ b/crates/crypto/proof-params/benches/swap_claim.rs
@@ -58,7 +58,7 @@ fn prove(
 
 fn swap_claim_proving_time(c: &mut Criterion) {
     let seed_phrase = SeedPhrase::generate(OsRng);
-    let sk_recipient = SpendKey::from_seed_phrase(seed_phrase, 0);
+    let sk_recipient = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
     let fvk_recipient = sk_recipient.full_viewing_key();
     let ivk_recipient = fvk_recipient.incoming();
     let (claim_address, _dtk_d) = ivk_recipient.payment_address(0u32.into());

--- a/crates/custody/src/soft_kms/config.rs
+++ b/crates/custody/src/soft_kms/config.rs
@@ -47,7 +47,7 @@ mod tests {
     #[test]
     fn toml_config_round_trip() {
         let seed_phrase = SeedPhrase::generate(rand_core::OsRng);
-        let spend_key = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let spend_key = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
 
         let pak = ed25519_consensus::SigningKey::new(rand_core::OsRng);
         let pvk = pak.verification_key();

--- a/crates/wallet/src/key_store.rs
+++ b/crates/wallet/src/key_store.rs
@@ -46,7 +46,7 @@ impl KeyStore {
     pub fn from_seed_phrase(seed_phrase: SeedPhrase) -> Self {
         // Currently we support a single spend authority per wallet. In the future,
         // we can derive multiple spend seeds from a single seed phrase.
-        let spend_key = SpendKey::from_seed_phrase(seed_phrase, 0);
+        let spend_key = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
 
         Self { spend_key }
     }

--- a/crates/wallet/src/key_store.rs
+++ b/crates/wallet/src/key_store.rs
@@ -43,7 +43,7 @@ impl KeyStore {
     }
 
     /// Create a new wallet.
-    pub fn from_seed_phrase(seed_phrase: SeedPhrase) -> Self {
+    pub fn from_seed_phrase_bip39(seed_phrase: SeedPhrase) -> Self {
         // Currently we support a single spend authority per wallet. In the future,
         // we can derive multiple spend seeds from a single seed phrase.
         let spend_key = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);

--- a/crates/wallet/src/key_store.rs
+++ b/crates/wallet/src/key_store.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use penumbra_keys::keys::{SeedPhrase, SpendKey};
+use penumbra_keys::keys::{Bip44Path, SeedPhrase, SpendKey};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
@@ -47,6 +47,13 @@ impl KeyStore {
         // Currently we support a single spend authority per wallet. In the future,
         // we can derive multiple spend seeds from a single seed phrase.
         let spend_key = SpendKey::from_seed_phrase_bip39(seed_phrase, 0);
+
+        Self { spend_key }
+    }
+
+    /// Create a new wallet using BIP44 derivation.
+    pub fn from_seed_phrase_bip44(seed_phrase: SeedPhrase, path: &Bip44Path) -> Self {
+        let spend_key = SpendKey::from_seed_phrase_bip44(seed_phrase, path);
 
         Self { spend_key }
     }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -26,7 +26,7 @@ pub use view_server::ViewServer;
 pub fn generate_spend_key(seed_phrase: &str) -> JsValue {
     utils::set_panic_hook();
     let seed = SeedPhrase::from_str(seed_phrase).unwrap();
-    let spend_key = SpendKey::from_seed_phrase(seed, 0);
+    let spend_key = SpendKey::from_seed_phrase_bip39(seed, 0);
 
     let proto = spend_key.to_proto();
     let spend_key_str = &bech32str::encode(


### PR DESCRIPTION
Towards #2946. 

This adds experimental BIP44 derivation wherein we:
1. derive a 64-byte binary seed from the seed phrase as described in BIP39 using PBKDF2 but using only `mnemonic` as the salt
2. define a BIP44 path `m/44'/6532'/0'` which matches the Penumbra `coin_type` and the account number (`0`) used in the test vector generator (the apostrophes indicate hardened derivation)
3. derive the spend key bytes from BIP32 child key derivation from the seed and the above BIP44 path 
