### PR TITLE
delegator_vote: use balance commitment to staked note

### DIFF
--- a/crates/bin/pcli/tests/network_integration.rs
+++ b/crates/bin/pcli/tests/network_integration.rs
@@ -1318,15 +1318,17 @@ fn delegate_submit_proposal_and_vote() {
         .args([
             "--data-path",
             tmpdir.path().to_str().unwrap(),
-            "governance",
+            "tx",
             "proposal",
             "template",
             "signaling",
         ])
         .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS))
-        .output()
-        .unwrap()
-        .stdout;
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
     let template_str = String::from_utf8(template).unwrap();
     let template_file = load_string_to_file(template_str, &tmpdir);
     let template_path = template_file.path().to_str().unwrap();
@@ -1366,7 +1368,6 @@ fn delegate_submit_proposal_and_vote() {
             "--data-path",
             tmpdir.path().to_str().unwrap(),
             "tx",
-            "proposal",
             "vote",
             "yes",
             "--on",

--- a/crates/core/app/src/action_handler/actions/delegator_vote.rs
+++ b/crates/core/app/src/action_handler/actions/delegator_vote.rs
@@ -1,14 +1,13 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use ark_ff::Zero;
 use async_trait::async_trait;
+use decaf377::Fr;
 use penumbra_chain::TransactionContext;
 use penumbra_proof_params::DELEGATOR_VOTE_PROOF_VERIFICATION_KEY;
 use penumbra_storage::{StateRead, StateWrite};
-use penumbra_transaction::{
-    action::{DelegatorVote, DelegatorVoteBody},
-    IsAction,
-};
+use penumbra_transaction::action::{DelegatorVote, DelegatorVoteBody};
 
 use crate::{
     governance::{StateReadExt as _, StateWriteExt as _},
@@ -28,9 +27,9 @@ impl ActionHandler for DelegatorVote {
                     start_position,
                     nullifier,
                     rk,
-                    unbonded_amount: _, // Used to compute the balance commitment.
+                    value,
                     // Unused in stateless checks:
-                    value: _,
+                    unbonded_amount: _,
                     vote: _,     // Only used when executing the vote
                     proposal: _, // Checked against the current open proposals statefully
                 },
@@ -45,7 +44,7 @@ impl ActionHandler for DelegatorVote {
             .verify(
                 &DELEGATOR_VOTE_PROOF_VERIFICATION_KEY,
                 context.anchor,
-                self.balance_commitment(),
+                value.commit(Fr::zero()),
                 *nullifier,
                 *rk,
                 *start_position,

--- a/crates/core/component/governance/src/delegator_vote/proof.rs
+++ b/crates/core/component/governance/src/delegator_vote/proof.rs
@@ -255,6 +255,19 @@ impl DelegatorVoteProof {
         // The blinding factor for the value commitment is zero since it
         // is not blinded.
         let zero_blinding = Fr::from(0);
+        tracing::debug!(
+            ?state_commitment_proof,
+            ?note,
+            ?spend_auth_randomizer,
+            ?ak,
+            ?nk,
+            ?anchor,
+            ?balance_commitment,
+            ?nullifier,
+            ?rk,
+            ?start_position,
+            "generating delegator vote proof"
+        );
         let circuit = DelegatorVoteCircuit {
             state_commitment_proof,
             note,

--- a/crates/core/transaction/src/action/delegator_vote.rs
+++ b/crates/core/transaction/src/action/delegator_vote.rs
@@ -24,8 +24,8 @@ pub struct DelegatorVote {
 impl IsAction for DelegatorVote {
     fn balance_commitment(&self) -> balance::Commitment {
         Value {
-            asset_id: VotingReceiptToken::new(self.body.proposal).id(),
             amount: self.body.unbonded_amount,
+            asset_id: VotingReceiptToken::new(self.body.proposal).id(),
         }
         .commit(Fr::zero())
     }

--- a/crates/core/transaction/src/plan/action/delegator_vote.rs
+++ b/crates/core/transaction/src/plan/action/delegator_vote.rs
@@ -1,4 +1,5 @@
 use ark_ff::UniformRand;
+use ark_ff::Zero;
 use decaf377::{FieldExt, Fq, Fr};
 use decaf377_rdsa::{Signature, SpendAuth};
 use penumbra_asset::{Balance, Value};
@@ -111,7 +112,7 @@ impl DelegatorVotePlan {
             *fvk.spend_verification_key(),
             *fvk.nullifier_key(),
             state_commitment_proof.root(),
-            self.balance().commit(Fr::from(0u64)),
+            self.staked_note.value().commit(Fr::zero()),
             self.nullifier(fvk),
             self.rk(fvk),
             self.start_position,


### PR DESCRIPTION
The `DelegatorVote` stateless checks verify both the action effect hash signature and the supplied proof against the validated public inputs. This PR changes the balance commitment used in the proof verification to match the one used in proof generation: a commitment to the `unbonded_amount` corresponding to the staked note, which represents the voting power at the time of delegation.