### PR TITLE
Improvements and fixes to wasm transaction planner and wasm view server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5733,8 +5733,10 @@ name = "penumbra-wasm"
 version = "0.60.0"
 dependencies = [
  "anyhow",
+ "ark-ff",
  "base64 0.21.4",
  "console_error_panic_hook",
+ "decaf377 0.5.0",
  "hex",
  "indexed_db_futures",
  "penumbra-asset",
@@ -5753,6 +5755,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde-wasm-bindgen",
+ "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -29,15 +29,19 @@ penumbra-tct           = { path = "../crypto/tct" }
 penumbra-transaction   = { path = "../core/transaction", default-features = false }
 
 anyhow                   = "1.0.75"
+ark-ff                   = { version = "0.4.2", features = ["std"] }
 base64                   = "0.21.2"
 console_error_panic_hook = { version = "0.1.7", optional = true }
+decaf377                 = { version = "0.5", features = ["r1cs"] }
 hex                      = "0.4.3"
 indexed_db_futures       = "0.3.0"
 rand_core                = { version = "0.6.4", features = ["getrandom"] }
 serde                    = { version = "1.0.186", features = ["derive"] }
 serde-wasm-bindgen       = "0.5.0"
+thiserror                = "1.0"
 wasm-bindgen             = "0.2.87"
 wasm-bindgen-futures     = "0.4.37"
+wasm-bindgen-test        = "0.3.0"
 web-sys                  = { version = "0.3.64", features = ["console"] }
 
 [dev-dependencies]

--- a/crates/wasm/src/error.rs
+++ b/crates/wasm/src/error.rs
@@ -1,0 +1,69 @@
+use base64::DecodeError;
+use hex::FromHexError;
+use penumbra_tct::error::{InsertBlockError, InsertEpochError, InsertError};
+use serde_wasm_bindgen::Error;
+use std::convert::Infallible;
+use thiserror::Error;
+use wasm_bindgen::{JsError, JsValue};
+use web_sys::DomException;
+
+pub type WasmResult<T> = Result<T, WasmError>;
+
+#[derive(Error, Debug)]
+pub enum WasmError {
+    #[error("{0}")]
+    Anyhow(#[from] anyhow::Error),
+
+    #[error("{0}")]
+    DecodeError(#[from] DecodeError),
+
+    #[error("{0}")]
+    Dom(#[from] DomError),
+
+    #[error("{0}")]
+    FromHexError(#[from] FromHexError),
+
+    #[error("{0}")]
+    Infallible(#[from] Infallible),
+
+    #[error("{0}")]
+    InsertBlockError(#[from] InsertBlockError),
+
+    #[error("{0}")]
+    InsertEpochError(#[from] InsertEpochError),
+
+    #[error("{0}")]
+    InsertError(#[from] InsertError),
+
+    #[error("{0}")]
+    Wasm(#[from] serde_wasm_bindgen::Error),
+}
+
+impl From<WasmError> for serde_wasm_bindgen::Error {
+    fn from(wasm_err: WasmError) -> Self {
+        Error::new(wasm_err.to_string())
+    }
+}
+
+impl From<WasmError> for JsValue {
+    fn from(error: WasmError) -> Self {
+        JsError::from(error).into()
+    }
+}
+
+#[derive(Debug)]
+pub struct DomError(DomException);
+
+impl std::fmt::Display for DomError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "DOM Exception: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for DomError {}
+
+impl From<DomException> for WasmError {
+    fn from(dom_exception: DomException) -> Self {
+        WasmError::Dom(DomError(dom_exception))
+    }
+}

--- a/crates/wasm/src/keys.rs
+++ b/crates/wasm/src/keys.rs
@@ -1,0 +1,106 @@
+use crate::error::WasmResult;
+use penumbra_keys::keys::{SeedPhrase, SpendKey};
+use penumbra_keys::{Address, FullViewingKey};
+use penumbra_proto::{core::crypto::v1alpha1 as pb, serializers::bech32str, DomainType};
+use rand_core::OsRng;
+use std::str::FromStr;
+use wasm_bindgen::prelude::*;
+
+/// generate a spend key from a seed phrase
+/// Arguments:
+///     seed_phrase: `string`
+/// Returns: `bech32 string`
+#[wasm_bindgen]
+pub fn generate_spend_key(seed_phrase: &str) -> WasmResult<JsValue> {
+    let seed = SeedPhrase::from_str(seed_phrase)?;
+    let spend_key = SpendKey::from_seed_phrase_bip39(seed, 0);
+
+    let proto = spend_key.to_proto();
+
+    let spend_key_str = bech32str::encode(
+        &proto.inner,
+        bech32str::spend_key::BECH32_PREFIX,
+        bech32str::Bech32m,
+    );
+
+    Ok(JsValue::from_str(&spend_key_str))
+}
+
+/// get full viewing key from spend key
+/// Arguments:
+///     spend_key_str: `bech32 string`
+/// Returns: `bech32 string`
+#[wasm_bindgen]
+pub fn get_full_viewing_key(spend_key: &str) -> WasmResult<JsValue> {
+    let spend_key = SpendKey::from_str(spend_key)?;
+
+    let fvk: &FullViewingKey = spend_key.full_viewing_key();
+
+    let proto = fvk.to_proto();
+
+    let fvk_bech32 = bech32str::encode(
+        &proto.inner,
+        bech32str::full_viewing_key::BECH32_PREFIX,
+        bech32str::Bech32m,
+    );
+    Ok(JsValue::from_str(&fvk_bech32))
+}
+
+/// get address by index using FVK
+/// Arguments:
+///     full_viewing_key: `bech32 string`
+///     index: `u32`
+/// Returns: `pb::Address`
+#[wasm_bindgen]
+pub fn get_address_by_index(full_viewing_key: &str, index: u32) -> WasmResult<JsValue> {
+    let fvk = FullViewingKey::from_str(full_viewing_key)?;
+    let (address, _dtk) = fvk.incoming().payment_address(index.into());
+    let proto = address.to_proto();
+    let result = serde_wasm_bindgen::to_value(&proto)?;
+    Ok(result)
+}
+
+/// get ephemeral (randomizer) address using FVK
+/// The derivation tree is like "spend key / address index / ephemeral address" so we must also pass index as an argument
+/// Arguments:
+///     full_viewing_key: `bech32 string`
+///     index: `u32`
+/// Returns: `pb::Address`
+#[wasm_bindgen]
+pub fn get_ephemeral_address(full_viewing_key: &str, index: u32) -> WasmResult<JsValue> {
+    let fvk = FullViewingKey::from_str(full_viewing_key)?;
+    let (address, _dtk) = fvk.ephemeral_address(OsRng, index.into());
+    let proto = address.to_proto();
+    let result = serde_wasm_bindgen::to_value(&proto)?;
+    Ok(result)
+}
+
+/// Check if the address is FVK controlled
+/// Arguments:
+///     full_viewing_key: `bech32 String`
+///     address: `bech32 String`
+/// Returns: `Option<pb::AddressIndex>`
+#[wasm_bindgen]
+pub fn is_controlled_address(full_viewing_key: &str, address: &str) -> WasmResult<JsValue> {
+    let fvk = FullViewingKey::from_str(full_viewing_key)?;
+    let index: Option<pb::AddressIndex> = fvk
+        .address_index(&Address::from_str(address)?)
+        .map(Into::into);
+    let result = serde_wasm_bindgen::to_value(&index)?;
+    Ok(result)
+}
+
+/// Get canonical short form address by index
+/// This feature is probably redundant and will be removed from wasm in the future
+/// Arguments:
+///     full_viewing_key: `bech32 string`
+///     index: `u32`
+/// Returns: `String`
+#[wasm_bindgen]
+pub fn get_short_address_by_index(full_viewing_key: &str, index: u32) -> WasmResult<JsValue> {
+    let fvk = FullViewingKey::from_str(full_viewing_key)?;
+
+    let (address, _dtk) = fvk.incoming().payment_address(index.into());
+    let short_address = address.display_short_form();
+    Ok(JsValue::from_str(&short_address))
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,131 +1,15 @@
-#![deny(clippy::unwrap_used)]
 #![allow(dead_code)]
 extern crate core;
 
+mod error;
+mod keys;
 mod note_record;
 mod planner;
+mod storage;
 mod swap_record;
 mod tx;
 mod utils;
 mod view_server;
-use penumbra_proto::{core::crypto::v1alpha1 as pb, serializers::bech32str, DomainType};
+mod wasm_planner;
 
-use penumbra_keys::{Address, FullViewingKey};
-use std::convert::TryFrom;
-use std::str::FromStr;
-
-use penumbra_keys::keys::{SeedPhrase, SpendKey};
-use wasm_bindgen::prelude::*;
-
-use penumbra_transaction::Transaction;
-
-pub use tx::send_plan;
 pub use view_server::ViewServer;
-
-#[wasm_bindgen]
-pub fn generate_spend_key(seed_phrase: &str) -> JsValue {
-    utils::set_panic_hook();
-    let seed =
-        SeedPhrase::from_str(seed_phrase).expect("the provided string is a valid seed phrase");
-    let spend_key = SpendKey::from_seed_phrase_bip39(seed, 0);
-
-    let proto = spend_key.to_proto();
-    let spend_key_str = &bech32str::encode(
-        &proto.inner,
-        bech32str::spend_key::BECH32_PREFIX,
-        bech32str::Bech32m,
-    );
-
-    serde_wasm_bindgen::to_value(&spend_key_str).expect("able to serialize spend key")
-}
-
-#[wasm_bindgen]
-pub fn get_full_viewing_key(spend_key_str: &str) -> JsValue {
-    utils::set_panic_hook();
-    let spend_key =
-        SpendKey::from_str(spend_key_str).expect("the provided string is a valid spend key");
-
-    let fvk: &FullViewingKey = spend_key.full_viewing_key();
-
-    let proto = pb::FullViewingKey::from(fvk.to_proto());
-
-    let fvk_str = &bech32str::encode(
-        &proto.inner,
-        bech32str::full_viewing_key::BECH32_PREFIX,
-        bech32str::Bech32m,
-    );
-    serde_wasm_bindgen::to_value(&fvk_str).expect("able to serialize full viewing key")
-}
-
-#[wasm_bindgen]
-pub fn get_address_by_index(full_viewing_key: &str, index: u32) -> JsValue {
-    utils::set_panic_hook();
-    let fvk = FullViewingKey::from_str(full_viewing_key.as_ref())
-        .expect("the provided string is a valid FullViewingKey");
-
-    let (address, _dtk) = fvk.incoming().payment_address(index.into());
-
-    let proto = address.to_proto();
-    let address_str = &bech32str::encode(
-        &proto.inner,
-        bech32str::address::BECH32_PREFIX,
-        bech32str::Bech32m,
-    );
-
-    serde_wasm_bindgen::to_value(&address_str).expect("able to serialize address")
-}
-
-#[wasm_bindgen]
-pub fn base64_to_bech32(prefix: &str, base64_str: &str) -> JsValue {
-    utils::set_panic_hook();
-
-    let bech32 = &bech32str::encode(
-        &base64::Engine::decode(&base64::engine::general_purpose::STANDARD, base64_str)
-            .expect("the provided string is a valid base64 string"),
-        prefix,
-        bech32str::Bech32m,
-    );
-    serde_wasm_bindgen::to_value(bech32).expect("able to serialize bech32 string")
-}
-#[wasm_bindgen]
-pub fn is_controlled_address(full_viewing_key: &str, address: &str) -> JsValue {
-    utils::set_panic_hook();
-    let fvk = FullViewingKey::from_str(full_viewing_key.as_ref())
-        .expect("the provided string is a valid FullViewingKey");
-
-    let index = fvk.address_index(&Address::from_str(address.as_ref()).expect("valid address"));
-
-    serde_wasm_bindgen::to_value(&index).expect("able to serialize address index")
-}
-
-#[wasm_bindgen]
-pub fn get_short_address_by_index(full_viewing_key: &str, index: u32) -> JsValue {
-    utils::set_panic_hook();
-    let fvk = FullViewingKey::from_str(full_viewing_key.as_ref())
-        .expect("The provided string is not a valid FullViewingKey");
-
-    let (address, _dtk) = fvk.incoming().payment_address(index.into());
-    let short_address = address.display_short_form();
-    serde_wasm_bindgen::to_value(&short_address).expect("able to serialize address")
-}
-
-#[wasm_bindgen]
-pub fn decode_transaction(tx_bytes: &str) -> JsValue {
-    utils::set_panic_hook();
-    let tx_vec: Vec<u8> =
-        base64::Engine::decode(&base64::engine::general_purpose::STANDARD, tx_bytes)
-            .expect("the provided tx string is a valid base64 string");
-    let transaction: Transaction =
-        Transaction::try_from(tx_vec).expect("the provided tx string is a valid transaction");
-    serde_wasm_bindgen::to_value(&transaction).expect("able to serialize transaction")
-}
-
-#[wasm_bindgen]
-pub fn decode_nct_root(tx_bytes: &str) -> JsValue {
-    utils::set_panic_hook();
-    let tx_vec: Vec<u8> =
-        hex::decode(tx_bytes).expect("the provided tx string is a valid hex string");
-    let root = penumbra_tct::Root::decode(tx_vec.as_slice())
-        .expect("the provided tx string is a valid nct root");
-    serde_wasm_bindgen::to_value(&root).expect("able to serialize nct root")
-}

--- a/crates/wasm/src/note_record.rs
+++ b/crates/wasm/src/note_record.rs
@@ -4,9 +4,8 @@ use penumbra_proto::{view::v1alpha1 as pb, DomainType, TypeUrl};
 use penumbra_sct::Nullifier;
 use penumbra_shielded_pool::{note, Note};
 use penumbra_tct as tct;
-use std::convert::{TryFrom, TryInto};
-
 use serde::{Deserialize, Serialize};
+use std::convert::{TryFrom, TryInto};
 
 /// Corresponds to the SpendableNoteRecord proto
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/wasm/src/storage.rs
+++ b/crates/wasm/src/storage.rs
@@ -1,0 +1,172 @@
+use crate::error::WasmResult;
+use crate::note_record::SpendableNoteRecord;
+use indexed_db_futures::prelude::OpenDbRequest;
+use indexed_db_futures::{IdbDatabase, IdbQuerySource};
+use penumbra_asset::asset::{DenomMetadata, Id};
+use penumbra_proto::core::chain::v1alpha1::{ChainParameters, FmdParameters};
+use penumbra_proto::core::crypto::v1alpha1::StateCommitment;
+use penumbra_proto::view::v1alpha1::{NotesRequest, SwapRecord};
+use penumbra_proto::DomainType;
+use penumbra_sct::Nullifier;
+use penumbra_shielded_pool::{note, Note};
+
+pub struct IndexedDBStorage {
+    db: IdbDatabase,
+}
+
+impl IndexedDBStorage {
+    pub async fn new() -> WasmResult<Self> {
+        let db_req: OpenDbRequest = IdbDatabase::open_u32("penumbra", 12)?;
+
+        let db: IdbDatabase = db_req.into_future().await?;
+
+        Ok(IndexedDBStorage { db })
+    }
+
+    pub async fn get_notes(&self, request: NotesRequest) -> WasmResult<Vec<SpendableNoteRecord>> {
+        let idb_tx = self.db.transaction_on_one("spendable_notes")?;
+        let store = idb_tx.object_store("spendable_notes")?;
+
+        let values = store.get_all()?.await?;
+
+        let notes: Vec<SpendableNoteRecord> = values
+            .into_iter()
+            .map(|js_value| serde_wasm_bindgen::from_value(js_value).ok())
+            .filter_map(|note_option| {
+                note_option.and_then(|note: SpendableNoteRecord| match request.asset_id.clone() {
+                    Some(asset_id) => {
+                        if note.note.asset_id() == asset_id.try_into().expect("Invalid asset id")
+                            && note.height_spent.is_none()
+                        {
+                            Some(note)
+                        } else {
+                            None
+                        }
+                    }
+                    None => Some(note),
+                })
+            })
+            .collect();
+
+        Ok(notes)
+    }
+
+    pub async fn get_asset(&self, id: &Id) -> WasmResult<Option<DenomMetadata>> {
+        let tx = self.db.transaction_on_one("assets")?;
+        let store = tx.object_store("assets")?;
+
+        Ok(store
+            .get_owned(base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                id.to_proto().inner,
+            ))?
+            .await?
+            .map(serde_wasm_bindgen::from_value)
+            .transpose()?)
+    }
+
+    pub async fn get_note(
+        &self,
+        commitment: &note::StateCommitment,
+    ) -> WasmResult<Option<SpendableNoteRecord>> {
+        let tx = self.db.transaction_on_one("spendable_notes")?;
+        let store = tx.object_store("spendable_notes")?;
+
+        Ok(store
+            .get_owned(base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                commitment.to_proto().inner,
+            ))?
+            .await?
+            .map(serde_wasm_bindgen::from_value)
+            .transpose()?)
+    }
+
+    pub async fn get_note_by_nullifier(
+        &self,
+        nullifier: &Nullifier,
+    ) -> WasmResult<Option<SpendableNoteRecord>> {
+        let tx = self.db.transaction_on_one("spendable_notes")?;
+        let store = tx.object_store("spendable_notes")?;
+
+        Ok(store
+            .index("nullifier")?
+            .get_owned(&base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                nullifier.to_proto().inner,
+            ))?
+            .await?
+            .map(serde_wasm_bindgen::from_value)
+            .transpose()?)
+    }
+
+    pub async fn store_advice(&self, note: Note) -> WasmResult<()> {
+        let tx = self.db.transaction_on_one("notes")?;
+        let store = tx.object_store("notes")?;
+
+        let note_proto: penumbra_proto::core::crypto::v1alpha1::Note = note.clone().try_into()?;
+        let note_js = serde_wasm_bindgen::to_value(&note_proto)?;
+
+        let commitment_proto = note.commit().to_proto();
+
+        let commitment_js = serde_wasm_bindgen::to_value(&commitment_proto)?;
+
+        store.put_key_val_owned(commitment_js, &note_js)?;
+
+        Ok(())
+    }
+
+    pub async fn read_advice(&self, commitment: note::StateCommitment) -> WasmResult<Option<Note>> {
+        let tx = self.db.transaction_on_one("notes")?;
+        let store = tx.object_store("notes")?;
+
+        let commitment_proto = commitment.to_proto();
+
+        let commitment_js = serde_wasm_bindgen::to_value(&commitment_proto)?;
+
+        Ok(store
+            .get_owned(commitment_js)?
+            .await?
+            .map(serde_wasm_bindgen::from_value)
+            .transpose()?)
+    }
+
+    pub async fn get_chain_parameters(&self) -> WasmResult<Option<ChainParameters>> {
+        let tx = self.db.transaction_on_one("chain_parameters")?;
+        let store = tx.object_store("chain_parameters")?;
+
+        Ok(store
+            .get_owned("chain_parameters")?
+            .await?
+            .map(serde_wasm_bindgen::from_value)
+            .transpose()?)
+    }
+
+    pub async fn get_fmd_parameters(&self) -> WasmResult<Option<FmdParameters>> {
+        let tx = self.db.transaction_on_one("fmd_parameters")?;
+        let store = tx.object_store("fmd_parameters")?;
+
+        Ok(store
+            .get_owned("fmd")?
+            .await?
+            .map(serde_wasm_bindgen::from_value)
+            .transpose()?)
+    }
+
+    pub async fn get_swap_by_commitment(
+        &self,
+        swap_commitment: StateCommitment,
+    ) -> WasmResult<Option<SwapRecord>> {
+        let tx = self.db.transaction_on_one("swaps")?;
+        let store = tx.object_store("swaps")?;
+
+        Ok(store
+            .get_owned(base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                swap_commitment.inner,
+            ))?
+            .await?
+            .map(serde_wasm_bindgen::from_value)
+            .transpose()?)
+    }
+}

--- a/crates/wasm/src/tx.rs
+++ b/crates/wasm/src/tx.rs
@@ -1,146 +1,257 @@
-use std::convert::TryInto;
-use std::str::FromStr;
-
-use penumbra_chain::params::{ChainParameters, FmdParameters};
-use penumbra_keys::{Address, FullViewingKey};
-
-use penumbra_keys::keys::{AddressIndex, SpendKey};
+use crate::error::WasmResult;
+use crate::storage::IndexedDBStorage;
+use crate::view_server::{load_tree, StoredTree};
+use penumbra_keys::keys::SpendKey;
+use penumbra_keys::FullViewingKey;
+use penumbra_proto::core::transaction::v1alpha1::{TransactionPerspective, TransactionView};
 use penumbra_tct::{Proof, StateCommitment, Tree};
 use penumbra_transaction::plan::TransactionPlan;
 use penumbra_transaction::{AuthorizationData, Transaction, WitnessData};
 use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
+use serde_wasm_bindgen::Error;
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::TryInto;
+use std::str::FromStr;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
-use crate::note_record::SpendableNoteRecord;
-use crate::planner::Planner;
-use crate::utils;
-use crate::view_server::{load_tree, StoredTree};
-use web_sys::console as web_console;
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SendTx {
-    notes: Vec<SpendableNoteRecord>,
-    chain_parameters: penumbra_proto::core::chain::v1alpha1::ChainParameters,
-    fmd_parameters: penumbra_proto::core::chain::v1alpha1::FmdParameters,
+pub struct TxInfoResponse {
+    txp: TransactionPerspective,
+    txv: TransactionView,
 }
 
+impl TxInfoResponse {
+    pub fn new(txp: TransactionPerspective, txv: TransactionView) -> TxInfoResponse {
+        Self { txp, txv }
+    }
+}
+
+/// encode transaction to bytes
+/// Arguments:
+///     transaction: `penumbra_transaction::Transaction`
+/// Returns: `<Vec<u8>`
 #[wasm_bindgen]
-pub fn send_plan(
-    full_viewing_key: &str,
-    value_js: JsValue,
-    dest_address: &str,
-    view_service_data: JsValue,
-) -> JsValue {
-    utils::set_panic_hook();
-    web_console::log_1(&value_js);
-
-    let value: penumbra_proto::core::crypto::v1alpha1::Value =
-        serde_wasm_bindgen::from_value(value_js).expect("able to parse send plan's Value from JS");
-
-    let address =
-        Address::from_str(dest_address).expect("send plan's destination address is valid");
-    let mut planner = Planner::new(OsRng);
-    planner.fee(Default::default());
-    planner.output(
-        value.try_into().expect("encoded protobuf Value is valid"),
-        address,
-    );
-
-    let fvk = FullViewingKey::from_str(full_viewing_key)
-        .expect("the provided string is a valid FullViewingKey");
-
-    let send_tx: SendTx = serde_wasm_bindgen::from_value(view_service_data)
-        .expect("able to parse send plan's SendTx from JS");
-
-    let chain_params: ChainParameters = send_tx
-        .chain_parameters
-        .try_into()
-        .expect("encoded protobuf ChainParameters is valid");
-    let fmd_params: FmdParameters = send_tx
-        .fmd_parameters
-        .try_into()
-        .expect("encoded protobuf FmdParameters is valid");
-
-    let plan = planner
-        .plan_with_spendable_and_votable_notes(
-            &chain_params,
-            &fmd_params,
-            &fvk,
-            AddressIndex::from(0u32),
-            send_tx.notes,
-            Default::default(),
-        )
-        .expect("valid send transaction parameters were provided");
-
-    serde_wasm_bindgen::to_value(&plan).expect("able to serialize send plan to JS")
+pub fn encode_tx(transaction: JsValue) -> WasmResult<JsValue> {
+    let tx: Transaction = serde_wasm_bindgen::from_value(transaction)?;
+    let tx_encoding: Vec<u8> = tx.try_into()?;
+    let result = serde_wasm_bindgen::to_value(&tx_encoding)?;
+    Ok(result)
 }
 
+/// decode base64 bytes to transaction
+/// Arguments:
+///     tx_bytes: `base64 String`
+/// Returns: `penumbra_transaction::Transaction`
 #[wasm_bindgen]
-pub fn encode_tx(transaction: JsValue) -> JsValue {
-    utils::set_panic_hook();
-    let tx: Transaction = serde_wasm_bindgen::from_value(transaction)
-        .expect("able to deserialize transaction from JS");
-    let tx_encoding: Vec<u8> = tx.try_into().expect("able to encode transaction to bytes");
-    serde_wasm_bindgen::to_value(&tx_encoding)
-        .expect("able to serialize transaction encoding to JS")
+pub fn decode_tx(tx_bytes: &str) -> WasmResult<JsValue> {
+    let tx_vec: Vec<u8> =
+        base64::Engine::decode(&base64::engine::general_purpose::STANDARD, tx_bytes)?;
+    let transaction: Transaction = Transaction::try_from(tx_vec)?;
+    let result = serde_wasm_bindgen::to_value(&transaction)?;
+    Ok(result)
 }
 
+/// TODO: Deprecated. Still used in `penumbra-zone/wallet`, remove when migration is complete.
+/// In the future, this function will be split into separate functions
+/// - sign the transaction
+/// - build transaction
+/// - get wittness
 #[wasm_bindgen]
 pub fn build_tx(
     spend_key_str: &str,
     full_viewing_key: &str,
     transaction_plan: JsValue,
     stored_tree: JsValue,
-) -> JsValue {
-    utils::set_panic_hook();
-    let plan: TransactionPlan = serde_wasm_bindgen::from_value(transaction_plan)
-        .expect("able to deserialize transaction plan from JS");
+) -> Result<JsValue, Error> {
+    let plan: TransactionPlan = serde_wasm_bindgen::from_value(transaction_plan)?;
 
-    let fvk = FullViewingKey::from_str(full_viewing_key)
-        .expect("the provided string is a valid FullViewingKey");
+    let fvk = FullViewingKey::from_str(full_viewing_key.as_ref())
+        .expect("The provided string is not a valid FullViewingKey");
 
-    let auth_data = sign_plan(spend_key_str, plan.clone());
+    let auth_data = sign_plan(spend_key_str, plan.clone())?;
 
-    let stored_tree: StoredTree = serde_wasm_bindgen::from_value(stored_tree)
-        .expect("able to deserialize stored tree from JS");
+    let stored_tree: StoredTree =
+        serde_wasm_bindgen::from_value(stored_tree).expect("able to parse StoredTree from JS");
 
     let nct = load_tree(stored_tree);
 
-    let witness_data = witness(nct, plan.clone());
+    let witness_data = witness(nct, plan.clone())?;
 
-    let tx = build_transaction(&fvk, plan.clone(), auth_data, witness_data);
+    let tx = build_transaction(&fvk, plan.clone(), auth_data, witness_data)?;
 
-    serde_wasm_bindgen::to_value(&tx).expect("able to serialize transaction to JS")
+    serde_wasm_bindgen::to_value(&tx)
 }
 
-pub fn sign_plan(spend_key_str: &str, transaction_plan: TransactionPlan) -> AuthorizationData {
-    let spend_key = SpendKey::from_str(spend_key_str).expect("spend key is valid");
+/// Get transaction view, transaction perspective
+/// Arguments:
+///     full_viewing_key: `bech32 String`
+///     tx: `pbt::Transaction`
+/// Returns: `TxInfoResponse`
+#[wasm_bindgen]
+pub async fn transaction_info(full_viewing_key: &str, tx: JsValue) -> Result<JsValue, Error> {
+    let transaction = serde_wasm_bindgen::from_value(tx)?;
+    let response = transaction_info_inner(full_viewing_key, transaction).await?;
 
-    transaction_plan.authorize(OsRng, &spend_key)
+    serde_wasm_bindgen::to_value(&response)
 }
 
-pub fn build_transaction(
+/// deprecated
+pub async fn transaction_info_inner(
+    full_viewing_key: &str,
+    tx: Transaction,
+) -> WasmResult<TxInfoResponse> {
+    let storage = IndexedDBStorage::new().await?;
+
+    let fvk = FullViewingKey::from_str(full_viewing_key)?;
+
+    // First, create a TxP with the payload keys visible to our FVK and no other data.
+    let mut txp = penumbra_transaction::TransactionPerspective {
+        payload_keys: tx
+            .payload_keys(&fvk)
+            .expect("Error generating payload keys"),
+        ..Default::default()
+    };
+
+    // Next, extend the TxP with the openings of commitments known to our view server
+    // but not included in the transaction body, for instance spent notes or swap claim outputs.
+    for action in tx.actions() {
+        use penumbra_transaction::Action;
+        match action {
+            Action::Spend(spend) => {
+                let nullifier = spend.body.nullifier;
+                // An error here indicates we don't know the nullifier, so we omit it from the Perspective.
+                if let Some(spendable_note_record) =
+                    storage.get_note_by_nullifier(&nullifier).await?
+                {
+                    txp.spend_nullifiers
+                        .insert(nullifier, spendable_note_record.note.clone());
+                }
+            }
+            Action::SwapClaim(claim) => {
+                let output_1_record = storage
+                    .get_note(&claim.body.output_1_commitment)
+                    .await?
+                    .expect("Error generating TxP: SwapClaim output 1 commitment not found");
+
+                let output_2_record = storage
+                    .get_note(&claim.body.output_2_commitment)
+                    .await?
+                    .expect("Error generating TxP: SwapClaim output 2 commitment not found");
+
+                txp.advice_notes
+                    .insert(claim.body.output_1_commitment, output_1_record.note.clone());
+                txp.advice_notes
+                    .insert(claim.body.output_2_commitment, output_2_record.note.clone());
+            }
+            _ => {}
+        }
+    }
+
+    // Now, generate a stub TxV from our minimal TxP, and inspect it to see what data we should
+    // augment the minimal TxP with to provide additional context (e.g., filling in denoms for
+    // visible asset IDs).
+    let min_view = tx.view_from_perspective(&txp);
+    let mut address_views = BTreeMap::new();
+    let mut asset_ids = BTreeSet::new();
+    for action_view in min_view.action_views() {
+        use penumbra_dex::{swap::SwapView, swap_claim::SwapClaimView};
+        use penumbra_transaction::view::action_view::{
+            ActionView, DelegatorVoteView, OutputView, SpendView,
+        };
+        match action_view {
+            ActionView::Spend(SpendView::Visible { note, .. }) => {
+                let address = note.address();
+                address_views.insert(address, fvk.view_address(address));
+                asset_ids.insert(note.asset_id());
+            }
+            ActionView::Output(OutputView::Visible { note, .. }) => {
+                let address = note.address();
+                address_views.insert(address, fvk.view_address(address));
+                asset_ids.insert(note.asset_id());
+            }
+            ActionView::Swap(SwapView::Visible { swap_plaintext, .. }) => {
+                let address = swap_plaintext.claim_address;
+                address_views.insert(address, fvk.view_address(address));
+                asset_ids.insert(swap_plaintext.trading_pair.asset_1());
+                asset_ids.insert(swap_plaintext.trading_pair.asset_2());
+            }
+            ActionView::SwapClaim(SwapClaimView::Visible {
+                output_1, output_2, ..
+            }) => {
+                // Both will be sent to the same address so this only needs to be added once
+                let address = output_1.address();
+                address_views.insert(address, fvk.view_address(address));
+                asset_ids.insert(output_1.asset_id());
+                asset_ids.insert(output_2.asset_id());
+            }
+            ActionView::DelegatorVote(DelegatorVoteView::Visible { note, .. }) => {
+                let address = note.address();
+                address_views.insert(address, fvk.view_address(address));
+                asset_ids.insert(note.asset_id());
+            }
+            _ => {}
+        }
+    }
+
+    // Now, extend the TxP with information helpful to understand the data it can view:
+
+    let mut denoms = Vec::new();
+
+    for id in asset_ids {
+        if let Some(denom) = storage.get_asset(&id).await? {
+            denoms.push(denom.clone());
+        }
+    }
+
+    txp.denoms.extend(denoms.into_iter());
+
+    txp.address_views = address_views.into_values().collect();
+
+    // Finally, compute the full TxV from the full TxP:
+    let txv = tx.view_from_perspective(&txp);
+
+    let txp_proto = TransactionPerspective::try_from(txp)?;
+    let txv_proto = TransactionView::try_from(txv)?;
+
+    let response = TxInfoResponse {
+        txp: txp_proto,
+        txv: txv_proto,
+    };
+    Ok(response)
+}
+
+fn sign_plan(
+    spend_key_str: &str,
+    transaction_plan: TransactionPlan,
+) -> WasmResult<AuthorizationData> {
+    let spend_key = SpendKey::from_str(spend_key_str)?;
+    let auth_data = transaction_plan.authorize(OsRng, &spend_key);
+    Ok(auth_data)
+}
+
+fn build_transaction(
     fvk: &FullViewingKey,
     plan: TransactionPlan,
     auth_data: AuthorizationData,
     witness_data: WitnessData,
-) -> Transaction {
-    plan.build(fvk, witness_data)
-        .expect("valid transaction plan was provided")
-        .authorize(&mut OsRng, &auth_data)
-        .expect("valid authorization data was provided")
+) -> WasmResult<Transaction> {
+    let tx = plan
+        .build(fvk, witness_data)?
+        .authorize(&mut OsRng, &auth_data)?;
+
+    Ok(tx)
 }
 
-fn witness(nct: Tree, plan: TransactionPlan) -> WitnessData {
+fn witness(nct: Tree, plan: TransactionPlan) -> WasmResult<WitnessData> {
     let note_commitments: Vec<StateCommitment> = plan
         .spend_plans()
         .filter(|plan| plan.note.amount() != 0u64.into())
         .map(|spend| spend.note.commit().into())
         .chain(
             plan.swap_claim_plans()
-                .map(|swap_claim| swap_claim.swap_plaintext.swap_commitment().into()),
+                .map(|swap_claim| swap_claim.swap_plaintext.swap_commitment()),
         )
         .collect();
 
@@ -173,5 +284,5 @@ fn witness(nct: Tree, plan: TransactionPlan) -> WitnessData {
     {
         witness_data.add_proof(nc, Proof::dummy(&mut OsRng, nc));
     }
-    witness_data
+    Ok(witness_data)
 }

--- a/crates/wasm/src/utils.rs
+++ b/crates/wasm/src/utils.rs
@@ -1,10 +1,21 @@
+use crate::error::WasmResult;
+use penumbra_proto::DomainType;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::JsValue;
+
 pub fn set_panic_hook() {
-    // When the `console_error_panic_hook` feature is enabled, we can call the
-    // `set_panic_hook` function at least once during initialization, and then
-    // we will get better error messages if our code ever panics.
-    //
-    // For more details see
-    // https://github.com/rustwasm/console_error_panic_hook#readme
     #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
+}
+
+/// decode SCT root
+/// Arguments:
+///     tx_bytes: `HEX string`
+/// Returns: `penumbra_tct::Root`
+#[wasm_bindgen]
+pub fn decode_nct_root(tx_bytes: &str) -> WasmResult<JsValue> {
+    let tx_vec: Vec<u8> = hex::decode(tx_bytes)?;
+    let root = penumbra_tct::Root::decode(tx_vec.as_slice())?;
+    let result = serde_wasm_bindgen::to_value(&root)?;
+    Ok(result)
 }

--- a/crates/wasm/src/wasm_planner.rs
+++ b/crates/wasm/src/wasm_planner.rs
@@ -1,0 +1,188 @@
+use crate::error::WasmResult;
+use crate::planner::Planner;
+use crate::storage::IndexedDBStorage;
+use crate::swap_record::SwapRecord;
+use anyhow::Result;
+use ark_ff::UniformRand;
+use decaf377::Fq;
+use penumbra_dex::swap_claim::SwapClaimPlan;
+use penumbra_proto::core::chain::v1alpha1::{ChainParameters, FmdParameters};
+use penumbra_proto::core::crypto::v1alpha1::{Address, DenomMetadata, Fee, StateCommitment, Value};
+use penumbra_proto::core::transaction::v1alpha1::{MemoPlaintext, TransactionPlan};
+use penumbra_proto::DomainType;
+use rand_core::OsRng;
+use serde_wasm_bindgen::Error;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::JsValue;
+
+#[wasm_bindgen]
+pub struct WasmPlanner {
+    planner: Planner<OsRng>,
+    storage: IndexedDBStorage,
+}
+
+#[wasm_bindgen]
+impl WasmPlanner {
+    #[wasm_bindgen(constructor)]
+    pub async fn new() -> Result<WasmPlanner, Error> {
+        let planner = WasmPlanner {
+            planner: Planner::new(OsRng),
+            storage: IndexedDBStorage::new().await?,
+        };
+        Ok(planner)
+    }
+
+    /// Add expiry height to plan
+    /// Arguments:
+    ///     expiry_height: `u64`
+    #[wasm_bindgen]
+    pub fn expiry_height(&mut self, expiry_height: JsValue) -> Result<(), Error> {
+        self.planner
+            .expiry_height(serde_wasm_bindgen::from_value(expiry_height)?);
+        Ok(())
+    }
+
+    /// Add memo to plan
+    /// Arguments:
+    ///     memo: `MemoPlaintext`
+    pub fn memo(&mut self, memo: JsValue) -> WasmResult<()> {
+        let memo_proto: MemoPlaintext = serde_wasm_bindgen::from_value(memo)?;
+        let _ = self.planner.memo(memo_proto.try_into()?);
+        Ok(())
+    }
+
+    /// Add fee to plan
+    /// Arguments:
+    ///     fee: `Fee`
+    pub fn fee(&mut self, fee: JsValue) -> WasmResult<()> {
+        let fee_proto: Fee = serde_wasm_bindgen::from_value(fee)?;
+        self.planner.fee(fee_proto.try_into()?);
+
+        Ok(())
+    }
+
+    /// Add output to plan
+    /// Arguments:
+    ///     value: `Value`
+    ///     address: `Address`
+    pub fn output(&mut self, value: JsValue, address: JsValue) -> WasmResult<()> {
+        let value_proto: Value = serde_wasm_bindgen::from_value(value)?;
+        let address_proto: Address = serde_wasm_bindgen::from_value(address)?;
+
+        self.planner
+            .output(value_proto.try_into()?, address_proto.try_into()?);
+
+        Ok(())
+    }
+
+    /// Add swap claim to plan
+    /// Arguments:
+    ///     swap_commitment: `StateCommitment`
+    #[wasm_bindgen]
+    pub async fn swap_claim(&mut self, swap_commitment: JsValue) -> WasmResult<()> {
+        let swap_commitment_proto: StateCommitment =
+            serde_wasm_bindgen::from_value(swap_commitment)?;
+
+        let swap_record: SwapRecord = self
+            .storage
+            .get_swap_by_commitment(swap_commitment_proto)
+            .await?
+            .expect("Swap record not found")
+            .try_into()?;
+        let chain_params_proto: ChainParameters = self
+            .storage
+            .get_chain_parameters()
+            .await?
+            .expect("Chain params not found");
+
+        let swap_claim_plan = SwapClaimPlan {
+            swap_plaintext: swap_record.swap,
+            position: swap_record.position,
+            output_data: swap_record.output_data,
+            epoch_duration: chain_params_proto.epoch_duration,
+            proof_blinding_r: Fq::rand(&mut OsRng),
+            proof_blinding_s: Fq::rand(&mut OsRng),
+        };
+
+        self.planner.swap_claim(swap_claim_plan);
+        Ok(())
+    }
+
+    /// Add swap  to plan
+    /// Arguments:
+    ///     input_value: `Value`
+    ///     into_denom: `DenomMetadata`
+    ///     swap_claim_fee: `Fee`
+    ///     claim_address: `Address`
+    pub fn swap(
+        &mut self,
+        input_value: JsValue,
+        into_denom: JsValue,
+        swap_claim_fee: JsValue,
+        claim_address: JsValue,
+    ) -> WasmResult<()> {
+        let input_value_proto: Value = serde_wasm_bindgen::from_value(input_value)?;
+        let into_denom_proto: DenomMetadata = serde_wasm_bindgen::from_value(into_denom)?;
+        let swap_claim_fee_proto: Fee = serde_wasm_bindgen::from_value(swap_claim_fee)?;
+        let claim_address_proto: Address = serde_wasm_bindgen::from_value(claim_address)?;
+
+        let _ = self.planner.swap(
+            input_value_proto.try_into()?,
+            into_denom_proto.try_into()?,
+            swap_claim_fee_proto.try_into()?,
+            claim_address_proto.try_into()?,
+        );
+
+        Ok(())
+    }
+
+    /// Build transaction plan
+    /// Arguments:
+    ///     self_address: `Address`
+    /// Returns: `TransactionPlan`
+    pub async fn plan(&mut self, self_address: JsValue) -> Result<JsValue, Error> {
+        let self_address_proto: Address = serde_wasm_bindgen::from_value(self_address)?;
+        let plan = self.plan_inner(self_address_proto).await?;
+        serde_wasm_bindgen::to_value(&plan)
+    }
+}
+
+impl WasmPlanner {
+    async fn plan_inner(&mut self, self_address: Address) -> WasmResult<TransactionPlan> {
+        let chain_params_proto: ChainParameters = self
+            .storage
+            .get_chain_parameters()
+            .await?
+            .expect("No found chain params");
+        let fmd_params_proto: FmdParameters = self
+            .storage
+            .get_fmd_parameters()
+            .await?
+            .expect("No found fmd");
+
+        let mut spendable_notes = Vec::new();
+
+        let (spendable_requests, _) = self.planner.notes_requests();
+
+        let idb_storage = IndexedDBStorage::new().await?;
+        for request in spendable_requests {
+            let notes = idb_storage.get_notes(request);
+            spendable_notes.extend(notes.await?);
+        }
+
+        // Plan the transaction using the gathered information
+
+        let plan: penumbra_transaction::plan::TransactionPlan =
+            self.planner.plan_with_spendable_and_votable_notes(
+                &chain_params_proto.try_into()?,
+                &fmd_params_proto.try_into()?,
+                spendable_notes,
+                Vec::new(),
+                self_address.try_into()?,
+            )?;
+
+        let plan_proto: TransactionPlan = plan.to_proto();
+
+        Ok(plan_proto)
+    }
+}


### PR DESCRIPTION
- added wasm planner which allows more flexible creation of TransactionPlan on TS side 
- added logic of storing and reading advice when scanning blocks
- added function for generating ephemeral address 
- planner reads data from indexedDB directly from rust

