### PR TITLE
pd: export storage state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2297,6 +2297,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4427,6 +4433,7 @@ dependencies = [
  "decaf377-rdsa",
  "directories",
  "ed25519-consensus",
+ "fs_extra",
  "futures",
  "hex",
  "http",

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -113,6 +113,7 @@ metrics-util = "0.13"
 clap = { version = "3", features = ["derive", "env"] }
 rustls-acme = "0.6"
 atty = "0.2"
+fs_extra = "1.3.0"
 
 [build-dependencies]
 vergen = "5"

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -119,6 +119,16 @@ enum RootCommand {
         #[clap(subcommand)]
         tn_cmd: TestnetCommand,
     },
+
+    /// Export the storage state the full node.
+    Export {
+        /// The path to the directory to export the state to.
+        #[clap(long, display_order = 100)]
+        export_dir: PathBuf,
+        /// Whether to prune the JMT tree before exporting.
+        #[clap(long, display_order = 200)]
+        prune: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -544,6 +554,9 @@ async fn main() -> anyhow::Result<()> {
                 "Writing config files for network"
             );
             t.write_configs()?;
+        }
+        RootCommand::Export { .. } => {
+            todo!()
         }
     }
     Ok(())


### PR DESCRIPTION
This PR adds a `pd export` command that copies the content of a full node data directory to an export target. It also incorporate an optional `--prune` flag that will compact the exported JMT state.