### PR TITLE
build: set resolver=1 for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
 
+# Set virtual workspace's resolver to v1, to support the "rust-docs" script.
+resolver = "1"
+
 exclude = [
     "tools/proto-compiler",
     "tools/parameter-setup",


### PR DESCRIPTION
Our cargo actions were emitting a warning:

    warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
    note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
    note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest

    
Updating the workspace's Cargo.toml to force use of resolver v1 for the workspace. Setting v2 broke the "rust-docs" script, so hardcoding the current behavior to eliminate warnings.

See related docs: https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html