### PR TITLE
fix(pclientd): disable r1cs logging

### DIFF
--- a/crates/bin/pclientd/src/main.rs
+++ b/crates/bin/pclientd/src/main.rs
@@ -9,7 +9,11 @@ async fn main() -> Result<()> {
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_ansi(atty::is(atty::Stream::Stdout))
         .with_target(true);
-    let filter_layer = EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("info"))?;
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("info"))?
+        // Force disabling of r1cs log messages, otherwise the `ark-groth16` crate
+        // can use a massive (>16GB) amount of memory generating unused trace statements.
+        .add_directive("r1cs=off".parse()?);
     let registry = tracing_subscriber::registry()
         .with(filter_layer)
         .with(fmt_layer);


### PR DESCRIPTION
Same as b6ade69cbed3ecb1cc0c25a6403473ad71143725, but this time for pclientd, as well. Refs #2977.