### PR TITLE
Remove usage of "unwrap" in the compact-block component

### DIFF
--- a/crates/core/component/compact-block/src/lib.rs
+++ b/crates/core/component/compact-block/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::unwrap_used)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg_attr(docsrs, doc(cfg(feature = "component")))]


### PR DESCRIPTION
Part of #2920