### PR TITLE
docs(deploy): add nofile limit to systemd configs

### DIFF
--- a/deployments/systemd/README.md
+++ b/deployments/systemd/README.md
@@ -1,10 +1,8 @@
 # systemd unit files for Penumbra
 
 Here are example unit files for running Penumbra (and the required Tendermint instance)
-via systemd. You'll need to customize the `User` declaration, and possibly the path
-to the home directory, as well, depending on your system. The paths to the binaries,
-in the `ExecStart` lines, assume that a symlink exists to the locally compiled versions,
-as described in the [install guide](https://guide.penumbra.zone/main/pd/build.html).
+via systemd. *You'll need to customize the the service files*, particularly the `User` declaration
+and binary fullpath in `ExecStart`, and possibly the path to the home directory, depending on your system.
 
 ## Installing
 Copy the service files to a system-wide location:

--- a/deployments/systemd/penumbra.service
+++ b/deployments/systemd/penumbra.service
@@ -7,7 +7,10 @@ ExecStart=/usr/local/bin/pd start --home $HOME/.penumbra/testnet_data/node0/pd
 Restart=on-failure
 RestartSec=5
 User=$USER
-Environment=RUST_LOG=info,pd=debug,penumbra=debug,jmt=debug
+# Raise filehandle limit for tower-abci.
+LimitNOFILE=65536
+# Consider configuring logrotate if using debug logs
+# Environment=RUST_LOG=info,pd=debug,penumbra=debug,jmt=debug
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Based on feedback in Discord for Testnet 59, some folks encountered

    thread 'tokio-runtime-worker' panicked at 'must be able to successfully commit to storage:
    IO error: While open a file for appending: /home/penumbra/.penumbra/testnet_data/node0/pd/rocksdb/004809.sst:
    Too many open files', /home/penumbra/penumbra/crates/core/app/src/app/mod.rs:427:14

The recommended fix was to modify systemd configs, so I'm updating the documented defaults to match.