### PR TITLE
storage: gate metrics collection behind a feature flag

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -19,7 +19,7 @@ tracing = "0.1"
 rocksdb = "0.21.0"
 futures = "0.3"
 hex = "0.4"
-metrics = "0.19.0"
+metrics = { version = "0.19.0", optional = true }
 parking_lot = "0.12"
 pin-project = "1.0.12"
 smallvec = { version = "1.10", features = ["union", "const_generics"] }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [features]
 migration = []
+default = ["metrics"]
 
 [dependencies]
 jmt = "0.6"

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -49,6 +49,7 @@ mod tests;
 mod utils;
 mod write;
 
+#[cfg(feature = "metrics")]
 pub use crate::metrics::register_metrics;
 pub use cache::Cache;
 pub use delta::{ArcStateDeltaExt, StateDelta};

--- a/crates/storage/src/metrics.rs
+++ b/crates/storage/src/metrics.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "metrics")]
 //! Crate-specific metrics functionality.
 //!
 //! This module re-exports the contents of the `metrics` crate.  This is

--- a/crates/storage/src/snapshot.rs
+++ b/crates/storage/src/snapshot.rs
@@ -12,10 +12,12 @@ use tokio::sync::mpsc;
 use tracing::Span;
 
 use crate::{
-    metrics,
     storage::{DbNodeKey, VersionedKeyHash},
     utils, StateRead,
 };
+
+#[cfg(feature = "metrics")]
+use crate::metrics;
 
 mod rocks_wrapper;
 use rocks_wrapper::RocksDbSnapshot;
@@ -159,9 +161,10 @@ impl StateRead for Snapshot {
                 .name("Snapshot::get_raw")
                 .spawn_blocking(move || {
                     span.in_scope(|| {
-                        let start = std::time::Instant::now();
+                        let _start = std::time::Instant::now();
                         let rsp = self2.get_jmt(key_hash);
-                        metrics::histogram!(metrics::STORAGE_GET_RAW_DURATION, start.elapsed());
+                        #[cfg(feature = "metrics")]
+                        metrics::histogram!(metrics::STORAGE_GET_RAW_DURATION, _start.elapsed());
                         rsp
                     })
                 })
@@ -178,7 +181,7 @@ impl StateRead for Snapshot {
                 .name("Snapshot::nonverifiable_get_raw")
                 .spawn_blocking(move || {
                     span.in_scope(|| {
-                        let start = std::time::Instant::now();
+                        let _start = std::time::Instant::now();
                         let nonverifiable_cf = inner
                             .db
                             .cf_handle("nonverifiable")
@@ -187,9 +190,10 @@ impl StateRead for Snapshot {
                             .snapshot
                             .get_cf(nonverifiable_cf, key)
                             .map_err(Into::into);
+                        #[cfg(feature = "metrics")]
                         metrics::histogram!(
                             metrics::STORAGE_NONCONSENSUS_GET_RAW_DURATION,
-                            start.elapsed()
+                            _start.elapsed()
                         );
                         rsp
                     })


### PR DESCRIPTION
This PR creates a `metrics` feature on `penumbra_storage` that is activated by default. The motivation for this addition is that downstream consumer of the crates may not necessarily want it.