### PR TITLE
feat(pd) more url formatting in logs

### DIFF
--- a/crates/bin/pclientd/src/lib.rs
+++ b/crates/bin/pclientd/src/lib.rs
@@ -278,7 +278,7 @@ impl Opt {
                     "Failed to load pclientd config file. Have you run `pclientd init` with a FVK?",
                 )?;
 
-                tracing::info!(?opt.home, ?config.bind_addr, ?config.grpc_url, "starting pclientd");
+                tracing::info!(?opt.home, ?config.bind_addr, %config.grpc_url, "starting pclientd");
                 let storage = opt
                     .load_or_init_sqlite(&config.full_viewing_key, &config.grpc_url)
                     .await?;

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -269,7 +269,7 @@ async fn main() -> anyhow::Result<()> {
                 ?grpc_bind,
                 ?grpc_auto_https,
                 ?metrics_bind,
-                ?tendermint_addr,
+                %tendermint_addr,
                 "starting pd"
             );
 


### PR DESCRIPTION
Follow-up to #3032. Trying to keep the log messages maximally legible, particularly the service start messages.