### PR TITLE
Remove usage of "unwrap" in the parameter-setup crate

### DIFF
--- a/tools/parameter-setup/src/main.rs
+++ b/tools/parameter-setup/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::unwrap_used)]
 use std::path::PathBuf;
 use std::{
     env, fs,


### PR DESCRIPTION
Part of #2920