### PR TITLE
pd: perform a `InitChain` handshake during genesis migrations

### DIFF
--- a/crates/bin/pd/src/consensus.rs
+++ b/crates/bin/pd/src/consensus.rs
@@ -98,16 +98,18 @@ impl Consensus {
         match &app_state {
             genesis::AppState::Checkpoint(h) => {
                 println!("checkpoint: {h:?}");
+                // finalize a compact block
+                // start an epoch?
                 /* fast-forward to commit */
             }
-            genesis::AppState::Content(_) => {
+            genesis::AppState::Content(genesis_app_state) => {
                 /* run application init_chain */
 
                 // Check that we haven't got a duplicated InitChain message for some reason:
                 if self.storage.latest_version() != u64::MAX {
                     anyhow::bail!("database already initialized");
                 }
-                self.app.init_chain(&app_state).await;
+                self.app.init_chain(&genesis_app_state).await;
             }
         }
 

--- a/crates/bin/pd/src/consensus.rs
+++ b/crates/bin/pd/src/consensus.rs
@@ -97,21 +97,18 @@ impl Consensus {
 
         match &app_state {
             genesis::AppState::Checkpoint(h) => {
-                println!("checkpoint: {h:?}");
-                // finalize a compact block
-                // start an epoch?
-                /* fast-forward to commit */
+                tracing::info!(?h, "genesis state is a checkpoint");
             }
-            genesis::AppState::Content(genesis_app_state) => {
-                /* run application init_chain */
-
+            genesis::AppState::Content(_) => {
+                tracing::info!("genesis state is a full configuration");
                 // Check that we haven't got a duplicated InitChain message for some reason:
                 if self.storage.latest_version() != u64::MAX {
                     anyhow::bail!("database already initialized");
                 }
-                self.app.init_chain(&genesis_app_state).await;
             }
         }
+
+        self.app.init_chain(&app_state).await;
 
         // Extract the Tendermint validators from the app state
         //

--- a/crates/bin/pd/src/info.rs
+++ b/crates/bin/pd/src/info.rs
@@ -83,7 +83,7 @@ impl Info {
             .unwrap_or_default()
             .try_into()?;
 
-        tracing::info!(?info, state_version = ?state.version(), app_version = last_block_height, "reporting height in info query");
+        tracing::info!(?info, state_version = ?state.version(), app_version = ?last_block_height, "reporting height in info query");
 
         let last_block_app_hash = state.app_hash().await?.0.to_vec().try_into()?;
 

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -78,13 +78,7 @@ impl App {
         events
     }
 
-    pub async fn init_chain(&mut self, app_state_general: &genesis::AppState) {
-        let app_state = match app_state_general {
-            genesis::AppState::Checkpoint(_) => {
-                unimplemented!("adding support with init handshake pr")
-            }
-            genesis::AppState::Content(state) => state,
-        };
+    pub async fn init_chain(&mut self, app_state: &genesis::Content) {
         let mut state_tx = self
             .state
             .try_begin_transaction()
@@ -117,12 +111,12 @@ impl App {
             },
         );
 
-        Distributions::init_chain(&mut state_tx, app_state_general).await;
-        Staking::init_chain(&mut state_tx, app_state_general).await;
+        Distributions::init_chain(&mut state_tx, app_state).await;
+        Staking::init_chain(&mut state_tx, app_state).await;
         IBCComponent::init_chain(&mut state_tx, &()).await;
         Dex::init_chain(&mut state_tx, &()).await;
         Governance::init_chain(&mut state_tx, &()).await;
-        ShieldedPool::init_chain(&mut state_tx, app_state_general).await;
+        ShieldedPool::init_chain(&mut state_tx, app_state).await;
 
         // Create a synthetic height-zero block
         App::finish_block(&mut state_tx).await;

--- a/crates/core/app/src/temp_storage_ext.rs
+++ b/crates/core/app/src/temp_storage_ext.rs
@@ -8,13 +8,13 @@ use crate::app::App;
 
 #[async_trait]
 pub trait TempStorageExt: Sized {
-    async fn apply_genesis(self, genesis: genesis::AppState) -> anyhow::Result<Self>;
+    async fn apply_genesis(self, genesis: genesis::Content) -> anyhow::Result<Self>;
     async fn apply_default_genesis(self) -> anyhow::Result<Self>;
 }
 
 #[async_trait]
 impl TempStorageExt for TempStorage {
-    async fn apply_genesis(self, genesis: genesis::AppState) -> anyhow::Result<Self> {
+    async fn apply_genesis(self, genesis: genesis::Content) -> anyhow::Result<Self> {
         // Check that we haven't already applied a genesis state:
         if self.latest_version() != u64::MAX {
             anyhow::bail!("database already initialized");

--- a/crates/core/app/src/temp_storage_ext.rs
+++ b/crates/core/app/src/temp_storage_ext.rs
@@ -8,13 +8,13 @@ use crate::app::App;
 
 #[async_trait]
 pub trait TempStorageExt: Sized {
-    async fn apply_genesis(self, genesis: genesis::Content) -> anyhow::Result<Self>;
+    async fn apply_genesis(self, genesis: genesis::AppState) -> anyhow::Result<Self>;
     async fn apply_default_genesis(self) -> anyhow::Result<Self>;
 }
 
 #[async_trait]
 impl TempStorageExt for TempStorage {
-    async fn apply_genesis(self, genesis: genesis::Content) -> anyhow::Result<Self> {
+    async fn apply_genesis(self, genesis: genesis::AppState) -> anyhow::Result<Self> {
         // Check that we haven't already applied a genesis state:
         if self.latest_version() != u64::MAX {
             anyhow::bail!("database already initialized");

--- a/crates/core/component/distributions/src/component.rs
+++ b/crates/core/component/distributions/src/component.rs
@@ -16,7 +16,7 @@ pub struct Distributions {}
 
 #[async_trait]
 impl Component for Distributions {
-    type AppState = genesis::AppState;
+    type AppState = genesis::Content;
 
     async fn init_chain<S: StateWrite>(_state: S, _app_state: &Self::AppState) {}
 

--- a/crates/core/component/shielded-pool/src/component/shielded_pool.rs
+++ b/crates/core/component/shielded-pool/src/component/shielded_pool.rs
@@ -20,17 +20,10 @@ pub struct ShieldedPool {}
 
 #[async_trait]
 impl Component for ShieldedPool {
-    type AppState = genesis::AppState;
+    type AppState = genesis::Content;
 
     #[instrument(name = "shielded_pool", skip(state, app_state))]
-    async fn init_chain<S: StateWrite>(mut state: S, app_state: &genesis::AppState) {
-        let app_state = match app_state {
-            genesis::AppState::Checkpoint(_) => {
-                unimplemented!("adding support with init handshake pr")
-            }
-            genesis::AppState::Content(app_state) => app_state,
-        };
-
+    async fn init_chain<S: StateWrite>(mut state: S, app_state: &genesis::Content) {
         // Register a denom for each asset in the genesis state
         for allocation in &app_state.allocations {
             tracing::debug!(?allocation, "processing allocation");

--- a/crates/core/component/stake/src/component.rs
+++ b/crates/core/component/stake/src/component.rs
@@ -889,17 +889,10 @@ impl<T: StateWrite + StateWriteExt + ?Sized> StakingImpl for T {}
 
 #[async_trait]
 impl Component for Staking {
-    type AppState = genesis::AppState;
+    type AppState = genesis::Content;
 
     #[instrument(name = "staking", skip(state, app_state))]
-    async fn init_chain<S: StateWrite>(mut state: S, app_state: &genesis::AppState) {
-        let app_state = match app_state {
-            genesis::AppState::Checkpoint(_) => {
-                unimplemented!("adding support with init handshake pr")
-            }
-            genesis::AppState::Content(state) => state,
-        };
-
+    async fn init_chain<S: StateWrite>(mut state: S, app_state: &genesis::Content) {
         let starting_height = state
             .get_block_height()
             .await


### PR DESCRIPTION
This PR adds support for handling an `InitChain` request when starting from a checkpointed state.