### PR TITLE
feat(pd): raises default peering limits

### DIFF
--- a/testnets/tm_config_template.toml
+++ b/testnets/tm_config_template.toml
@@ -231,10 +231,10 @@ addr_book_file = "config/addrbook.json"
 addr_book_strict = true
 
 # Maximum number of inbound peers
-max_num_inbound_peers = 40
+max_num_inbound_peers = 100
 
 # Maximum number of outbound peers to connect to, excluding persistent peers
-max_num_outbound_peers = 10
+max_num_outbound_peers = 50
 
 # List of node IDs, to which a connection will be (re)established ignoring any existing limits
 unconditional_peer_ids = ""


### PR DESCRIPTION
Makes a few changes to `pd`, designed to improve peering behavior on testnets:

  * raises the default values for inbound/outbound peers
  * limits the number of peers discovered during join to 5, randomized

We originally decided to add node discovery logic to aid in peering. There's a downside, however, to reusing all peers of the bootstrap node: the CI deployment nodes get swamped, and the network remains centralized on the nodes that Penumbra Labs run. Instead, let's just take a handful, at random, and trust the p2p gossip to discover more over time.

Refs #3056.