### PR TITLE
pd: write post genesis height when starting from a checkpoint

### DIFF
--- a/crates/bin/pd/src/consensus.rs
+++ b/crates/bin/pd/src/consensus.rs
@@ -95,9 +95,10 @@ impl Consensus {
         let app_state: genesis::AppState = serde_json::from_slice(&init_chain.app_state_bytes)
             .expect("can parse app_state in genesis file");
 
-        match &app_state {
+        let initial_height = match &app_state {
             genesis::AppState::Checkpoint(h) => {
                 tracing::info!(?h, "genesis state is a checkpoint");
+                init_chain.initial_height.into()
             }
             genesis::AppState::Content(_) => {
                 tracing::info!("genesis state is a full configuration");
@@ -105,10 +106,11 @@ impl Consensus {
                 if self.storage.latest_version() != u64::MAX {
                     anyhow::bail!("database already initialized");
                 }
+                1u64
             }
-        }
+        };
 
-        self.app.init_chain(&app_state).await;
+        self.app.init_chain(initial_height, &app_state).await;
 
         // Extract the Tendermint validators from the app state
         //

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -78,7 +78,7 @@ impl App {
         events
     }
 
-    pub async fn init_chain(&mut self, app_state: &genesis::AppState) {
+    pub async fn init_chain(&mut self, post_genesis_height: u64, app_state: &genesis::AppState) {
         let mut state_tx = self
             .state
             .try_begin_transaction()
@@ -119,7 +119,9 @@ impl App {
                 Governance::init_chain(&mut state_tx, &()).await;
                 ShieldedPool::init_chain(&mut state_tx, app_state).await;
             }
-            genesis::AppState::Checkpoint(_) => { /* no-op */ }
+            genesis::AppState::Checkpoint(_) => {
+                state_tx.put_block_height(post_genesis_height);
+            }
         };
 
         App::finish_block(&mut state_tx).await;

--- a/crates/core/app/src/temp_storage_ext.rs
+++ b/crates/core/app/src/temp_storage_ext.rs
@@ -22,7 +22,7 @@ impl TempStorageExt for TempStorage {
 
         // Apply the genesis state to the storage
         let mut app = App::new(self.latest_snapshot()).await?;
-        app.init_chain(&genesis).await;
+        app.init_chain(1u64, &genesis).await;
         app.commit(self.deref().clone()).await;
 
         Ok(self)


### PR DESCRIPTION
In order to perform an `InitChain` handshake, we need to reset the application height to zero. After starting from a checkpointed genesis, we need to write the new post-genesis height back to the state.