### PR TITLE
pd(upgrade): generate a checkpointed genesis post-upgrade

### DIFF
--- a/crates/bin/pd/src/testnet/generate.rs
+++ b/crates/bin/pd/src/testnet/generate.rs
@@ -255,6 +255,19 @@ impl TestnetConfig {
         Ok(genesis)
     }
 
+    pub(crate) fn make_checkpoint(
+        genesis: Genesis<genesis::AppState>,
+        checkpoint: Option<Vec<u8>>,
+    ) -> Genesis<genesis::AppState> {
+        match checkpoint {
+            Some(checkpoint) => Genesis {
+                app_state: genesis::AppState::Checkpoint(checkpoint),
+                ..genesis
+            },
+            None => genesis,
+        }
+    }
+
     /// Generate and write to disk the Tendermint configs for each validator at genesis.
     pub fn write_configs(&self) -> anyhow::Result<()> {
         // Loop over each validator and write its config separately.

--- a/crates/bin/pd/src/upgrade.rs
+++ b/crates/bin/pd/src/upgrade.rs
@@ -66,6 +66,8 @@ pub async fn migrate(path_to_export: PathBuf, upgrade: Upgrade) -> anyhow::Resul
                 .expect("infaillible conversion");
             genesis.initial_height = post_ugprade_height as i64;
             genesis.genesis_time = tendermint::time::Time::now();
+            let checkpoint = [32u8; 32].to_vec();
+            let genesis = TestnetConfig::make_checkpoint(genesis, Some(checkpoint));
 
             let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");
             tracing::info!("genesis: {}", genesis_json);


### PR DESCRIPTION
After running the migration, we want to produce a checkpointed genesis that will fast-forward state initialization the next time the software boots up. 