### PR TITLE
Fix broken SQL statement that forgot the wrong notes

### DIFF
--- a/crates/view/src/sync.rs
+++ b/crates/view/src/sync.rs
@@ -228,8 +228,9 @@ pub async fn scan_block(
     #[cfg(feature = "sct-divergence-check")]
     tracing::debug!(tct_root = %state_commitment_tree.root(), "tct root");
 
-    //Filter nullifiers to remove any without matching note commitments
-
+    // Filter nullifiers to remove any without matching note note_commitments
+    // This is a very important optimization to avoid unnecessary query load on the storage backend
+    // -- it results in 100x+ slower sync times if we don't do this!
     let filtered_nullifiers = storage.filter_nullifiers(spent_nullifiers).await?;
 
     // Construct filtered block


### PR DESCRIPTION
The statement previously was returning the wrong asset denomination, which meant we were forgetting delegation tokens because we thought they were upenumbra. This is now fixed, and some relevant debugging statements have been added.