### PR TITLE
pcli: display ics20 withdrawals in pcli v tx

### DIFF
--- a/crates/bin/pcli/src/command/view/tx.rs
+++ b/crates/bin/pcli/src/command/view/tx.rs
@@ -382,8 +382,19 @@ impl TxCmd {
                         "Claim Liquidity Position Reward".to_string(),
                         "".to_string(),
                     ],
-                    penumbra_transaction::ActionView::Ics20Withdrawal(_) => {
-                        ["Ics20 Withdrawal".to_string(), "".to_string()]
+                    penumbra_transaction::ActionView::Ics20Withdrawal(w) => {
+                        let unit = w.denom.best_unit_for(w.amount);
+                        [
+                            "Ics20 Withdrawal".to_string(),
+                            // TODO: why doesn't format_value include the unit?
+                            format!(
+                                "{}{} via {} to {}",
+                                unit.format_value(w.amount),
+                                unit,
+                                w.source_channel,
+                                w.destination_chain_address,
+                            ),
+                        ]
                     }
                     penumbra_transaction::ActionView::DaoDeposit(_) => {
                         ["Dao Deposit".to_string(), "".to_string()]

--- a/crates/core/component/ibc/src/ics20_withdrawal.rs
+++ b/crates/core/component/ibc/src/ics20_withdrawal.rs
@@ -34,6 +34,7 @@ pub struct Ics20Withdrawal {
     // the source channel used for the withdrawal
     pub source_channel: ChannelId,
 }
+
 impl Ics20Withdrawal {
     pub fn value(&self) -> Value {
         Value {


### PR DESCRIPTION
Now it looks like
```
Scanning blocks from last sync height 2965 to latest height 2965
[0s] ██████████████████████████████████████████████████       0/0       0/s ETA: 0s
 Action Type       Description
 Spend             [account 1] spent 3000penumbra
 Output            1766penumbra to [account 1]
 Ics20 Withdrawal  1234penumbra via channel-0 to osmo1kh0fwkdy05yp579d8vczgharkcexfw582zj488

 Transaction Fee                0penumbra
 Transaction Memo Sender        penumbrav2t1cus5kaxcdh3x6th437s9eslze9mnvmcdxyhw9px79ewfgpd7utu253m52dhevxgf7yqrx04qks5267ysx9rmn7ckhqf0lkc6c9jzr63y8tuvq8d8yh6vatzf7l49xa2xs5xrls
 Transaction Memo Text
 Transaction Expiration Height  0
 ```