### PR TITLE
ibc: use GTE instead of GT in client height comparison

### DIFF
--- a/crates/core/component/ibc/src/component/msg_handler/connection_open_ack.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/connection_open_ack.rs
@@ -195,7 +195,7 @@ async fn consensus_height_is_correct<S: StateRead>(
         state.get_revision_number().await?,
         state.get_block_height().await?,
     )?;
-    if msg.consensus_height_of_a_on_b > current_height {
+    if msg.consensus_height_of_a_on_b >= current_height {
         anyhow::bail!("consensus height is greater than the current block height",);
     }
 

--- a/crates/core/component/ibc/src/component/msg_handler/connection_open_try.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/connection_open_try.rs
@@ -204,7 +204,7 @@ async fn consensus_height_is_correct<S: StateRead>(
         state.get_revision_number().await?,
         state.get_block_height().await?,
     )?;
-    if msg.consensus_height_of_b_on_a > current_height {
+    if msg.consensus_height_of_b_on_a >= current_height {
         anyhow::bail!("consensus height is greater than the current block height",);
     }
 


### PR DESCRIPTION
previously, our validation of heights was too permissive.

https://github.com/cosmos/ibc-go/blob/56a519c188ae841818b9ecd11244240941cc5d90/modules/core/03-connection/keeper/handshake.go#L177