### PR TITLE
pd: fast chain init when starting from checkpoint

### DIFF
--- a/crates/bin/pd/src/consensus.rs
+++ b/crates/bin/pd/src/consensus.rs
@@ -95,10 +95,10 @@ impl Consensus {
         let app_state: genesis::AppState = serde_json::from_slice(&init_chain.app_state_bytes)
             .expect("can parse app_state in genesis file");
 
-        let initial_height = match &app_state {
+        match &app_state {
             genesis::AppState::Checkpoint(h) => {
                 tracing::info!(?h, "genesis state is a checkpoint");
-                init_chain.initial_height.into()
+                /* perform upgrade specific check */
             }
             genesis::AppState::Content(_) => {
                 tracing::info!("genesis state is a full configuration");
@@ -106,11 +106,10 @@ impl Consensus {
                 if self.storage.latest_version() != u64::MAX {
                     anyhow::bail!("database already initialized");
                 }
-                1u64
             }
-        };
+        }
 
-        self.app.init_chain(initial_height, &app_state).await;
+        self.app.init_chain(&app_state).await;
 
         // Extract the Tendermint validators from the app state
         //

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -80,7 +80,7 @@ impl App {
         events
     }
 
-    pub async fn init_chain(&mut self, post_genesis_height: u64, app_state: &genesis::AppState) {
+    pub async fn init_chain(&mut self, app_state: &genesis::AppState) {
         let mut state_tx = self
             .state
             .try_begin_transaction()
@@ -113,19 +113,16 @@ impl App {
                         start_height: 0,
                     },
                 );
-
-                Distributions::init_chain(&mut state_tx, app_state).await;
-                Staking::init_chain(&mut state_tx, app_state).await;
-                IBCComponent::init_chain(&mut state_tx, &()).await;
-                Dex::init_chain(&mut state_tx, &()).await;
-                Governance::init_chain(&mut state_tx, &()).await;
-                ShieldedPool::init_chain(&mut state_tx, app_state).await;
             }
-            genesis::AppState::Checkpoint(_) => {
-                state_tx.put_block_height(post_genesis_height);
-            }
+            genesis::AppState::Checkpoint(_) => { /* perform upgrade specific check */ }
         };
 
+        Distributions::init_chain(&mut state_tx, app_state).await;
+        Staking::init_chain(&mut state_tx, app_state).await;
+        IBCComponent::init_chain(&mut state_tx, app_state).await;
+        Dex::init_chain(&mut state_tx, &()).await;
+        Governance::init_chain(&mut state_tx, &()).await;
+        ShieldedPool::init_chain(&mut state_tx, app_state).await;
         App::finish_block(&mut state_tx).await;
         state_tx.apply();
     }

--- a/crates/core/app/src/temp_storage_ext.rs
+++ b/crates/core/app/src/temp_storage_ext.rs
@@ -22,7 +22,7 @@ impl TempStorageExt for TempStorage {
 
         // Apply the genesis state to the storage
         let mut app = App::new(self.latest_snapshot()).await?;
-        app.init_chain(1u64, &genesis).await;
+        app.init_chain(&genesis).await;
         app.commit(self.deref().clone()).await;
 
         Ok(self)

--- a/crates/core/component/distributions/src/component.rs
+++ b/crates/core/component/distributions/src/component.rs
@@ -16,7 +16,7 @@ pub struct Distributions {}
 
 #[async_trait]
 impl Component for Distributions {
-    type AppState = genesis::Content;
+    type AppState = genesis::AppState;
 
     async fn init_chain<S: StateWrite>(_state: S, _app_state: &Self::AppState) {}
 

--- a/crates/core/component/ibc/src/component/ibc_component.rs
+++ b/crates/core/component/ibc/src/component/ibc_component.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use ibc_types::{
     core::client::Height, lightclients::tendermint::ConsensusState as TendermintConsensusState,
 };
+use penumbra_chain::genesis;
 use penumbra_component::Component;
 use penumbra_storage::StateWrite;
 use tendermint::abci;
@@ -16,12 +17,14 @@ pub struct IBCComponent {}
 
 #[async_trait]
 impl Component for IBCComponent {
-    type AppState = ();
+    type AppState = genesis::AppState;
 
-    #[instrument(name = "ibc", skip(state, _app_state))]
-    async fn init_chain<S: StateWrite>(mut state: S, _app_state: &()) {
-        // set the initial client count
-        state.put_client_counter(ClientCounter(0));
+    #[instrument(name = "ibc", skip(state, app_state))]
+    async fn init_chain<S: StateWrite>(mut state: S, app_state: &genesis::AppState) {
+        match app_state {
+            genesis::AppState::Content(_) => state.put_client_counter(ClientCounter(0)),
+            genesis::AppState::Checkpoint(_) => { /* perform upgrade specific check */ }
+        }
     }
 
     #[instrument(name = "ibc", skip(state, begin_block))]


### PR DESCRIPTION
This PR closes #3004, and simplifies chain initialization. It splits handling checkpointed genesis states and full genesis configurations. This allows skipping most of the component initialization work when a checkpointed state is provided, while leaving space for upgrade-specific health checks to be performed by each component's `init_chain`.