### PR TITLE
[wasm] Remove async constructor

### DIFF
--- a/crates/wasm/publish/package.json
+++ b/crates/wasm/publish/package.json
@@ -5,7 +5,8 @@
   "license": "ISC",
   "scripts": {
     "format": "prettier --write .",
-    "publish-wasm": "tsc && node build/publish-wasm.js"
+    "compile-wasm": "tsc && node build/run.js",
+    "publish-wasm": "npm run compile-wasm -- --publish"
   },
   "dependencies": {
     "wasm-pack": "^0.12.1"

--- a/crates/wasm/publish/run.ts
+++ b/crates/wasm/publish/run.ts
@@ -2,9 +2,9 @@ import path from 'path';
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
 
-const targets = ['web', 'nodejs', 'bundler'];
+const TARGETS = ['web', 'nodejs', 'bundler'];
 
-targets.forEach(target => {
+TARGETS.forEach(target => {
   // Run wasm-pack for each target
   execSync(
     `wasm-pack build ../ --release --target ${target} --out-name index --out-dir publish/${target}`,
@@ -23,8 +23,10 @@ targets.forEach(target => {
   process.chdir(target);
   execSync('npm pack', { stdio: 'inherit' });
 
-  // Publish to npm
-  execSync('npm publish --access public', { stdio: 'inherit' });
+  // Publish to npm if flag provided
+  if (process.argv.includes('--publish')) {
+    execSync('npm publish --access public', { stdio: 'inherit' });
+  }
 
   // Change working directory back to parent
   process.chdir('..');

--- a/crates/wasm/src/planner.rs
+++ b/crates/wasm/src/planner.rs
@@ -92,7 +92,6 @@ impl<R: RngCore + CryptoRng> Planner<R> {
                     address_index: None,
                     amount_to_spend: Some(amount.into()),
                     include_spent: false,
-                    ..Default::default()
                 })
                 .collect(),
             self.vote_intents
@@ -107,7 +106,6 @@ impl<R: RngCore + CryptoRng> Planner<R> {
                         account_group_id: None,
                         votable_at_height: *start_block_height,
                         address_index: None,
-                        ..Default::default()
                     },
                 )
                 .collect(),

--- a/crates/wasm/src/tx.rs
+++ b/crates/wasm/src/tx.rs
@@ -67,7 +67,7 @@ pub fn build_tx(
 ) -> Result<JsValue, Error> {
     let plan: TransactionPlan = serde_wasm_bindgen::from_value(transaction_plan)?;
 
-    let fvk = FullViewingKey::from_str(full_viewing_key.as_ref())
+    let fvk = FullViewingKey::from_str(full_viewing_key)
         .expect("The provided string is not a valid FullViewingKey");
 
     let auth_data = sign_plan(spend_key_str, plan.clone())?;
@@ -248,7 +248,7 @@ fn witness(nct: Tree, plan: TransactionPlan) -> WasmResult<WitnessData> {
     let note_commitments: Vec<StateCommitment> = plan
         .spend_plans()
         .filter(|plan| plan.note.amount() != 0u64.into())
-        .map(|spend| spend.note.commit().into())
+        .map(|spend| spend.note.commit())
         .chain(
             plan.swap_claim_plans()
                 .map(|swap_claim| swap_claim.swap_plaintext.swap_commitment()),

--- a/crates/wasm/src/view_server.rs
+++ b/crates/wasm/src/view_server.rs
@@ -67,7 +67,7 @@ pub struct ViewServer {
 
 #[wasm_bindgen]
 impl ViewServer {
-    #[wasm_bindgen(constructor)]
+    #[wasm_bindgen]
     pub async fn new(
         full_viewing_key: &str,
         epoch_duration: u64,


### PR DESCRIPTION
This PR does a few things:

- Remove async constructor in favor of awaitable `new()`. Javascript constructors cannot be awaited.
- Separate building & publishing for wasm-pack to make local debugging easier
- Ran clippy --fix on wasm crate