### PR TITLE
docs: link directly to proper cometbft version

### DIFF
--- a/docs/guide/src/pd.md
+++ b/docs/guide/src/pd.md
@@ -5,4 +5,4 @@ Penumbra:
 
 - [Building `pd`](./pd/build.md) describes how to build `pd`;
 - [Joining a Testnet](./pd/join-testnet.md) describes how to join the current testnet;
-- [Creating a Testnet](./pd/create-testnet.md) describes how to create a custom testnet, for instance for local development.
+- [Creating a Testnet](./dev/devnet-quickstart.md) describes how to create a custom testnet, for instance for local development.

--- a/docs/guide/src/pd/build.md
+++ b/docs/guide/src/pd/build.md
@@ -20,7 +20,7 @@ on your system to join your node to the testnet.
 **NOTE**: Previous versions of Penumbra used Tendermint, but as of Testnet 61 (released 2023-09-25),
 only CometBFT is supported. **Do not use** any version of Tendermint, which may not work with `pd`.
 
-Follow the [CometBFT installation instructions](https://docs.cometbft.com/v0.34/guides/install)
+You can download `v0.34.27` [from the CometBFT releases page](https://github.com/cometbft/cometbft/releases/tag/v0.34.27)
 to install a binary. If you prefer to compile from source instead,
 make sure you are compiling version `v0.34.27`:
 

--- a/docs/protocol/src/SUMMARY.md
+++ b/docs/protocol/src/SUMMARY.md
@@ -34,6 +34,7 @@
     - [The `eddy` construction](./crypto/flow/eddy.md)
     - [Distributed Key Generation](./crypto/flow-encryption/dkg.md)
     - [Homomorphic Threshold Encryption](./crypto/flow-encryption/threshold-encryption.md)
+    - [Flow Encryption and Consensus](./protocol/flow-consensus.md)
   - [Transaction Signing](./crypto/transaction_signing.md)
 - [Groth 16 Setup Ceremony](./setup.md)
   - [Groth16 Recap](./setup/groth16_recap.md)

--- a/docs/protocol/src/crypto.md
+++ b/docs/protocol/src/crypto.md
@@ -20,7 +20,7 @@ construction that allows users to outsource a probabalistic detection
 capability, allowing a third party to scan and filter the chain on their behalf,
 without revealing precisely which transactions are theirs.
 
-- The [Homomorphic Threshold Decryption](./crypto/threshold.md) section
+- The [Homomorphic Threshold Decryption](./crypto/flow-encryption/threshold-encryption.md) section
 describes the construction used to [batch flows of
 value](./concepts/batching_flows.md) across transactions.
 

--- a/docs/protocol/src/crypto/transaction_signing.md
+++ b/docs/protocol/src/crypto/transaction_signing.md
@@ -1,6 +1,6 @@
 # Transaction Signing
 
-Transactions are signed used the [`decaf377-rdsa` construction](../crypto/decaf377-rdas.md). As described briefly in that section, there are two signature domains used in Penumbra: `SpendAuth` signatures and `Binding` signatures.
+Transactions are signed used the [`decaf377-rdsa` construction](../crypto/decaf377-rdsa.md). As described briefly in that section, there are two signature domains used in Penumbra: `SpendAuth` signatures and `Binding` signatures.
 
 ## `SpendAuth` Signatures
 


### PR DESCRIPTION
Based on feedback in Discord. Also fixes a broken link in the guide.