### PR TITLE
ibc: fix connection paths to use ibc-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3056,9 +3056,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-types"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cb94ee2ea0b99bdfb39d81fce2d5a58df6f8339de33082bd7591d87636082d"
+version = "0.6.1"
+source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
 dependencies = [
  "ibc-types-core-channel",
  "ibc-types-core-client",
@@ -3074,9 +3073,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-channel"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3fd1babfdd6915629edce6998015baabca38ee1fd499eeb289a6ddbacede44"
+version = "0.6.1"
+source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3107,9 +3105,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-client"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90157729c90395e751e2a982777e57ee9165e4158df96d53c6371ff67cbd130"
+version = "0.6.1"
+source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3134,9 +3131,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-commitment"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e515b46558e40a9afdd5753c2f24a7d7c97771260ea7a19a07a48ed9980c2a04"
+version = "0.6.1"
+source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3169,9 +3165,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-connection"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0bef166ca621277ef93323dd3a785ab14ffcd53566dc426bb42928f6b14a5f"
+version = "0.6.1"
+source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3199,9 +3194,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-domain-type"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27328d1b182b8066b132f13a0fb5f95723fb334bd9cf276c9c539b77e245a08"
+version = "0.6.1"
+source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3210,9 +3204,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-identifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a56946db3ef7dcc54da5e34eb529c5f0c0c3ce36ee22cc56c63c6cb3e2d7fa9"
+version = "0.6.1"
+source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
 dependencies = [
  "displaydoc",
  "serde",
@@ -3221,9 +3214,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-lightclients-tendermint"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97b600aabf32ab08086c5d776e50ed02a9f9a035a76fc8671bc8c719aefbc27"
+version = "0.6.1"
+source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3258,9 +3250,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-path"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ac7bc0fe7b48b04da27079bc41ef2c9383bb6db6b5d9cff5f621cf33d83e22"
+version = "0.6.1"
+source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3281,9 +3272,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-timestamp"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e7bde1000525c415ccd7171eb14d4de92adb47cc759946bee110fe0f38173cd"
+version = "0.6.1"
+source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
 dependencies = [
  "bytes",
  "displaydoc",
@@ -3300,9 +3290,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-transfer"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176fa0ea502edc3e176d9f0a9f31b12603bc0b8d37d537bc51a518dfed3391b2"
+version = "0.6.1"
+source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
 dependencies = [
  "displaydoc",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2135563fb5c609d2b2b87c1e8ce7bc41b0b45430fa9661f457981503dd5bf0"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anyhow"
@@ -230,7 +230,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "rayon",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -492,30 +492,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
 [[package]]
 name = "async-dup"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7427a12b8dc09291528cfb1da2447059adb4a257388c2acd6497a79d55cf6f7c"
+checksum = "865d94538a2d4f7197f9e08daf94203c06be78fe87a9d293ba4dd718028c5783"
 dependencies = [
  "futures-io",
- "simple-mutex",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.5.1"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
+checksum = "2c1da3ae8dabd9c00f453a329dfe1fb28da3c0a72e2478cdcd93171740c20499"
 dependencies = [
  "async-lock",
  "async-task",
  "concurrent-queue",
- "fastrand 1.9.0",
+ "fastrand 2.0.1",
  "futures-lite",
  "slab",
 ]
@@ -589,36 +588,53 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
 ]
 
 [[package]]
 name = "async-net"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4051e67316bc7eff608fe723df5d32ed639946adcd69e07df41fd42a7b411f1f"
+checksum = "0434b1ed18ce1cf5769b8ac540e33f01fa9471058b5e89da9e06f3c882a8c12f"
 dependencies = [
  "async-io",
- "autocfg",
  "blocking",
  "futures-lite",
 ]
 
 [[package]]
 name = "async-process"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
+checksum = "bf012553ce51eb7aa6dc2143804cc8252bd1cb681a1c5cb7fa94ca88682dee1d"
 dependencies = [
  "async-io",
  "async-lock",
- "autocfg",
+ "async-signal",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 3.0.0",
  "futures-lite",
- "rustix 0.37.23",
- "signal-hook",
+ "rustix 0.38.14",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99f3cb3f9ff89f7d718fbb942c9eb91bedff12e396adf09a622dfe7ffec2bc2"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-core",
+ "futures-io",
+ "libc",
+ "signal-hook-registry",
+ "slab",
  "windows-sys 0.48.0",
 ]
 
@@ -693,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.4.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
+checksum = "b9441c6b2fe128a7c2bf680a44c34d0df31ce09e5b7e401fcca3faa483dbc921"
 
 [[package]]
 name = "async-trait"
@@ -719,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-waker"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -787,7 +803,7 @@ dependencies = [
  "http-body",
  "hyper",
  "itoa",
- "matchit 0.7.2",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -953,7 +969,7 @@ dependencies = [
  "pbkdf2",
  "rand_core 0.6.4",
  "ripemd",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle",
  "zeroize",
 ]
@@ -1057,17 +1073,18 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
+checksum = "94c4ef1f913d78636d78d538eec1f18de81e481f44b1be0a81060090530846e1"
 dependencies = [
  "async-channel",
  "async-lock",
  "async-task",
- "atomic-waker",
- "fastrand 1.9.0",
+ "fastrand 2.0.1",
+ "futures-io",
  "futures-lite",
- "log",
+ "piper",
+ "tracing",
 ]
 
 [[package]]
@@ -1121,7 +1138,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1399,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2237,6 +2254,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "event-listener"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e56284f00d94c1bc7fd3c77027b4623c88c1f53d8d2394c6199f2921dea325"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "ff"
@@ -2604,9 +2632,9 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "git2"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ef350ba88a33b4d524b1d1c79096c9ade5ef8c59395df0e60d1e1889414c0e"
+checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
 dependencies = [
  "bitflags 2.4.0",
  "libc",
@@ -2659,7 +2687,7 @@ dependencies = [
  "indexmap 1.9.3",
  "slab",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "tracing",
 ]
 
@@ -2746,7 +2774,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1 0.10.5",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -3069,7 +3097,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle-encoding",
  "tendermint",
  "tendermint-proto",
@@ -3097,7 +3125,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle-encoding",
  "tendermint",
  "tendermint-proto",
@@ -3129,7 +3157,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle-encoding",
  "tendermint",
  "tendermint-light-client-verifier",
@@ -3162,7 +3190,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle-encoding",
  "tendermint",
  "tendermint-proto",
@@ -3218,7 +3246,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle-encoding",
  "tendermint",
  "tendermint-light-client-verifier",
@@ -3306,7 +3334,7 @@ dependencies = [
  "prost",
  "ripemd",
  "serde",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sha3",
 ]
 
@@ -3437,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
@@ -3549,7 +3577,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "thiserror",
  "tracing",
 ]
@@ -3581,7 +3609,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3789,15 +3817,15 @@ checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "matchit"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
+checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -3981,7 +4009,7 @@ dependencies = [
  "tendermint-proto",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "tonic",
  "tonic-web",
  "tower",
@@ -4302,9 +4330,9 @@ dependencies = [
 
 [[package]]
 name = "parking"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
+checksum = "e52c774a4c39359c1d1c52e43f73dd91a75a614652c825408eec30c95a9b2067"
 
 [[package]]
 name = "parking_lot"
@@ -4474,7 +4502,7 @@ dependencies = [
  "tendermint",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "toml 0.7.8",
  "tonic",
  "tower",
@@ -4523,7 +4551,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with 1.14.0",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "tempfile",
  "tendermint",
  "tokio",
@@ -4614,7 +4642,7 @@ dependencies = [
  "tendermint-rpc",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "toml 0.5.11",
  "tonic",
  "tonic-reflection",
@@ -4777,7 +4805,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "thiserror",
  "tracing",
 ]
@@ -4902,7 +4930,7 @@ dependencies = [
  "penumbra-storage",
  "prost",
  "serde",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "tendermint",
  "tendermint-light-client-verifier",
  "tokio",
@@ -4958,7 +4986,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "tendermint",
  "tendermint-light-client-verifier",
  "thiserror",
@@ -5101,7 +5129,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "tendermint",
  "tendermint-light-client-verifier",
  "tokio",
@@ -5154,7 +5182,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "thiserror",
  "tracing",
 ]
@@ -5222,7 +5250,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "thiserror",
  "tracing",
 ]
@@ -5266,7 +5294,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "tracing",
 ]
 
@@ -5470,7 +5498,7 @@ dependencies = [
  "prost",
  "rocksdb",
  "serde",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "smallvec",
  "tempfile",
  "tendermint",
@@ -5549,7 +5577,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "tonic",
  "tower-http 0.3.5",
  "tracing-subscriber 0.3.17",
@@ -5578,7 +5606,7 @@ dependencies = [
  "tendermint-rpc",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "tonic",
  "tower",
  "tower-service",
@@ -5600,7 +5628,7 @@ dependencies = [
  "tendermint-proto",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "tonic",
  "tower",
  "tower-service",
@@ -5707,7 +5735,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "tendermint",
  "tokio",
  "tokio-stream",
@@ -5805,7 +5833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.0",
+ "indexmap 2.0.1",
 ]
 
 [[package]]
@@ -5839,6 +5867,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs8"
@@ -6446,9 +6485,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -6456,14 +6495,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -6513,7 +6550,7 @@ version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
- "aho-corasick 1.1.0",
+ "aho-corasick 1.1.1",
  "memchr",
  "regex-automata 0.3.8",
  "regex-syntax 0.7.5",
@@ -6534,7 +6571,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
- "aho-corasick 1.1.0",
+ "aho-corasick 1.1.1",
  "memchr",
  "regex-syntax 0.7.5",
 ]
@@ -6706,7 +6743,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.18",
+ "semver 1.0.19",
 ]
 
 [[package]]
@@ -6734,9 +6771,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.13"
+version = "0.38.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -6778,7 +6815,7 @@ checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.5",
+ "rustls-webpki 0.101.6",
  "sct 0.7.0",
 ]
 
@@ -6844,9 +6881,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.5"
+version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
  "ring",
  "untrusted",
@@ -6878,11 +6915,11 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "safe-proc-macro2"
-version = "1.0.36"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "814c536dcd27acf03296c618dab7ad62d28e70abd7ba41d3f34a2ce707a2c666"
+checksum = "7fd85be67db87168aa3c13fd0da99f48f2ab005dccad5af5626138dc1df20eb6"
 dependencies = [
- "unicode-xid 0.2.4",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -7029,9 +7066,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
 
 [[package]]
 name = "semver-parser"
@@ -7095,7 +7132,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.1",
  "itoa",
  "ryu",
  "serde",
@@ -7225,9 +7262,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -7255,9 +7292,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -7276,9 +7313,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "c1b21f559e07218024e7e9f90f96f601825397de0e25420135f7f952453fed0b"
 dependencies = [
  "lazy_static",
 ]
@@ -7336,15 +7373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple-mutex"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7371,9 +7399,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "smol"
@@ -7628,9 +7656,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.0",
+ "fastrand 2.0.1",
  "redox_syscall 0.3.5",
- "rustix 0.38.13",
+ "rustix 0.38.14",
  "windows-sys 0.48.0",
 ]
 
@@ -7654,7 +7682,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "signature",
  "subtle",
  "subtle-encoding",
@@ -7725,7 +7753,7 @@ dependencies = [
  "hyper-rustls",
  "peg",
  "pin-project",
- "semver 1.0.18",
+ "semver 1.0.19",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -7775,18 +7803,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",
@@ -7985,7 +8013,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
 ]
 
 [[package]]
@@ -8004,9 +8032,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8035,7 +8063,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8057,7 +8085,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8144,7 +8172,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -8179,7 +8207,7 @@ dependencies = [
  "pin-project",
  "thiserror",
  "tokio",
- "tokio-util 0.7.8",
+ "tokio-util 0.7.9",
  "tower",
  "tracing",
 ]
@@ -8501,9 +8529,9 @@ dependencies = [
 
 [[package]]
 name = "waker-fn"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"
@@ -8689,7 +8717,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.13",
+ "rustix 0.38.14",
 ]
 
 [[package]]
@@ -8710,9 +8738,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,9 +2732,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 dependencies = [
  "ahash 0.8.3",
  "allocator-api2",
@@ -2746,7 +2746,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -3056,8 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types"
-version = "0.6.1"
-source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b43b668833f6b5d0dcc1266e8cf69f4e6de9901e5b62dfa52dd056dbc7b3b165"
 dependencies = [
  "ibc-types-core-channel",
  "ibc-types-core-client",
@@ -3073,8 +3074,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-channel"
-version = "0.6.1"
-source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c3b3ed03e9e27e2b97976b5674b9433de55d76eeb97791dc963ed2c6c6a09f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3105,8 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-client"
-version = "0.6.1"
-source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230141b83062ee50bc19ea50faafb3f0c48033a56dd8753d38b25f7359cfb7be"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3131,8 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-commitment"
-version = "0.6.1"
-source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0365a823d3ba58e4cb360c9f99886ec5804f06679db8bb33a2e69fb346259fe"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3165,8 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-connection"
-version = "0.6.1"
-source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1ea314ed48eb7b6e187647e9d64d13d5e00fa984497691bf6f00efc483bc16"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3194,8 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-domain-type"
-version = "0.6.1"
-source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e454817af59a7ef3b646ccaf07452d0853889e6bd157fd3cb37e2a3c6126cc6b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3204,8 +3210,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-identifier"
-version = "0.6.1"
-source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2003e722cbf2c87ca0176aa91be70cddc9aae6a3f6c845af4e323aa41782d7d9"
 dependencies = [
  "displaydoc",
  "serde",
@@ -3214,8 +3221,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-lightclients-tendermint"
-version = "0.6.1"
-source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a66c0a6e4171afa6908000864d68f9e23b82b1f502c714adbb0fd14565c3c9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3250,8 +3258,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-path"
-version = "0.6.1"
-source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ba330a92d982881717a20be24d2404a8e26544a0759298e0d59197260f4315"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3272,8 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-timestamp"
-version = "0.6.1"
-source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e07ce8c8adce5c646b5819962709b9719ae186c0e1b53af1ac53ef9f43084eba"
 dependencies = [
  "bytes",
  "displaydoc",
@@ -3290,8 +3300,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-transfer"
-version = "0.6.1"
-source = "git+https://github.com/penumbra-zone/ibc-types.git?branch=client-paths-type#d054995e5aa67f944262c3d8e799a90c7c7ba9cb"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae2ffa0b14380ed3e97ad05e6998f0fbb38751454a56e5381ca9c0e6cf42f4e"
 dependencies = [
  "displaydoc",
  "serde",
@@ -3459,7 +3470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -48,7 +48,7 @@ tendermint = { version = "0.33.0", features = ["rust-crypto"] }
 jmt = "0.7"
 
 # External dependencies
-ibc-types = { version = "0.6.0", default-features = false, features = ["std", "with_serde"]}
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", features = ["std", "with_serde"] }
 
 ibc-proto = { version = "0.33.0" }
 ark-ff = { version = "0.4", default-features = false }

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -48,7 +48,7 @@ tendermint = { version = "0.33.0", features = ["rust-crypto"] }
 jmt = "0.7"
 
 # External dependencies
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", features = ["std", "with_serde"] }
+ibc-types = { version = "0.6.3", features = ["std", "with_serde"] }
 
 ibc-proto = { version = "0.33.0" }
 ark-ff = { version = "0.4", default-features = false }

--- a/crates/bin/pclientd/Cargo.toml
+++ b/crates/bin/pclientd/Cargo.toml
@@ -62,7 +62,7 @@ directories = "4.0.1"
 tempfile = "3.3.0"
 assert_cmd = "2.0"
 base64 = "0.20"
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type" }
+ibc-types = { version = "0.6.3" }
 ibc-proto = { version = "0.33.0", default-features = false, features = ["server"] }
 
 [build-dependencies]

--- a/crates/bin/pclientd/Cargo.toml
+++ b/crates/bin/pclientd/Cargo.toml
@@ -62,7 +62,7 @@ directories = "4.0.1"
 tempfile = "3.3.0"
 assert_cmd = "2.0"
 base64 = "0.20"
-ibc-types = "0.6.0"
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type" }
 ibc-proto = { version = "0.33.0", default-features = false, features = ["server"] }
 
 [build-dependencies]

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -55,7 +55,7 @@ tendermint-config = "0.33.0"
 tendermint-proto = "0.33.0"
 tendermint = "0.33.0"
 tendermint-light-client-verifier = "0.33.0"
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type" }
+ibc-types = { version = "0.6.3" }
 
 ibc-proto = { version = "0.33.0", default-features = false, features = ["server"] }
 prost = "0.11"

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -55,7 +55,7 @@ tendermint-config = "0.33.0"
 tendermint-proto = "0.33.0"
 tendermint = "0.33.0"
 tendermint-light-client-verifier = "0.33.0"
-ibc-types = "0.6.0"
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type" }
 
 ibc-proto = { version = "0.33.0", default-features = false, features = ["server"] }
 prost = "0.11"

--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -62,7 +62,7 @@ parking_lot = "0.12"
 tendermint = "0.33.0"
 tendermint-proto = "0.33.0"
 tendermint-light-client-verifier = "0.33.0"
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", default-features = false }
+ibc-types = { version = "0.6.3", default-features = false }
 ibc-proto = { version = "0.33.0", default-features = false, features = ["server"] }
 
 [dev-dependencies]

--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -62,7 +62,7 @@ parking_lot = "0.12"
 tendermint = "0.33.0"
 tendermint-proto = "0.33.0"
 tendermint-light-client-verifier = "0.33.0"
-ibc-types = { version = "0.6.0", default-features = false }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", default-features = false }
 ibc-proto = { version = "0.33.0", default-features = false, features = ["server"] }
 
 [dev-dependencies]

--- a/crates/core/component/chain/Cargo.toml
+++ b/crates/core/component/chain/Cargo.toml
@@ -17,7 +17,7 @@ penumbra-num = { path = "../../../core/num", default-features = false }
 decaf377 = "0.5"
 
 tendermint = "0.33.0"
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", default-features = false }
+ibc-types = { version = "0.6.3", default-features = false }
 ics23 = "0.10.1"
 
 # Crates.io deps

--- a/crates/core/component/chain/Cargo.toml
+++ b/crates/core/component/chain/Cargo.toml
@@ -17,7 +17,7 @@ penumbra-num = { path = "../../../core/num", default-features = false }
 decaf377 = "0.5"
 
 tendermint = "0.33.0"
-ibc-types = { version = "0.6.0", default-features = false }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", default-features = false }
 ics23 = "0.10.1"
 
 # Crates.io deps

--- a/crates/core/component/ibc/Cargo.toml
+++ b/crates/core/component/ibc/Cargo.toml
@@ -30,7 +30,7 @@ penumbra-num = { path = "../../../core/num", default-features = false }
 penumbra-keys = { path = "../../../core/keys", default-features = false }
 
 # Penumbra dependencies
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", default_features = false }
+ibc-types = { version = "0.6.3", default-features = false }
 ibc-proto = { version = "0.33.0", default-features = false }
 
 # Crates.io deps

--- a/crates/core/component/ibc/Cargo.toml
+++ b/crates/core/component/ibc/Cargo.toml
@@ -30,7 +30,7 @@ penumbra-num = { path = "../../../core/num", default-features = false }
 penumbra-keys = { path = "../../../core/keys", default-features = false }
 
 # Penumbra dependencies
-ibc-types = { version = "0.6.0", default-features = false }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", default_features = false }
 ibc-proto = { version = "0.33.0", default-features = false }
 
 # Crates.io deps

--- a/crates/core/component/ibc/src/component/connection.rs
+++ b/crates/core/component/ibc/src/component/connection.rs
@@ -3,16 +3,21 @@ use async_trait::async_trait;
 // TODO(erwan): remove in polish MERGEBLOCK
 // use ibc_types::core::ics02_client::client_def::AnyClient;
 // use ibc_types::core::ics02_client::client_def::ClientDef;
-use ibc_types::core::{connection::ConnectionEnd, connection::ConnectionId};
+use ibc_types::{
+    core::{connection::ConnectionEnd, connection::ConnectionId},
+    path::ConnectionPath,
+};
 use penumbra_proto::{StateReadProto, StateWriteProto};
 use penumbra_storage::{StateRead, StateWrite};
 
 use super::{connection_counter::ConnectionCounter, state_key};
 
+// This type is defined by cosmos SDK, and committed, to the store, but not
+
 #[async_trait]
 pub trait StateWriteExt: StateWrite {
     fn put_connection_counter(&mut self, counter: ConnectionCounter) {
-        self.put(state_key::connections::counter().into(), counter);
+        self.put(state_key::counter().into(), counter);
     }
 
     // puts a new connection into the state, updating the connections associated with the client,
@@ -23,11 +28,7 @@ pub trait StateWriteExt: StateWrite {
         connection: ConnectionEnd,
     ) -> Result<()> {
         self.put(
-            state_key::connections::by_connection_id(connection_id),
-            connection.clone(),
-        );
-        self.put(
-            state_key::connections::by_client_id(&connection.client_id, connection_id),
+            ConnectionPath::new(connection_id).to_string(),
             connection.clone(),
         );
         let counter = self
@@ -41,12 +42,8 @@ pub trait StateWriteExt: StateWrite {
 
     fn update_connection(&mut self, connection_id: &ConnectionId, connection: ConnectionEnd) {
         self.put(
-            state_key::connections::by_connection_id(connection_id),
+            ConnectionPath::new(connection_id).to_string(),
             connection.clone(),
-        );
-        self.put(
-            state_key::connections::by_client_id(&connection.client_id, connection_id),
-            connection,
         );
     }
 }
@@ -56,13 +53,13 @@ impl<T: StateWrite> StateWriteExt for T {}
 #[async_trait]
 pub trait StateReadExt: StateRead {
     async fn get_connection_counter(&self) -> Result<ConnectionCounter> {
-        self.get(state_key::connections::counter())
+        self.get(state_key::counter())
             .await
             .map(|counter| counter.unwrap_or(ConnectionCounter(0)))
     }
 
     async fn get_connection(&self, connection_id: &ConnectionId) -> Result<Option<ConnectionEnd>> {
-        self.get(&state_key::connections::by_connection_id(connection_id))
+        self.get(&ConnectionPath::new(connection_id).to_string())
             .await
     }
 }

--- a/crates/core/component/ibc/src/component/rpc/connection_query.rs
+++ b/crates/core/component/ibc/src/component/rpc/connection_query.rs
@@ -11,12 +11,13 @@ use ibc_proto::ibc::core::connection::v1::{
 };
 
 use ibc_types::core::connection::{ConnectionId, IdentifiedConnectionEnd};
+use ibc_types::path::ConnectionPath;
 use ibc_types::DomainType;
 use penumbra_chain::component::AppHashRead;
 use prost::Message;
 use std::str::FromStr;
 
-use crate::component::{state_key, ConnectionStateReadExt};
+use crate::component::ConnectionStateReadExt;
 
 use super::IbcQuery;
 
@@ -33,7 +34,8 @@ impl ConnectionQuery for IbcQuery {
 
         let (conn, proof) = snapshot
             .get_with_proof_to_apphash(
-                state_key::connections::by_connection_id(connection_id)
+                ConnectionPath::new(connection_id)
+                    .to_string()
                     .as_bytes()
                     .to_vec(),
             )

--- a/crates/core/component/ibc/src/component/state_key.rs
+++ b/crates/core/component/ibc/src/component/state_key.rs
@@ -8,44 +8,17 @@ pub fn ibc_params() -> &'static str {
     "ibc/params"
 }
 
-// TODO (ava): move these to ibc-types eventually
+// these are internal helpers that are used by penumbra-ibc, but not part of the IBC spec (that is,
+// counterparties don't expect to verify proofs about them)
 pub fn client_processed_heights(client_id: &ClientId, height: &Height) -> String {
-    format!("ibc/clients/{client_id}/processedHeights/{height}")
+    format!("clients/{client_id}/processedHeights/{height}")
 }
 pub fn client_processed_times(client_id: &ClientId, height: &Height) -> String {
-    format!("ibc/clients/{client_id}/processedTimes/{height}")
+    format!("clients/{client_id}/processedTimes/{height}")
 }
-
-pub mod connections {
-    use ibc_types::core::client::ClientId;
-    use ibc_types::core::connection::ConnectionId;
-
-    use std::string::String;
-
-    // This is part of the ICS-3 spec but not exposed yet:
-    // https://github.com/cosmos/ibc/tree/main/spec/core/ics-003-connection-semantics
-    #[allow(dead_code)]
-    pub fn by_client_id_list(client_id: &ClientId) -> String {
-        format!("ibc/clients/{client_id}/connections/")
-    }
-
-    pub fn by_client_id(client_id: &ClientId, connection_id: &ConnectionId) -> String {
-        format!(
-            "ibc/clients/{}/connections/{}",
-            client_id,
-            connection_id.as_str()
-        )
-    }
-
-    pub fn by_connection_id(connection_id: &ConnectionId) -> String {
-        format!("ibc/connections/{}", connection_id.as_str())
-    }
-
-    pub fn counter() -> &'static str {
-        "ibc/ics03-connection/connection_counter"
-    }
+pub fn counter() -> &'static str {
+    "ibc/connection_counter"
 }
-
 pub fn ics20_value_balance(channel_id: &ChannelId, asset_id: &asset::Id) -> String {
     format!("ibc/ics20-value-balance/{channel_id}/{asset_id}")
 }

--- a/crates/core/component/ibc/src/component/state_key.rs
+++ b/crates/core/component/ibc/src/component/state_key.rs
@@ -11,10 +11,10 @@ pub fn ibc_params() -> &'static str {
 // these are internal helpers that are used by penumbra-ibc, but not part of the IBC spec (that is,
 // counterparties don't expect to verify proofs about them)
 pub fn client_processed_heights(client_id: &ClientId, height: &Height) -> String {
-    format!("clients/{client_id}/processedHeights/{height}")
+    format!("ibc/clients/{client_id}/processedHeights/{height}")
 }
 pub fn client_processed_times(client_id: &ClientId, height: &Height) -> String {
-    format!("clients/{client_id}/processedTimes/{height}")
+    format!("ibc/clients/{client_id}/processedTimes/{height}")
 }
 pub fn counter() -> &'static str {
     "ibc/connection_counter"

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -27,7 +27,7 @@ penumbra-asset = { path = "../asset", default-features = false }
 penumbra-keys = { path = "../keys", default-features = false }
 
 # Git deps
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", default_features = false }
+ibc-types = { version = "0.6.3", default-features = false }
 
 # Crates.io deps
 ibc-proto = { version = "0.33.0", default-features = false }

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -27,7 +27,7 @@ penumbra-asset = { path = "../asset", default-features = false }
 penumbra-keys = { path = "../keys", default-features = false }
 
 # Git deps
-ibc-types = { version = "0.6.0", default-features = false }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", default_features = false }
 
 # Crates.io deps
 ibc-proto = { version = "0.33.0", default-features = false }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 subtle-encoding = "0.5"
 bech32 = "0.8"
 penumbra-storage = { path = "../storage", optional = true }
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", features = ["std"]}
+ibc-types = { version = "0.6.3", features = ["std"]}
 pin-project = "1"
 async-trait = "0.1.52"
 async-stream = "0.2.0"

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 subtle-encoding = "0.5"
 bech32 = "0.8"
 penumbra-storage = { path = "../storage", optional = true }
-ibc-types = { version = "0.6.0", features = ["std"] }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", features = ["std"]}
 pin-project = "1"
 async-trait = "0.1.52"
 async-stream = "0.2.0"

--- a/crates/proto/src/protobuf.rs
+++ b/crates/proto/src/protobuf.rs
@@ -182,13 +182,20 @@ extern crate ibc_types;
 use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::channel::v1::Channel as RawChannel;
 use ibc_proto::ibc::core::client::v1::Height as RawHeight;
+use ibc_proto::ibc::core::connection::v1::ClientPaths as RawClientPaths;
 use ibc_proto::ibc::core::connection::v1::ConnectionEnd as RawConnectionEnd;
 
 use ibc_types::core::channel::ChannelEnd;
 use ibc_types::core::client::Height;
-use ibc_types::core::connection::ConnectionEnd;
+use ibc_types::core::connection::{ClientPaths, ConnectionEnd};
 use ibc_types::lightclients::tendermint::client_state::ClientState;
 
+impl TypeUrl for ClientPaths {
+    const TYPE_URL: &'static str = "/ibc.core.connection.v1.ClientPaths";
+}
+impl DomainType for ClientPaths {
+    type Proto = RawClientPaths;
+}
 impl TypeUrl for ConnectionEnd {
     const TYPE_URL: &'static str = "/ibc.core.connection.v1.ConnectionEnd";
 }

--- a/crates/view/Cargo.toml
+++ b/crates/view/Cargo.toml
@@ -40,7 +40,7 @@ penumbra-compact-block = { path = "../core/component/compact-block", default-fea
 penumbra-app = { path = "../core/app" }
 penumbra-transaction = { path = "../core/transaction" }
 
-ibc-types = { version = "0.6.0", default-features = false }
+ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", default_features = false }
 
 ark-std = { version = "0.4", default-features = false }
 decaf377 = { version = "0.5", features = ["r1cs"] }

--- a/crates/view/Cargo.toml
+++ b/crates/view/Cargo.toml
@@ -40,7 +40,7 @@ penumbra-compact-block = { path = "../core/component/compact-block", default-fea
 penumbra-app = { path = "../core/app" }
 penumbra-transaction = { path = "../core/transaction" }
 
-ibc-types = { git = "https://github.com/penumbra-zone/ibc-types.git", branch = "client-paths-type", default_features = false }
+ibc-types = { version = "0.6.3", default-features = false }
 
 ark-std = { version = "0.4", default-features = false }
 decaf377 = { version = "0.5", features = ["r1cs"] }


### PR DESCRIPTION
IBC on main will be broken until this is merged; we still had some of the ibc standard paths defined in the `penumbra-ibc` crate, which recently got changed. This broke compatibility, but these keys shouldn't even be in this crate. This PR removes the hardcoded `connection` keys and replaces them with the ones exposed by `ibc-types`, and also fixes the `ClientConnections` mapping logic to be consistent with the spec and the ecosystem.

This is blocking on release of a new version of ibc-types which includes a domain type we previously missed, `ClientPaths`