### PR TITLE
deploy: make peer limits customizable

### DIFF
--- a/deployments/charts/penumbra-node/templates/deployment.yaml
+++ b/deployments/charts/penumbra-node/templates/deployment.yaml
@@ -112,6 +112,10 @@ spec:
               sed -i -e 's/moniker.*/moniker = "{{ $moniker }}"/' /penumbra-config/testnet_data/node0/cometbft/config/config.toml
               {{- end }}
 
+              # configure peer settings
+              sed -i -e 's/max_num_inbound_peers.*/max_num_inbound_peers = {{ $.Values.cometbft.config.p2p.max_num_inbound_peers | int }}/' /penumbra-config/testnet_data/node0/cometbft/config/config.toml
+              sed -i -e 's/max_num_outbound_peers.*/max_num_outbound_peers = {{ $.Values.cometbft.config.p2p.max_num_outbound_peers | int }}/' /penumbra-config/testnet_data/node0/cometbft/config/config.toml
+
               # set ownership for cometbft configs to match cometbft container "tmuser" uid/gid
               chown -R 100:1000 /penumbra-config/testnet_data/node0/cometbft
 

--- a/deployments/charts/penumbra-node/values.yaml
+++ b/deployments/charts/penumbra-node/values.yaml
@@ -39,6 +39,11 @@ cometbft:
     pullPolicy: IfNotPresent
     # https://github.com/cometbft/cometbft#supported-versions
     tag: "v0.37.2"
+  # Override sections of the CometBFT config. Applies to all nodes.
+  config:
+    p2p:
+      max_num_inbound_peers: 300
+      max_num_outbound_peers: 200
 
 # Configure nodes. By default, only one is created.
 # Extend this list to add more. Valid node attributes are:

--- a/testnets/tm_config_template.toml
+++ b/testnets/tm_config_template.toml
@@ -267,7 +267,9 @@ seed_mode = false
 private_peer_ids = ""
 
 # Toggle to disable guard against peers connecting from the same ip.
-allow_duplicate_ip = false
+# On Penumbra testnets, we permit reuse of IP addresses to aid in peering.
+# On mainnet, this option should retain its default value of "false".
+allow_duplicate_ip = true
 
 # Peer connection configuration.
 handshake_timeout = "20s"


### PR DESCRIPTION
We've been raising the peering limits on our PL nodes, as the testnet grows, maxing out concurrent connections.

We also update the CometBFT default value for `p2p.allow_duplicate_ip` false -> true. The purpose of this option is raise the cost for attackers to spam a network with node/validator identities run on the same host. That's relevant for mainnet, but during testnet, we want to maximize the ability to peer, so newcomers can join in.

Refs #3056.