### PR TITLE
docs: revert to cometbft v034 for testnet docs

### DIFF
--- a/docs/guide/src/pd/build.md
+++ b/docs/guide/src/pd/build.md
@@ -14,16 +14,17 @@ which you can safely ignore.
 
 ### Installing CometBFT
 
-You'll need to have [CometBFT installed](https://docs.cometbft.com/v0.37/guides/install)
+You'll need to have [CometBFT installed](https://docs.cometbft.com/v0.34/guides/install)
 on your system to join your node to the testnet.
 
 **NOTE**: Previous versions of Penumbra used Tendermint, but as of Testnet 61 (released 2023-09-25),
 only CometBFT is supported. **Do not use** any version of Tendermint, which may not work with `pd`.
+As of Testnet 62 (scheduled for 2023-10-10), Penumbra will use CometBFT v0.37.2.
 
-You can download `v0.37.2` [from the CometBFT releases page](https://github.com/cometbft/cometbft/releases/tag/v0.37.2)
+You can download `v0.34.27` [from the CometBFT releases page](https://github.com/cometbft/cometbft/releases/tag/v0.34.27)
 to install a binary. If you prefer to compile from source instead,
-make sure you are compiling version `v0.37.2`:
+make sure you are compiling version `v0.34.27`:
 
 ```bash
-git checkout v0.37.2
+git checkout v0.34.27
 ```

--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -4,7 +4,7 @@ We provide instructions for running both fullnode deployments and validator depl
 fullnode will sync with the network but will not have any voting power, and will
 not be eligible for staking or funding stream rewards. For more information on
 what a fullnode is, see the [CometBFT
-documentation](https://docs.cometbft.com/v0.37/core/using-cometbft#adding-a-non-validator).
+documentation](https://docs.cometbft.com/v0.34/core/using-cometbft#adding-a-non-validator).
 
 A regular validator will participate in voting and rewards, if it becomes part
 of the consensus set.  Of course, these rewards, like all other testnet tokens,


### PR DESCRIPTION
We've migrated to cometbft v0.37.x on preview, and updated the docs at the same time, but it's too early for docs changes: those trying to join the currently active Testnet 61 must still use v0.34.27. When we release 62, we'll update the docs then to match.

Refs #2263.