### PR TITLE
ci: build container images in external repos

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -97,6 +97,64 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  osiris:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      # We use the GHA Repository Dispatch functionality to trigger a container
+      # build in the penumbra-zone/osiris repo.
+      - name: Trigger remote build
+        shell: bash
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+        run: |-
+          export PENUMBRA_VERSION='${{ github.event.inputs.image_tag || github.ref_name }}'
+          cd deployments/
+          ./scripts/gha-repository-dispatch penumbra-zone/osiris
+
+  galileo:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      # We use the GHA Repository Dispatch functionality to trigger a container
+      # build in the penumbra-zone/galileo repo.
+      - name: Trigger remote build
+        shell: bash
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+        run: |-
+          export PENUMBRA_VERSION='${{ github.event.inputs.image_tag || github.ref_name }}'
+          # Galileo only runs against public testnets, so skip building non-tagged versions.
+          if ! grep -q '^v' <<< "$PENUMBRA_VERSION" ; then
+            echo "Detected version '$PENUBRA_VERSION', skipping Galileo container build"
+            exit 0
+          fi
+          cd deployments/
+          ./scripts/gha-repository-dispatch penumbra-zone/galileo
+
+  hermes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      # We use the GHA Repository Dispatch functionality to trigger a container
+      # build in the penumbra-zone/hermes repo.
+      - name: Trigger remote build
+        shell: bash
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+        run: |-
+          export PENUMBRA_VERSION='${{ github.event.inputs.image_tag || github.ref_name }}'
+          # Hermes only runs against public testnets, so we need only build tags, but for now
+          # we build even on main, to ensure a working build as ibc code changes.
+          cd deployments/
+          ./scripts/gha-repository-dispatch penumbra-zone/hermes
+
   relayer:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -72,8 +72,24 @@ jobs:
       - name: bounce grpcui
         run: kubectl rollout restart deployment grpcui-testnet
 
-      # TODO: Set up some tagging logic to associate osiris versions with specific releases.
-      # This workflow only runs on new tags, so it won't bounce osiris often, but it'll always
-      # pull the latest image when it does. That *might* not be what we want.
       - name: bounce osiris
-        run: kubectl rollout restart deployment osiris-testnet
+        shell: bash
+        run: |-
+          # Set the exact version for the current testnet for Osiris, so deps match.
+          kubectl set image deployments \
+              -l "app.kubernetes.io/instance=osiris-testnet"
+              "osiris=ghcr.io/penumbra-zone/osiris:penumbra-${PENUMBRA_VERSION}"
+          # Wait for rollout to complete. Will block until pods are marked Ready.
+          kubectl rollout status deployment \
+              -l "app.kubernetes.io/instance=osiris-testnet"
+
+      - name: bounce galileo
+        shell: bash
+        run: |-
+          # Set the exact version for the current testnet for Galileo, so deps match.
+          kubectl set image deployments \
+              -l "app.kubernetes.io/instance=galileo"
+              "galileo=ghcr.io/penumbra-zone/galileo:penumbra-${PENUMBRA_VERSION}"
+          # Wait for rollout to complete. Will block until pods are marked Ready.
+          kubectl rollout status deployment \
+              -l "app.kubernetes.io/instance=galileo"

--- a/deployments/scripts/gha-repository-dispatch
+++ b/deployments/scripts/gha-repository-dispatch
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Utility script to trigger GitHub Action workflows across different repositories [0].
+# Requires a GitHub Personal Access Token (PAT), exported as GITHUB_PAT env var [1].
+#
+# [0] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch
+# [1] https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+set -euo pipefail
+
+
+# Unpack cli args.
+github_repo="${1:-}"
+github_pat="${GITHUB_PAT:-}"
+if [[ -z "$github_repo" ]]; then
+    echo >&2 "ERROR: No GitHub repository was specified"
+    echo >&2 "Usage: $0 <github_repo>"
+    exit 1
+elif [[ -z "$github_pat" ]] ; then
+    echo >&2 "ERROR: export GitHub Personal Access Token as GITHUB_PAT env var."
+    exit 1
+fi
+
+# Support overriding the upstream version of Penumbra, but default to 'main'.
+penumbra_version="${PENUMBRA_VERSION:-main}"
+
+# Build URL for repository dispatch API endpoint.
+github_repository_url="https://api.github.com/repos/${github_repo}/dispatches"
+
+# Accept arguments for workflow, and emit valid JSON for curl request.
+# Using printf allows us to interpolate bash variables in JSON,
+# without an insane amount of quote-handling.
+function format_json_payload() {
+    local v
+    v="${1:-}"
+    shift
+    printf '{"event_type": "container-build", "client_payload": { "penumbra_version": "%s" }}' "$v"
+}
+
+json_payload="$(format_json_payload "$penumbra_version")"
+curl -f -X POST "$github_repository_url" \
+          -H 'Accept: application/vnd.github.v3+json' \
+          -H 'Content-Type: application/json' \
+          -H "Authorization: token $github_pat" \
+          --data "$json_payload"


### PR DESCRIPTION
There are a few container images used for Penumbra, but not managed within this repository:

    * https://github.com/penumbra-zone/galileo
    * https://github.com/penumbra-zone/osiris
    * https://github.com/penumbra-zone/hermes

We leverage the Repository Dispatch feature [0] of GitHub actions, so that within penumbra-zone/penumbra CI actions, we can trigger container builds in those other repos.

[0] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch