### PR TITLE
build(pd): upgrade to tower-abci v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3562,9 +3562,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jmt"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e49c5d2c13e15f77f22cee3df3dc822b46051b217112035d72687cb57a9cbde"
+checksum = "23f1cb339f7d5288603665c0ccbef7ad33a782ced36e18b6b207f175479eb3b7"
 dependencies = [
  "anyhow",
  "borsh",
@@ -8181,9 +8181,9 @@ dependencies = [
 
 [[package]]
 name = "tower-abci"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c629f4e6844d9c506d4b3b7894821015c72c818fc4e7e66275d34e5e0b43a2"
+checksum = "a27715826a50956390a46848fe47ece6f75ec19384afd4da98b740873630f4e4"
 dependencies = [
  "bytes",
  "futures",

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -46,7 +46,7 @@ penumbra-tendermint-proxy = { path = "../../util/tendermint-proxy" }
 # Penumbra dependencies
 decaf377 = { version = "0.5", features = ["parallel"] }
 decaf377-rdsa = { version = "0.7" }
-tower-abci = "0.9.0"
+tower-abci = "0.10.0"
 jmt = "0.8"
 tower-actor = "0.1.0"
 

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -68,6 +68,7 @@ enum RootCommand {
             default_value = "127.0.0.1:26658",
             display_order = 400
         )]
+        // TODO: Add support for Unix domain sockets, available in tower-abci >=0.10.0
         abci_bind: SocketAddr,
         /// Bind the gRPC server to this socket.
         ///
@@ -325,7 +326,7 @@ async fn main() -> anyhow::Result<()> {
                         .info(info.clone())
                         .finish()
                         .context("failed to build abci server")?
-                        .listen(abci_bind),
+                        .listen_tcp(abci_bind),
                 )
                 .expect("failed to spawn abci server");
 

--- a/crates/narsil/narsil/Cargo.toml
+++ b/crates/narsil/narsil/Cargo.toml
@@ -24,7 +24,7 @@ penumbra-chain = { path = "../../core/component/chain", features = [
 penumbra-app = { path = "../../core/app" }
 
 # Penumbra dependencies
-tower-abci = "0.9.0"
+tower-abci = "0.10.0"
 tower-actor = "0.1.0"
 
 # External dependencies

--- a/crates/narsil/narsil/src/bin/narsild.rs
+++ b/crates/narsil/narsil/src/bin/narsild.rs
@@ -166,7 +166,7 @@ async fn main() -> anyhow::Result<()> {
                         .info(info.clone())
                         .finish()
                         .ok_or_else(|| anyhow::anyhow!("failed to build abci server"))?
-                        .listen(abci_bind),
+                        .listen_tcp(abci_bind),
                 )
                 .expect("failed to spawn abci server");
 


### PR DESCRIPTION
While working on #2263, noticed that we aren't using the most recent version of tower-abci. This change bumps to latest, ahead of upcoming more substantive changes in v0.11.0 [0]. Opted to preserve the TCP-only ABCI support for pd out of simplicity.

Also includes mention of `jmt` in the cargo lockfile as a follow-up to f482b485ad265511e2040fa2d9090c5bc04273c7.

[0] https://github.com/penumbra-zone/tower-abci/issues/34