### PR TITLE
chore: update cometbft config template

### DIFF
--- a/crates/bin/pd/src/testnet/config.rs
+++ b/crates/bin/pd/src/testnet/config.rs
@@ -37,17 +37,17 @@ impl TestnetTendermintConfig {
         tm_rpc_bind: Option<SocketAddr>,
         tm_p2p_bind: Option<SocketAddr>,
     ) -> anyhow::Result<Self> {
-        tracing::debug!("List of TM peers: {:?}", peers);
+        tracing::debug!("List of CometBFT peers: {:?}", peers);
         let moniker: Moniker = Moniker::from_str(node_name)?;
         let mut tm_config = TendermintConfig::parse_toml(include_str!(
-            "../../../../../testnets/tm_config_template.toml"
+            "../../../../../testnets/cometbft_config_template.toml"
         ))
-        .context("Failed to parse the TOML config template for Tendermint")?;
+        .context("Failed to parse the TOML config template for CometBFT")?;
         tm_config.moniker = moniker;
         tm_config.p2p.seeds = peers;
         tracing::debug!("External address looks like: {:?}", external_address);
         tm_config.p2p.external_address = external_address;
-        // The Tendermint config wants URLs, not SocketAddrs, so we'll prepend protocol.
+        // The CometBFT config wants URLs, not SocketAddrs, so we'll prepend protocol.
         if let Some(rpc) = tm_rpc_bind {
             tm_config.rpc.laddr =
                 parse_tm_address(None, &Url::parse(format!("tcp://{}", rpc).as_str())?)?;
@@ -56,9 +56,6 @@ impl TestnetTendermintConfig {
             tm_config.p2p.laddr =
                 parse_tm_address(None, &Url::parse(format!("tcp://{}", p2p).as_str())?)?;
         }
-        // We don't use pprof_laddr, and tendermint-rs incorrectly prepends "tcp://" to it,
-        // which emits an error on service start, so let's remove it entirely.
-        tm_config.rpc.pprof_laddr = None;
 
         Ok(Self(tm_config))
     }

--- a/testnets/cometbft_config_template.toml
+++ b/testnets/cometbft_config_template.toml
@@ -3,7 +3,7 @@
 
 # NOTE: Any path below can be absolute (e.g. "/var/myawesomeapp/data") or
 # relative to the home directory (e.g. "data"). The home directory is
-# "$HOME/.tendermint" by default, but could be changed via $TMHOME env variable
+# "$HOME/.cometbft" by default, but could be changed via $CMTHOME env variable
 # or --home cmd flag.
 
 #######################################################################
@@ -11,16 +11,20 @@
 #######################################################################
 
 # TCP or UNIX socket address of the ABCI application,
-# or the name of an ABCI application compiled in with the Tendermint binary
+# or the name of an ABCI application compiled in with the CometBFT binary
 proxy_app = "tcp://127.0.0.1:26658"
 
 # A custom human readable name for this node
 moniker = ""
 
-# If this node is many blocks behind the tip of the chain, FastSync
+# If this node is many blocks behind the tip of the chain, BlockSync
 # allows them to catchup quickly by downloading blocks in parallel
 # and verifying their commits
+#
+# Deprecated: this key will be removed and BlockSync will be enabled
+# unconditionally in the next major release.
 fast_sync = true
+block_sync = true
 
 # Database backend: goleveldb | cleveldb | boltdb | rocksdb | badgerdb
 # * goleveldb (github.com/syndtr/goleveldb - most popular implementation)
@@ -63,7 +67,7 @@ priv_validator_key_file = "config/priv_validator_key.json"
 # Path to the JSON file containing the last sign state of a validator
 priv_validator_state_file = "data/priv_validator_state.json"
 
-# TCP or UNIX socket address for Tendermint to listen on for
+# TCP or UNIX socket address for CometBFT to listen on for
 # connections from an external PrivValidator process
 priv_validator_laddr = ""
 
@@ -96,16 +100,10 @@ laddr = "tcp://0.0.0.0:26657"
 cors_allowed_origins = []
 
 # A list of methods the client is allowed to use with cross-domain requests
-cors_allowed_methods = ["HEAD", "GET", "POST"]
+cors_allowed_methods = ["HEAD", "GET", "POST", ]
 
 # A list of non simple headers the client is allowed to use with cross-domain requests
-cors_allowed_headers = [
-    "Origin",
-    "Accept",
-    "Content-Type",
-    "X-Requested-With",
-    "X-Server-Time",
-]
+cors_allowed_headers = ["Origin", "Accept", "Content-Type", "X-Requested-With", "X-Server-Time", ]
 
 # TCP or UNIX socket address for the gRPC server to listen on
 # NOTE: This server only supports /broadcast_tx_commit
@@ -116,7 +114,7 @@ grpc_laddr = ""
 # If you want to accept a larger number than the default, make sure
 # you increase your OS limits.
 # 0 - unlimited.
-# Should be < ulimit -Sn - MaxNumInboundPeers - MaxNumOutboundPeers - N of wal, db and other open files
+# Should be < {ulimit -Sn} - {MaxNumInboundPeers} - {MaxNumOutboundPeers} - {N of wal, db and other open files}
 # 1024 - 40 - 10 - 50 = 924 = ~900
 grpc_max_open_connections = 900
 
@@ -128,7 +126,7 @@ unsafe = false
 # If you want to accept a larger number than the default, make sure
 # you increase your OS limits.
 # 0 - unlimited.
-# Should be < ulimit -Sn - MaxNumInboundPeers - MaxNumOutboundPeers - N of wal, db and other open files
+# Should be < {ulimit -Sn} - {MaxNumInboundPeers} - {MaxNumOutboundPeers} - {N of wal, db and other open files}
 # 1024 - 40 - 10 - 50 = 924 = ~900
 max_open_connections = 900
 
@@ -166,7 +164,7 @@ experimental_websocket_write_buffer_size = 200
 #
 # Enabling this experimental parameter will cause the WebSocket connection to
 # be closed instead if it cannot read fast enough, allowing for greater
-# predictability in subscription behaviour.
+# predictability in subscription behavior.
 experimental_close_on_slow_client = false
 
 # How long to wait for a tx to be committed during /broadcast_tx_commit.
@@ -182,22 +180,22 @@ max_body_bytes = 1000000
 max_header_bytes = 1048576
 
 # The path to a file containing certificate that is used to create the HTTPS server.
-# Might be either absolute path or path related to Tendermint's config directory.
+# Might be either absolute path or path related to CometBFT's config directory.
 # If the certificate is signed by a certificate authority,
 # the certFile should be the concatenation of the server's certificate, any intermediates,
 # and the CA's certificate.
-# NOTE: both tls_cert_file and tls_key_file must be present for Tendermint to create HTTPS server.
+# NOTE: both tls_cert_file and tls_key_file must be present for CometBFT to create HTTPS server.
 # Otherwise, HTTP server is run.
 tls_cert_file = ""
 
 # The path to a file containing matching private key that is used to create the HTTPS server.
-# Might be either absolute path or path related to Tendermint's config directory.
-# NOTE: both tls-cert-file and tls-key-file must be present for Tendermint to create HTTPS server.
+# Might be either absolute path or path related to CometBFT's config directory.
+# NOTE: both tls-cert-file and tls-key-file must be present for CometBFT to create HTTPS server.
 # Otherwise, HTTP server is run.
 tls_key_file = ""
 
 # pprof listen address (https://golang.org/pkg/net/http/pprof)
-pprof_laddr = "127.0.0.1:6060"
+pprof_laddr = ""
 
 #######################################################
 ###           P2P Configuration Options             ###
@@ -282,7 +280,7 @@ dial_timeout = "3s"
 
 # Mempool version to use:
 #   1) "v0" - (default) FIFO mempool.
-#   2) "v1" - prioritized mempool.
+#   2) "v1" - prioritized mempool (deprecated; will be removed in the next release).
 version = "v0"
 
 recheck = true
@@ -306,7 +304,7 @@ cache_size = 10000
 keep-invalid-txs-in-cache = false
 
 # Maximum size of a single transaction.
-# NOTE: the max size of a tx transmitted over the network is max_tx_bytes.
+# NOTE: the max size of a tx transmitted over the network is {max_tx_bytes}.
 max_tx_bytes = 1048576
 
 # Maximum size of a batch of transactions to send to a peer
@@ -378,6 +376,19 @@ chunk_fetchers = "4"
 version = "v0"
 
 #######################################################
+###       Block Sync Configuration Options          ###
+#######################################################
+[blocksync]
+
+# Block Sync version to use:
+#
+# In v0.37, v1 and v2 of the block sync protocols were deprecated.
+# Please use v0 instead.
+#
+#   1) "v0" - the default block sync implementation
+version = "v0"
+
+#######################################################
 ###         Consensus Configuration Options         ###
 #######################################################
 [consensus]
@@ -403,7 +414,7 @@ timeout_commit = "5s"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart
-# if the same consensus key was used to sign double_sign_check_height last blocks.
+# if the same consensus key was used to sign {double_sign_check_height} last blocks.
 # So, validators should stop the state machine, wait for some blocks, and then restart the state machine to avoid panic.
 double_sign_check_height = 0
 
@@ -421,6 +432,7 @@ peer_query_maj23_sleep_duration = "2s"
 #######################################################
 ###         Storage Configuration Options           ###
 #######################################################
+[storage]
 
 # Set to true to discard ABCI responses from the state store, which can save a
 # considerable amount of disk space. Set to false to ensure ABCI responses are


### PR DESCRIPTION
As of CometBFT v0.37.x, fastsync has been deprecated in favor of blocksync, but v0.38.x will disregard both options. We can't yet update the value since we're on v0.37.x still, but I'm still pulling in the config file changes to comments and explanations created by diffing a newly generated CometBFT config against our TOML template.
    
Refs #3144. Refs #2263.

