### PR TITLE
proto: use tonic-build 0.9

### DIFF
--- a/crates/proto/src/gen/penumbra.core.app.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.core.app.v1alpha1.rs
@@ -163,7 +163,7 @@ pub mod query_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -219,11 +219,30 @@ pub mod query_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Gets the app parameters.
         pub async fn app_parameters(
             &mut self,
             request: impl tonic::IntoRequest<super::AppParametersRequest>,
-        ) -> Result<tonic::Response<super::AppParametersResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::AppParametersResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -237,14 +256,25 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.app.v1alpha1.QueryService/AppParameters",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.app.v1alpha1.QueryService",
+                        "AppParameters",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// General-purpose key-value state query API, that can be used to query
         /// arbitrary keys in the JMT storage.
         pub async fn key_value(
             &mut self,
             request: impl tonic::IntoRequest<super::KeyValueRequest>,
-        ) -> Result<tonic::Response<super::KeyValueResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::KeyValueResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -258,7 +288,15 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.app.v1alpha1.QueryService/KeyValue",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.app.v1alpha1.QueryService",
+                        "KeyValue",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// General-purpose prefixed key-value state query API, that can be used to query
         /// arbitrary prefixes in the JMT storage.
@@ -266,7 +304,7 @@ pub mod query_service_client {
         pub async fn prefix_value(
             &mut self,
             request: impl tonic::IntoRequest<super::PrefixValueRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::PrefixValueResponse>>,
             tonic::Status,
         > {
@@ -283,7 +321,15 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.app.v1alpha1.QueryService/PrefixValue",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.app.v1alpha1.QueryService",
+                        "PrefixValue",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
     }
 }
@@ -299,16 +345,22 @@ pub mod query_service_server {
         async fn app_parameters(
             &self,
             request: tonic::Request<super::AppParametersRequest>,
-        ) -> Result<tonic::Response<super::AppParametersResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::AppParametersResponse>,
+            tonic::Status,
+        >;
         /// General-purpose key-value state query API, that can be used to query
         /// arbitrary keys in the JMT storage.
         async fn key_value(
             &self,
             request: tonic::Request<super::KeyValueRequest>,
-        ) -> Result<tonic::Response<super::KeyValueResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::KeyValueResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the PrefixValue method.
         type PrefixValueStream: futures_core::Stream<
-                Item = Result<super::PrefixValueResponse, tonic::Status>,
+                Item = std::result::Result<super::PrefixValueResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -318,7 +370,10 @@ pub mod query_service_server {
         async fn prefix_value(
             &self,
             request: tonic::Request<super::PrefixValueRequest>,
-        ) -> Result<tonic::Response<Self::PrefixValueStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::PrefixValueStream>,
+            tonic::Status,
+        >;
     }
     /// Query operations for the overall Penumbra application.
     #[derive(Debug)]
@@ -326,6 +381,8 @@ pub mod query_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: QueryService> QueryServiceServer<T> {
@@ -338,6 +395,8 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -361,6 +420,22 @@ pub mod query_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServiceServer<T>
     where
@@ -374,7 +449,7 @@ pub mod query_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -396,7 +471,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::AppParametersRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).app_parameters(request).await
                             };
@@ -405,6 +480,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -414,6 +491,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -436,13 +517,15 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::KeyValueRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).key_value(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -452,6 +535,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -475,7 +562,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::PrefixValueRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).prefix_value(request).await
                             };
@@ -484,6 +571,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -493,6 +582,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -521,12 +614,14 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: QueryService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto/src/gen/penumbra.core.component.chain.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.core.component.chain.v1alpha1.rs
@@ -103,7 +103,7 @@ pub mod query_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -159,11 +159,30 @@ pub mod query_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// TODO: move to SCT cf sct/src/component/view.rs:9 "make epoch management the responsibility of this component"
         pub async fn epoch_by_height(
             &mut self,
             request: impl tonic::IntoRequest<super::EpochByHeightRequest>,
-        ) -> Result<tonic::Response<super::EpochByHeightResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::EpochByHeightResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -177,7 +196,15 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.chain.v1alpha1.QueryService/EpochByHeight",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.chain.v1alpha1.QueryService",
+                        "EpochByHeight",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -193,7 +220,10 @@ pub mod query_service_server {
         async fn epoch_by_height(
             &self,
             request: tonic::Request<super::EpochByHeightRequest>,
-        ) -> Result<tonic::Response<super::EpochByHeightResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::EpochByHeightResponse>,
+            tonic::Status,
+        >;
     }
     /// Query operations for the chain component.
     #[derive(Debug)]
@@ -201,6 +231,8 @@ pub mod query_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: QueryService> QueryServiceServer<T> {
@@ -213,6 +245,8 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -236,6 +270,22 @@ pub mod query_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServiceServer<T>
     where
@@ -249,7 +299,7 @@ pub mod query_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -271,7 +321,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::EpochByHeightRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).epoch_by_height(request).await
                             };
@@ -280,6 +330,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -289,6 +341,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -317,12 +373,14 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: QueryService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto/src/gen/penumbra.core.component.dex.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.core.component.dex.v1alpha1.rs
@@ -812,7 +812,7 @@ pub mod query_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -868,11 +868,30 @@ pub mod query_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Get the batch clearing prices for a specific block height and trading pair.
         pub async fn batch_swap_output_data(
             &mut self,
             request: impl tonic::IntoRequest<super::BatchSwapOutputDataRequest>,
-        ) -> Result<tonic::Response<super::BatchSwapOutputDataResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::BatchSwapOutputDataResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -886,13 +905,24 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.dex.v1alpha1.QueryService/BatchSwapOutputData",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.dex.v1alpha1.QueryService",
+                        "BatchSwapOutputData",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Get the precise swap execution used for a specific batch swap.
         pub async fn swap_execution(
             &mut self,
             request: impl tonic::IntoRequest<super::SwapExecutionRequest>,
-        ) -> Result<tonic::Response<super::SwapExecutionResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::SwapExecutionResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -906,13 +936,24 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.dex.v1alpha1.QueryService/SwapExecution",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.dex.v1alpha1.QueryService",
+                        "SwapExecution",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Get the precise execution used to perform on-chain arbitrage.
         pub async fn arb_execution(
             &mut self,
             request: impl tonic::IntoRequest<super::ArbExecutionRequest>,
-        ) -> Result<tonic::Response<super::ArbExecutionResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ArbExecutionResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -926,13 +967,21 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.dex.v1alpha1.QueryService/ArbExecution",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.dex.v1alpha1.QueryService",
+                        "ArbExecution",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Stream all swap executions over a range of heights, optionally subscribing to future executions.
         pub async fn swap_executions(
             &mut self,
             request: impl tonic::IntoRequest<super::SwapExecutionsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::SwapExecutionsResponse>>,
             tonic::Status,
         > {
@@ -949,13 +998,21 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.dex.v1alpha1.QueryService/SwapExecutions",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.dex.v1alpha1.QueryService",
+                        "SwapExecutions",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Stream all arbitrage executions over a range of heights, optionally subscribing to future executions.
         pub async fn arb_executions(
             &mut self,
             request: impl tonic::IntoRequest<super::ArbExecutionsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::ArbExecutionsResponse>>,
             tonic::Status,
         > {
@@ -972,13 +1029,21 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.dex.v1alpha1.QueryService/ArbExecutions",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.dex.v1alpha1.QueryService",
+                        "ArbExecutions",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Query all liquidity positions on the DEX.
         pub async fn liquidity_positions(
             &mut self,
             request: impl tonic::IntoRequest<super::LiquidityPositionsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::LiquidityPositionsResponse>>,
             tonic::Status,
         > {
@@ -995,7 +1060,15 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.dex.v1alpha1.QueryService/LiquidityPositions",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.dex.v1alpha1.QueryService",
+                        "LiquidityPositions",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Query liquidity positions by ID.
         ///
@@ -1003,7 +1076,7 @@ pub mod query_service_client {
         pub async fn liquidity_position_by_id(
             &mut self,
             request: impl tonic::IntoRequest<super::LiquidityPositionByIdRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::LiquidityPositionByIdResponse>,
             tonic::Status,
         > {
@@ -1020,13 +1093,21 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.dex.v1alpha1.QueryService/LiquidityPositionById",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.dex.v1alpha1.QueryService",
+                        "LiquidityPositionById",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Query multiple liquidity positions by ID.
         pub async fn liquidity_positions_by_id(
             &mut self,
             request: impl tonic::IntoRequest<super::LiquidityPositionsByIdRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<
                 tonic::codec::Streaming<super::LiquidityPositionsByIdResponse>,
             >,
@@ -1045,13 +1126,21 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.dex.v1alpha1.QueryService/LiquidityPositionsById",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.dex.v1alpha1.QueryService",
+                        "LiquidityPositionsById",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Query liquidity positions on a specific pair, sorted by effective price.
         pub async fn liquidity_positions_by_price(
             &mut self,
             request: impl tonic::IntoRequest<super::LiquidityPositionsByPriceRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<
                 tonic::codec::Streaming<super::LiquidityPositionsByPriceResponse>,
             >,
@@ -1070,7 +1159,15 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.dex.v1alpha1.QueryService/LiquidityPositionsByPrice",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.dex.v1alpha1.QueryService",
+                        "LiquidityPositionsByPrice",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Get the current (direct) spread on a trading pair.
         ///
@@ -1079,7 +1176,7 @@ pub mod query_service_client {
         pub async fn spread(
             &mut self,
             request: impl tonic::IntoRequest<super::SpreadRequest>,
-        ) -> Result<tonic::Response<super::SpreadResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::SpreadResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -1093,7 +1190,15 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.dex.v1alpha1.QueryService/Spread",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.dex.v1alpha1.QueryService",
+                        "Spread",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -1116,7 +1221,7 @@ pub mod simulation_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -1172,11 +1277,30 @@ pub mod simulation_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Simulate routing and trade execution.
         pub async fn simulate_trade(
             &mut self,
             request: impl tonic::IntoRequest<super::SimulateTradeRequest>,
-        ) -> Result<tonic::Response<super::SimulateTradeResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::SimulateTradeResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1190,7 +1314,15 @@ pub mod simulation_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.dex.v1alpha1.SimulationService/SimulateTrade",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.dex.v1alpha1.SimulationService",
+                        "SimulateTrade",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -1206,20 +1338,29 @@ pub mod query_service_server {
         async fn batch_swap_output_data(
             &self,
             request: tonic::Request<super::BatchSwapOutputDataRequest>,
-        ) -> Result<tonic::Response<super::BatchSwapOutputDataResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::BatchSwapOutputDataResponse>,
+            tonic::Status,
+        >;
         /// Get the precise swap execution used for a specific batch swap.
         async fn swap_execution(
             &self,
             request: tonic::Request<super::SwapExecutionRequest>,
-        ) -> Result<tonic::Response<super::SwapExecutionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SwapExecutionResponse>,
+            tonic::Status,
+        >;
         /// Get the precise execution used to perform on-chain arbitrage.
         async fn arb_execution(
             &self,
             request: tonic::Request<super::ArbExecutionRequest>,
-        ) -> Result<tonic::Response<super::ArbExecutionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ArbExecutionResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the SwapExecutions method.
         type SwapExecutionsStream: futures_core::Stream<
-                Item = Result<super::SwapExecutionsResponse, tonic::Status>,
+                Item = std::result::Result<super::SwapExecutionsResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -1227,10 +1368,13 @@ pub mod query_service_server {
         async fn swap_executions(
             &self,
             request: tonic::Request<super::SwapExecutionsRequest>,
-        ) -> Result<tonic::Response<Self::SwapExecutionsStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::SwapExecutionsStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the ArbExecutions method.
         type ArbExecutionsStream: futures_core::Stream<
-                Item = Result<super::ArbExecutionsResponse, tonic::Status>,
+                Item = std::result::Result<super::ArbExecutionsResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -1238,10 +1382,16 @@ pub mod query_service_server {
         async fn arb_executions(
             &self,
             request: tonic::Request<super::ArbExecutionsRequest>,
-        ) -> Result<tonic::Response<Self::ArbExecutionsStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::ArbExecutionsStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the LiquidityPositions method.
         type LiquidityPositionsStream: futures_core::Stream<
-                Item = Result<super::LiquidityPositionsResponse, tonic::Status>,
+                Item = std::result::Result<
+                    super::LiquidityPositionsResponse,
+                    tonic::Status,
+                >,
             >
             + Send
             + 'static;
@@ -1249,20 +1399,26 @@ pub mod query_service_server {
         async fn liquidity_positions(
             &self,
             request: tonic::Request<super::LiquidityPositionsRequest>,
-        ) -> Result<tonic::Response<Self::LiquidityPositionsStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::LiquidityPositionsStream>,
+            tonic::Status,
+        >;
         /// Query liquidity positions by ID.
         ///
         /// To get multiple positions, use `LiquidityPositionsById`.
         async fn liquidity_position_by_id(
             &self,
             request: tonic::Request<super::LiquidityPositionByIdRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::LiquidityPositionByIdResponse>,
             tonic::Status,
         >;
         /// Server streaming response type for the LiquidityPositionsById method.
         type LiquidityPositionsByIdStream: futures_core::Stream<
-                Item = Result<super::LiquidityPositionsByIdResponse, tonic::Status>,
+                Item = std::result::Result<
+                    super::LiquidityPositionsByIdResponse,
+                    tonic::Status,
+                >,
             >
             + Send
             + 'static;
@@ -1270,10 +1426,16 @@ pub mod query_service_server {
         async fn liquidity_positions_by_id(
             &self,
             request: tonic::Request<super::LiquidityPositionsByIdRequest>,
-        ) -> Result<tonic::Response<Self::LiquidityPositionsByIdStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::LiquidityPositionsByIdStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the LiquidityPositionsByPrice method.
         type LiquidityPositionsByPriceStream: futures_core::Stream<
-                Item = Result<super::LiquidityPositionsByPriceResponse, tonic::Status>,
+                Item = std::result::Result<
+                    super::LiquidityPositionsByPriceResponse,
+                    tonic::Status,
+                >,
             >
             + Send
             + 'static;
@@ -1281,7 +1443,7 @@ pub mod query_service_server {
         async fn liquidity_positions_by_price(
             &self,
             request: tonic::Request<super::LiquidityPositionsByPriceRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<Self::LiquidityPositionsByPriceStream>,
             tonic::Status,
         >;
@@ -1292,7 +1454,7 @@ pub mod query_service_server {
         async fn spread(
             &self,
             request: tonic::Request<super::SpreadRequest>,
-        ) -> Result<tonic::Response<super::SpreadResponse>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<super::SpreadResponse>, tonic::Status>;
     }
     /// Query operations for the DEX component.
     #[derive(Debug)]
@@ -1300,6 +1462,8 @@ pub mod query_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: QueryService> QueryServiceServer<T> {
@@ -1312,6 +1476,8 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -1335,6 +1501,22 @@ pub mod query_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServiceServer<T>
     where
@@ -1348,7 +1530,7 @@ pub mod query_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -1370,7 +1552,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::BatchSwapOutputDataRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).batch_swap_output_data(request).await
                             };
@@ -1379,6 +1561,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1388,6 +1572,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -1410,7 +1598,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::SwapExecutionRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).swap_execution(request).await
                             };
@@ -1419,6 +1607,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1428,6 +1618,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -1450,7 +1644,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::ArbExecutionRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).arb_execution(request).await
                             };
@@ -1459,6 +1653,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1468,6 +1664,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -1491,7 +1691,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::SwapExecutionsRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).swap_executions(request).await
                             };
@@ -1500,6 +1700,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1509,6 +1711,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -1532,7 +1738,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::ArbExecutionsRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).arb_executions(request).await
                             };
@@ -1541,6 +1747,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1550,6 +1758,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -1574,7 +1786,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::LiquidityPositionsRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).liquidity_positions(request).await
                             };
@@ -1583,6 +1795,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1592,6 +1806,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -1614,7 +1832,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::LiquidityPositionByIdRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).liquidity_position_by_id(request).await
                             };
@@ -1623,6 +1841,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1632,6 +1852,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -1656,7 +1880,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::LiquidityPositionsByIdRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).liquidity_positions_by_id(request).await
                             };
@@ -1665,6 +1889,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1674,6 +1900,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -1700,7 +1930,7 @@ pub mod query_service_server {
                                 super::LiquidityPositionsByPriceRequest,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).liquidity_positions_by_price(request).await
                             };
@@ -1709,6 +1939,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1718,6 +1950,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -1740,13 +1976,15 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::SpreadRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).spread(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1756,6 +1994,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -1784,12 +2026,14 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: QueryService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
@@ -1813,7 +2057,10 @@ pub mod simulation_service_server {
         async fn simulate_trade(
             &self,
             request: tonic::Request<super::SimulateTradeRequest>,
-        ) -> Result<tonic::Response<super::SimulateTradeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SimulateTradeResponse>,
+            tonic::Status,
+        >;
     }
     /// Simulation for the DEX component.
     ///
@@ -1825,6 +2072,8 @@ pub mod simulation_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: SimulationService> SimulationServiceServer<T> {
@@ -1837,6 +2086,8 @@ pub mod simulation_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -1860,6 +2111,22 @@ pub mod simulation_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for SimulationServiceServer<T>
     where
@@ -1873,7 +2140,7 @@ pub mod simulation_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -1895,7 +2162,7 @@ pub mod simulation_service_server {
                             &mut self,
                             request: tonic::Request<super::SimulateTradeRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).simulate_trade(request).await
                             };
@@ -1904,6 +2171,8 @@ pub mod simulation_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1913,6 +2182,10 @@ pub mod simulation_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -1941,12 +2214,14 @@ pub mod simulation_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: SimulationService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto/src/gen/penumbra.core.component.governance.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.core.component.governance.v1alpha1.rs
@@ -556,7 +556,7 @@ pub mod query_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -612,10 +612,29 @@ pub mod query_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         pub async fn proposal_info(
             &mut self,
             request: impl tonic::IntoRequest<super::ProposalInfoRequest>,
-        ) -> Result<tonic::Response<super::ProposalInfoResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ProposalInfoResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -629,13 +648,21 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.governance.v1alpha1.QueryService/ProposalInfo",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.governance.v1alpha1.QueryService",
+                        "ProposalInfo",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Used for computing voting power ?
         pub async fn proposal_rate_data(
             &mut self,
             request: impl tonic::IntoRequest<super::ProposalRateDataRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::ProposalRateDataResponse>>,
             tonic::Status,
         > {
@@ -652,7 +679,15 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.governance.v1alpha1.QueryService/ProposalRateData",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.governance.v1alpha1.QueryService",
+                        "ProposalRateData",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
     }
 }
@@ -667,10 +702,16 @@ pub mod query_service_server {
         async fn proposal_info(
             &self,
             request: tonic::Request<super::ProposalInfoRequest>,
-        ) -> Result<tonic::Response<super::ProposalInfoResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ProposalInfoResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the ProposalRateData method.
         type ProposalRateDataStream: futures_core::Stream<
-                Item = Result<super::ProposalRateDataResponse, tonic::Status>,
+                Item = std::result::Result<
+                    super::ProposalRateDataResponse,
+                    tonic::Status,
+                >,
             >
             + Send
             + 'static;
@@ -678,7 +719,10 @@ pub mod query_service_server {
         async fn proposal_rate_data(
             &self,
             request: tonic::Request<super::ProposalRateDataRequest>,
-        ) -> Result<tonic::Response<Self::ProposalRateDataStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::ProposalRateDataStream>,
+            tonic::Status,
+        >;
     }
     /// Query operations for the governance component.
     #[derive(Debug)]
@@ -686,6 +730,8 @@ pub mod query_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: QueryService> QueryServiceServer<T> {
@@ -698,6 +744,8 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -721,6 +769,22 @@ pub mod query_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServiceServer<T>
     where
@@ -734,7 +798,7 @@ pub mod query_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -756,7 +820,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::ProposalInfoRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).proposal_info(request).await
                             };
@@ -765,6 +829,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -774,6 +840,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -798,7 +868,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::ProposalRateDataRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).proposal_rate_data(request).await
                             };
@@ -807,6 +877,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -816,6 +888,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -844,12 +920,14 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: QueryService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto/src/gen/penumbra.core.component.sct.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.core.component.sct.v1alpha1.rs
@@ -36,7 +36,7 @@ pub mod query_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -92,11 +92,30 @@ pub mod query_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// TODO: change to generic tx-by-commitment
         pub async fn transaction_by_note(
             &mut self,
             request: impl tonic::IntoRequest<super::TransactionByNoteRequest>,
-        ) -> Result<tonic::Response<super::TransactionByNoteResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::TransactionByNoteResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -110,7 +129,15 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.sct.v1alpha1.QueryService/TransactionByNote",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.sct.v1alpha1.QueryService",
+                        "TransactionByNote",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -126,7 +153,10 @@ pub mod query_service_server {
         async fn transaction_by_note(
             &self,
             request: tonic::Request<super::TransactionByNoteRequest>,
-        ) -> Result<tonic::Response<super::TransactionByNoteResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::TransactionByNoteResponse>,
+            tonic::Status,
+        >;
     }
     /// Query operations for the SCT component.
     #[derive(Debug)]
@@ -134,6 +164,8 @@ pub mod query_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: QueryService> QueryServiceServer<T> {
@@ -146,6 +178,8 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -169,6 +203,22 @@ pub mod query_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServiceServer<T>
     where
@@ -182,7 +232,7 @@ pub mod query_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -204,7 +254,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::TransactionByNoteRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).transaction_by_note(request).await
                             };
@@ -213,6 +263,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -222,6 +274,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -250,12 +306,14 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: QueryService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto/src/gen/penumbra.core.component.shielded_pool.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.core.component.shielded_pool.v1alpha1.rs
@@ -308,7 +308,7 @@ pub mod query_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -364,10 +364,29 @@ pub mod query_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         pub async fn denom_metadata_by_id(
             &mut self,
             request: impl tonic::IntoRequest<super::DenomMetadataByIdRequest>,
-        ) -> Result<tonic::Response<super::DenomMetadataByIdResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::DenomMetadataByIdResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -381,7 +400,15 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.shielded_pool.v1alpha1.QueryService/DenomMetadataById",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.shielded_pool.v1alpha1.QueryService",
+                        "DenomMetadataById",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -396,7 +423,10 @@ pub mod query_service_server {
         async fn denom_metadata_by_id(
             &self,
             request: tonic::Request<super::DenomMetadataByIdRequest>,
-        ) -> Result<tonic::Response<super::DenomMetadataByIdResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::DenomMetadataByIdResponse>,
+            tonic::Status,
+        >;
     }
     /// Query operations for the shielded pool component.
     #[derive(Debug)]
@@ -404,6 +434,8 @@ pub mod query_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: QueryService> QueryServiceServer<T> {
@@ -416,6 +448,8 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -439,6 +473,22 @@ pub mod query_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServiceServer<T>
     where
@@ -452,7 +502,7 @@ pub mod query_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -474,7 +524,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::DenomMetadataByIdRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).denom_metadata_by_id(request).await
                             };
@@ -483,6 +533,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -492,6 +544,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -520,12 +576,14 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: QueryService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto/src/gen/penumbra.core.component.stake.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.core.component.stake.v1alpha1.rs
@@ -565,7 +565,7 @@ pub mod query_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -621,11 +621,27 @@ pub mod query_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Queries the current validator set, with filtering.
         pub async fn validator_info(
             &mut self,
             request: impl tonic::IntoRequest<super::ValidatorInfoRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::ValidatorInfoResponse>>,
             tonic::Status,
         > {
@@ -642,12 +658,23 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.stake.v1alpha1.QueryService/ValidatorInfo",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.stake.v1alpha1.QueryService",
+                        "ValidatorInfo",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         pub async fn validator_status(
             &mut self,
             request: impl tonic::IntoRequest<super::ValidatorStatusRequest>,
-        ) -> Result<tonic::Response<super::ValidatorStatusResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ValidatorStatusResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -661,12 +688,23 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.stake.v1alpha1.QueryService/ValidatorStatus",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.stake.v1alpha1.QueryService",
+                        "ValidatorStatus",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         pub async fn validator_penalty(
             &mut self,
             request: impl tonic::IntoRequest<super::ValidatorPenaltyRequest>,
-        ) -> Result<tonic::Response<super::ValidatorPenaltyResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ValidatorPenaltyResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -680,12 +718,20 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.stake.v1alpha1.QueryService/ValidatorPenalty",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.stake.v1alpha1.QueryService",
+                        "ValidatorPenalty",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         pub async fn current_validator_rate(
             &mut self,
             request: impl tonic::IntoRequest<super::CurrentValidatorRateRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::CurrentValidatorRateResponse>,
             tonic::Status,
         > {
@@ -702,12 +748,23 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.stake.v1alpha1.QueryService/CurrentValidatorRate",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.stake.v1alpha1.QueryService",
+                        "CurrentValidatorRate",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         pub async fn next_validator_rate(
             &mut self,
             request: impl tonic::IntoRequest<super::NextValidatorRateRequest>,
-        ) -> Result<tonic::Response<super::NextValidatorRateResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::NextValidatorRateResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -721,7 +778,15 @@ pub mod query_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.core.component.stake.v1alpha1.QueryService/NextValidatorRate",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.core.component.stake.v1alpha1.QueryService",
+                        "NextValidatorRate",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -735,7 +800,7 @@ pub mod query_service_server {
     pub trait QueryService: Send + Sync + 'static {
         /// Server streaming response type for the ValidatorInfo method.
         type ValidatorInfoStream: futures_core::Stream<
-                Item = Result<super::ValidatorInfoResponse, tonic::Status>,
+                Item = std::result::Result<super::ValidatorInfoResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -743,23 +808,38 @@ pub mod query_service_server {
         async fn validator_info(
             &self,
             request: tonic::Request<super::ValidatorInfoRequest>,
-        ) -> Result<tonic::Response<Self::ValidatorInfoStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::ValidatorInfoStream>,
+            tonic::Status,
+        >;
         async fn validator_status(
             &self,
             request: tonic::Request<super::ValidatorStatusRequest>,
-        ) -> Result<tonic::Response<super::ValidatorStatusResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ValidatorStatusResponse>,
+            tonic::Status,
+        >;
         async fn validator_penalty(
             &self,
             request: tonic::Request<super::ValidatorPenaltyRequest>,
-        ) -> Result<tonic::Response<super::ValidatorPenaltyResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ValidatorPenaltyResponse>,
+            tonic::Status,
+        >;
         async fn current_validator_rate(
             &self,
             request: tonic::Request<super::CurrentValidatorRateRequest>,
-        ) -> Result<tonic::Response<super::CurrentValidatorRateResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CurrentValidatorRateResponse>,
+            tonic::Status,
+        >;
         async fn next_validator_rate(
             &self,
             request: tonic::Request<super::NextValidatorRateRequest>,
-        ) -> Result<tonic::Response<super::NextValidatorRateResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::NextValidatorRateResponse>,
+            tonic::Status,
+        >;
     }
     /// Query operations for the staking component.
     #[derive(Debug)]
@@ -767,6 +847,8 @@ pub mod query_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: QueryService> QueryServiceServer<T> {
@@ -779,6 +861,8 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -802,6 +886,22 @@ pub mod query_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for QueryServiceServer<T>
     where
@@ -815,7 +915,7 @@ pub mod query_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -838,7 +938,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::ValidatorInfoRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).validator_info(request).await
                             };
@@ -847,6 +947,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -856,6 +958,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -878,7 +984,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::ValidatorStatusRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).validator_status(request).await
                             };
@@ -887,6 +993,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -896,6 +1004,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -918,7 +1030,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::ValidatorPenaltyRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).validator_penalty(request).await
                             };
@@ -927,6 +1039,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -936,6 +1050,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -958,7 +1076,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::CurrentValidatorRateRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).current_validator_rate(request).await
                             };
@@ -967,6 +1085,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -976,6 +1096,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -998,7 +1122,7 @@ pub mod query_service_server {
                             &mut self,
                             request: tonic::Request<super::NextValidatorRateRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).next_validator_rate(request).await
                             };
@@ -1007,6 +1131,8 @@ pub mod query_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1016,6 +1142,10 @@ pub mod query_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -1044,12 +1174,14 @@ pub mod query_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: QueryService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto/src/gen/penumbra.custody.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.custody.v1alpha1.rs
@@ -82,7 +82,7 @@ pub mod custody_protocol_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -140,11 +140,30 @@ pub mod custody_protocol_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Requests authorization of the transaction with the given description.
         pub async fn authorize(
             &mut self,
             request: impl tonic::IntoRequest<super::AuthorizeRequest>,
-        ) -> Result<tonic::Response<super::AuthorizeResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::AuthorizeResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -158,7 +177,15 @@ pub mod custody_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.custody.v1alpha1.CustodyProtocolService/Authorize",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.custody.v1alpha1.CustodyProtocolService",
+                        "Authorize",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -174,7 +201,10 @@ pub mod custody_protocol_service_server {
         async fn authorize(
             &self,
             request: tonic::Request<super::AuthorizeRequest>,
-        ) -> Result<tonic::Response<super::AuthorizeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::AuthorizeResponse>,
+            tonic::Status,
+        >;
     }
     /// The custody protocol is used by a wallet client to request authorization for
     /// a transaction they've constructed.
@@ -192,6 +222,8 @@ pub mod custody_protocol_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: CustodyProtocolService> CustodyProtocolServiceServer<T> {
@@ -204,6 +236,8 @@ pub mod custody_protocol_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -227,6 +261,22 @@ pub mod custody_protocol_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>>
     for CustodyProtocolServiceServer<T>
@@ -241,7 +291,7 @@ pub mod custody_protocol_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -263,13 +313,15 @@ pub mod custody_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::AuthorizeRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).authorize(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -279,6 +331,10 @@ pub mod custody_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -307,12 +363,14 @@ pub mod custody_protocol_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: CustodyProtocolService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto/src/gen/penumbra.narsil.ledger.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.narsil.ledger.v1alpha1.rs
@@ -542,7 +542,7 @@ pub mod ledger_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -598,10 +598,26 @@ pub mod ledger_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         pub async fn info(
             &mut self,
             request: impl tonic::IntoRequest<super::InfoRequest>,
-        ) -> Result<tonic::Response<super::InfoResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::InfoResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -615,7 +631,15 @@ pub mod ledger_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.narsil.ledger.v1alpha1.LedgerService/Info",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.narsil.ledger.v1alpha1.LedgerService",
+                        "Info",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -630,7 +654,7 @@ pub mod ledger_service_server {
         async fn info(
             &self,
             request: tonic::Request<super::InfoRequest>,
-        ) -> Result<tonic::Response<super::InfoResponse>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<super::InfoResponse>, tonic::Status>;
     }
     /// Methods for narsil clients to communicate with narsild.
     #[derive(Debug)]
@@ -638,6 +662,8 @@ pub mod ledger_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: LedgerService> LedgerServiceServer<T> {
@@ -650,6 +676,8 @@ pub mod ledger_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -673,6 +701,22 @@ pub mod ledger_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for LedgerServiceServer<T>
     where
@@ -686,7 +730,7 @@ pub mod ledger_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -707,13 +751,15 @@ pub mod ledger_service_server {
                             &mut self,
                             request: tonic::Request<super::InfoRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).info(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -723,6 +769,10 @@ pub mod ledger_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -751,12 +801,14 @@ pub mod ledger_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: LedgerService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto/src/gen/penumbra.tools.summoning.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.tools.summoning.v1alpha1.rs
@@ -121,7 +121,7 @@ pub mod ceremony_coordinator_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -179,6 +179,22 @@ pub mod ceremony_coordinator_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// The protocol used to participate in the ceremony.
         ///
         /// The message flow is
@@ -196,7 +212,7 @@ pub mod ceremony_coordinator_service_client {
             request: impl tonic::IntoStreamingRequest<
                 Message = super::ParticipateRequest,
             >,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::ParticipateResponse>>,
             tonic::Status,
         > {
@@ -213,7 +229,15 @@ pub mod ceremony_coordinator_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.tools.summoning.v1alpha1.CeremonyCoordinatorService/Participate",
             );
-            self.inner.streaming(request.into_streaming_request(), path, codec).await
+            let mut req = request.into_streaming_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.tools.summoning.v1alpha1.CeremonyCoordinatorService",
+                        "Participate",
+                    ),
+                );
+            self.inner.streaming(req, path, codec).await
         }
     }
 }
@@ -227,7 +251,7 @@ pub mod ceremony_coordinator_service_server {
     pub trait CeremonyCoordinatorService: Send + Sync + 'static {
         /// Server streaming response type for the Participate method.
         type ParticipateStream: futures_core::Stream<
-                Item = Result<super::ParticipateResponse, tonic::Status>,
+                Item = std::result::Result<super::ParticipateResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -246,7 +270,10 @@ pub mod ceremony_coordinator_service_server {
         async fn participate(
             &self,
             request: tonic::Request<tonic::Streaming<super::ParticipateRequest>>,
-        ) -> Result<tonic::Response<Self::ParticipateStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::ParticipateStream>,
+            tonic::Status,
+        >;
     }
     /// Runs a Phase 2 MPC ceremony with dynamic slot allocation.
     #[derive(Debug)]
@@ -254,6 +281,8 @@ pub mod ceremony_coordinator_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: CeremonyCoordinatorService> CeremonyCoordinatorServiceServer<T> {
@@ -266,6 +295,8 @@ pub mod ceremony_coordinator_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -289,6 +320,22 @@ pub mod ceremony_coordinator_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>>
     for CeremonyCoordinatorServiceServer<T>
@@ -303,7 +350,7 @@ pub mod ceremony_coordinator_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -328,13 +375,15 @@ pub mod ceremony_coordinator_service_server {
                                 tonic::Streaming<super::ParticipateRequest>,
                             >,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).participate(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -344,6 +393,10 @@ pub mod ceremony_coordinator_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.streaming(method, req).await;
                         Ok(res)
@@ -372,12 +425,14 @@ pub mod ceremony_coordinator_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: CeremonyCoordinatorService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto/src/gen/penumbra.util.tendermint_proxy.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.util.tendermint_proxy.v1alpha1.rs
@@ -208,7 +208,7 @@ pub mod tendermint_proxy_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -266,11 +266,30 @@ pub mod tendermint_proxy_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Status queries the current status.
         pub async fn get_status(
             &mut self,
             request: impl tonic::IntoRequest<super::GetStatusRequest>,
-        ) -> Result<tonic::Response<super::GetStatusResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::GetStatusResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -284,13 +303,24 @@ pub mod tendermint_proxy_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.util.tendermint_proxy.v1alpha1.TendermintProxyService/GetStatus",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.util.tendermint_proxy.v1alpha1.TendermintProxyService",
+                        "GetStatus",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Broadcast a transaction asynchronously.
         pub async fn broadcast_tx_async(
             &mut self,
             request: impl tonic::IntoRequest<super::BroadcastTxAsyncRequest>,
-        ) -> Result<tonic::Response<super::BroadcastTxAsyncResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::BroadcastTxAsyncResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -304,13 +334,24 @@ pub mod tendermint_proxy_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.util.tendermint_proxy.v1alpha1.TendermintProxyService/BroadcastTxAsync",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.util.tendermint_proxy.v1alpha1.TendermintProxyService",
+                        "BroadcastTxAsync",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Broadcast a transaction synchronously.
         pub async fn broadcast_tx_sync(
             &mut self,
             request: impl tonic::IntoRequest<super::BroadcastTxSyncRequest>,
-        ) -> Result<tonic::Response<super::BroadcastTxSyncResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::BroadcastTxSyncResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -324,13 +365,21 @@ pub mod tendermint_proxy_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.util.tendermint_proxy.v1alpha1.TendermintProxyService/BroadcastTxSync",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.util.tendermint_proxy.v1alpha1.TendermintProxyService",
+                        "BroadcastTxSync",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Fetch a transaction by hash.
         pub async fn get_tx(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTxRequest>,
-        ) -> Result<tonic::Response<super::GetTxResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::GetTxResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -344,7 +393,15 @@ pub mod tendermint_proxy_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.util.tendermint_proxy.v1alpha1.TendermintProxyService/GetTx",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.util.tendermint_proxy.v1alpha1.TendermintProxyService",
+                        "GetTx",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// ABCIQuery defines a query handler that supports ABCI queries directly to the
         /// application, bypassing Tendermint completely. The ABCI query must contain
@@ -352,7 +409,10 @@ pub mod tendermint_proxy_service_client {
         pub async fn abci_query(
             &mut self,
             request: impl tonic::IntoRequest<super::AbciQueryRequest>,
-        ) -> Result<tonic::Response<super::AbciQueryResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::AbciQueryResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -366,13 +426,24 @@ pub mod tendermint_proxy_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.util.tendermint_proxy.v1alpha1.TendermintProxyService/ABCIQuery",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.util.tendermint_proxy.v1alpha1.TendermintProxyService",
+                        "ABCIQuery",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// GetBlockByHeight queries block for given height.
         pub async fn get_block_by_height(
             &mut self,
             request: impl tonic::IntoRequest<super::GetBlockByHeightRequest>,
-        ) -> Result<tonic::Response<super::GetBlockByHeightResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::GetBlockByHeightResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -386,7 +457,15 @@ pub mod tendermint_proxy_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.util.tendermint_proxy.v1alpha1.TendermintProxyService/GetBlockByHeight",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.util.tendermint_proxy.v1alpha1.TendermintProxyService",
+                        "GetBlockByHeight",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -402,34 +481,49 @@ pub mod tendermint_proxy_service_server {
         async fn get_status(
             &self,
             request: tonic::Request<super::GetStatusRequest>,
-        ) -> Result<tonic::Response<super::GetStatusResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetStatusResponse>,
+            tonic::Status,
+        >;
         /// Broadcast a transaction asynchronously.
         async fn broadcast_tx_async(
             &self,
             request: tonic::Request<super::BroadcastTxAsyncRequest>,
-        ) -> Result<tonic::Response<super::BroadcastTxAsyncResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::BroadcastTxAsyncResponse>,
+            tonic::Status,
+        >;
         /// Broadcast a transaction synchronously.
         async fn broadcast_tx_sync(
             &self,
             request: tonic::Request<super::BroadcastTxSyncRequest>,
-        ) -> Result<tonic::Response<super::BroadcastTxSyncResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::BroadcastTxSyncResponse>,
+            tonic::Status,
+        >;
         /// Fetch a transaction by hash.
         async fn get_tx(
             &self,
             request: tonic::Request<super::GetTxRequest>,
-        ) -> Result<tonic::Response<super::GetTxResponse>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<super::GetTxResponse>, tonic::Status>;
         /// ABCIQuery defines a query handler that supports ABCI queries directly to the
         /// application, bypassing Tendermint completely. The ABCI query must contain
         /// a valid and supported path, including app, custom, p2p, and store.
         async fn abci_query(
             &self,
             request: tonic::Request<super::AbciQueryRequest>,
-        ) -> Result<tonic::Response<super::AbciQueryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::AbciQueryResponse>,
+            tonic::Status,
+        >;
         /// GetBlockByHeight queries block for given height.
         async fn get_block_by_height(
             &self,
             request: tonic::Request<super::GetBlockByHeightRequest>,
-        ) -> Result<tonic::Response<super::GetBlockByHeightResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetBlockByHeightResponse>,
+            tonic::Status,
+        >;
     }
     /// Defines the gRPC query service for proxying requests to an upstream Tendermint RPC.
     #[derive(Debug)]
@@ -437,6 +531,8 @@ pub mod tendermint_proxy_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: TendermintProxyService> TendermintProxyServiceServer<T> {
@@ -449,6 +545,8 @@ pub mod tendermint_proxy_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -472,6 +570,22 @@ pub mod tendermint_proxy_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>>
     for TendermintProxyServiceServer<T>
@@ -486,7 +600,7 @@ pub mod tendermint_proxy_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -508,13 +622,15 @@ pub mod tendermint_proxy_service_server {
                             &mut self,
                             request: tonic::Request<super::GetStatusRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).get_status(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -524,6 +640,10 @@ pub mod tendermint_proxy_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -546,7 +666,7 @@ pub mod tendermint_proxy_service_server {
                             &mut self,
                             request: tonic::Request<super::BroadcastTxAsyncRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).broadcast_tx_async(request).await
                             };
@@ -555,6 +675,8 @@ pub mod tendermint_proxy_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -564,6 +686,10 @@ pub mod tendermint_proxy_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -586,7 +712,7 @@ pub mod tendermint_proxy_service_server {
                             &mut self,
                             request: tonic::Request<super::BroadcastTxSyncRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).broadcast_tx_sync(request).await
                             };
@@ -595,6 +721,8 @@ pub mod tendermint_proxy_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -604,6 +732,10 @@ pub mod tendermint_proxy_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -625,13 +757,15 @@ pub mod tendermint_proxy_service_server {
                             &mut self,
                             request: tonic::Request<super::GetTxRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).get_tx(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -641,6 +775,10 @@ pub mod tendermint_proxy_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -663,13 +801,15 @@ pub mod tendermint_proxy_service_server {
                             &mut self,
                             request: tonic::Request<super::AbciQueryRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).abci_query(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -679,6 +819,10 @@ pub mod tendermint_proxy_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -701,7 +845,7 @@ pub mod tendermint_proxy_service_server {
                             &mut self,
                             request: tonic::Request<super::GetBlockByHeightRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).get_block_by_height(request).await
                             };
@@ -710,6 +854,8 @@ pub mod tendermint_proxy_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -719,6 +865,10 @@ pub mod tendermint_proxy_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -747,12 +897,14 @@ pub mod tendermint_proxy_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: TendermintProxyService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/crates/proto/src/gen/penumbra.view.v1alpha1.rs
+++ b/crates/proto/src/gen/penumbra.view.v1alpha1.rs
@@ -768,7 +768,7 @@ pub mod view_protocol_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -824,11 +824,27 @@ pub mod view_protocol_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         /// Get current status of chain sync
         pub async fn status(
             &mut self,
             request: impl tonic::IntoRequest<super::StatusRequest>,
-        ) -> Result<tonic::Response<super::StatusResponse>, tonic::Status> {
+        ) -> std::result::Result<tonic::Response<super::StatusResponse>, tonic::Status> {
             self.inner
                 .ready()
                 .await
@@ -842,14 +858,22 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/Status",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "Status",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Stream sync status updates until the view service has caught up with the chain.
         /// Returns a stream of `StatusStreamResponse`s.
         pub async fn status_stream(
             &mut self,
             request: impl tonic::IntoRequest<super::StatusStreamRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::StatusStreamResponse>>,
             tonic::Status,
         > {
@@ -866,14 +890,22 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/StatusStream",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "StatusStream",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Queries for notes that have been accepted by the chain.
         /// Returns a stream of `NotesResponse`s.
         pub async fn notes(
             &mut self,
             request: impl tonic::IntoRequest<super::NotesRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::NotesResponse>>,
             tonic::Status,
         > {
@@ -890,13 +922,21 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/Notes",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "Notes",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Returns a stream of `NotesForVotingResponse`s.
         pub async fn notes_for_voting(
             &mut self,
             request: impl tonic::IntoRequest<super::NotesForVotingRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::NotesForVotingResponse>>,
             tonic::Status,
         > {
@@ -913,7 +953,15 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/NotesForVoting",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "NotesForVoting",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Returns authentication paths for the given note commitments.
         ///
@@ -924,7 +972,10 @@ pub mod view_protocol_service_client {
         pub async fn witness(
             &mut self,
             request: impl tonic::IntoRequest<super::WitnessRequest>,
-        ) -> Result<tonic::Response<super::WitnessResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::WitnessResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -938,12 +989,23 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/Witness",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "Witness",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         pub async fn witness_and_build(
             &mut self,
             request: impl tonic::IntoRequest<super::WitnessAndBuildRequest>,
-        ) -> Result<tonic::Response<super::WitnessAndBuildResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::WitnessAndBuildResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -957,14 +1019,22 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/WitnessAndBuild",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "WitnessAndBuild",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Queries for assets.
         /// Returns a stream of `AssetsResponse`s.
         pub async fn assets(
             &mut self,
             request: impl tonic::IntoRequest<super::AssetsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::AssetsResponse>>,
             tonic::Status,
         > {
@@ -981,13 +1051,24 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/Assets",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "Assets",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Query for the current app parameters.
         pub async fn app_parameters(
             &mut self,
             request: impl tonic::IntoRequest<super::AppParametersRequest>,
-        ) -> Result<tonic::Response<super::AppParametersResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::AppParametersResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1001,13 +1082,24 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/AppParameters",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "AppParameters",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Query for the current FMD parameters.
         pub async fn fmd_parameters(
             &mut self,
             request: impl tonic::IntoRequest<super::FmdParametersRequest>,
-        ) -> Result<tonic::Response<super::FmdParametersResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::FmdParametersResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1021,13 +1113,24 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/FMDParameters",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "FMDParameters",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Query for an address given an address index
         pub async fn address_by_index(
             &mut self,
             request: impl tonic::IntoRequest<super::AddressByIndexRequest>,
-        ) -> Result<tonic::Response<super::AddressByIndexResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::AddressByIndexResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1041,13 +1144,24 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/AddressByIndex",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "AddressByIndex",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Query for an address given an address index
         pub async fn index_by_address(
             &mut self,
             request: impl tonic::IntoRequest<super::IndexByAddressRequest>,
-        ) -> Result<tonic::Response<super::IndexByAddressResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::IndexByAddressResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1061,13 +1175,24 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/IndexByAddress",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "IndexByAddress",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Query for an ephemeral address
         pub async fn ephemeral_address(
             &mut self,
             request: impl tonic::IntoRequest<super::EphemeralAddressRequest>,
-        ) -> Result<tonic::Response<super::EphemeralAddressResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::EphemeralAddressResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1081,14 +1206,22 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/EphemeralAddress",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "EphemeralAddress",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Query for balance of a given address.
         /// Returns a stream of `BalancesResponses`.
         pub async fn balances(
             &mut self,
             request: impl tonic::IntoRequest<super::BalancesRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::BalancesResponse>>,
             tonic::Status,
         > {
@@ -1105,13 +1238,24 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/Balances",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "Balances",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Query for a note by its note commitment, optionally waiting until the note is detected.
         pub async fn note_by_commitment(
             &mut self,
             request: impl tonic::IntoRequest<super::NoteByCommitmentRequest>,
-        ) -> Result<tonic::Response<super::NoteByCommitmentResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::NoteByCommitmentResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1125,13 +1269,24 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/NoteByCommitment",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "NoteByCommitment",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Query for a swap by its swap commitment, optionally waiting until the swap is detected.
         pub async fn swap_by_commitment(
             &mut self,
             request: impl tonic::IntoRequest<super::SwapByCommitmentRequest>,
-        ) -> Result<tonic::Response<super::SwapByCommitmentResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::SwapByCommitmentResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1145,13 +1300,21 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/SwapByCommitment",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "SwapByCommitment",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Query for all unclaimed swaps.
         pub async fn unclaimed_swaps(
             &mut self,
             request: impl tonic::IntoRequest<super::UnclaimedSwapsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::UnclaimedSwapsResponse>>,
             tonic::Status,
         > {
@@ -1168,13 +1331,24 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/UnclaimedSwaps",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "UnclaimedSwaps",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Query for whether a nullifier has been spent, optionally waiting until it is spent.
         pub async fn nullifier_status(
             &mut self,
             request: impl tonic::IntoRequest<super::NullifierStatusRequest>,
-        ) -> Result<tonic::Response<super::NullifierStatusResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::NullifierStatusResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1188,13 +1362,21 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/NullifierStatus",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "NullifierStatus",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Query for a given transaction by its hash.
         pub async fn transaction_info_by_hash(
             &mut self,
             request: impl tonic::IntoRequest<super::TransactionInfoByHashRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::TransactionInfoByHashResponse>,
             tonic::Status,
         > {
@@ -1211,14 +1393,22 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/TransactionInfoByHash",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "TransactionInfoByHash",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Query for the full transactions in the given range of blocks.
         /// Returns a stream of `TransactionInfoResponse`s.
         pub async fn transaction_info(
             &mut self,
             request: impl tonic::IntoRequest<super::TransactionInfoRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::TransactionInfoResponse>>,
             tonic::Status,
         > {
@@ -1235,13 +1425,24 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/TransactionInfo",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "TransactionInfo",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Query for a transaction plan
         pub async fn transaction_planner(
             &mut self,
             request: impl tonic::IntoRequest<super::TransactionPlannerRequest>,
-        ) -> Result<tonic::Response<super::TransactionPlannerResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::TransactionPlannerResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1255,13 +1456,21 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/TransactionPlanner",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "TransactionPlanner",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Broadcast a transaction to the network, optionally waiting for full confirmation.
         pub async fn broadcast_transaction(
             &mut self,
             request: impl tonic::IntoRequest<super::BroadcastTransactionRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::BroadcastTransactionResponse>,
             tonic::Status,
         > {
@@ -1278,13 +1487,21 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/BroadcastTransaction",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "BroadcastTransaction",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// Query for owned position IDs for the given trading pair and in the given position state.
         pub async fn owned_position_ids(
             &mut self,
             request: impl tonic::IntoRequest<super::OwnedPositionIdsRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::OwnedPositionIdsResponse>>,
             tonic::Status,
         > {
@@ -1301,13 +1518,24 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/OwnedPositionIds",
             );
-            self.inner.server_streaming(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "OwnedPositionIds",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Authorize a transaction plan and build the transaction.
         pub async fn authorize_and_build(
             &mut self,
             request: impl tonic::IntoRequest<super::AuthorizeAndBuildRequest>,
-        ) -> Result<tonic::Response<super::AuthorizeAndBuildResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::AuthorizeAndBuildResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1321,7 +1549,15 @@ pub mod view_protocol_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewProtocolService/AuthorizeAndBuild",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "penumbra.view.v1alpha1.ViewProtocolService",
+                        "AuthorizeAndBuild",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -1339,7 +1575,7 @@ pub mod view_auth_service_client {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
-            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D: TryInto<tonic::transport::Endpoint>,
             D::Error: Into<StdError>,
         {
             let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
@@ -1395,10 +1631,29 @@ pub mod view_auth_service_client {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
         pub async fn view_auth(
             &mut self,
             request: impl tonic::IntoRequest<super::ViewAuthRequest>,
-        ) -> Result<tonic::Response<super::ViewAuthResponse>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::ViewAuthResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -1412,7 +1667,12 @@ pub mod view_auth_service_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/penumbra.view.v1alpha1.ViewAuthService/ViewAuth",
             );
-            self.inner.unary(request.into_request(), path, codec).await
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("penumbra.view.v1alpha1.ViewAuthService", "ViewAuth"),
+                );
+            self.inner.unary(req, path, codec).await
         }
     }
 }
@@ -1428,10 +1688,10 @@ pub mod view_protocol_service_server {
         async fn status(
             &self,
             request: tonic::Request<super::StatusRequest>,
-        ) -> Result<tonic::Response<super::StatusResponse>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<super::StatusResponse>, tonic::Status>;
         /// Server streaming response type for the StatusStream method.
         type StatusStreamStream: futures_core::Stream<
-                Item = Result<super::StatusStreamResponse, tonic::Status>,
+                Item = std::result::Result<super::StatusStreamResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -1440,10 +1700,13 @@ pub mod view_protocol_service_server {
         async fn status_stream(
             &self,
             request: tonic::Request<super::StatusStreamRequest>,
-        ) -> Result<tonic::Response<Self::StatusStreamStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::StatusStreamStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the Notes method.
         type NotesStream: futures_core::Stream<
-                Item = Result<super::NotesResponse, tonic::Status>,
+                Item = std::result::Result<super::NotesResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -1452,10 +1715,10 @@ pub mod view_protocol_service_server {
         async fn notes(
             &self,
             request: tonic::Request<super::NotesRequest>,
-        ) -> Result<tonic::Response<Self::NotesStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::NotesStream>, tonic::Status>;
         /// Server streaming response type for the NotesForVoting method.
         type NotesForVotingStream: futures_core::Stream<
-                Item = Result<super::NotesForVotingResponse, tonic::Status>,
+                Item = std::result::Result<super::NotesForVotingResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -1463,7 +1726,10 @@ pub mod view_protocol_service_server {
         async fn notes_for_voting(
             &self,
             request: tonic::Request<super::NotesForVotingRequest>,
-        ) -> Result<tonic::Response<Self::NotesForVotingStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::NotesForVotingStream>,
+            tonic::Status,
+        >;
         /// Returns authentication paths for the given note commitments.
         ///
         /// This method takes a batch of input commitments, rather than just one, so
@@ -1473,14 +1739,17 @@ pub mod view_protocol_service_server {
         async fn witness(
             &self,
             request: tonic::Request<super::WitnessRequest>,
-        ) -> Result<tonic::Response<super::WitnessResponse>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<super::WitnessResponse>, tonic::Status>;
         async fn witness_and_build(
             &self,
             request: tonic::Request<super::WitnessAndBuildRequest>,
-        ) -> Result<tonic::Response<super::WitnessAndBuildResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::WitnessAndBuildResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the Assets method.
         type AssetsStream: futures_core::Stream<
-                Item = Result<super::AssetsResponse, tonic::Status>,
+                Item = std::result::Result<super::AssetsResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -1489,35 +1758,50 @@ pub mod view_protocol_service_server {
         async fn assets(
             &self,
             request: tonic::Request<super::AssetsRequest>,
-        ) -> Result<tonic::Response<Self::AssetsStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::AssetsStream>, tonic::Status>;
         /// Query for the current app parameters.
         async fn app_parameters(
             &self,
             request: tonic::Request<super::AppParametersRequest>,
-        ) -> Result<tonic::Response<super::AppParametersResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::AppParametersResponse>,
+            tonic::Status,
+        >;
         /// Query for the current FMD parameters.
         async fn fmd_parameters(
             &self,
             request: tonic::Request<super::FmdParametersRequest>,
-        ) -> Result<tonic::Response<super::FmdParametersResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::FmdParametersResponse>,
+            tonic::Status,
+        >;
         /// Query for an address given an address index
         async fn address_by_index(
             &self,
             request: tonic::Request<super::AddressByIndexRequest>,
-        ) -> Result<tonic::Response<super::AddressByIndexResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::AddressByIndexResponse>,
+            tonic::Status,
+        >;
         /// Query for an address given an address index
         async fn index_by_address(
             &self,
             request: tonic::Request<super::IndexByAddressRequest>,
-        ) -> Result<tonic::Response<super::IndexByAddressResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::IndexByAddressResponse>,
+            tonic::Status,
+        >;
         /// Query for an ephemeral address
         async fn ephemeral_address(
             &self,
             request: tonic::Request<super::EphemeralAddressRequest>,
-        ) -> Result<tonic::Response<super::EphemeralAddressResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::EphemeralAddressResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the Balances method.
         type BalancesStream: futures_core::Stream<
-                Item = Result<super::BalancesResponse, tonic::Status>,
+                Item = std::result::Result<super::BalancesResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -1526,20 +1810,26 @@ pub mod view_protocol_service_server {
         async fn balances(
             &self,
             request: tonic::Request<super::BalancesRequest>,
-        ) -> Result<tonic::Response<Self::BalancesStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::BalancesStream>, tonic::Status>;
         /// Query for a note by its note commitment, optionally waiting until the note is detected.
         async fn note_by_commitment(
             &self,
             request: tonic::Request<super::NoteByCommitmentRequest>,
-        ) -> Result<tonic::Response<super::NoteByCommitmentResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::NoteByCommitmentResponse>,
+            tonic::Status,
+        >;
         /// Query for a swap by its swap commitment, optionally waiting until the swap is detected.
         async fn swap_by_commitment(
             &self,
             request: tonic::Request<super::SwapByCommitmentRequest>,
-        ) -> Result<tonic::Response<super::SwapByCommitmentResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::SwapByCommitmentResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the UnclaimedSwaps method.
         type UnclaimedSwapsStream: futures_core::Stream<
-                Item = Result<super::UnclaimedSwapsResponse, tonic::Status>,
+                Item = std::result::Result<super::UnclaimedSwapsResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -1547,23 +1837,29 @@ pub mod view_protocol_service_server {
         async fn unclaimed_swaps(
             &self,
             request: tonic::Request<super::UnclaimedSwapsRequest>,
-        ) -> Result<tonic::Response<Self::UnclaimedSwapsStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::UnclaimedSwapsStream>,
+            tonic::Status,
+        >;
         /// Query for whether a nullifier has been spent, optionally waiting until it is spent.
         async fn nullifier_status(
             &self,
             request: tonic::Request<super::NullifierStatusRequest>,
-        ) -> Result<tonic::Response<super::NullifierStatusResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::NullifierStatusResponse>,
+            tonic::Status,
+        >;
         /// Query for a given transaction by its hash.
         async fn transaction_info_by_hash(
             &self,
             request: tonic::Request<super::TransactionInfoByHashRequest>,
-        ) -> Result<
+        ) -> std::result::Result<
             tonic::Response<super::TransactionInfoByHashResponse>,
             tonic::Status,
         >;
         /// Server streaming response type for the TransactionInfo method.
         type TransactionInfoStream: futures_core::Stream<
-                Item = Result<super::TransactionInfoResponse, tonic::Status>,
+                Item = std::result::Result<super::TransactionInfoResponse, tonic::Status>,
             >
             + Send
             + 'static;
@@ -1572,20 +1868,32 @@ pub mod view_protocol_service_server {
         async fn transaction_info(
             &self,
             request: tonic::Request<super::TransactionInfoRequest>,
-        ) -> Result<tonic::Response<Self::TransactionInfoStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::TransactionInfoStream>,
+            tonic::Status,
+        >;
         /// Query for a transaction plan
         async fn transaction_planner(
             &self,
             request: tonic::Request<super::TransactionPlannerRequest>,
-        ) -> Result<tonic::Response<super::TransactionPlannerResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::TransactionPlannerResponse>,
+            tonic::Status,
+        >;
         /// Broadcast a transaction to the network, optionally waiting for full confirmation.
         async fn broadcast_transaction(
             &self,
             request: tonic::Request<super::BroadcastTransactionRequest>,
-        ) -> Result<tonic::Response<super::BroadcastTransactionResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::BroadcastTransactionResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the OwnedPositionIds method.
         type OwnedPositionIdsStream: futures_core::Stream<
-                Item = Result<super::OwnedPositionIdsResponse, tonic::Status>,
+                Item = std::result::Result<
+                    super::OwnedPositionIdsResponse,
+                    tonic::Status,
+                >,
             >
             + Send
             + 'static;
@@ -1593,12 +1901,18 @@ pub mod view_protocol_service_server {
         async fn owned_position_ids(
             &self,
             request: tonic::Request<super::OwnedPositionIdsRequest>,
-        ) -> Result<tonic::Response<Self::OwnedPositionIdsStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::OwnedPositionIdsStream>,
+            tonic::Status,
+        >;
         /// Authorize a transaction plan and build the transaction.
         async fn authorize_and_build(
             &self,
             request: tonic::Request<super::AuthorizeAndBuildRequest>,
-        ) -> Result<tonic::Response<super::AuthorizeAndBuildResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::AuthorizeAndBuildResponse>,
+            tonic::Status,
+        >;
     }
     /// The view protocol is used by a view client, who wants to do some
     /// transaction-related actions, to request data from a view service, which is
@@ -1612,6 +1926,8 @@ pub mod view_protocol_service_server {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: ViewProtocolService> ViewProtocolServiceServer<T> {
@@ -1624,6 +1940,8 @@ pub mod view_protocol_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -1647,6 +1965,22 @@ pub mod view_protocol_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for ViewProtocolServiceServer<T>
     where
@@ -1660,7 +1994,7 @@ pub mod view_protocol_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -1682,13 +2016,15 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::StatusRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).status(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1698,6 +2034,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -1721,7 +2061,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::StatusStreamRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).status_stream(request).await
                             };
@@ -1730,6 +2070,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1739,6 +2081,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -1762,13 +2108,15 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::NotesRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).notes(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1778,6 +2126,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -1801,7 +2153,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::NotesForVotingRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).notes_for_voting(request).await
                             };
@@ -1810,6 +2162,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1819,6 +2173,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -1841,13 +2199,15 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::WitnessRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).witness(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1857,6 +2217,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -1879,7 +2243,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::WitnessAndBuildRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).witness_and_build(request).await
                             };
@@ -1888,6 +2252,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1897,6 +2263,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -1920,13 +2290,15 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::AssetsRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).assets(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1936,6 +2308,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -1958,7 +2334,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::AppParametersRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).app_parameters(request).await
                             };
@@ -1967,6 +2343,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -1976,6 +2354,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -1998,7 +2380,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::FmdParametersRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).fmd_parameters(request).await
                             };
@@ -2007,6 +2389,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2016,6 +2400,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -2038,7 +2426,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::AddressByIndexRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).address_by_index(request).await
                             };
@@ -2047,6 +2435,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2056,6 +2446,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -2078,7 +2472,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::IndexByAddressRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).index_by_address(request).await
                             };
@@ -2087,6 +2481,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2096,6 +2492,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -2118,7 +2518,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::EphemeralAddressRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).ephemeral_address(request).await
                             };
@@ -2127,6 +2527,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2136,6 +2538,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -2159,13 +2565,15 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::BalancesRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).balances(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2175,6 +2583,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -2197,7 +2609,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::NoteByCommitmentRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).note_by_commitment(request).await
                             };
@@ -2206,6 +2618,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2215,6 +2629,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -2237,7 +2655,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::SwapByCommitmentRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).swap_by_commitment(request).await
                             };
@@ -2246,6 +2664,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2255,6 +2675,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -2278,7 +2702,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::UnclaimedSwapsRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).unclaimed_swaps(request).await
                             };
@@ -2287,6 +2711,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2296,6 +2722,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -2318,7 +2748,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::NullifierStatusRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).nullifier_status(request).await
                             };
@@ -2327,6 +2757,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2336,6 +2768,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -2358,7 +2794,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::TransactionInfoByHashRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).transaction_info_by_hash(request).await
                             };
@@ -2367,6 +2803,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2376,6 +2814,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -2400,7 +2842,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::TransactionInfoRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).transaction_info(request).await
                             };
@@ -2409,6 +2851,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2418,6 +2862,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -2440,7 +2888,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::TransactionPlannerRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).transaction_planner(request).await
                             };
@@ -2449,6 +2897,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2458,6 +2908,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -2480,7 +2934,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::BroadcastTransactionRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).broadcast_transaction(request).await
                             };
@@ -2489,6 +2943,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2498,6 +2954,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -2522,7 +2982,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::OwnedPositionIdsRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).owned_position_ids(request).await
                             };
@@ -2531,6 +2991,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2540,6 +3002,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
                         Ok(res)
@@ -2562,7 +3028,7 @@ pub mod view_protocol_service_server {
                             &mut self,
                             request: tonic::Request<super::AuthorizeAndBuildRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 (*inner).authorize_and_build(request).await
                             };
@@ -2571,6 +3037,8 @@ pub mod view_protocol_service_server {
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2580,6 +3048,10 @@ pub mod view_protocol_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -2608,12 +3080,14 @@ pub mod view_protocol_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: ViewProtocolService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
@@ -2637,13 +3111,18 @@ pub mod view_auth_service_server {
         async fn view_auth(
             &self,
             request: tonic::Request<super::ViewAuthRequest>,
-        ) -> Result<tonic::Response<super::ViewAuthResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ViewAuthResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct ViewAuthServiceServer<T: ViewAuthService> {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
     impl<T: ViewAuthService> ViewAuthServiceServer<T> {
@@ -2656,6 +3135,8 @@ pub mod view_auth_service_server {
                 inner,
                 accept_compression_encodings: Default::default(),
                 send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
             }
         }
         pub fn with_interceptor<F>(
@@ -2679,6 +3160,22 @@ pub mod view_auth_service_server {
             self.send_compression_encodings.enable(encoding);
             self
         }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
     }
     impl<T, B> tonic::codegen::Service<http::Request<B>> for ViewAuthServiceServer<T>
     where
@@ -2692,7 +3189,7 @@ pub mod view_auth_service_server {
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -2714,13 +3211,15 @@ pub mod view_auth_service_server {
                             &mut self,
                             request: tonic::Request<super::ViewAuthRequest>,
                         ) -> Self::Future {
-                            let inner = self.0.clone();
+                            let inner = Arc::clone(&self.0);
                             let fut = async move { (*inner).view_auth(request).await };
                             Box::pin(fut)
                         }
                     }
                     let accept_compression_encodings = self.accept_compression_encodings;
                     let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
@@ -2730,6 +3229,10 @@ pub mod view_auth_service_server {
                             .apply_compression_config(
                                 accept_compression_encodings,
                                 send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
@@ -2758,12 +3261,14 @@ pub mod view_auth_service_server {
                 inner,
                 accept_compression_encodings: self.accept_compression_encodings,
                 send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
             }
         }
     }
     impl<T: ViewAuthService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
-            Self(self.0.clone())
+            Self(Arc::clone(&self.0))
         }
     }
     impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {

--- a/tools/proto-compiler/Cargo.lock
+++ b/tools/proto-compiler/Cargo.lock
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -728,11 +728,10 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "bytes",
  "prost",
 ]
 
@@ -1099,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/tools/proto-compiler/Cargo.toml
+++ b/tools/proto-compiler/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1"
 prost = "0.11"
 prost-types = "0.11"
 prost-build = "0.11"
-tonic-build = { version = "0.8.0", features = ["cleanup-markdown"] }
+tonic-build = { version = "0.9.0", features = ["cleanup-markdown"] }
 pbjson = "0.5"
 pbjson-types = "0.5"
 pbjson-build = "0.5"


### PR DESCRIPTION
This generates `max_decoding_message_size` methods we need to configure the summoner service.