### PR TITLE
abci query: support nonexistence proofs

### DIFF
--- a/crates/bin/pd/src/info.rs
+++ b/crates/bin/pd/src/info.rs
@@ -147,9 +147,8 @@ impl Info {
                         format!("failed to get key {}", String::from_utf8_lossy(&key))
                     })?;
 
-                let Some((value, proof_ops)) = rsp else {
-                    anyhow::bail!("key not found")
-                };
+                let (value, proof_ops) = rsp;
+                let value = value.unwrap_or_else(Vec::new);
 
                 Ok(response::Query {
                     code: 0.into(),

--- a/crates/core/component/chain/src/component/app_hash.rs
+++ b/crates/core/component/chain/src/component/app_hash.rs
@@ -76,7 +76,7 @@ pub trait AppHashRead {
     async fn get_with_proof_to_apphash_tm(
         &self,
         key: Vec<u8>,
-    ) -> anyhow::Result<Option<(Vec<u8>, tendermint::merkle::proof::ProofOps)>>;
+    ) -> anyhow::Result<(Option<Vec<u8>>, tendermint::merkle::proof::ProofOps)>;
 
     async fn app_hash(&self) -> anyhow::Result<AppHash>;
 }
@@ -126,10 +126,8 @@ impl AppHashRead for Snapshot {
     async fn get_with_proof_to_apphash_tm(
         &self,
         key: Vec<u8>,
-    ) -> Result<Option<(Vec<u8>, TendermintMerkleProof)>> {
-        let (Some(value), ics23_proof) = self.get_with_proof_to_apphash(key.to_vec()).await? else {
-            return Ok(None);
-        };
+    ) -> Result<(Option<Vec<u8>>, TendermintMerkleProof)> {
+        let (value, ics23_proof) = self.get_with_proof_to_apphash(key.to_vec()).await?;
 
         let jmt_op = tendermint::merkle::proof::ProofOp {
             field_type: "jmt:v".to_string(),
@@ -146,7 +144,7 @@ impl AppHashRead for Snapshot {
             ops: vec![jmt_op, root_op],
         };
 
-        Ok(Some((value, proof)))
+        Ok((value, proof))
     }
 }
 


### PR DESCRIPTION
Previously, we would error in the ABCI query interface if a key was not found. This PR changes that behavior to instead return an empty vec for the requested value, along with a nonexistence proof to the root hash showing the value doesn't exist in the state.

This is required for relayers to build timeout packets. I verified that this change works locally using hermes.