### PR TITLE
ci: fix moon names in host monikers

### DIFF
--- a/deployments/helmfile.d/vars/penumbra-devnet-nodes-ips.yml
+++ b/deployments/helmfile.d/vars/penumbra-devnet-nodes-ips.yml
@@ -5,4 +5,4 @@ nodes:
   - external_address: 34.16.34.194:26656
     moniker: deimos
   - external_address: 34.173.166.32:26656
-    moniker: naid
+    moniker: naiad

--- a/deployments/helmfile.d/vars/penumbra-preview-nodes-ips.yml
+++ b/deployments/helmfile.d/vars/penumbra-preview-nodes-ips.yml
@@ -5,6 +5,6 @@ nodes:
   - external_address: 34.28.180.178:26656
     moniker: deimos
   - external_address: 34.42.196.153:26656
-    moniker: naid
+    moniker: naiad
   - external_address: 35.239.76.154:26656
     moniker: thalassa

--- a/deployments/helmfile.d/vars/penumbra-testnet-nodes-ips.yml
+++ b/deployments/helmfile.d/vars/penumbra-testnet-nodes-ips.yml
@@ -5,6 +5,6 @@ nodes:
   - external_address: 35.224.80.161:26656
     moniker: deimos
   - external_address: 34.68.200.112:26656
-    moniker: naid
+    moniker: naiad
   - external_address: 35.192.219.42:26656
     moniker: thalassa

--- a/deployments/scripts/get-lb-ips
+++ b/deployments/scripts/get-lb-ips
@@ -14,7 +14,7 @@ fi
 # Declare monikers for nodes on the network.
 # These monikers will be added to the generated vars file,
 # alongside the IP info.
-node_names=(phobos-seed deimos naid thalassa)
+node_names=(phobos-seed deimos naiad thalassa)
 
 HELM_RELEASE="${1:-}"
 shift 1


### PR DESCRIPTION
Follow up to #3155. We've been using moon names as a mnemonic for human-readable names for services related to Penumbra testnets. Due to a typo, the moon of Neptune "Naiad" was misspelled, and that typo made it into a few config files. This is a purely cosmetic change with zero impact on service behavior or performance.