### PR TITLE
docs: update cometbft to v0.37.2 for Testnet 62

### DIFF
--- a/docs/guide/src/pd/build.md
+++ b/docs/guide/src/pd/build.md
@@ -14,17 +14,12 @@ which you can safely ignore.
 
 ### Installing CometBFT
 
-You'll need to have [CometBFT installed](https://docs.cometbft.com/v0.34/guides/install)
+You'll need to have [CometBFT installed](https://docs.cometbft.com/v0.37/guides/install)
 on your system to join your node to the testnet.
 
-**NOTE**: Previous versions of Penumbra used Tendermint, but as of Testnet 61 (released 2023-09-25),
-only CometBFT is supported. **Do not use** any version of Tendermint, which may not work with `pd`.
-As of Testnet 62 (scheduled for 2023-10-10), Penumbra will use CometBFT v0.37.2.
+**NOTE**: Previous versions of Penumbra used Tendermint, but as of Testnet 62 (released 2023-10-10),
+only CometBFT `v0.37.2` is supported. **Do not use** any version of Tendermint, which may not work with `pd`.
 
-You can download `v0.34.27` [from the CometBFT releases page](https://github.com/cometbft/cometbft/releases/tag/v0.34.27)
+You can download `v0.37.2` [from the CometBFT releases page](https://github.com/cometbft/cometbft/releases/tag/v0.37.2)
 to install a binary. If you prefer to compile from source instead,
-make sure you are compiling version `v0.34.27`:
-
-```bash
-git checkout v0.34.27
-```
+make sure you are compiling version `v0.37.2`.

--- a/docs/guide/src/pd/join-testnet.md
+++ b/docs/guide/src/pd/join-testnet.md
@@ -4,7 +4,7 @@ We provide instructions for running both fullnode deployments and validator depl
 fullnode will sync with the network but will not have any voting power, and will
 not be eligible for staking or funding stream rewards. For more information on
 what a fullnode is, see the [CometBFT
-documentation](https://docs.cometbft.com/v0.34/core/using-cometbft#adding-a-non-validator).
+documentation](https://docs.cometbft.com/v0.37/core/using-cometbft#adding-a-non-validator).
 
 A regular validator will participate in voting and rewards, if it becomes part
 of the consensus set.  Of course, these rewards, like all other testnet tokens,


### PR DESCRIPTION
Revert "docs: revert to cometbft v034 for testnet docs" This reverts commit be6e8aa952360fd7b766b2cb69f9518410a4ad3f.

Sprinkles in some clarifying language based on discussion in Discord.