### PR TITLE
deploy: update docker-compose setup

### DIFF
--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -1,6 +1,7 @@
 ---
 # docker-compose file for running a Penumbra node.
-# Requires testnet config generation on the host machine.
+# Stores the node config in a docker "volume", which should be
+# reset between testnets: `docker volume rm compose_penumbra-pd-node0` or similar.
 # See docs for details:  https://guide.penumbra.zone/main/pd/join-testnet.html
 
 # N.B. the "latest" tag for Penumbra container images maps to the latest
@@ -8,25 +9,45 @@
 version: "3.7"
 services:
 
-  # The Penumbra daemon
-  pd-node0:
+  # Initialize node config, via `pd testnet join`.
+  pd-node0-init:
     image: ghcr.io/penumbra-zone/penumbra:latest
-    environment:
-      - RUST_LOG=info,pd=debug,penumbra=debug,jmt=debug
     command: >-
       sh -c
       "
+      pd --version &&
       if ! test -e /pd/testnet_data/node0/cometbft/config/config.toml ; then
-          >&2 printf 'ERROR: testnet config not found. Run `pd testnet join` on the host machine.'
+          >&2 printf 'WARN: testnet config not found. Creating fresh node identity.'
           >&2 echo ' See docs for details: https://guide.penumbra.zone/main/pd/join-testnet.html'
-          exit 1
+          /bin/pd testnet --testnet-dir /pd/testnet_data join
+      else
+          >&2 echo 'Node config already found, using it'
       fi &&
-      /bin/pd start --home /pd/testnet_data/node0/pd --grpc-bind 0.0.0.0:8080 --abci-bind 0.0.0.0:26658
+      chown 100 -R /pd/testnet_data/node0/cometbft &&
+      chown 1000 -R /pd/testnet_data/node0/pd &&
+      ls -l /pd/testnet_data/node0/ && exit 0
       "
     restart: on-failure
     volumes:
-      - ~/.penumbra:/pd
+      - penumbra-pd-node0:/pd
+    # run initcontainer as root so we can chown dirs for app containers.
+    user: "0"
+
+  # The Penumbra daemon
+  pd-node0:
+    image: ghcr.io/penumbra-zone/penumbra:latest
+    # consider verbose debugging logs:
+    # environment:
+      # RUST_LOG: h2=off,debug
+    command: >-
+      /bin/pd start --home /pd/testnet_data/node0/pd
+      --grpc-bind 0.0.0.0:8080 --abci-bind 0.0.0.0:26658
+    restart: on-failure
+    volumes:
+      - penumbra-pd-node0:/pd
     user: "${UID:-1000}"
+    depends_on:
+      - pd-node0-init
     ports:
       - "26658:26658"
       - "8080:8080"
@@ -34,16 +55,16 @@ services:
   # The CometBFT node
   cometbft-node0:
     image: "docker.io/cometbft/cometbft:v0.37.2"
-    user: "${UID:-1000}"
     ports:
       - "26656:26656"
       - "26657:26657"
     volumes:
-      - ~/.penumbra/testnet_data/node0/cometbft:/cometbft
-    entrypoint: cometbft
-    command: start --proxy_app=tcp://pd-node0:26658
+      - penumbra-pd-node0:/cometbft
     environment:
-      - ID=0
-      - LOG=${LOG:-cometbft.log}
+      CMTHOME: /cometbft/testnet_data/node0/cometbft
+    command: start --proxy_app=tcp://pd-node0:26658
     depends_on:
       - pd-node0
+
+volumes:
+  penumbra-pd-node0: {}


### PR DESCRIPTION
Dusted off the compose setup and updated it to use an initcontainer, same as with the recent overhaul of deploy logic (#2983). This change also removes the requirement for the host machine to use `pd` to bootstrap the config: now, docker-compose is all that's required. The goal is to make the Penumbra containers easier to work with, for example for the block explorer push.