### PR TITLE
Make Summonerd a bit more responsive & Fix ranking bug

### DIFF
--- a/tools/summonerd/src/coordinator.rs
+++ b/tools/summonerd/src/coordinator.rs
@@ -1,126 +1,64 @@
 use std::{collections::HashMap, time::Duration};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use penumbra_keys::Address;
 use penumbra_num::Amount;
 use rand::rngs::OsRng;
-use tokio::sync::mpsc::{self, error::TryRecvError};
+use tokio::sync::mpsc::{self};
+use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 
 use crate::{participant::Participant, storage::Storage};
 
 /// Wait time of 10 minutes
 const CONTRIBUTION_TIME_SECS: u64 = 10 * 60;
 
-pub struct Coordinator {
+struct ContributionHandler {
     storage: Storage,
-    participants: HashMap<Address, (Participant, Amount)>,
-    new_participant_rx: mpsc::Receiver<(Participant, Amount)>,
+    start_contribution_rx: mpsc::Receiver<(Address, Participant)>,
+    done_contribution_tx: mpsc::Sender<()>,
 }
 
-impl Coordinator {
-    pub fn new(storage: Storage) -> (Self, mpsc::Sender<(Participant, Amount)>) {
-        let (new_participant_tx, new_participant_rx) = mpsc::channel(9001);
+impl ContributionHandler {
+    pub fn new(
+        storage: Storage,
+    ) -> (
+        Self,
+        mpsc::Sender<(Address, Participant)>,
+        mpsc::Receiver<()>,
+    ) {
+        let (start_contribution_tx, start_contribution_rx) = mpsc::channel(1);
+        let (done_contribution_tx, done_contribution_rx) = mpsc::channel(1);
         (
             Self {
                 storage,
-                participants: HashMap::new(),
-                new_participant_rx,
+                start_contribution_rx,
+                done_contribution_tx,
             },
-            new_participant_tx,
+            start_contribution_tx,
+            done_contribution_rx,
         )
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn run(mut self) -> Result<()> {
         loop {
-            tracing::debug!(
-                participant_count = self.participants.len(),
-                "top of coordinator loop"
-            );
-            // 0. Wait for the first participant
-            if self.participants.is_empty() {
-                self.wait_for_participant().await?;
-            }
-            // 1. Check for new connections, but don't wait for them.
-            self.dequeue_participants()?;
-            // 2. Score connections
-            self.prune_participants();
-            let ranked = self.score_participants();
-            // In theory ranked could've become empty for some reason in the meantime
-            if ranked.is_empty() {
-                continue;
-            }
-            // 3. Update everyone on status.
-            let contributor = ranked[0];
-            let contributor_bid = self.participants[&contributor].1;
-            self.inform_participants_of_status(&ranked, contributor_bid)
-                .await;
-            // 5. Get contribution, or error if they don't respond quickly enough
-            self.contribute(contributor).await?;
-            // 6. Remove from pool regardless of what happened
-            self.participants.remove(&contributor);
-        }
-    }
-}
-
-impl Coordinator {
-    async fn wait_for_participant(&mut self) -> Result<()> {
-        if let Some((participant, bid)) = self.new_participant_rx.recv().await {
-            let address = participant.address();
-            tracing::info!(?address, "has been added as a participant");
-            self.participants.insert(address, (participant, bid));
-            Ok(())
-        } else {
-            Err(anyhow!("Participant queue was closed"))
-        }
-    }
-
-    fn dequeue_participants(&mut self) -> Result<()> {
-        loop {
-            match self.new_participant_rx.try_recv() {
-                Ok((participant, bid)) => {
-                    let address = participant.address();
-                    tracing::info!(?address, "has been added as a participant");
-                    self.participants.insert(address, (participant, bid));
+            let (who, participant) = match self.start_contribution_rx.recv().await {
+                None => {
+                    tracing::debug!("start channel closed.");
+                    return Ok(());
                 }
-                Err(TryRecvError::Empty) => return Ok(()),
-                Err(e @ TryRecvError::Disconnected) => {
-                    return Err(e).with_context(|| "Channel with incoming connections was closed")
-                }
-            }
-        }
-    }
-
-    fn prune_participants(&mut self) {
-        self.participants
-            .retain(|_, (connection, _)| connection.is_live());
-    }
-
-    fn score_participants(&self) -> Vec<Address> {
-        let mut out: Vec<Address> = self.participants.keys().cloned().collect();
-        out.sort_by_cached_key(|addr| self.participants[addr].1);
-        out
-    }
-
-    async fn inform_participants_of_status(&mut self, ranked: &[Address], contributor_bid: Amount) {
-        for (i, address) in ranked.iter().enumerate() {
-            let (connection, bid) = self
-                .participants
-                .get(address)
-                .expect("Ranked participants are chosen from the set of connections");
-            if let Err(e) =
-                connection.try_notify(i as u32, ranked.len() as u32, contributor_bid, *bid)
-            {
-                tracing::info!(?e, ?address, "pruning connection that we failed to notify");
-                self.participants.remove(address);
+                Some((w, p)) => (w, p),
             };
+            self.contribute(who, participant).await?;
+            self.done_contribution_tx.send(()).await?;
         }
     }
 
-    #[tracing::instrument(skip(self))]
-    async fn contribute(&mut self, contributor: Address) -> Result<()> {
+    #[tracing::instrument(skip(self, participant))]
+    async fn contribute(&mut self, contributor: Address, participant: Participant) -> Result<()> {
         match tokio::time::timeout(
             Duration::from_secs(CONTRIBUTION_TIME_SECS),
-            self.contribute_inner(contributor),
+            self.contribute_inner(contributor, participant),
         )
         .await
         {
@@ -133,13 +71,13 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(skip(self))]
-    async fn contribute_inner(&mut self, contributor: Address) -> Result<()> {
+    #[tracing::instrument(skip(self, participant))]
+    async fn contribute_inner(
+        &mut self,
+        contributor: Address,
+        mut participant: Participant,
+    ) -> Result<()> {
         let parent = self.storage.current_crs().await?;
-        let (participant, _) = self
-            .participants
-            .get_mut(&contributor)
-            .expect("We ask for the contributions of participants we're connected to");
         let maybe = participant.contribute(&parent).await?;
         if let Some(unvalidated) = maybe {
             if let Some(contribution) =
@@ -158,5 +96,145 @@ impl Coordinator {
         }
         self.storage.strike(&contributor).await?;
         return Ok(());
+    }
+}
+
+struct ParticipantQueue {
+    participants: HashMap<Address, (Participant, Amount)>,
+}
+
+impl ParticipantQueue {
+    fn new() -> Self {
+        Self {
+            participants: HashMap::new(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.participants.len()
+    }
+
+    fn bid(&self, address: &Address) -> Option<Amount> {
+        self.participants.get(address).map(|(_, bid)| *bid)
+    }
+
+    fn add(&mut self, participant: Participant, bid: Amount) {
+        let address = participant.address();
+        tracing::info!(?address, "has been added as a participant");
+        self.participants.insert(address, (participant, bid));
+    }
+
+    fn prune(&mut self) {
+        self.participants
+            .retain(|_, (connection, _)| connection.is_live());
+    }
+
+    fn score(&self) -> Vec<Address> {
+        let mut out: Vec<Address> = self.participants.keys().cloned().collect();
+        out.sort_by_cached_key(|addr| self.participants[addr].1);
+        out
+    }
+
+    fn remove(&mut self, address: &Address) -> Option<(Participant, Amount)> {
+        self.participants.remove(address)
+    }
+
+    async fn inform(&mut self, ranked: &[Address], contributor_bid: Amount) {
+        for (i, address) in ranked.iter().enumerate() {
+            let (connection, bid) = self
+                .participants
+                .get(address)
+                .expect("Ranked participants are chosen from the set of connections");
+            if let Err(e) =
+                connection.try_notify(i as u32, ranked.len() as u32, contributor_bid, *bid)
+            {
+                tracing::info!(?e, ?address, "pruning connection that we failed to notify");
+                self.participants.remove(address);
+            };
+        }
+    }
+}
+
+pub struct Coordinator {
+    storage: Storage,
+    participants: ParticipantQueue,
+    new_participant_rx: mpsc::Receiver<(Participant, Amount)>,
+}
+
+impl Coordinator {
+    pub fn new(storage: Storage) -> (Self, mpsc::Sender<(Participant, Amount)>) {
+        let (new_participant_tx, new_participant_rx) = mpsc::channel(9001);
+        (
+            Self {
+                storage,
+                participants: ParticipantQueue::new(),
+                new_participant_rx,
+            },
+            new_participant_tx,
+        )
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        enum Event {
+            NewParticipant(Participant, Amount),
+            ContributionDone,
+        }
+
+        let (contribution_handler, start_contribution_tx, done_contribution_rx) =
+            ContributionHandler::new(self.storage);
+        tokio::spawn(contribution_handler.run());
+        // Merge the events from both being notified of new participants, and of completed
+        // contributions.
+        let mut stream = ReceiverStream::new(self.new_participant_rx)
+            .map(|(participant, bid)| Event::NewParticipant(participant, bid))
+            .merge(ReceiverStream::new(done_contribution_rx).map(|_| Event::ContributionDone));
+
+        // We start by needing a contribution.
+        let mut want_contribution = true;
+        loop {
+            tracing::debug!(
+                participant_count = self.participants.len(),
+                "top of coordinator loop"
+            );
+            // 1. Wait for a new event
+            match stream.next().await {
+                None => anyhow::bail!("coordinator event stream closed unexpectedly."),
+                Some(Event::NewParticipant(participant, bid)) => {
+                    self.participants.add(participant, bid);
+                }
+                Some(Event::ContributionDone) => {
+                    // We always want a new contribution now.
+                    want_contribution = true;
+                }
+            }
+            // 2. Score connections
+            self.participants.prune();
+            let ranked = self.participants.score();
+            // In theory ranked could've become empty for some reason in the meantime
+            if ranked.is_empty() {
+                continue;
+            }
+            // 3. Update everyone on status.
+            let contributor = ranked[0];
+            let contributor_bid = self
+                .participants
+                .bid(&contributor)
+                .expect("contributor should be in participant queue");
+            self.participants.inform(&ranked, contributor_bid).await;
+            // 4. If we want a new contribution, get that process going.
+            if want_contribution {
+                // 5. Remove from pool regardless of what will happen
+                let (participant, _) = self
+                    .participants
+                    .remove(&contributor)
+                    .expect("the selected contributor exists");
+                start_contribution_tx
+                    .send((contributor, participant))
+                    .await
+                    .map_err(|_| anyhow!("failed to send start contribution message to handler"))?;
+                // 6. We no longer want to make a new contribution until this one finishes.
+                want_contribution = false;
+            }
+        }
     }
 }


### PR DESCRIPTION
No issue addressed here, but this is a quick fix to the coordinator loop to be able to send updates to clients whenever the queue changes.

I also took the opportunity to fix a bug I noticed, which was that by sorting addresses by the amount bid, we were then choosing the lowest bid, and not the highest.

The idea with the new queue is to create a merged event stream of new participants, and the completion of contributions, and then react to which of those is happening first in the loop accordingly.