### PR TITLE
penumbra: regen proto with `protoc@24.4`

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -55,7 +55,7 @@ jobs:
           toolchain: stable
           override: false
 
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@v1.27.1
         with:
           buf_api_token: ${{ secrets.BUF_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +68,7 @@ jobs:
           curl -sSfL -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
           unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d $HOME/.local
         env:
-          PROTOC_VERSION: "23.3"
+          PROTOC_VERSION: "24.4"
 
       # We exclude the proto_descriptor file from diff inspection, since
       # different versions of `protoc` can generate non-substantive changes,

--- a/docs/guide/src/dev/protobuf.md
+++ b/docs/guide/src/dev/protobuf.md
@@ -17,12 +17,18 @@ The Rust code files are generated with our own tooling, located at `tools/proto-
 
 The `protoc` tool is required to generate our protobuf specs via `tools/proto-compiler`.
 We mandate the use of a specific major version of the `protoc` tool, to make outputs
-predictable. Currently, the supported version is `23.x`. Obtain the most recent
+predictable. Currently, the supported version is `24.x`. Obtain the most recent
 pre-compiled binary from the [`protoc` website] for that major version.
 After installing, run `protoc --version` and confirm you're running
-at least `23.3` (or newer). Don't install `protoc` from package managers
+at least `24.4` (or newer). Don't install `protoc` from package managers
 such as `apt`, as those versions are often outdated, and will not work
 with Penumbra.
+
+To install the protoc tool from the zip file, extract it to a directory on your PATH:
+
+```shell
+unzip protoc-24.4-linux-x86_64.zip -d ~/.local/
+```
 
 ## Installing buf
 
@@ -30,7 +36,7 @@ The `buf` tool is required to update lockfiles used for version management in
 the [Buf Schema Registry](https://buf.build.penumbra-zone/penumbra). Visit
 the [buf download page](https://buf.build/docs/installation/) to obtain a version.
 After installing, run `buf --version` and confirm you're running at least
-`1.17.0` (or newer).
+`1.27.0` (or newer).
 
 ## Building protos
 


### PR DESCRIPTION
For some reason, I was able to work around the caching issue locally by upgrading to `protoc@24.4` and `buf@1.27`