### PR TITLE
test: run e2e test of ceremony in CI

### DIFF
--- a/.github/workflows/summoner_smoke.yml
+++ b/.github/workflows/summoner_smoke.yml
@@ -1,0 +1,29 @@
+name: Summoner smoke Test
+on:
+  pull_request: # Temp: for testing only, this will be slow so will run on demand
+  push:
+    branches:
+      - main
+
+jobs:
+  smoke_test:
+    runs-on: buildjet-16vcpu-ubuntu-2004
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    environment: smoke-test
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Load rust cache
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
+
+      - name: Run e2e test of summoner
+        run: |
+          export PATH="$HOME/bin:$PATH"
+          ./deployments/scripts/smoke-summoner.sh

--- a/.github/workflows/summoner_smoke.yml
+++ b/.github/workflows/summoner_smoke.yml
@@ -1,6 +1,6 @@
 name: Summoner smoke Test
 on:
-  pull_request: # Temp: for testing only, this will be slow so will run on demand
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/summoner_smoke.yml
+++ b/.github/workflows/summoner_smoke.yml
@@ -1,6 +1,9 @@
+# Since the summoner smoke test takes ~18m to run, we don't want
+# to run it on every PR. Instead, we want to run it on demand,
+# and for now on merges into `main`.
 name: Summoner smoke Test
 on:
-  pull_request:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/summoner_smoke.yml
+++ b/.github/workflows/summoner_smoke.yml
@@ -23,6 +23,18 @@ jobs:
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
 
+      - name: Install cometbft binary
+        run: |
+          COMETBFT_VERSION="0.37.2"
+          curl -L -O "https://github.com/cometbft/cometbft/releases/download/v${COMETBFT_VERSION}/cometbft_${COMETBFT_VERSION}_linux_amd64.tar.gz"
+          tar -xzf "cometbft_${COMETBFT_VERSION}_linux_amd64.tar.gz" cometbft
+          mkdir -p $HOME/bin
+          cp cometbft $HOME/bin
+          echo $PATH
+          export PATH=$HOME/bin:$PATH
+          which cometbft
+          cometbft version
+
       - name: Run e2e test of summoner
         run: |
           export PATH="$HOME/bin:$PATH"

--- a/crates/bin/pcli/src/command/ceremony.rs
+++ b/crates/bin/pcli/src/command/ceremony.rs
@@ -102,6 +102,11 @@ impl CeremonyCmd {
                 handle_bid(app, *coordinator_address, index, bid).await?;
                 let address = app.fvk.payment_address(index).0;
 
+                // After we bid, we need to wait a couple of seconds just for the transaction to be
+                // picked up by the coordinator. Else, there is a race wherein the coordinator will kick the
+                // client out of the queue because it doesn't see the transaction yet.
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
                 let (req_tx, req_rx) = mpsc::channel::<ParticipateRequest>(10);
                 tracing::debug!(?address, "participate request");
                 req_tx

--- a/deployments/scripts/smoke-summoner.sh
+++ b/deployments/scripts/smoke-summoner.sh
@@ -82,10 +82,10 @@ cargo run --quiet --release --bin pcli -- --node http://127.0.0.1:8080 --home /t
 echo "Stopping phase 1 run..."
 if ! kill -0 "$phase1_pid" ; then
     >&2 echo "ERROR: phase 1 exited early"
-    kill -9 "$phase1_pid"
     exit 1
 else
-    echo "Phase 1 complete."
+    echo "Phase 1 complete. Stopping phase 1 run..."
+    kill -9 "$phase1_pid"
 fi
 
 echo "Transitioning..."
@@ -105,10 +105,10 @@ cargo run --quiet --release --bin pcli -- --node http://127.0.0.1:8080 --home /t
 echo "Stopping phase 2 run..."
 if ! kill -0 "$phase2_pid" ; then
     >&2 echo "ERROR: phase 2 exited early"
-    kill -9 "$phase2_pid"
     exit 1
 else
-    echo "Phase 2 complete."
+    echo "Phase 2 complete. Stopping phase 2 run..."
+    kill -9 "$phase2_pid"
 fi
 
 rm -rf /tmp/summonerd

--- a/deployments/scripts/smoke-summoner.sh
+++ b/deployments/scripts/smoke-summoner.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Run e2e summoner ceremony in CI
+set -euo pipefail
+
+export RUST_LOG="summonerd=info,pcli=info"
+# This is not a secret, it is a test account seed phrase, used for integration tests like this one only.
+export SEED_PHRASE="comfort ten front cycle churn burger oak absent rice ice urge result art couple benefit cabbage frequent obscure hurry trick segment cool job debate"
+
+echo "Building latest version of summonerd from source..."
+cargo build --quiet --release --bin summonerd
+
+echo "Generating phase 1 root..."
+cargo run --quiet --release --bin summonerd -- generate-phase1 --output phase1.bin
+
+echo "Setting up storage directory..."
+mkdir /tmp/summonerd
+cargo run --quiet --release --bin pcli -- --home /tmp/summonerd --node https://grpc.testnet-preview.penumbra.zone keys generate
+export SUMMONER_ADDRESS=$(PCLI_UNLEASH_DANGER="yes" cargo run --quiet --release --bin pcli -- --home /tmp/summonerd --node https://grpc.testnet-preview.penumbra.zone view address 0 2>&1)
+export SUMMONER_FVK=$(PCLI_UNLEASH_DANGER="yes" cargo run --quiet --release --bin pcli -- --home /tmp/summonerd --node https://grpc.testnet-preview.penumbra.zone keys export full-viewing-key 2>&1)
+
+echo "Starting phase 1 run..."
+cargo run --quiet --release --bin summonerd -- start --phase 1 --storage-dir /tmp/summonerd --fvk $SUMMONER_FVK --node https://grpc.testnet-preview.penumbra.zone &
+phase1_pid="$!"
+echo $phase1_pid
+# If script ends early, ensure phase 1 is halted.
+trap 'kill -9 "$phase1_pid"' EXIT
+
+echo "Setting up test accounts..."
+# We are returning 0 always here because the backup wallet file does not respect the location of
+# the home directory.
+echo $SEED_PHRASE | cargo run --quiet --release --bin pcli -- --home /tmp/account1 keys import phrase || true
+export ACCOUNT1_ADDRESS=$(PCLI_UNLEASH_DANGER="yes" cargo run --quiet --release --bin pcli -- --home /tmp/account1 --node https://grpc.testnet-preview.penumbra.zone view address 0 2>&1)
+
+cargo run --quiet --release --bin pcli -- --home /tmp/account2 --node https://grpc.testnet-preview.penumbra.zone keys generate || true
+export ACCOUNT2_ADDRESS=$(PCLI_UNLEASH_DANGER="yes" cargo run --quiet --release --bin pcli -- --home /tmp/account2 --node https://grpc.testnet-preview.penumbra.zone view address 0 2>&1)
+cargo run --quiet --release --bin pcli -- --home /tmp/account3 --node https://grpc.testnet-preview.penumbra.zone keys generate || true
+export ACCOUNT3_ADDRESS=$(PCLI_UNLEASH_DANGER="yes" cargo run --quiet --release --bin pcli -- --home /tmp/account3 --node https://grpc.testnet-preview.penumbra.zone view address 0 2>&1)
+# TODO: Send tokens to test accounts 2 and 3
+
+echo "Phase 1 contributions..."
+cargo run --quiet --release --bin pcli -- --node https://grpc.testnet-preview.penumbra.zone --home /tmp/account1 ceremony contribute --coordinator-url http://127.0.0.1:8081 --coordinator-address $SUMMONER_ADDRESS --phase 1 --bid 10penumbra
+# TODO: Accounts 2, 3 contribution
+
+echo "Stopping phase 1 run..."
+if ! kill -0 "$phase1_pid" ; then
+    >&2 echo "ERROR: phase 1 exited early"
+    kill -9 "$phase1_pid"
+    exit 1
+else
+    echo "Phase 1 complete."
+fi
+
+echo "Transitioning..."
+cargo run --quiet --release --bin summonerd -- transition --storage-dir /tmp/summonerd
+
+echo "Starting phase 2 run..."
+cargo run --quiet --release --bin summonerd -- start --phase 2 --storage-dir /tmp/summonerd --fvk $SUMMONER_FVK --node https://grpc.testnet-preview.penumbra.zone &
+phase2_pid="$!"
+echo $phase2_pid
+# If script ends early, ensure phase 2 is halted.
+trap 'kill -9 "$phase2_pid"' EXIT
+
+echo "Phase 2 contributions..."
+cargo run --quiet --release --bin pcli -- --node https://grpc.testnet-preview.penumbra.zone --home /tmp/account1 ceremony contribute --coordinator-url http://127.0.0.1:8081 --coordinator-address $SUMMONER_ADDRESS --phase 2 --bid 10penumbra
+# TODO: Accounts 2, 3 contribution
+
+# TODO: Export keys
+
+echo "Stopping phase 2 run..."
+if ! kill -0 "$phase2_pid" ; then
+    >&2 echo "ERROR: phase 2 exited early"
+    kill -9 "$phase2_pid"
+    exit 1
+else
+    echo "Phase 2 complete."
+fi
+
+rm -rf /tmp/summonerd
+rm -rf /tmp/account1
+rm -rf /tmp/account2
+rm -rf /tmp/account3
+exit 0

--- a/deployments/scripts/smoke-summoner.sh
+++ b/deployments/scripts/smoke-summoner.sh
@@ -17,6 +17,7 @@ mkdir /tmp/summonerd
 cargo run --quiet --release --bin pcli -- --home /tmp/summonerd --node https://grpc.testnet-preview.penumbra.zone keys generate
 export SUMMONER_ADDRESS=$(PCLI_UNLEASH_DANGER="yes" cargo run --quiet --release --bin pcli -- --home /tmp/summonerd --node https://grpc.testnet-preview.penumbra.zone view address 0 2>&1)
 export SUMMONER_FVK=$(PCLI_UNLEASH_DANGER="yes" cargo run --quiet --release --bin pcli -- --home /tmp/summonerd --node https://grpc.testnet-preview.penumbra.zone keys export full-viewing-key 2>&1)
+cargo run --quiet --release --bin summonerd -- init --storage-dir /tmp/summonerd --phase1-root phase1.bin
 
 echo "Starting phase 1 run..."
 cargo run --quiet --release --bin summonerd -- start --phase 1 --storage-dir /tmp/summonerd --fvk $SUMMONER_FVK --node https://grpc.testnet-preview.penumbra.zone &

--- a/deployments/scripts/smoke-summoner.sh
+++ b/deployments/scripts/smoke-summoner.sh
@@ -100,7 +100,13 @@ trap 'kill -9 "$phase2_pid"' EXIT
 echo "Phase 2 contributions..."
 cargo run --quiet --release --bin pcli -- --node http://127.0.0.1:8080 --home /tmp/account1 ceremony contribute --coordinator-url http://127.0.0.1:8081 --coordinator-address $SUMMONER_ADDRESS --phase 2 --bid 10penumbra
 
-# TODO: Export keys
+echo "Exporting keys..."
+cargo run --quiet --release --bin summonerd -- export --storage-dir /tmp/summonerd --target-dir ./crates/crypto/proof-params/src/gen
+
+# We have a set of tests in the pcli crate that generate and verify proofs using the
+# proving keys present in the `penumbra-proof-params` crate.
+echo "Check tests pass using the new proving keys..."
+cargo test -p pcli
 
 echo "Stopping phase 2 run..."
 if ! kill -0 "$phase2_pid" ; then


### PR DESCRIPTION
Closes #3189

Thanks to #3208 the runtime of this went from ~60m down to ~18m! One can see a successful run of the CI job [here](https://github.com/penumbra-zone/penumbra/actions/runs/6590202104/job/17906325476?pr=3204) which was executed on the second to last commit here: f548956c744086992590ce1f8bc73798138e8877.

I've used the [`workflow_dispatch` option](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) to only run this job on demand (will work once the CI job is on the default branch), and on merges into `main`. It may make sense later to run the job only nightly/weekly instead of every merge into `main`, but while the summoner is under active development I think running on merge into `main` is reasonable.