### PR TITLE
Tx planner updates [wasm]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5774,7 +5774,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-wasm"
-version = "0.62.0"
+version = "0.63.0-preview-2"
 dependencies = [
  "anyhow",
  "ark-ff",

--- a/crates/wasm/src/error.rs
+++ b/crates/wasm/src/error.rs
@@ -1,11 +1,13 @@
+use std::convert::Infallible;
+
 use base64::DecodeError;
 use hex::FromHexError;
-use penumbra_tct::error::{InsertBlockError, InsertEpochError, InsertError};
 use serde_wasm_bindgen::Error;
-use std::convert::Infallible;
 use thiserror::Error;
 use wasm_bindgen::{JsError, JsValue};
 use web_sys::DomException;
+
+use penumbra_tct::error::{InsertBlockError, InsertEpochError, InsertError};
 
 pub type WasmResult<T> = Result<T, WasmError>;
 

--- a/crates/wasm/src/keys.rs
+++ b/crates/wasm/src/keys.rs
@@ -3,10 +3,12 @@ use std::str::FromStr;
 use rand_core::OsRng;
 use wasm_bindgen::prelude::*;
 
-use crate::error::WasmResult;
 use penumbra_keys::keys::{Bip44Path, SeedPhrase, SpendKey};
 use penumbra_keys::{Address, FullViewingKey};
 use penumbra_proto::{core::keys::v1alpha1 as pb, serializers::bech32str, DomainType};
+
+use crate::error::WasmResult;
+use crate::utils;
 
 /// generate a spend key from a seed phrase
 /// Arguments:
@@ -14,6 +16,8 @@ use penumbra_proto::{core::keys::v1alpha1 as pb, serializers::bech32str, DomainT
 /// Returns: `bech32 string`
 #[wasm_bindgen]
 pub fn generate_spend_key(seed_phrase: &str) -> WasmResult<JsValue> {
+    utils::set_panic_hook();
+
     let seed = SeedPhrase::from_str(seed_phrase)?;
     let path = Bip44Path::new(0);
     let spend_key = SpendKey::from_seed_phrase_bip44(seed, &path);
@@ -35,6 +39,8 @@ pub fn generate_spend_key(seed_phrase: &str) -> WasmResult<JsValue> {
 /// Returns: `bech32 string`
 #[wasm_bindgen]
 pub fn get_full_viewing_key(spend_key: &str) -> WasmResult<JsValue> {
+    utils::set_panic_hook();
+
     let spend_key = SpendKey::from_str(spend_key)?;
 
     let fvk: &FullViewingKey = spend_key.full_viewing_key();
@@ -55,6 +61,8 @@ pub fn get_full_viewing_key(spend_key: &str) -> WasmResult<JsValue> {
 /// Returns: `bech32 string`
 #[wasm_bindgen]
 pub fn get_wallet_id(full_viewing_key: &str) -> WasmResult<String> {
+    utils::set_panic_hook();
+
     let fvk = FullViewingKey::from_str(full_viewing_key)?;
     Ok(fvk.wallet_id().to_string())
 }
@@ -66,6 +74,8 @@ pub fn get_wallet_id(full_viewing_key: &str) -> WasmResult<String> {
 /// Returns: `pb::Address`
 #[wasm_bindgen]
 pub fn get_address_by_index(full_viewing_key: &str, index: u32) -> WasmResult<JsValue> {
+    utils::set_panic_hook();
+
     let fvk = FullViewingKey::from_str(full_viewing_key)?;
     let (address, _dtk) = fvk.incoming().payment_address(index.into());
     let proto = address.to_proto();
@@ -81,6 +91,8 @@ pub fn get_address_by_index(full_viewing_key: &str, index: u32) -> WasmResult<Js
 /// Returns: `pb::Address`
 #[wasm_bindgen]
 pub fn get_ephemeral_address(full_viewing_key: &str, index: u32) -> WasmResult<JsValue> {
+    utils::set_panic_hook();
+
     let fvk = FullViewingKey::from_str(full_viewing_key)?;
     let (address, _dtk) = fvk.ephemeral_address(OsRng, index.into());
     let proto = address.to_proto();
@@ -95,6 +107,8 @@ pub fn get_ephemeral_address(full_viewing_key: &str, index: u32) -> WasmResult<J
 /// Returns: `Option<pb::AddressIndex>`
 #[wasm_bindgen]
 pub fn is_controlled_address(full_viewing_key: &str, address: &str) -> WasmResult<JsValue> {
+    utils::set_panic_hook();
+
     let fvk = FullViewingKey::from_str(full_viewing_key)?;
     let index: Option<pb::AddressIndex> = fvk
         .address_index(&Address::from_str(address)?)
@@ -111,8 +125,9 @@ pub fn is_controlled_address(full_viewing_key: &str, address: &str) -> WasmResul
 /// Returns: `String`
 #[wasm_bindgen]
 pub fn get_short_address_by_index(full_viewing_key: &str, index: u32) -> WasmResult<JsValue> {
-    let fvk = FullViewingKey::from_str(full_viewing_key)?;
+    utils::set_panic_hook();
 
+    let fvk = FullViewingKey::from_str(full_viewing_key)?;
     let (address, _dtk) = fvk.incoming().payment_address(index.into());
     let short_address = address.display_short_form();
     Ok(JsValue::from_str(&short_address))

--- a/crates/wasm/src/utils.rs
+++ b/crates/wasm/src/utils.rs
@@ -1,9 +1,18 @@
-use crate::error::WasmResult;
-use penumbra_proto::DomainType;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
+use penumbra_proto::DomainType;
+
+use crate::error::WasmResult;
+use crate::utils;
+
 pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
     #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
 }
@@ -14,6 +23,8 @@ pub fn set_panic_hook() {
 /// Returns: `penumbra_tct::Root`
 #[wasm_bindgen]
 pub fn decode_nct_root(tx_bytes: &str) -> WasmResult<JsValue> {
+    utils::set_panic_hook();
+
     let tx_vec: Vec<u8> = hex::decode(tx_bytes)?;
     let root = penumbra_tct::Root::decode(tx_vec.as_slice())?;
     let result = serde_wasm_bindgen::to_value(&root)?;

--- a/crates/wasm/src/view_server.rs
+++ b/crates/wasm/src/view_server.rs
@@ -23,6 +23,7 @@ use crate::error::WasmResult;
 use crate::note_record::SpendableNoteRecord;
 use crate::storage::IndexedDBStorage;
 use crate::swap_record::SwapRecord;
+use crate::utils;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StoredTree {
@@ -87,6 +88,8 @@ impl ViewServer {
         stored_tree: JsValue,
         idb_constants: JsValue,
     ) -> WasmResult<ViewServer> {
+        utils::set_panic_hook();
+
         let fvk = FullViewingKey::from_str(full_viewing_key)?;
         let stored_tree: StoredTree = serde_wasm_bindgen::from_value(stored_tree)?;
         let tree = load_tree(stored_tree);
@@ -114,6 +117,8 @@ impl ViewServer {
     /// Returns: `bool`
     #[wasm_bindgen]
     pub async fn scan_block(&mut self, compact_block: JsValue) -> WasmResult<bool> {
+        utils::set_panic_hook();
+
         let block_proto: penumbra_proto::core::component::compact_block::v1alpha1::CompactBlock =
             serde_wasm_bindgen::from_value(compact_block)?;
 
@@ -259,6 +264,8 @@ impl ViewServer {
     /// Returns: `ScanBlockResult`
     #[wasm_bindgen]
     pub fn flush_updates(&mut self) -> WasmResult<JsValue> {
+        utils::set_panic_hook();
+
         let nct_updates: Updates = self
             .nct
             .updates(
@@ -290,6 +297,8 @@ impl ViewServer {
     /// Returns: `Root`
     #[wasm_bindgen]
     pub fn get_nct_root(&mut self) -> Result<JsValue, Error> {
+        utils::set_panic_hook();
+
         let root = self.nct.root();
         serde_wasm_bindgen::to_value(&root)
     }
@@ -305,6 +314,8 @@ impl ViewServer {
         position_value: JsValue,
         position_state_value: JsValue,
     ) -> Result<JsValue, Error> {
+        utils::set_panic_hook();
+
         let position: Position = serde_wasm_bindgen::from_value(position_value)?;
         let position_state = serde_wasm_bindgen::from_value(position_state_value)?;
         let lp_nft = LpNft::new(position.id(), position_state);

--- a/crates/wasm/src/wasm_planner.rs
+++ b/crates/wasm/src/wasm_planner.rs
@@ -1,27 +1,30 @@
+use ark_ff::UniformRand;
+use decaf377::Fq;
+use rand_core::OsRng;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::JsValue;
+
+use penumbra_chain::params::{ChainParameters, FmdParameters};
+use penumbra_dex::swap_claim::SwapClaimPlan;
+use penumbra_proto::core::asset::v1alpha1::{DenomMetadata, Value};
+use penumbra_proto::core::component::fee::v1alpha1::Fee;
+use penumbra_proto::core::keys::v1alpha1::Address;
+use penumbra_proto::core::transaction::v1alpha1::MemoPlaintext;
+use penumbra_proto::crypto::tct::v1alpha1::StateCommitment;
+use penumbra_proto::DomainType;
+
 use crate::error::WasmResult;
 use crate::planner::Planner;
 use crate::storage::IndexedDBStorage;
 use crate::swap_record::SwapRecord;
-use anyhow::Result;
-use ark_ff::UniformRand;
-use decaf377::Fq;
-use penumbra_dex::swap_claim::SwapClaimPlan;
-use penumbra_proto::core::asset::v1alpha1::{DenomMetadata, Value};
-use penumbra_proto::core::component::chain::v1alpha1::{ChainParameters, FmdParameters};
-use penumbra_proto::core::component::fee::v1alpha1::Fee;
-use penumbra_proto::core::keys::v1alpha1::Address;
-use penumbra_proto::core::transaction::v1alpha1::{MemoPlaintext, TransactionPlan};
-use penumbra_proto::crypto::tct::v1alpha1::StateCommitment;
-use penumbra_proto::DomainType;
-use rand_core::OsRng;
-use serde_wasm_bindgen::Error;
-use wasm_bindgen::prelude::wasm_bindgen;
-use wasm_bindgen::JsValue;
+use crate::utils;
 
 #[wasm_bindgen]
 pub struct WasmPlanner {
     planner: Planner<OsRng>,
     storage: IndexedDBStorage,
+    chain_params: ChainParameters,
+    fmd_params: FmdParameters,
 }
 
 #[wasm_bindgen]
@@ -30,13 +33,23 @@ impl WasmPlanner {
     /// Function opens a connection to indexedDb
     /// Arguments:
     ///     idb_constants: `IndexedDbConstants`
+    ///     chain_params: `ChainParams`
+    ///     fmd_params: `FmdParameters`
     /// Returns: `WasmPlanner`
     #[wasm_bindgen]
-    pub async fn new(idb_constants: JsValue) -> Result<WasmPlanner, Error> {
+    pub async fn new(
+        idb_constants: JsValue,
+        chain_params: JsValue,
+        fmd_params: JsValue,
+    ) -> WasmResult<WasmPlanner> {
+        utils::set_panic_hook();
+
         let constants = serde_wasm_bindgen::from_value(idb_constants)?;
         let planner = WasmPlanner {
             planner: Planner::new(OsRng),
             storage: IndexedDBStorage::new(constants).await?,
+            chain_params: serde_wasm_bindgen::from_value(chain_params)?,
+            fmd_params: serde_wasm_bindgen::from_value(fmd_params)?,
         };
         Ok(planner)
     }
@@ -45,9 +58,10 @@ impl WasmPlanner {
     /// Arguments:
     ///     expiry_height: `u64`
     #[wasm_bindgen]
-    pub fn expiry_height(&mut self, expiry_height: JsValue) -> Result<(), Error> {
-        self.planner
-            .expiry_height(serde_wasm_bindgen::from_value(expiry_height)?);
+    pub fn expiry_height(&mut self, expiry_height: u64) -> WasmResult<()> {
+        utils::set_panic_hook();
+
+        self.planner.expiry_height(expiry_height);
         Ok(())
     }
 
@@ -55,6 +69,8 @@ impl WasmPlanner {
     /// Arguments:
     ///     memo: `MemoPlaintext`
     pub fn memo(&mut self, memo: JsValue) -> WasmResult<()> {
+        utils::set_panic_hook();
+
         let memo_proto: MemoPlaintext = serde_wasm_bindgen::from_value(memo)?;
         let _ = self.planner.memo(memo_proto.try_into()?);
         Ok(())
@@ -64,6 +80,8 @@ impl WasmPlanner {
     /// Arguments:
     ///     fee: `Fee`
     pub fn fee(&mut self, fee: JsValue) -> WasmResult<()> {
+        utils::set_panic_hook();
+
         let fee_proto: Fee = serde_wasm_bindgen::from_value(fee)?;
         self.planner.fee(fee_proto.try_into()?);
 
@@ -75,6 +93,8 @@ impl WasmPlanner {
     ///     value: `Value`
     ///     address: `Address`
     pub fn output(&mut self, value: JsValue, address: JsValue) -> WasmResult<()> {
+        utils::set_panic_hook();
+
         let value_proto: Value = serde_wasm_bindgen::from_value(value)?;
         let address_proto: Address = serde_wasm_bindgen::from_value(address)?;
 
@@ -89,6 +109,8 @@ impl WasmPlanner {
     ///     swap_commitment: `StateCommitment`
     #[wasm_bindgen]
     pub async fn swap_claim(&mut self, swap_commitment: JsValue) -> WasmResult<()> {
+        utils::set_panic_hook();
+
         let swap_commitment_proto: StateCommitment =
             serde_wasm_bindgen::from_value(swap_commitment)?;
 
@@ -98,17 +120,12 @@ impl WasmPlanner {
             .await?
             .expect("Swap record not found")
             .try_into()?;
-        let chain_params_proto: ChainParameters = self
-            .storage
-            .get_chain_parameters()
-            .await?
-            .expect("Chain params not found");
 
         let swap_claim_plan = SwapClaimPlan {
             swap_plaintext: swap_record.swap,
             position: swap_record.position,
             output_data: swap_record.output_data,
-            epoch_duration: chain_params_proto.epoch_duration,
+            epoch_duration: self.chain_params.epoch_duration,
             proof_blinding_r: Fq::rand(&mut OsRng),
             proof_blinding_s: Fq::rand(&mut OsRng),
         };
@@ -130,6 +147,8 @@ impl WasmPlanner {
         swap_claim_fee: JsValue,
         claim_address: JsValue,
     ) -> WasmResult<()> {
+        utils::set_panic_hook();
+
         let input_value_proto: Value = serde_wasm_bindgen::from_value(input_value)?;
         let into_denom_proto: DenomMetadata = serde_wasm_bindgen::from_value(into_denom)?;
         let swap_claim_fee_proto: Fee = serde_wasm_bindgen::from_value(swap_claim_fee)?;
@@ -145,52 +164,33 @@ impl WasmPlanner {
         Ok(())
     }
 
-    /// Build transaction plan
+    /// Builds transaction plan.
+    /// Refund address provided in the case there is extra balances to be returned.
     /// Arguments:
-    ///     self_address: `Address`
+    ///     refund_address: `Address`
     /// Returns: `TransactionPlan`
-    pub async fn plan(&mut self, self_address: JsValue) -> Result<JsValue, Error> {
-        let self_address_proto: Address = serde_wasm_bindgen::from_value(self_address)?;
-        let plan = self.plan_inner(self_address_proto).await?;
-        serde_wasm_bindgen::to_value(&plan)
-    }
-}
-
-impl WasmPlanner {
-    async fn plan_inner(&mut self, self_address: Address) -> WasmResult<TransactionPlan> {
-        let chain_params_proto: ChainParameters = self
-            .storage
-            .get_chain_parameters()
-            .await?
-            .expect("No found chain params");
-        let fmd_params_proto: FmdParameters = self
-            .storage
-            .get_fmd_parameters()
-            .await?
-            .expect("No found fmd");
+    pub async fn plan(&mut self, refund_address: JsValue) -> WasmResult<JsValue> {
+        utils::set_panic_hook();
 
         let mut spendable_notes = Vec::new();
 
         let (spendable_requests, _) = self.planner.notes_requests();
-
         for request in spendable_requests {
             let notes = self.storage.get_notes(request);
             spendable_notes.extend(notes.await?);
         }
 
         // Plan the transaction using the gathered information
+        let refund_address_proto: Address = serde_wasm_bindgen::from_value(refund_address)?;
+        let plan = self.planner.plan_with_spendable_and_votable_notes(
+            &self.chain_params,
+            &self.fmd_params,
+            spendable_notes,
+            Vec::new(),
+            refund_address_proto.try_into()?,
+        )?;
 
-        let plan: penumbra_transaction::plan::TransactionPlan =
-            self.planner.plan_with_spendable_and_votable_notes(
-                &chain_params_proto.try_into()?,
-                &fmd_params_proto.try_into()?,
-                spendable_notes,
-                Vec::new(),
-                self_address.try_into()?,
-            )?;
-
-        let plan_proto: TransactionPlan = plan.to_proto();
-
-        Ok(plan_proto)
+        let plan_proto = plan.to_proto();
+        Ok(serde_wasm_bindgen::to_value(&plan_proto)?)
     }
 }


### PR DESCRIPTION
- Moving chain+fmd params to be passed in versus grabbing global indexdb tables
- adding error console hook to all wasm-bindgen functions. Without this, we cannot debug from javascript.