### PR TITLE
Improve summonerd performance through parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5312,6 +5312,7 @@ dependencies = [
  "penumbra-stake",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "rayon",
 ]
 
 [[package]]

--- a/crates/bin/pcli/src/command/ceremony.rs
+++ b/crates/bin/pcli/src/command/ceremony.rs
@@ -144,11 +144,11 @@ impl CeremonyCmd {
                 };
                 let contribution = if *phase == 1 {
                     let parent = Phase1RawCeremonyCRS::try_from(unparsed_parent)?.assume_valid();
-                    let contribution = Phase1CeremonyContribution::make(&mut OsRng, &parent);
+                    let contribution = Phase1CeremonyContribution::make(&parent);
                     contribution.try_into()?
                 } else {
                     let parent = Phase2RawCeremonyCRS::try_from(unparsed_parent)?.assume_valid();
-                    let contribution = Phase2CeremonyContribution::make(&mut OsRng, &parent);
+                    let contribution = Phase2CeremonyContribution::make(&parent);
                     contribution.try_into()?
                 };
 

--- a/crates/bin/pcli/src/command/ceremony.rs
+++ b/crates/bin/pcli/src/command/ceremony.rs
@@ -143,11 +143,13 @@ impl CeremonyCmd {
                     }
                 };
                 let contribution = if *phase == 1 {
-                    let parent = Phase1RawCeremonyCRS::unchecked_from_protobuf(unparsed_parent)?.assume_valid();
+                    let parent = Phase1RawCeremonyCRS::unchecked_from_protobuf(unparsed_parent)?
+                        .assume_valid();
                     let contribution = Phase1CeremonyContribution::make(&parent);
                     contribution.try_into()?
                 } else {
-                    let parent = Phase2RawCeremonyCRS::unchecked_from_protobuf(unparsed_parent)?.assume_valid();
+                    let parent = Phase2RawCeremonyCRS::unchecked_from_protobuf(unparsed_parent)?
+                        .assume_valid();
                     let contribution = Phase2CeremonyContribution::make(&parent);
                     contribution.try_into()?
                 };

--- a/crates/bin/pcli/src/command/ceremony.rs
+++ b/crates/bin/pcli/src/command/ceremony.rs
@@ -143,11 +143,11 @@ impl CeremonyCmd {
                     }
                 };
                 let contribution = if *phase == 1 {
-                    let parent = Phase1RawCeremonyCRS::try_from(unparsed_parent)?.assume_valid();
+                    let parent = Phase1RawCeremonyCRS::unchecked_from_protobuf(unparsed_parent)?.assume_valid();
                     let contribution = Phase1CeremonyContribution::make(&parent);
                     contribution.try_into()?
                 } else {
-                    let parent = Phase2RawCeremonyCRS::try_from(unparsed_parent)?.assume_valid();
+                    let parent = Phase2RawCeremonyCRS::unchecked_from_protobuf(unparsed_parent)?.assume_valid();
                     let contribution = Phase2CeremonyContribution::make(&parent);
                     contribution.try_into()?
                 };

--- a/crates/crypto/proof-setup/Cargo.toml
+++ b/crates/crypto/proof-setup/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-ark-ec = "0.4.2"
-ark-ff = "0.4.2"
-ark-groth16 = "0.4.0"
-ark-poly = "0.4.2"
+ark-ec = { version = "0.4.2", default_features = false }
+ark-ff = { version = "0.4.2", default_features = false }
+ark-groth16 = { version = "0.4.0", default_features = false }
+ark-poly = { version = "0.4.2", default_features = false }
 ark-relations = "0.4"
 ark-serialize = "0.4.2"
 blake2b_simd = "0.5"
 rand_core = { version = "0.6", features = ["getrandom"] }
-decaf377 = "0.5"
+decaf377 = { version = "0.5", default_features = false }
 penumbra-dex = { path = "../../core/component/dex/" }
 penumbra-dao = { path = "../../core/component/dao/", features = ["component"] }
 penumbra-governance = { path = "../../core/component/governance/" }
@@ -33,3 +33,7 @@ rand_chacha = "0.3.1"
 [[bench]]
 name = "all"
 harness = false
+
+[features]
+default = []
+parallel = ["ark-ec/parallel", "ark-ff/parallel", "ark-groth16/parallel", "decaf377/parallel"]

--- a/crates/crypto/proof-setup/Cargo.toml
+++ b/crates/crypto/proof-setup/Cargo.toml
@@ -21,6 +21,7 @@ penumbra-proof-params = { path = "../proof-params" }
 penumbra-proto = { path = "../../proto" }
 penumbra-shielded-pool = { path = "../../core/component/shielded-pool/" }
 penumbra-stake = { path = "../../core/component/stake/", features = ["component"] }
+rayon = { version = "1.8.0", optional = true }
 
 [dev-dependencies]
 ark-r1cs-std = "0.4.0"
@@ -36,4 +37,4 @@ harness = false
 
 [features]
 default = []
-parallel = ["ark-ec/parallel", "ark-ff/parallel", "ark-groth16/parallel", "decaf377/parallel"]
+parallel = ["ark-ec/parallel", "ark-ff/parallel", "ark-groth16/parallel", "decaf377/parallel", "rayon"]

--- a/crates/crypto/proof-setup/Cargo.toml
+++ b/crates/crypto/proof-setup/Cargo.toml
@@ -37,4 +37,4 @@ harness = false
 
 [features]
 default = []
-parallel = ["ark-ec/parallel", "ark-ff/parallel", "ark-groth16/parallel", "decaf377/parallel", "rayon"]
+parallel = ["ark-ec/parallel", "ark-ff/parallel", "ark-groth16/parallel", "decaf377/parallel", "rayon", "penumbra-shielded-pool/parallel"]

--- a/crates/crypto/proof-setup/src/all.rs
+++ b/crates/crypto/proof-setup/src/all.rs
@@ -76,6 +76,18 @@ impl Phase2RawCeremonyCRS {
             ]),
         }
     }
+
+    pub fn unchecked_from_protobuf(value: pb::CeremonyCrs) -> anyhow::Result<Self> {
+        Ok(Self([
+            from_bytes_unchecked::<Phase2RawCRSElements>(value.spend.as_slice())?,
+            from_bytes_unchecked::<Phase2RawCRSElements>(value.output.as_slice())?,
+            from_bytes_unchecked::<Phase2RawCRSElements>(value.delegator_vote.as_slice())?,
+            from_bytes_unchecked::<Phase2RawCRSElements>(value.undelegate_claim.as_slice())?,
+            from_bytes_unchecked::<Phase2RawCRSElements>(value.swap.as_slice())?,
+            from_bytes_unchecked::<Phase2RawCRSElements>(value.swap_claim.as_slice())?,
+            from_bytes_unchecked::<Phase2RawCRSElements>(value.nullifer_derivation_crs.as_slice())?,
+        ]))
+    }
 }
 
 impl TryInto<pb::CeremonyCrs> for Phase2RawCeremonyCRS {
@@ -408,6 +420,193 @@ impl Phase2RawCeremonyContribution {
                 x6.assume_valid(),
             ]),
         }
+    }
+
+    pub fn unchecked_from_protobuf(value: pb::participate_request::Contribution) -> Result<Self> {
+        Ok(Self([
+            Phase2RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .spend
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase2RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .spend
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<DLogProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .spend
+                        .as_slice(),
+                )?,
+            },
+            Phase2RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .output
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase2RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .output
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<DLogProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .output
+                        .as_slice(),
+                )?,
+            },
+            Phase2RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .delegator_vote
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase2RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .delegator_vote
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<DLogProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .delegator_vote
+                        .as_slice(),
+                )?,
+            },
+            Phase2RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .undelegate_claim
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase2RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .undelegate_claim
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<DLogProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .undelegate_claim
+                        .as_slice(),
+                )?,
+            },
+            Phase2RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .swap
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase2RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .swap
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<DLogProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .swap
+                        .as_slice(),
+                )?,
+            },
+            Phase2RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .swap_claim
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase2RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .swap_claim
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<DLogProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .swap_claim
+                        .as_slice(),
+                )?,
+            },
+            Phase2RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .nullifer_derivation_crs
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase2RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .nullifer_derivation_crs
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<DLogProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .nullifer_derivation_crs
+                        .as_slice(),
+                )?,
+            },
+        ]))
     }
 }
 
@@ -817,6 +1016,193 @@ impl Phase1RawCeremonyContribution {
                 x6.assume_valid(),
             ]),
         }
+    }
+
+    pub fn unchecked_from_protobuf(value: pb::participate_request::Contribution) -> Result<Self> {
+        Ok(Self([
+            Phase1RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .spend
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase1RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .spend
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<LinkingProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .spend
+                        .as_slice(),
+                )?,
+            },
+            Phase1RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .output
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase1RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .output
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<LinkingProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .output
+                        .as_slice(),
+                )?,
+            },
+            Phase1RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .delegator_vote
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase1RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .delegator_vote
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<LinkingProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .delegator_vote
+                        .as_slice(),
+                )?,
+            },
+            Phase1RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .undelegate_claim
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase1RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .undelegate_claim
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<LinkingProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .undelegate_claim
+                        .as_slice(),
+                )?,
+            },
+            Phase1RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .swap
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase1RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .swap
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<LinkingProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .swap
+                        .as_slice(),
+                )?,
+            },
+            Phase1RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .swap_claim
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase1RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .swap_claim
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<LinkingProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .swap_claim
+                        .as_slice(),
+                )?,
+            },
+            Phase1RawContribution {
+                parent: ContributionHash::try_from(
+                    value
+                        .parent_hashes
+                        .as_ref()
+                        .ok_or(anyhow!("no parent hashes"))?
+                        .nullifer_derivation_crs
+                        .as_slice(),
+                )?,
+                new_elements: from_bytes_unchecked::<Phase1RawCRSElements>(
+                    value
+                        .updated
+                        .as_ref()
+                        .ok_or(anyhow!("no updated"))?
+                        .nullifer_derivation_crs
+                        .as_slice(),
+                )?,
+                linking_proof: from_bytes_unchecked::<LinkingProof>(
+                    value
+                        .update_proofs
+                        .as_ref()
+                        .ok_or(anyhow!("no update proofs"))?
+                        .nullifer_derivation_crs
+                        .as_slice(),
+                )?,
+            },
+        ]))
     }
 }
 

--- a/crates/crypto/proof-setup/src/lib.rs
+++ b/crates/crypto/proof-setup/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod all;
+mod parallel_utils;
 pub mod single;

--- a/crates/crypto/proof-setup/src/parallel_utils.rs
+++ b/crates/crypto/proof-setup/src/parallel_utils.rs
@@ -1,0 +1,36 @@
+pub fn transform<A, B, const N: usize>(data: [A; N], f: impl Fn(A) -> B) -> [B; N] {
+    match data.into_iter().map(f).collect::<Vec<B>>().try_into() {
+        Ok(x) => x,
+        _ => panic!("The size of the iterator should not have changed"),
+    }
+}
+
+#[cfg(not(feature = "parallel"))]
+pub fn transform_parallel<A, B, const N: usize>(data: [A; N], f: impl Fn(A) -> B) -> [B; N] {
+    transform(data, f)
+}
+
+#[cfg(feature = "parallel")]
+pub fn transform_parallel<A: Send, B: Sync + Send, const N: usize>(
+    data: [A; N],
+    f: impl Fn(A) -> B + Sync + Send,
+) -> [B; N] {
+    use rayon::prelude::*;
+    let out: Vec<B> = data.into_par_iter().map(f).collect();
+    // Note: we do it this way because we don't have a Debug implementation for B
+    match out.try_into() {
+        Ok(x) => x,
+        _ => panic!("The size of the iterator should not have changed"),
+    }
+}
+
+pub fn flatten_results<A, E, const N: usize>(data: [Result<A, E>; N]) -> Result<[A; N], E> {
+    let mut buf = Vec::with_capacity(N);
+    for x in data {
+        buf.push(x?);
+    }
+    match buf.try_into() {
+        Ok(x) => Ok(x),
+        _ => panic!("The size of the iterator should not have changed"),
+    }
+}

--- a/tools/summonerd/Cargo.toml
+++ b/tools/summonerd/Cargo.toml
@@ -32,7 +32,7 @@ penumbra-asset = { path = "../../crates/core/asset/" }
 penumbra-keys = { path = "../../crates/core/keys/" }
 penumbra-num = { path = "../../crates/core/num/" }
 penumbra-proof-params = { path = "../../crates/crypto/proof-params" }
-penumbra-proof-setup = { path = "../../crates/crypto/proof-setup/" }
+penumbra-proof-setup = { path = "../../crates/crypto/proof-setup/", features = ["parallel"] }
 penumbra-proto = { path = "../../crates/proto/" } 
 penumbra-view = { path = "../../crates/view/" }
 rand = "0.8"

--- a/tools/summonerd/src/participant.rs
+++ b/tools/summonerd/src/participant.rs
@@ -80,7 +80,10 @@ impl Participant {
             msg: Some(RequestMsg::Contribution(contribution)),
         }) = msg
         {
-            Ok(Some(P::deserialize_contribution(contribution)?))
+            let deserialized =
+                tokio::task::spawn_blocking(move || P::deserialize_contribution(contribution))
+                    .await??;
+            Ok(Some(deserialized))
         } else {
             Ok(None)
         }

--- a/tools/summonerd/src/storage.rs
+++ b/tools/summonerd/src/storage.rs
@@ -208,12 +208,12 @@ impl Storage {
             Some(x) => x,
         };
         let crs = if is_root {
-            Phase1RawCeremonyCRS::try_from(pb::CeremonyCrs::decode(
+            Phase1RawCeremonyCRS::unchecked_from_protobuf(pb::CeremonyCrs::decode(
                 contribution_or_crs.as_slice(),
             )?)?
             .assume_valid()
         } else {
-            Phase1RawCeremonyContribution::try_from(PBContribution::decode(
+            Phase1RawCeremonyContribution::unchecked_from_protobuf(PBContribution::decode(
                 contribution_or_crs.as_slice(),
             )?)?
             .assume_valid()
@@ -235,12 +235,12 @@ impl Storage {
             Some(x) => x,
         };
         let crs = if is_root {
-            Phase2RawCeremonyCRS::try_from(pb::CeremonyCrs::decode(
+            Phase2RawCeremonyCRS::unchecked_from_protobuf(pb::CeremonyCrs::decode(
                 contribution_or_crs.as_slice(),
             )?)?
             .assume_valid()
         } else {
-            Phase2RawCeremonyContribution::try_from(PBContribution::decode(
+            Phase2RawCeremonyContribution::unchecked_from_protobuf(PBContribution::decode(
                 contribution_or_crs.as_slice(),
             )?)?
             .assume_valid()


### PR DESCRIPTION
Closes #3202, although I'm not quite sure we're exploiting everything we can.

In particular, the way you enable parallelism in arkworks through spooky action at a distance always makes me unsure if I've done things correctly. Would appreciate a review of that specifically.

(Also, I refactored some of the code so this PR ends up being a net decrease in loc 8^))