### PR TITLE
deploy: add support for cometbft postgres indexing

### DIFF
--- a/deployments/charts/penumbra-node/files/postgres-cometbft-schema.sql
+++ b/deployments/charts/penumbra-node/files/postgres-cometbft-schema.sql
@@ -1,0 +1,85 @@
+/*
+  This file defines the database schema for the PostgresQL ("psql") event sink
+  implementation in CometBFT. The operator must create a database and install
+  this schema before using the database to index events.
+ */
+
+-- The blocks table records metadata about each block.
+-- The block record does not include its events or transactions (see tx_results).
+CREATE TABLE blocks (
+  rowid      BIGSERIAL PRIMARY KEY,
+
+  height     BIGINT NOT NULL,
+  chain_id   VARCHAR NOT NULL,
+
+  -- When this block header was logged into the sink, in UTC.
+  created_at TIMESTAMPTZ NOT NULL,
+
+  UNIQUE (height, chain_id)
+);
+
+-- Index blocks by height and chain, since we need to resolve block IDs when
+-- indexing transaction records and transaction events.
+CREATE INDEX idx_blocks_height_chain ON blocks(height, chain_id);
+
+-- The tx_results table records metadata about transaction results.  Note that
+-- the events from a transaction are stored separately.
+CREATE TABLE tx_results (
+  rowid BIGSERIAL PRIMARY KEY,
+
+  -- The block to which this transaction belongs.
+  block_id BIGINT NOT NULL REFERENCES blocks(rowid),
+  -- The sequential index of the transaction within the block.
+  index INTEGER NOT NULL,
+  -- When this result record was logged into the sink, in UTC.
+  created_at TIMESTAMPTZ NOT NULL,
+  -- The hex-encoded hash of the transaction.
+  tx_hash VARCHAR NOT NULL,
+  -- The protobuf wire encoding of the TxResult message.
+  tx_result BYTEA NOT NULL,
+
+  UNIQUE (block_id, index)
+);
+
+-- The events table records events. All events (both block and transaction) are
+-- associated with a block ID; transaction events also have a transaction ID.
+CREATE TABLE events (
+  rowid BIGSERIAL PRIMARY KEY,
+
+  -- The block and transaction this event belongs to.
+  -- If tx_id is NULL, this is a block event.
+  block_id BIGINT NOT NULL REFERENCES blocks(rowid),
+  tx_id    BIGINT NULL REFERENCES tx_results(rowid),
+
+  -- The application-defined type label for the event.
+  type VARCHAR NOT NULL
+);
+
+-- The attributes table records event attributes.
+CREATE TABLE attributes (
+   event_id      BIGINT NOT NULL REFERENCES events(rowid),
+   key           VARCHAR NOT NULL, -- bare key
+   composite_key VARCHAR NOT NULL, -- composed type.key
+   value         VARCHAR NULL,
+
+   UNIQUE (event_id, key)
+);
+
+-- A joined view of events and their attributes. Events that do not have any
+-- attributes are represented as a single row with empty key and value fields.
+CREATE VIEW event_attributes AS
+  SELECT block_id, tx_id, type, key, composite_key, value
+  FROM events LEFT JOIN attributes ON (events.rowid = attributes.event_id);
+
+-- A joined view of all block events (those having tx_id NULL).
+CREATE VIEW block_events AS
+  SELECT blocks.rowid as block_id, height, chain_id, type, key, composite_key, value
+  FROM blocks JOIN event_attributes ON (blocks.rowid = event_attributes.block_id)
+  WHERE event_attributes.tx_id IS NULL;
+
+-- A joined view of all transaction events.
+CREATE VIEW tx_events AS
+  SELECT height, index, chain_id, type, key, composite_key, value, tx_results.created_at
+  FROM blocks JOIN tx_results ON (blocks.rowid = tx_results.block_id)
+  JOIN event_attributes ON (tx_results.rowid = event_attributes.tx_id)
+  WHERE event_attributes.tx_id IS NOT NULL;

--- a/deployments/charts/penumbra-node/templates/configmap-postgresql-cometbft-schema.yaml
+++ b/deployments/charts/penumbra-node/templates/configmap-postgresql-cometbft-schema.yaml
@@ -1,0 +1,13 @@
+---
+{{- /*
+The database schema file for CometBFT is required for event indexing via postgres.
+See more info at "https://docs.cometbft.com/v0.37/app-dev/indexing-transactions#postgresql".
+*/}}
+{{- if eq .Values.cometbft.config.indexer "psql" }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "penumbra-node.fullname" . }}-postgres-schema
+data:
+  postgres-cometbft-schema.sql: {{ .Files.Get (printf "files/postgres-cometbft-schema.sql") | quote }}
+{{ end }}

--- a/deployments/charts/penumbra-node/templates/deployment.yaml
+++ b/deployments/charts/penumbra-node/templates/deployment.yaml
@@ -67,6 +67,23 @@ spec:
       {{- else }}
           emptyDir: {}
       {{- end }}
+      {{- if eq $.Values.cometbft.config.indexer "psql" }}
+      {{- if $.Values.persistence.enabled }}
+        - name: db
+          persistentVolumeClaim:
+            claimName: {{ $fn_name }}-db
+      {{- else }}
+          emptyDir: {}
+      {{- end }}
+      {{- end }}
+      {{- if eq $.Values.cometbft.config.indexer "psql" }}
+        - name: postgres-schema
+          configMap:
+            name: {{ include "penumbra-node.fullname" $ }}-postgres-schema
+            items:
+              - key: "postgres-cometbft-schema.sql"
+                path: "postgres-cometbft-schema.sql"
+      {{ end }}
       initContainers:
         - name: {{ $.Chart.Name }}-init
           securityContext:
@@ -99,6 +116,10 @@ spec:
                   --moniker {{ . | quote }} \
                   {{- end }}
                   {{ $.Values.penumbra_bootstrap_node_cometbft_rpc_url }}
+
+                  {{ if eq $.Values.cometbft.config.indexer "psql" -}}
+                  sed -i -e 's#^indexer.*#indexer = "psql"\npsql-conn = "{{ $.Values.cometbft.config.postgres_connection_url }}"#' /penumbra-config/testnet_data/node0/cometbft/config/config.toml
+                  {{- end }}
               fi
 
               # set ownership for pd user
@@ -193,6 +214,39 @@ spec:
             - name: config
               mountPath: /cometbft
               subPath: testnet_data/node0/cometbft
+      {{- if eq $.Values.cometbft.config.indexer "psql" }}
+        - name: postgres
+          securityContext:
+            {{- toYaml $.Values.postgres.securityContext | nindent 12 }}
+          image: "{{ $.Values.postgres.image.repository }}:{{ $.Values.postgres.image.tag }}"
+          imagePullPolicy: {{ $.Values.postgres.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          # Lazy to hardcode these values, but the db connection is intra-cluster.
+          env:
+            - name: POSTGRES_DB
+              value: penumbra
+            - name: POSTGRES_USER
+              value: penumbra
+            - name: POSTGRES_PASSWORD
+              value: penumbra
+          readinessProbe:
+            tcpSocket:
+              port: 5432
+            timeoutSeconds: 10
+            initialDelaySeconds: 10
+          resources:
+            {{- toYaml $.Values.postgres.resources | nindent 12 }}
+          volumeMounts:
+            - name: postgres-schema
+              mountPath: /docker-entrypoint-initdb.d
+              readOnly: true
+            - name: db
+              mountPath: /var/lib/postgresql
+      {{ end }}
+
       {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml $ | nindent 8 }}

--- a/deployments/charts/penumbra-node/templates/pvc.yml
+++ b/deployments/charts/penumbra-node/templates/pvc.yml
@@ -2,12 +2,11 @@
 {{ $count := (.Values.nodes | len | int) }}
 {{ range $i,$e := until $count }}
 {{ $fn_name := printf "%s-fn-%d" $.Release.Name $i }}
-{{ $pvc_name := printf "%s-config" $fn_name }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ $pvc_name }}
+  name: {{ $fn_name }}-config
   labels:
     {{- include "penumbra-node.labels" $ | nindent 4 }}
 spec:
@@ -18,5 +17,26 @@ spec:
   {{- if $.Values.persistence.storageClassName }}
   storageClassName: {{ $.Values.persistence.storageClassName }}
   {{- end }}
+---
+{{- if eq $.Values.cometbft.config.indexer "psql" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fn_name }}-db
+  labels:
+    {{- include "penumbra-node.labels" $ | nindent 4 }}
+spec:
+  accessModes: {{ $.Values.persistence.accessModes }}
+  resources:
+    requests:
+      # Storage for db is <1% of storage for node state.
+      # We could dynamically compute that based on persistence size,
+      # but it's also fine if we just hardcode the value for now.
+      storage: 2G
+  {{- if $.Values.persistence.storageClassName }}
+  storageClassName: {{ $.Values.persistence.storageClassName }}
+  {{- end }}
+{{- end }}
+
 {{- end }}
 {{- end }}

--- a/deployments/charts/penumbra-node/templates/service.yaml
+++ b/deployments/charts/penumbra-node/templates/service.yaml
@@ -29,6 +29,12 @@ spec:
       port: 26660
       targetPort: 26660
       protocol: TCP
+  {{- if eq $.Values.cometbft.config.indexer "psql" }}
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+  {{- end }}
   selector:
     app: {{ $fn_name }}
     {{- include "penumbra-node.selectorLabels" $ | nindent 4 }}

--- a/deployments/charts/penumbra-node/values.yaml
+++ b/deployments/charts/penumbra-node/values.yaml
@@ -44,6 +44,17 @@ cometbft:
     p2p:
       max_num_inbound_peers: 300
       max_num_outbound_peers: 200
+    # Set the indexer strategy. Can be "kv" or "psql".
+    indexer: kv
+    # URL for connecting to the postgresql database. Only used if `indexer=psql`.
+    postgres_connection_url: "postgresql://penumbra:penumbra@localhost:5432/penumbra?sslmode=disable"
+
+# settings for optional postgres sidecar, used for indexing cometbft events
+postgres:
+  image:
+    repository: docker.io/library/postgres
+    pullPolicy: IfNotPresent
+    tag: "latest"
 
 # Configure nodes. By default, only one is created.
 # Extend this list to add more. Valid node attributes are:

--- a/deployments/helmfile.d/penumbra-preview.yaml
+++ b/deployments/helmfile.d/penumbra-preview.yaml
@@ -62,3 +62,26 @@ releases:
       - persistence:
           enabled: true
           size: 10G
+
+  - name: penumbra-preview-cuiloa-node
+    chart: ../charts/penumbra-node
+    needs:
+      - penumbra-preview
+      # It's not strictly necessary to wait for node deploys, but doing so allows us to exercise
+      # the public HTTPS RPC endpoint for joining, which is nice.
+      - penumbra-preview-nodes
+    values:
+      - penumbra_bootstrap_node_cometbft_rpc_url: "https://rpc.testnet-preview.penumbra.zone"
+      - ingressRoute:
+          enabled: false
+      - image:
+          tag: main
+      - persistence:
+          enabled: true
+          size: 50G
+      - cometbft:
+          config:
+            indexer: psql
+      - part_of: penumbra-preview
+      - nodes:
+        - moniker: cuiloa


### PR DESCRIPTION
The penumbra-node chart now has opt-in support for storing CometBFT events in a postgres sidecar. See relevant docs at [0]. The sole downstream use case for this work to date is cuiloa [1], a block explorer for Penumbra. There are some shortcuts in this logic, mostly related to hardcoding db connection info, but the db is intra-cluster cluster only, so the risk is minimal. Prioritizing developer velocity right now.

[0] https://docs.cometbft.com/v0.37/app-dev/indexing-transactions#postgresql
[1] https://github.com/ejmg/cuiloa