### PR TITLE
Disable buildjet caching on smoketest workflows

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - name: Load rust cache
-        uses: astriaorg/buildjet-rust-cache@v2.5.1
+      # - name: Load rust cache
+      #  uses: astriaorg/buildjet-rust-cache@v2.5.1
 
       - name: Install cometbft binary
         run: |


### PR DESCRIPTION
Raised by @conorsch in #3227