### PR TITLE
ci: enable debug logging for validators

### DIFF
--- a/deployments/charts/penumbra-network/templates/deployment.yaml
+++ b/deployments/charts/penumbra-network/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
             - "0.0.0.0:9000"
             - --home
             - "/penumbra-config/{{ $val_name }}/node{{ $i }}/pd"
+          env:
+            {{- toYaml $.Values.containerEnv | nindent 12 }}
           ports:
             - name: pd-grpc
               containerPort: 8080

--- a/deployments/charts/penumbra-network/templates/job-generate.yaml
+++ b/deployments/charts/penumbra-network/templates/job-generate.yaml
@@ -59,6 +59,8 @@ spec:
             allowPrivilegeEscalation: true
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- toYaml $.Values.containerEnv | nindent 12 }}
           command:
             - sh
             - -c

--- a/deployments/charts/penumbra-network/values.yaml
+++ b/deployments/charts/penumbra-network/values.yaml
@@ -51,6 +51,11 @@ containerArgs:
   # store state in emptyDir for now
   - /penumbra-config/testnet_data/node0/pd
 
+# Environment variables for pd containers.
+containerEnv:
+  - name: RUST_LOG
+    value: info,pd=debug,penumbra=debug
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
On Testnet 62 Iapetus, we experienced a chain halt at block height
279655. We recently removed debug logging from the testnet nodes, which caused problems for figuring out what went wrong. Full debug output generates a lot of text, which raises hosting costs. Here, we selectively re-enable debug just on the validator nodes, where it's most useful.