### PR TITLE
Proof-Setup: Use faster verification method for phase1

### DIFF
--- a/crates/crypto/proof-setup/benches/all.rs
+++ b/crates/crypto/proof-setup/benches/all.rs
@@ -66,7 +66,7 @@ fn benchmarks(c: &mut Criterion) {
 
 criterion_group! {
   name = benches;
-  config = Criterion::default().sample_size(2);
+  config = Criterion::default().sample_size(10);
   targets = benchmarks
 }
 criterion_main!(benches);

--- a/crates/crypto/proof-setup/src/single/phase1.rs
+++ b/crates/crypto/proof-setup/src/single/phase1.rs
@@ -1,12 +1,13 @@
+use anyhow::anyhow;
 use ark_ec::Group;
 use ark_ff::{One, UniformRand, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use rand_core::{CryptoRngCore, OsRng};
 
-use crate::parallel_utils::transform_parallel;
+use crate::parallel_utils::{flatten_results, transform_parallel};
 use crate::single::dlog;
 use crate::single::group::{
-    pairing, BatchedPairingChecker11, BatchedPairingChecker12, GroupHasher, F, G1, G2,
+    BatchedPairingChecker11, BatchedPairingChecker12, GroupHasher, F, G1, G2,
 };
 use crate::single::log::{ContributionHash, Hashable, Phase};
 
@@ -72,9 +73,11 @@ impl RawCRSElements {
     /// This checks if the structure of the elements uses the secret scalars
     /// hidden behind the group elements correctly.
     #[must_use]
-    pub fn validate(self) -> Option<CRSElements> {
+    pub fn validate(self) -> anyhow::Result<CRSElements> {
         // 0. Check that we can extract a valid degree out of these elements.
-        let d = self.get_degree()?;
+        let d = self
+            .get_degree()
+            .ok_or_else(|| anyhow!("failed to get degree"))?;
         // 1. Check that the elements committing to the secret values are not 0.
         if self.alpha_1.is_zero()
             || self.beta_1.is_zero()
@@ -82,7 +85,7 @@ impl RawCRSElements {
             || self.x_1[1].is_zero()
             || self.x_2[1].is_zero()
         {
-            return None;
+            anyhow::bail!("one of alpha_1, beta_1, beta_2, x_1[1], x_2[1] was zero");
         }
         // 2. Check that the two beta commitments match.
         // 3. Check that the x values match on both groups.
@@ -103,34 +106,33 @@ impl RawCRSElements {
         for (&beta_x_i, &x_i) in self.beta_x_1.iter().zip(self.x_2.iter()) {
             checker2.add(beta_x_i, x_i);
         }
-        if !self
-            .x_2
-            .iter()
-            .zip(self.beta_x_1.iter())
-            .all(|(x_i, beta_x_i)| pairing(self.beta_1, x_i) == pairing(beta_x_i, G2::generator()))
-        {
-            return None;
-        }
         // 6. Check that the x_i are the correct powers of x.
         let mut checker3 = BatchedPairingChecker11::new(self.x_2[1], G2::generator());
         for (&x_i, &x_i_plus_1) in self.x_1.iter().zip(self.x_1.iter().skip(1)) {
             checker3.add(x_i, x_i_plus_1);
         }
         // "神だけが私を裁ける"
-        if transform_parallel(
-            [Ok(checker0), Ok(checker1), Ok(checker2), Err(checker3)],
-            |x| match x {
-                Ok(x) => x.check(&mut OsRng),
-                Err(x) => x.check(&mut OsRng),
+        flatten_results(transform_parallel(
+            [
+                (0, Ok(checker0)),
+                (1, Ok(checker1)),
+                (2, Ok(checker2)),
+                (3, Err(checker3)),
+            ],
+            |(i, x)| {
+                let ok = match x {
+                    Ok(x) => x.check(&mut OsRng),
+                    Err(x) => x.check(&mut OsRng),
+                };
+                if ok {
+                    Ok(())
+                } else {
+                    Err(anyhow!("checker {} failed", i))
+                }
             },
-        )
-        .iter()
-        .any(|x| !x)
-        {
-            return None;
-        }
+        ))?;
 
-        Some(CRSElements {
+        Ok(CRSElements {
             degree: d,
             raw: self,
         })
@@ -246,6 +248,7 @@ impl RawContribution {
         self.new_elements
             .to_owned()
             .validate()
+            .ok()
             .map(|new_elements| Contribution {
                 parent: self.parent,
                 new_elements,
@@ -504,27 +507,27 @@ mod test {
     #[test]
     fn test_root_crs_is_valid() {
         let root = CRSElements::root(D);
-        assert!(root.raw.validate().is_some());
+        assert!(root.raw.validate().is_ok());
     }
 
     #[test]
     fn test_nontrivial_crs_is_valid() {
         let crs = non_trivial_crs();
-        assert!(crs.validate().is_some());
+        assert!(crs.validate().is_ok());
     }
 
     #[test]
     fn test_changing_alpha_makes_crs_invalid() {
         let mut crs = non_trivial_crs();
         crs.alpha_1 = G1::generator();
-        assert!(crs.validate().is_none());
+        assert!(crs.validate().is_err());
     }
 
     #[test]
     fn test_changing_beta_makes_crs_invalid() {
         let mut crs = non_trivial_crs();
         crs.beta_1 = G1::generator();
-        assert!(crs.validate().is_none());
+        assert!(crs.validate().is_err());
     }
 
     #[test]
@@ -534,11 +537,11 @@ mod test {
         let x = F::rand(&mut OsRng);
 
         let crs0 = make_crs(F::zero(), beta, x);
-        assert!(crs0.validate().is_none());
+        assert!(crs0.validate().is_err());
         let crs1 = make_crs(alpha, F::zero(), x);
-        assert!(crs1.validate().is_none());
+        assert!(crs1.validate().is_err());
         let crs2 = make_crs(alpha, beta, F::zero());
-        assert!(crs2.validate().is_none());
+        assert!(crs2.validate().is_err());
     }
 
     #[test]
@@ -561,7 +564,7 @@ mod test {
             alpha_x_1: vec![G1::generator() * alpha, G1::generator() * (alpha * x)],
             beta_x_1: vec![G1::generator() * beta, G1::generator() * (beta * x)],
         };
-        assert!(crs.validate().is_none());
+        assert!(crs.validate().is_err());
     }
 
     #[test]
@@ -572,7 +575,7 @@ mod test {
             ContributionHash([0u8; CONTRIBUTION_HASH_SIZE]),
             &root,
         );
-        assert!(contribution.new_elements.raw.validate().is_some());
+        assert!(contribution.new_elements.raw.validate().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
There was some vestigial debugging aid code doing many pairings instead of a batched pairing checks; this was very slow. Removing this code, we get a verification time of 4s, rather than 2+ minutes.