### PR TITLE
build: require rust 1.73

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
-        run: rustup update 1.67.1 --no-self-update && rustup default 1.67.1
+        run: rustup update 1.73.0 --no-self-update && rustup default 1.73.0
       - name: Install cargo-dist
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.5/cargo-dist-v0.0.5-installer.sh | sh
       - id: create-release
@@ -107,7 +107,7 @@ jobs:
         with:
           lfs: true
       - name: Install Rust
-        run: rustup update 1.67.1 --no-self-update && rustup default 1.67.1
+        run: rustup update 1.73.0 --no-self-update && rustup default 1.73.0
       - name: Install cargo-dist
         run: ${{ matrix.install-dist }}
       - name: Run cargo-dist

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ opt-level = "s"
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.0.5"
 # The preferred Rust toolchain to use in CI (rustup toolchain syntax).
-# We use the same value as the MSRV in pd/Cargo.toml.
-rust-toolchain-version = "1.65"
+# We use the same value as the MSRV in crates/bin/pd/Cargo.toml.
+rust-toolchain-version = "1.73"
 # CI backends to support (see 'cargo dist generate-ci')
 ci = ["github"]
 # Target platforms to build apps for (Rust target-triple syntax)

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 # Pin a MSRV. Anything more recent than this value is OK.
 # If a lower version is used for build, the build will fail.
-rust-version = "1.65"
+rust-version = "1.73"
 
 [features]
 std = ["ibc-types/std"]


### PR DESCRIPTION
During release of Rhea 63, we encountered build errors for folks with outdated rust versions. Our CI jobs using 1.65 also failed. N.B. we're behind on `cargo-dist` versions; upgrading that tool may ease this change.

Refs #3182.