### PR TITLE
updates for summonerd webapp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -5905,7 +5905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -7220,11 +7220,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -7253,9 +7253,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
+checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
@@ -7696,10 +7696,12 @@ dependencies = [
  "axum 0.6.20",
  "bytes",
  "camino",
+ "chrono",
  "clap 3.2.25",
  "console-subscriber",
  "decaf377 0.5.0",
  "futures",
+ "hex",
  "http-body",
  "metrics-tracing-context",
  "penumbra-asset",
@@ -8228,7 +8230,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8250,7 +8252,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -9069,9 +9071,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
+checksum = "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32"
 dependencies = [
  "memchr",
 ]
@@ -9124,18 +9126,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.20"
+version = "0.7.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd66a62464e3ffd4e37bd09950c2b9dd6c4f8767380fabba0d523f9a775bc85a"
+checksum = "686b7e407015242119c33dab17b8f61ba6843534de936d94368856528eae4dcc"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.20"
+version = "0.7.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255c4596d41e6916ced49cfafea18727b24d67878fa180ddfd69b9df34fd1726"
+checksum = "020f3dfe25dfc38dfea49ce62d5d45ecdd7f0d8a724fa63eb36b6eba4ec76806"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",

--- a/tools/summonerd/Cargo.toml
+++ b/tools/summonerd/Cargo.toml
@@ -25,9 +25,11 @@ axum = "0.6"
 bytes = "1"
 camino = "1"
 clap = { version = "3", features = ["derive", "env", "color"] }
+chrono = "0.4"
 console-subscriber = "0.2"
 decaf377 = "0.5"
 futures = "0.3.28"
+hex = "0.4"
 http-body = "0.4.5"
 metrics-tracing-context = "0.11.0"
 penumbra-asset = { path = "../../crates/core/asset/" }

--- a/tools/summonerd/src/main.rs
+++ b/tools/summonerd/src/main.rs
@@ -185,14 +185,15 @@ impl Opt {
                         tokio::spawn(coordinator.run::<Phase2>().instrument(coordinator_span))
                     }
                 };
-                let service = CoordinatorService::new(knower, storage.clone(), queue, marker);
+                let service =
+                    CoordinatorService::new(knower, storage.clone(), queue.clone(), marker);
                 let grpc_server = Server::builder().add_service(
                     CeremonyCoordinatorServiceServer::new(service)
                         .max_encoding_message_size(max_message_size(marker))
                         .max_decoding_message_size(max_message_size(marker)),
                 );
 
-                let web_app = web_app(storage);
+                let web_app = web_app(marker, queue, storage);
 
                 let router = grpc_server.into_router().merge(web_app);
 

--- a/tools/summonerd/src/storage.rs
+++ b/tools/summonerd/src/storage.rs
@@ -357,27 +357,23 @@ impl Storage {
         let mut conn = self.pool.get()?;
         let tx = conn.transaction()?;
         let query = match marker {
-            PhaseMarker::P1 => format!(
-                "SELECT hash, time, address from phase1_contributions WHERE address IS NOT NULL ORDER BY slot DESC LIMIT {}",
-                n
-            ),
-            PhaseMarker::P2 => format!(
-                "SELECT hash, time, address from phase2_contributions WHERE address IS NOT NULL ORDER BY slot DESC LIMIT {}",
-                n
-            ),
+            PhaseMarker::P1 =>
+                "SELECT hash, time, address from phase1_contributions WHERE address IS NOT NULL ORDER BY slot DESC LIMIT ?1",
+            PhaseMarker::P2 =>
+                "SELECT hash, time, address from phase2_contributions WHERE address IS NOT NULL ORDER BY slot DESC LIMIT ?1",
         };
 
         let mut out = Vec::new();
-        let mut stmt = tx.prepare(&query)?;
-        let mut rows = stmt.query([])?;
+        let mut stmt = tx.prepare(query)?;
+        let mut rows = stmt.query([n])?;
         while let Some(row) = rows.next()? {
             let hash_bytes: Vec<u8> = row.get(0)?;
             let unix_timestamp: u64 = row.get(1)?;
             // Convert unix timestamp to date time
             let date_time =
                 chrono::DateTime::from_timestamp(unix_timestamp as i64, 0).unwrap_or_default();
-            let hash: String = hex::encode(hash_bytes);
-            let address_bytes: Vec<u8> = row.get(0)?;
+            let hash: String = hex::encode_upper(hash_bytes);
+            let address_bytes: Vec<u8> = row.get(2)?;
             let address: Address = address_bytes.try_into()?;
             out.push((hash, date_time.to_string(), address.display_short_form()));
         }

--- a/tools/summonerd/src/web.rs
+++ b/tools/summonerd/src/web.rs
@@ -63,8 +63,8 @@ pub async fn main_page(State(state): State<Arc<WebAppState>>) -> impl IntoRespon
 struct MainTemplate {
     num_contributions_so_far_phase_1: u64,
     num_contributions_so_far_phase_2: u64,
-    recent_contributions_phase_2: Vec<String>,
-    recent_contributions_phase_1: Vec<String>,
+    recent_contributions_phase_2: Vec<(String, String)>,
+    recent_contributions_phase_1: Vec<(String, String)>,
 }
 
 struct HtmlTemplate<T>(T);

--- a/tools/summonerd/src/web.rs
+++ b/tools/summonerd/src/web.rs
@@ -26,8 +26,19 @@ pub fn web_app(storage: Storage) -> Router {
 }
 
 pub async fn main_page(State(state): State<Arc<WebAppState>>) -> impl IntoResponse {
-    // TODO: Grab from the database, so we will need the state
-    let phase_number = 1;
+    let has_transitioned = state
+        .storage
+        .transition_extra_information()
+        .await
+        .expect("Can get transition status");
+
+    let phase_number: u64;
+    if has_transitioned.is_some() {
+        phase_number = 2;
+    } else {
+        phase_number = 1;
+    }
+
     let template = MainTemplate { phase_number };
     HtmlTemplate(template)
 }

--- a/tools/summonerd/src/web.rs
+++ b/tools/summonerd/src/web.rs
@@ -41,7 +41,7 @@ pub async fn phase_1(State(state): State<Arc<WebAppState>>) -> impl IntoResponse
         .await
         .expect("Can get contributions so far");
 
-    let recent_contributions_phase_1 = state
+    let contributions_by_hash_time_shortaddr = state
         .storage
         .last_n_contributors(PhaseMarker::P1, 5)
         .await
@@ -49,7 +49,7 @@ pub async fn phase_1(State(state): State<Arc<WebAppState>>) -> impl IntoResponse
 
     let template = Phase1Template {
         num_contributions_so_far_phase_1,
-        recent_contributions_phase_1,
+        contributions_by_hash_time_shortaddr,
     };
     HtmlTemplate(template)
 }
@@ -63,7 +63,7 @@ pub async fn phase_2(State(state): State<Arc<WebAppState>>) -> impl IntoResponse
         .await
         .expect("Can get contributions so far");
 
-    let recent_contributions_phase_2 = state
+    let contributions_by_hash_time_shortaddr = state
         .storage
         .last_n_contributors(PhaseMarker::P2, 5)
         .await
@@ -71,7 +71,7 @@ pub async fn phase_2(State(state): State<Arc<WebAppState>>) -> impl IntoResponse
 
     let template = Phase2Template {
         num_contributions_so_far_phase_2,
-        recent_contributions_phase_2,
+        contributions_by_hash_time_shortaddr,
     };
     HtmlTemplate(template)
 }
@@ -86,14 +86,14 @@ struct MainTemplate {
 #[template(path = "phase1.html")]
 struct Phase1Template {
     num_contributions_so_far_phase_1: u64,
-    recent_contributions_phase_1: Vec<(String, String)>,
+    contributions_by_hash_time_shortaddr: Vec<(String, String, String)>,
 }
 
 #[derive(Template)]
 #[template(path = "phase2.html")]
 struct Phase2Template {
     num_contributions_so_far_phase_2: u64,
-    recent_contributions_phase_2: Vec<(String, String)>,
+    contributions_by_hash_time_shortaddr: Vec<(String, String, String)>,
 }
 
 struct HtmlTemplate<T>(T);

--- a/tools/summonerd/templates/main.html
+++ b/tools/summonerd/templates/main.html
@@ -5,8 +5,8 @@
 {% if recent_contributions_phase_1.len() != 0 %}
 Recent phase 1 contributors:
 <ul>
-    {% for contributor in recent_contributions_phase_1 %}
-    <li>{{ contributor|e }}</li>
+    {% for contribution in recent_contributions_phase_1 %}
+    <li>{{ contribution.0|e }} contributed at {{ contribution.1 }}</li>
     {% endfor %}
 </ul>
 {% endif %}
@@ -16,8 +16,8 @@ Recent phase 1 contributors:
 {% if recent_contributions_phase_2.len() != 0 %}
 Recent phase 2 contributors:
 <ul>
-    {% for contributor in recent_contributions_phase_2 %}
-    <li>{{ contributor|e }}</li>
+    {% for contribution in recent_contributions_phase_2 %}
+    <li>{{ contribution.0|e }} contributed at {{ contribution.1 }}</li>
     {% endfor %}
 </ul>
 {% endif %}

--- a/tools/summonerd/templates/main.html
+++ b/tools/summonerd/templates/main.html
@@ -1,26 +1,6 @@
 <h1>✨✨✨✨ Penumbra Summoning Ceremony ✨✨✨✨</h1>
 
-<h2>Previous Contributions in phase 1: {{ num_contributions_so_far_phase_1 }}</h2>
-
-{% if recent_contributions_phase_1.len() != 0 %}
-Recent phase 1 contributors:
-<ul>
-    {% for contribution in recent_contributions_phase_1 %}
-    <li>{{ contribution.0|e }} contributed at {{ contribution.1 }}</li>
-    {% endfor %}
-</ul>
-{% endif %}
-
-<h2>Previous Contributions in phase 2: {{ num_contributions_so_far_phase_2 }}</h2>
-
-{% if recent_contributions_phase_2.len() != 0 %}
-Recent phase 2 contributors:
-<ul>
-    {% for contribution in recent_contributions_phase_2 %}
-    <li>{{ contribution.0|e }} contributed at {{ contribution.1 }}</li>
-    {% endfor %}
-</ul>
-{% endif %}
+<h2>Penumbra Summoning Ceremony is currently in phase: {{ phase_number }} of 2</h2>
 
 <h2>How to become a Penumbra Summoner:</h2>
 
@@ -37,7 +17,7 @@ Recent phase 2 contributors:
 <p>
     In the Terminal, run:
 
-<pre>cargo run --quiet --release --bin pcli -- --node https://grpc.testnet.penumbra.zone ceremony contribute --coordinator-url COORDINATOR_URL --coordinator-address SUMMONER_ADDRESS --phase PHASE_NUMBER --bid 1penumbra</pre>
+<pre>cargo run --quiet --release --bin pcli -- --node https://grpc.testnet.penumbra.zone ceremony contribute --coordinator-url COORDINATOR_URL --coordinator-address SUMMONER_ADDRESS --phase {{ phase_number }} --bid 1penumbra</pre>
 </p>
 
 <p>

--- a/tools/summonerd/templates/main.html
+++ b/tools/summonerd/templates/main.html
@@ -1,6 +1,8 @@
 <h1>✨✨✨✨ Penumbra Summoning Ceremony ✨✨✨✨</h1>
 
-<h2>Penumbra Summoning Ceremony is currently in phase: {{ phase_number }} of 2</h2>
+<h2><a href="/phase/{{ phase_number }}">Penumbra Summoning Ceremony</a> is currently in phase: <a
+        href="/phase/{{ phase_number }}">{{ phase_number }}</a> of 2
+</h2>
 
 <h2>How to become a Penumbra Summoner:</h2>
 
@@ -17,7 +19,7 @@
 <p>
     In the Terminal, run:
 
-<pre>cargo run --quiet --release --bin pcli -- --node https://grpc.testnet.penumbra.zone ceremony contribute --coordinator-url COORDINATOR_URL --coordinator-address SUMMONER_ADDRESS --phase {{ phase_number }} --bid 1penumbra</pre>
+<pre>cargo run --quiet --release --bin pcli -- ceremony contribute --coordinator-url COORDINATOR_URL --coordinator-address SUMMONER_ADDRESS --phase {{ phase_number }} --bid 1penumbra</pre>
 </p>
 
 <p>

--- a/tools/summonerd/templates/main.html
+++ b/tools/summonerd/templates/main.html
@@ -19,7 +19,7 @@
 <p>
     In the Terminal, run:
 
-<pre>cargo run --quiet --release --bin pcli -- ceremony contribute --coordinator-url COORDINATOR_URL --coordinator-address SUMMONER_ADDRESS --phase {{ phase_number }} --bid 1penumbra</pre>
+<pre>cargo run --quiet --release --bin pcli -- ceremony contribute --phase {{ phase_number }} --bid 1penumbra</pre>
 </p>
 
 <p>

--- a/tools/summonerd/templates/phase1.html
+++ b/tools/summonerd/templates/phase1.html
@@ -1,12 +1,33 @@
 <h1>✨✨✨✨ Penumbra Summoning Ceremony ✨✨✨✨</h1>
 
+{% if snapshot_participants_top_median.is_some() %}
+{% let value = snapshot_participants_top_median.as_ref().unwrap() %}
+<span>Waiting:</span>
+<span>{{ value.0 }}</span>
+<span>Top Bid:</span>
+<span>{{ value.1 }}</span>
+<span>Median Bid:</span>
+<span>{{ value.2 }}</span>
+{% endif %}
+
 <h2>Previous Contributions in phase 1: {{ num_contributions_so_far_phase_1 }}</h2>
 
-{% if contributions_by_hash_time_shortaddr.len() != 0 %}
+{% if contributions_by_slot_hash_time_shortaddr.len() != 0 %}
 Recent phase 1 contributors:
-<ul>
-    {% for contribution in contributions_by_hash_time_shortaddr %}
-    <li>{{ contribution.2 }} contributed {{ contribution.0 }} at {{ contribution.1 }}</li>
+<table>
+    <tr>
+      <td>Slot</td>
+      <td>Who</td>
+      <td>What</td>
+      <td>When</td>
+    </tr>
+    {% for contribution in contributions_by_slot_hash_time_shortaddr.iter() %}
+    <tr>
+      <td>{{ contribution.0 }}</td>
+      <td>{{ contribution.3 }}</td>
+      <td>{{ contribution.1 }}</td>
+      <td>{{ contribution.2 }}</td>
+    </tr>
     {% endfor %}
-</ul>
+</table>
 {% endif %}

--- a/tools/summonerd/templates/phase1.html
+++ b/tools/summonerd/templates/phase1.html
@@ -2,11 +2,11 @@
 
 <h2>Previous Contributions in phase 1: {{ num_contributions_so_far_phase_1 }}</h2>
 
-{% if recent_contributions_phase_1.len() != 0 %}
+{% if contributions_by_hash_time_shortaddr.len() != 0 %}
 Recent phase 1 contributors:
 <ul>
-    {% for contribution in recent_contributions_phase_1 %}
-    <li>{{ contribution.0|e }} contributed at {{ contribution.1 }}</li>
+    {% for contribution in contributions_by_hash_time_shortaddr %}
+    <li>{{ contribution.2 }} contributed {{ contribution.0 }} at {{ contribution.1 }}</li>
     {% endfor %}
 </ul>
 {% endif %}

--- a/tools/summonerd/templates/phase1.html
+++ b/tools/summonerd/templates/phase1.html
@@ -1,0 +1,12 @@
+<h1>✨✨✨✨ Penumbra Summoning Ceremony ✨✨✨✨</h1>
+
+<h2>Previous Contributions in phase 1: {{ num_contributions_so_far_phase_1 }}</h2>
+
+{% if recent_contributions_phase_1.len() != 0 %}
+Recent phase 1 contributors:
+<ul>
+    {% for contribution in recent_contributions_phase_1 %}
+    <li>{{ contribution.0|e }} contributed at {{ contribution.1 }}</li>
+    {% endfor %}
+</ul>
+{% endif %}

--- a/tools/summonerd/templates/phase2.html
+++ b/tools/summonerd/templates/phase2.html
@@ -2,11 +2,11 @@
 
 <h2>Previous Contributions in phase 2: {{ num_contributions_so_far_phase_2 }}</h2>
 
-{% if recent_contributions_phase_2.len() != 0 %}
+{% if contributions_by_hash_time_shortaddr.len() != 0 %}
 Recent phase 2 contributors:
 <ul>
-    {% for contribution in recent_contributions_phase_2 %}
-    <li>{{ contribution.0|e }} contributed at {{ contribution.1 }}</li>
+    {% for contribution in contributions_by_hash_time_shortaddr %}
+    <li>{{ contribution.2 }} contributed {{ contribution.0 }} at {{ contribution.1 }}</li>
     {% endfor %}
 </ul>
 {% endif %}

--- a/tools/summonerd/templates/phase2.html
+++ b/tools/summonerd/templates/phase2.html
@@ -1,12 +1,33 @@
 <h1>✨✨✨✨ Penumbra Summoning Ceremony ✨✨✨✨</h1>
 
+{% if snapshot_participants_top_median.is_some() %}
+{% let value = snapshot_participants_top_median.as_ref().unwrap() %}
+<span>Waiting:</span>
+<span>{{ value.0 }}</span>
+<span>Top Bid:</span>
+<span>{{ value.1 }}</span>
+<span>Median Bid:</span>
+<span>{{ value.2 }}</span>
+{% endif %}
+
 <h2>Previous Contributions in phase 2: {{ num_contributions_so_far_phase_2 }}</h2>
 
-{% if contributions_by_hash_time_shortaddr.len() != 0 %}
+{% if contributions_by_slot_hash_time_shortaddr.len() != 0 %}
 Recent phase 2 contributors:
-<ul>
-    {% for contribution in contributions_by_hash_time_shortaddr %}
-    <li>{{ contribution.2 }} contributed {{ contribution.0 }} at {{ contribution.1 }}</li>
+<table>
+    <tr>
+      <td>Slot</td>
+      <td>Who</td>
+      <td>What</td>
+      <td>When</td>
+    </tr>
+    {% for contribution in contributions_by_slot_hash_time_shortaddr.iter() %}
+    <tr>
+      <td>{{ contribution.0 }}</td>
+      <td>{{ contribution.3 }}</td>
+      <td>{{ contribution.1 }}</td>
+      <td>{{ contribution.2 }}</td>
+    </tr>
     {% endfor %}
-</ul>
+</table>
 {% endif %}

--- a/tools/summonerd/templates/phase2.html
+++ b/tools/summonerd/templates/phase2.html
@@ -1,0 +1,12 @@
+<h1>✨✨✨✨ Penumbra Summoning Ceremony ✨✨✨✨</h1>
+
+<h2>Previous Contributions in phase 2: {{ num_contributions_so_far_phase_2 }}</h2>
+
+{% if recent_contributions_phase_2.len() != 0 %}
+Recent phase 2 contributors:
+<ul>
+    {% for contribution in recent_contributions_phase_2 %}
+    <li>{{ contribution.0|e }} contributed at {{ contribution.1 }}</li>
+    {% endfor %}
+</ul>
+{% endif %}


### PR DESCRIPTION
Closes #3220

This splits the web app into three pages.

## Main page

This currently displays the current phase, where the current phase info is determined by looking in the database to see if the transition between phase 1 and 2 has occurred. 

It also contains instructions for this phase, where the `--phase` CLI arg is populated using the information determined as above. 

Remaining TODOs:
- [-] Populate the text on the page with the COORDINATOR_URL and SUMMONER_ADDRESS - no longer needed as we will hardcode these in pcli to simplify the user's experience

## `/phase/1` and `/phase/2` pages

These are identical pages, one per phase, that show the:

- The number of contributions in that phase
- The most recent 5 contributions: short address, hash, time of contribution completed

Remaining TODOs:
- [x] Show most recent bid amount
- [x] If phase is currently active, show the number of folks connected
