### PR TITLE
feat(pcli): more informative error message

### DIFF
--- a/crates/bin/pcli/src/config.rs
+++ b/crates/bin/pcli/src/config.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use url::Url;
@@ -27,8 +27,11 @@ pub struct PcliConfig {
 }
 
 impl PcliConfig {
-    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let contents = std::fs::read_to_string(path)?;
+    pub fn load<P: AsRef<Path> + std::fmt::Display>(path: P) -> Result<Self> {
+        let contents = std::fs::read_to_string(&path).context(format!(
+            "pcli config file not found: {}. hint: run 'pcli init' to create new keys",
+            &path
+        ))?;
         Ok(toml::from_str(&contents)?)
     }
 


### PR DESCRIPTION
Follow up to the new `pcli init` logic [0], adding a more informative error message, in case folks forget to rotate their address format, as required by Rhea 63.

[0] https://github.com/penumbra-zone/penumbra/pull/3239