### PR TITLE
Further summonerd parallelization

### DIFF
--- a/crates/bin/pcli/src/command/ceremony.rs
+++ b/crates/bin/pcli/src/command/ceremony.rs
@@ -81,9 +81,12 @@ pub enum CeremonyCmd {
     Contribute {
         #[clap(long)]
         phase: u8,
-        #[clap(long, default_value="https://summoning-dev.penumbra.zone")]
+        #[clap(long, default_value = "https://summoning-dev.penumbra.zone")]
         coordinator_url: Url,
-        #[clap(long, default_value="penumbra1zjd6p7d6xta200mzcxtcudqthe4yfsnm6cw7wpr6tdecj6gsdpjmjld6vezu7rdj3kr8u9rl9pkhgst99sxy8wlvl8wqsst0wjhy0wewsczx9d6ys96z84rhewdwrm537y6wwz")]
+        #[clap(
+            long,
+            default_value = "penumbra1zjd6p7d6xta200mzcxtcudqthe4yfsnm6cw7wpr6tdecj6gsdpjmjld6vezu7rdj3kr8u9rl9pkhgst99sxy8wlvl8wqsst0wjhy0wewsczx9d6ys96z84rhewdwrm537y6wwz"
+        )]
         coordinator_address: Address,
         #[clap(long)]
         bid: String,

--- a/crates/crypto/proof-setup/src/parallel_utils.rs
+++ b/crates/crypto/proof-setup/src/parallel_utils.rs
@@ -1,3 +1,5 @@
+use rayon::prelude::{IndexedParallelIterator, IntoParallelIterator};
+
 pub fn transform<A, B, const N: usize>(data: [A; N], f: impl Fn(A) -> B) -> [B; N] {
     match data.into_iter().map(f).collect::<Vec<B>>().try_into() {
         Ok(x) => x,
@@ -33,4 +35,27 @@ pub fn flatten_results<A, E, const N: usize>(data: [Result<A, E>; N]) -> Result<
         Ok(x) => Ok(x),
         _ => panic!("The size of the iterator should not have changed"),
     }
+}
+
+#[cfg(not(feature = "parallel"))]
+pub fn zip_map_parallel<A: Send, B: Send, C: Sync + Send>(
+    a: &mut [A],
+    b: &mut [B],
+    f: impl Fn(&A, &B) -> C + Send + Sync,
+) -> Vec<C> {
+    a.iter().zip(b.iter()).map(|(a, b)| f(a, b)).collect()
+}
+
+#[cfg(feature = "parallel")]
+pub fn zip_map_parallel<A: Send, B: Send, C: Sync + Send>(
+    a: &mut [A],
+    b: &mut [B],
+    f: impl Fn(&A, &B) -> C + Send + Sync,
+) -> Vec<C> {
+    use rayon::prelude::*;
+
+    a.into_par_iter()
+        .zip(b.into_par_iter())
+        .map(|(a, b)| f(a, b))
+        .collect()
 }

--- a/crates/crypto/proof-setup/src/parallel_utils.rs
+++ b/crates/crypto/proof-setup/src/parallel_utils.rs
@@ -1,5 +1,3 @@
-use rayon::prelude::{IndexedParallelIterator, IntoParallelIterator};
-
 pub fn transform<A, B, const N: usize>(data: [A; N], f: impl Fn(A) -> B) -> [B; N] {
     match data.into_iter().map(f).collect::<Vec<B>>().try_into() {
         Ok(x) => x,


### PR DESCRIPTION
Because some of the circuits are smaller, you want a slightly more intrusive level of parallelization for some operations,
in order to more effectively distribute work. This PR does that in a couple places.

## Server Side

Deserialization, which needs to validate elements, now parallelizes the validation in each circuit. (The infamous scalar multiplications).

## Client Side

Parallelize phase1 contribution creation further, now it consistently utilizes all cores.

The client side part is less important, since we don't control it, but it's still nice if beefier contributors can finish making their contribution faster.