### PR TITLE
ci: use apply rather than sync for deploys

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -55,17 +55,9 @@ jobs:
           location: us-central1
 
       - name: install helmfile
-        run: |
-          helmfile_version="0.157.0"
-          helmfile_url="https://github.com/helmfile/helmfile/releases/download/v${helmfile_version}/helmfile_${helmfile_version}_linux_amd64.tar.gz"
-          mkdir -p /tmp/helmfile-download
-          cd /tmp/helmfile-download || exit 1
-          curl -SfL -O "$helmfile_url"
-          tar -xzf helmfile*.tar.gz
-          mkdir -p "$HOME/bin"
-          cp helmfile "$HOME/bin/"
-          export PATH="$HOME/bin:$PATH"
-          which helmfile
+        uses: mamezou-tech/setup-helmfile@v1.3.0
+        with:
+          helmfile-version: "v0.157.0"
 
       - name: deploy
         run: |-

--- a/deployments/ci.sh
+++ b/deployments/ci.sh
@@ -49,8 +49,7 @@ function helm_uninstall() {
 # as necessary. Will *not* replace certain durable resources like
 # the LoadBalancer Service objects, which are annotated with helm.sh/resource-policy=keep.
 function helm_install() {
-    # TODO: make sure helmfile is present in ci environemnt.
-    helmfile sync -f "$HELMFILE_MANIFEST" --args \
+    helmfile apply -f "$HELMFILE_MANIFEST" --args \
         --set="image.tag=${PENUMBRA_VERSION}"
 }
 


### PR DESCRIPTION
This reverts commit 155df60540ada18f8c4315d41b1a3bfad11dd76d, which itself reverted commit 25c4e6fd531136f97bbdee71aef269f05c35ccf0.

ci: use helmfile gha helper
For including helm-diff, required for running "helmfile apply"

Refs #3279.