### PR TITLE
ci: set cors headers for buf studio

### DIFF
--- a/deployments/charts/penumbra-node/templates/ingressroute.yaml
+++ b/deployments/charts/penumbra-node/templates/ingressroute.yaml
@@ -14,6 +14,10 @@ spec:
   routes:
   - kind: Rule
     match: Host(`{{ .Values.ingressRoute.hosts.pd }}`)
+    {{- with .Values.ingressRoute.middlewares }}
+    middlewares:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     services:
 {{- /*
 Skip nodes with seed_mode=true when looping over nodes, to exclude from LB RPCs.

--- a/deployments/charts/penumbra-node/values.yaml
+++ b/deployments/charts/penumbra-node/values.yaml
@@ -84,6 +84,10 @@ ingressRoute:
     tm: tm.chart-example.local
   # Secret object containing TLS info
   secretName: ""
+  # Traefik middleware CRDs, to be applied to pd's gRPC service.
+  # These config objects must already exist in the API, i.e. create them out of band.
+  middlewares:
+    - name: cors-bufstudio
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Ensures that the ad-hoc changes made to the HTTPS reverse proxy fronting the pd gRPC services persist. We want to ensure that the pd gRPC services is usable with https://buf.build/studio/, and now it is.

Refs #3281.