### PR TITLE
ci: only run buf lint on PRs against main

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -1,5 +1,11 @@
 name: Protobuf
-on: pull_request
+on:
+  # Exclude feature branches, only run if the PR is targeting main.
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - "main"
 jobs:
   lint:
     name: Lint protobuf
@@ -55,7 +61,7 @@ jobs:
           toolchain: stable
           override: false
 
-      - uses: bufbuild/buf-setup-action@v1.27.1
+      - uses: bufbuild/buf-setup-action@v1
         with:
           buf_api_token: ${{ secrets.BUF_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Also ensures we're using the most recent stable version of buf across all workflows, via the `v1` version specifier.

Closes #3292.