### PR TITLE
Fix broken list-tx-hashes function for swap claims

### DIFF
--- a/crates/bin/pcli/src/command/view/balance.rs
+++ b/crates/bin/pcli/src/command/view/balance.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use comfy_table::{presets, Table};
 use penumbra_asset::{asset::Cache, Value};
-use penumbra_keys::{keys::AddressIndex, FullViewingKey};
+use penumbra_keys::FullViewingKey;
 use penumbra_view::ViewClient;
 #[derive(Debug, clap::Args)]
 pub struct BalanceCmd {
@@ -22,9 +22,9 @@ impl BalanceCmd {
         let mut table = Table::new();
         table.load_preset(presets::NOTHING);
 
-        let rows: Vec<(Option<AddressIndex>, Value)> = if self.by_note {
+        let rows: Vec<(Option<u32>, Value)> = if self.by_note {
             let notes = view
-                .unspent_notes_by_address_and_asset(fvk.wallet_id())
+                .unspent_notes_by_account_and_asset(fvk.wallet_id())
                 .await?;
 
             notes
@@ -40,7 +40,7 @@ impl BalanceCmd {
                 .collect()
         } else {
             let notes = view
-                .unspent_notes_by_address_and_asset(fvk.wallet_id())
+                .unspent_notes_by_account_and_asset(fvk.wallet_id())
                 .await?;
 
             notes
@@ -63,12 +63,10 @@ impl BalanceCmd {
                 .collect()
         };
 
-        let (indexed_rows, ephemeral_rows) = combine_ephemeral(rows, self.by_note);
-
         table.set_header(vec!["Account", "Amount"]);
 
-        for row in indexed_rows.iter().chain(ephemeral_rows.iter()) {
-            table.add_row(format_row(row, &asset_cache));
+        for row in rows.clone() {
+            table.add_row(format_row(&row, &asset_cache));
         }
 
         println!("{table}");
@@ -77,64 +75,16 @@ impl BalanceCmd {
     }
 }
 
-fn format_row(row: &(Option<AddressIndex>, Value), asset_cache: &Cache) -> Vec<String> {
+fn format_row(row: &(Option<u32>, Value), asset_cache: &Cache) -> Vec<String> {
     let (index, value) = row;
 
     let mut string_row = Vec::with_capacity(2);
 
     if let Some(index) = index {
-        string_row.push(format!("{}", index.account));
+        string_row.push(format!("{}", index));
+
+        string_row.push(value.format(asset_cache));
     }
-    string_row.push(value.format(asset_cache));
 
     string_row
-}
-
-/// Split the rows into (indexed, ephemeral) pair with all of the ephemeral notes
-/// combined by asset. The AddressIndex is left in to signal the ephemerality to
-/// the table parsing. This should be changed when well typed, JSON output is supported
-#[allow(clippy::type_complexity)]
-fn combine_ephemeral(
-    rows: Vec<(Option<AddressIndex>, Value)>,
-    by_note: bool,
-) -> (
-    Vec<(Option<AddressIndex>, Value)>,
-    Vec<(Option<AddressIndex>, Value)>,
-) {
-    if by_note {
-        return (rows, Vec::new());
-    }
-
-    // get all ephemeral rows
-    let (mut ephemeral_notes, indexed_rows): (Vec<_>, Vec<_>) =
-        rows.into_iter().partition(|(index, _)| {
-            if let Some(index) = index {
-                u128::from(*index) > u64::MAX as u128
-            } else {
-                false
-            }
-        });
-
-    let ephemeral_rows = if ephemeral_notes.len() <= 1 {
-        // Nothing to combine
-        ephemeral_notes
-    } else {
-        // Simulate a `SELECT SUM(note.amount) GROUP BY is_ephemeral` by sorting
-        // the notes by asset, and the summing rows together until the asset_id changes
-        ephemeral_notes.sort_by(|row1, row2| row1.1.asset_id.cmp(&row2.1.asset_id));
-        let mut new_ephemeral_notes = vec![];
-        let mut cur_row = ephemeral_notes[0];
-        for row in ephemeral_notes.iter().skip(1) {
-            if cur_row.1.asset_id == row.1.asset_id {
-                cur_row.1.amount += row.1.amount;
-            } else {
-                new_ephemeral_notes.push(cur_row);
-                cur_row = *row;
-            }
-        }
-        // Make sure to get the currently-in-progress row
-        new_ephemeral_notes.push(cur_row);
-        new_ephemeral_notes
-    };
-    (indexed_rows, ephemeral_rows)
 }

--- a/crates/view/src/sync.rs
+++ b/crates/view/src/sync.rs
@@ -27,7 +27,14 @@ pub struct FilteredBlock {
 impl FilteredBlock {
     pub fn inbound_transaction_ids(&self) -> BTreeSet<[u8; 32]> {
         let mut ids = BTreeSet::new();
-        let sources = self.new_notes.iter().map(|n| n.source);
+        let sources: Vec<NoteSource> = self
+            .new_notes
+            .clone()
+            .iter()
+            .map(|n| n.source)
+            .chain(self.new_swaps.iter().map(|n| n.source))
+            .collect();
+
         for source in sources {
             if let NoteSource::Transaction { id } = source {
                 ids.insert(id);

--- a/crates/wasm/src/storage.rs
+++ b/crates/wasm/src/storage.rs
@@ -124,11 +124,6 @@ impl IndexedDBStorage {
     }
 
     pub async fn store_advice(&self, note: Note) -> WasmResult<()> {
-        // Do not insert advice for zero amounts, simply return Ok because this is fine
-        if u128::from(note.amount()) == 0u128 {
-            return Ok(());
-        }
-
         let tx = self
             .db
             .transaction_on_one_with_mode(&self.constants.tables.notes, Readwrite)?;


### PR DESCRIPTION
View: removes code to skip storage of output notes of value 0, adds code to include transaction ids for incoming swaps to filtered blocks.

Closes #2547
Closes #3214 