### PR TITLE
pd: add `--enable-expensive-rpc` flag

### DIFF
--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -21,6 +21,7 @@ use pd::testnet::{
     join::testnet_join,
 };
 use pd::upgrade::{self, Upgrade};
+use penumbra_proto::core::component::dex::v1alpha1::simulation_service_server::SimulationServiceServer;
 use penumbra_proto::util::tendermint_proxy::v1alpha1::tendermint_proxy_service_server::TendermintProxyServiceServer;
 use penumbra_storage::{StateDelta, Storage};
 use penumbra_tendermint_proxy::TendermintProxy;
@@ -114,6 +115,13 @@ enum RootCommand {
             alias = "tendermint-addr",
         )]
         cometbft_addr: Url,
+
+        /// Enable the trade simulation service, which allows clients to simulate
+        /// trades without submitting them. This is useful for approximating the
+        /// cost of a trade before submitting it. But, it is a potential DoS vector,
+        /// so it is disabled by default.
+        #[clap(short, long, display_order = 500)]
+        simulate_trade_service: bool,
     },
     /// Generate, join, or reset a testnet.
     Testnet {
@@ -263,6 +271,7 @@ async fn main() -> anyhow::Result<()> {
             grpc_auto_https,
             metrics_bind,
             cometbft_addr,
+            simulate_trade_service,
         } => {
             tracing::info!(
                 ?abci_bind,
@@ -270,6 +279,7 @@ async fn main() -> anyhow::Result<()> {
                 ?grpc_auto_https,
                 ?metrics_bind,
                 %cometbft_addr,
+                ?simulate_trade_service,
                 "starting pd"
             );
 
@@ -364,7 +374,7 @@ async fn main() -> anyhow::Result<()> {
             use penumbra_shielded_pool::component::rpc::Server as ShieldedPoolServer;
             use penumbra_stake::component::rpc::Server as StakeServer;
 
-            let grpc_server = Server::builder()
+            let mut grpc_server = Server::builder()
                 .trace_fn(|req| match remote_addr(req) {
                     Some(remote_addr) => {
                         tracing::error_span!("grpc", ?remote_addr)
@@ -413,6 +423,12 @@ async fn main() -> anyhow::Result<()> {
                     .register_encoded_file_descriptor_set(penumbra_proto::FILE_DESCRIPTOR_SET)
                     .build()
                     .with_context(|| "could not configure grpc reflection service")?));
+
+            if simulate_trade_service {
+                grpc_server = grpc_server.add_service(we(SimulationServiceServer::new(
+                    DexServer::new(storage.clone()),
+                )));
+            }
 
             let grpc_server = if let Some(domain) = grpc_auto_https {
                 use pd::auto_https::Wrapper;

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -116,12 +116,12 @@ enum RootCommand {
         )]
         cometbft_addr: Url,
 
-        /// Enable the trade simulation service, which allows clients to simulate
-        /// trades without submitting them. This is useful for approximating the
-        /// cost of a trade before submitting it. But, it is a potential DoS vector,
-        /// so it is disabled by default.
+        /// Enable expensive RPCs, such as the trade simulation service.
+        /// The trade simulation service allows clients to simulate trades without submitting them.
+        /// This is useful for approximating the cost of a trade before submitting it.
+        /// But, it is a potential DoS vector, so it is disabled by default.
         #[clap(short, long, display_order = 500)]
-        simulate_trade_service: bool,
+        enable_expensive_rpc: bool,
     },
     /// Generate, join, or reset a testnet.
     Testnet {
@@ -271,7 +271,7 @@ async fn main() -> anyhow::Result<()> {
             grpc_auto_https,
             metrics_bind,
             cometbft_addr,
-            simulate_trade_service,
+            enable_expensive_rpc,
         } => {
             tracing::info!(
                 ?abci_bind,
@@ -279,7 +279,7 @@ async fn main() -> anyhow::Result<()> {
                 ?grpc_auto_https,
                 ?metrics_bind,
                 %cometbft_addr,
-                ?simulate_trade_service,
+                ?enable_expensive_rpc,
                 "starting pd"
             );
 
@@ -424,7 +424,7 @@ async fn main() -> anyhow::Result<()> {
                     .build()
                     .with_context(|| "could not configure grpc reflection service")?));
 
-            if simulate_trade_service {
+            if enable_expensive_rpc {
                 grpc_server = grpc_server.add_service(we(SimulationServiceServer::new(
                     DexServer::new(storage.clone()),
                 )));

--- a/deployments/charts/penumbra-node/templates/deployment.yaml
+++ b/deployments/charts/penumbra-node/templates/deployment.yaml
@@ -170,6 +170,7 @@ spec:
             - 0.0.0.0:9000
             - --home
             - /penumbra-config/testnet_data/node0/pd
+            - --enable-expensive-rpc
           ports:
             - name: pd-grpc
               containerPort: 8080


### PR DESCRIPTION
This PR adds a `--simulate-trade-service` flag to `pd` that activates the DEX trade simulation service, which allow users to send `SimulateTrade` RPCs. The service is disabled by default, because it can be onerous to run it against a rich orderbook, and therefore is a potential DoS vector. 