### PR TITLE
pd: disable tokio console support by default

### DIFF
--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -44,7 +44,7 @@ use tendermint::v0_37::abci::{ConsensusRequest, MempoolRequest};
 )]
 struct Opt {
     /// Enable Tokio Console support.
-    #[clap(long, default_value = "false")]
+    #[clap(long)]
     tokio_console: bool,
     /// Command to run.
     #[clap(subcommand)]

--- a/crates/narsil/narsil/src/bin/narsild.rs
+++ b/crates/narsil/narsil/src/bin/narsild.rs
@@ -37,7 +37,7 @@ use url::Url;
 )]
 struct Opt {
     /// Enable Tokio Console support.
-    #[clap(long, default_value = "false")]
+    #[clap(long)]
     tokio_console: bool,
     /// Command to run.
     #[clap(subcommand)]


### PR DESCRIPTION
Setting `default_value = "false"` to a boolean flag, actually makes it default to true.