### PR TITLE
Summonerd: gracefully handle participant message channel closing

### DIFF
--- a/tools/summonerd/src/participant.rs
+++ b/tools/summonerd/src/participant.rs
@@ -75,6 +75,12 @@ impl Participant {
         parent: &P::CRS,
     ) -> Result<Option<P::RawContribution>> {
         tracing::info!("sending ContributeNow message to participant");
+        // This can happen as a result of them closing their connection or it dropping
+        // by this point.
+        if self.tx.is_closed() {
+            tracing::info!("participant receiving channel was closed");
+            return Ok(None);
+        }
         self.tx
             .send(Ok(ParticipateResponse {
                 msg: Some(ResponseMsg::ContributeNow(ContributeNow {


### PR DESCRIPTION
Basically, we should treat this as a rare but expected thing, and blame and strike the participant for this, rather than bring down the server as if it were an unexpected failure.

This oversight seems to have been the cause off a crash at 2023-11-12T06:49:56Z.