### PR TITLE
Summonerd friendlier error messages

### DIFF
--- a/tools/summonerd/src/participant.rs
+++ b/tools/summonerd/src/participant.rs
@@ -106,4 +106,10 @@ impl Participant {
         self.tx.send(Ok(response)).await?;
         Ok(())
     }
+
+    pub fn try_notify_timeout(&mut self) {
+        if let Err(e) = self.tx.try_send(Err(Status::deadline_exceeded("Unfortunately, it took too long to complete your contribution. We only allow a certain amount of time in order to allow as many people as possible to contribute. Your machine has too poor a network connection or processor to contribute fast enough. If you try again, you will run into this error again, and your contribution will still not be included. We kindly ask that you improve your machine if you would like to contribute."))) {
+            tracing::debug!(?e, "failed to notify of timeout");
+        }
+    }
 }

--- a/tools/summonerd/src/server.rs
+++ b/tools/summonerd/src/server.rs
@@ -88,7 +88,7 @@ impl server::CeremonyCoordinatorService for CoordinatorService {
             ContributionAllowed::Banned => {
                 tracing::debug!(?address, "is banned");
                 return Err(Status::permission_denied(
-                    "nyo contwibution *cries* fow you".to_string(),
+                    "Unfortunately, you have been banned from participating in the ceremony, most likely because of timeouts. Repeatedly timing out prevents other users from participating, and we want to enable as many people to participate as possible. Your machine's network connection and performance are not sufficient to participate, and re-attempting without changing these will result in another timeout and your contribution not being included.".to_string(),
                 ));
             }
             ContributionAllowed::AlreadyContributed => {


### PR DESCRIPTION
This improves the ban error message, and also adds an error message for timeouts, versus just closing the connection.