### PR TITLE
fix(metrics): rename grafana metrics to catch up

### DIFF
--- a/deployments/config/grafana/dashboards/Client Info.json
+++ b/deployments/config/grafana/dashboards/Client Info.json
@@ -139,7 +139,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(penumbra_pd_oblivious_client_compact_block_served_total[5m])",
+          "expr": "rate(penumbra_component_compact_block_compact_block_range_served_total[5m])",
           "legendFormat": "Rate of served compact blocks (5m)",
           "range": true,
           "refId": "A"
@@ -150,7 +150,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(penumbra_pd_oblivious_client_compact_block_served_total[30s])",
+          "expr": "rate(penumbra_component_compact_block_compact_block_range_served_total[30s])",
           "hide": false,
           "legendFormat": "Rate of served compact blocks (30s)",
           "range": true,
@@ -240,7 +240,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "penumbra_pd_oblivious_client_compact_active_connections",
+          "expr": "penumbra_component_compact_block_compact_block_range_active_connections",
           "refId": "A"
         }
       ],

--- a/deployments/config/grafana/dashboards/Transactions.json
+++ b/deployments/config/grafana/dashboards/Transactions.json
@@ -147,18 +147,22 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.3",
+      "pluginVersion": "10.1.5",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
+          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "penumbra_dex_path_search_duration_seconds_count{instance=\"penumbra-testnet-preview-val-0-metrics:9000\"}",
+          "expr": "avg(penumbra_dex_path_search_duration_seconds_count)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
           "instant": false,
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "useBackend": false
         }
       ],
       "title": "DEX path search count",
@@ -188,6 +192,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -267,7 +272,7 @@
         "current": {
           "selected": false,
           "text": "Prometheus",
-          "value": "Prometheus"
+          "value": "PBFA97CFB590B2093"
         },
         "hide": 0,
         "includeAll": false,

--- a/deployments/config/grafana/dashboards/sync.json
+++ b/deployments/config/grafana/dashboards/sync.json
@@ -105,7 +105,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
-          "expr": "rate(penumbra_pd_oblivious_client_compact_block_served_total[5m])",
+          "expr": "rate(penumbra_component_compact_block_compact_block_range_served_total[5m])",
           "instant": false,
           "range": true,
           "refId": "A"
@@ -197,7 +197,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
-          "expr": "penumbra_pd_oblivious_client_compact_active_connections",
+          "expr": "penumbra_component_compact_block_compact_block_range_active_connections",
           "instant": false,
           "range": true,
           "refId": "A"


### PR DESCRIPTION
A few grafana charts have gone dark, as a result of the underlying metric being renamed. Here are a few quick fixes. H/t to @hdevalence for catching the CB block rename.