### PR TITLE
Try restoring SQLite pragmas

### DIFF
--- a/crates/view/src/storage.rs
+++ b/crates/view/src/storage.rs
@@ -108,6 +108,10 @@ impl Storage {
                     OpenFlags::default() & !OpenFlags::SQLITE_OPEN_URI,
                 )
                 .with_init(|conn| {
+                    // "NORMAL" will be consistent, but maybe not durable -- this is fine,
+                    // since all our data is being synced from the chain, so if we lose a dbtx,
+                    // it's like we're resuming sync from a previous height.
+                    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")?;
                     // We use `prepare_cached` a fair amount: this is an overestimate of the number
                     // of cached prepared statements likely to be used.
                     conn.set_prepared_statement_cache_capacity(32);

--- a/crates/view/src/storage.rs
+++ b/crates/view/src/storage.rs
@@ -117,7 +117,11 @@ impl Storage {
                     conn.set_prepared_statement_cache_capacity(32);
                     Ok(())
                 });
-            Ok(r2d2::Pool::new(manager)?)
+            Ok(r2d2::Pool::builder()
+                // We set max_size=1 to avoid "database is locked" sqlite errors,
+                // when accessing across multiple threads.
+                .max_size(1)
+                .build(manager)?)
         } else {
             let manager = SqliteConnectionManager::memory();
             // Max size needs to be set to 1, otherwise a new in-memory database is created for each


### PR DESCRIPTION
Closes #3329

This restores configurations we had prior to migrating to rusqlite.

Even on MacOS this results in speed improvements syncing the chain with a newly generated wallet:
```
~/c/p/penumbra3 ((v0.63.1)|✔) $ cargo run --quiet --release --bin pcli -- --home /tmp/pcli-scratch-sync-test/ view sync
Scanning blocks from last sync height 0 to latest height 241904
[28s] ██████████████████████████████████████████████████  241904/241904  8429/s ETA: 0s
```
vs
```
~/c/p/penumbra2 (sqlite-pragmas|✔) $ cargo run --quiet --release --bin pcli -- --home /tmp/pcli-scratch-sync-test/ view sync
2023-11-15T05:52:24.778662Z ERROR r2d2: database is locked
2023-11-15T05:52:24.778666Z ERROR r2d2: database is locked
Scanning blocks from last sync height 0 to latest height 241981
[18s] ██████████████████████████████████████████████████  241981/241981  13035/s ETA: 0s
```

Note however that now there are errors. So this isn't a complete solution.  Nothing will conflict with this PR, so there's no rush to merge it.