### PR TITLE
Use result instead of expect for clues

### DIFF
--- a/crates/core/transaction/src/plan/auth.rs
+++ b/crates/core/transaction/src/plan/auth.rs
@@ -1,5 +1,7 @@
-use penumbra_keys::keys::SpendKey;
+use anyhow::Result;
 use rand::{CryptoRng, RngCore};
+
+use penumbra_keys::keys::SpendKey;
 
 use crate::{plan::TransactionPlan, AuthorizationData};
 
@@ -11,8 +13,8 @@ impl TransactionPlan {
         &self,
         mut rng: R,
         sk: &SpendKey,
-    ) -> AuthorizationData {
-        let effect_hash = self.effect_hash(sk.full_viewing_key());
+    ) -> Result<AuthorizationData> {
+        let effect_hash = self.effect_hash(sk.full_viewing_key())?;
         let mut spend_auths = Vec::new();
         let mut delegator_vote_auths = Vec::new();
 
@@ -28,10 +30,10 @@ impl TransactionPlan {
             let auth_sig = rsk.sign(&mut rng, effect_hash.as_ref());
             delegator_vote_auths.push(auth_sig);
         }
-        AuthorizationData {
+        Ok(AuthorizationData {
             effect_hash,
             spend_auths,
             delegator_vote_auths,
-        }
+        })
     }
 }

--- a/crates/core/transaction/src/plan/build.rs
+++ b/crates/core/transaction/src/plan/build.rs
@@ -2,16 +2,18 @@ use anyhow::{anyhow, Context, Result};
 use ark_ff::Zero;
 use decaf377::Fr;
 use decaf377_rdsa as rdsa;
-use penumbra_keys::{symmetric::PayloadKey, FullViewingKey};
 use rand_core::{CryptoRng, RngCore};
 
-use super::TransactionPlan;
+use penumbra_keys::{symmetric::PayloadKey, FullViewingKey};
+
 use crate::{
     action::Action,
     memo::MemoCiphertext,
     transaction::{DetectionData, TransactionParameters},
     AuthorizationData, AuthorizingData, Transaction, TransactionBody, WitnessData,
 };
+
+use super::TransactionPlan;
 
 impl TransactionPlan {
     /// Build the transaction this plan describes.
@@ -101,7 +103,7 @@ impl TransactionPlan {
         } else {
             let mut fmd_clues = Vec::new();
             for clue_plan in self.clue_plans() {
-                fmd_clues.push(clue_plan.clue());
+                fmd_clues.push(clue_plan.clue()?);
             }
             Some(DetectionData { fmd_clues })
         };
@@ -310,7 +312,7 @@ impl TransactionPlan {
         } else {
             let mut fmd_clues = Vec::new();
             for clue_plan in self.clue_plans() {
-                fmd_clues.push(clue_plan.clue());
+                fmd_clues.push(clue_plan.clue()?);
             }
             Some(DetectionData { fmd_clues })
         };

--- a/crates/core/transaction/src/plan/clue.rs
+++ b/crates/core/transaction/src/plan/clue.rs
@@ -1,8 +1,8 @@
-use decaf377_fmd::{Clue, ExpandedClueKey};
+use rand::{CryptoRng, RngCore};
+
+use decaf377_fmd::{Clue, Error, ExpandedClueKey};
 use penumbra_keys::Address;
 use penumbra_proto::{core::transaction::v1alpha1 as pb, DomainType, TypeUrl};
-
-use rand::{CryptoRng, RngCore};
 
 #[derive(Clone, Debug)]
 pub struct CluePlan {
@@ -28,12 +28,10 @@ impl CluePlan {
     }
 
     /// Create a [`Clue`] from the [`CluePlan`].
-    pub fn clue(&self) -> Clue {
+    pub fn clue(&self) -> Result<Clue, Error> {
         let clue_key = self.address.clue_key();
-        let expanded_clue_key = ExpandedClueKey::new(clue_key).expect("valid address");
-        expanded_clue_key
-            .create_clue_deterministic(self.precision_bits, self.rseed)
-            .expect("can construct clue key")
+        let expanded_clue_key = ExpandedClueKey::new(clue_key)?;
+        expanded_clue_key.create_clue_deterministic(self.precision_bits, self.rseed)
     }
 }
 

--- a/crates/custody/src/soft_kms.rs
+++ b/crates/custody/src/soft_kms.rs
@@ -1,16 +1,16 @@
 //! A basic software key management system that stores keys in memory but
 //! presents as an asynchronous signer.
 
-use penumbra_proto::custody::v1alpha1::{self as pb, AuthorizeResponse};
-use penumbra_transaction::AuthorizationData;
 use rand_core::OsRng;
 use tonic::{async_trait, Request, Response, Status};
+
+pub use config::Config;
+use penumbra_proto::custody::v1alpha1::{self as pb, AuthorizeResponse};
+use penumbra_transaction::AuthorizationData;
 
 use crate::{policy::Policy, AuthorizeRequest};
 
 mod config;
-
-pub use config::Config;
 
 /// A basic software key management system that stores keys in memory but
 /// presents as an asynchronous signer.
@@ -33,7 +33,7 @@ impl SoftKms {
             policy.check(request)?;
         }
 
-        Ok(request.plan.authorize(OsRng, &self.config.spend_key))
+        request.plan.authorize(OsRng, &self.config.spend_key)
     }
 }
 

--- a/crates/wasm/src/tx.rs
+++ b/crates/wasm/src/tx.rs
@@ -77,7 +77,7 @@ pub fn authorize(spend_key_str: &str, transaction_plan: JsValue) -> WasmResult<J
     let spend_key = SpendKey::from_str(spend_key_str)?;
     let plan: TransactionPlan = plan_proto.try_into()?;
 
-    let auth_data: AuthorizationData = plan.authorize(OsRng, &spend_key);
+    let auth_data: AuthorizationData = plan.authorize(OsRng, &spend_key)?;
     let result = serde_wasm_bindgen::to_value(&auth_data.to_proto())?;
     Ok(result)
 }


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/penumbra/issues/3332

Uses of `unwrap()` are in tests, fyi.

Re-arrangement of imports seem to be a RustRover IDE thing. Think it's ok, but can revert if preferred otherwise.