### PR TITLE
Prepare 0.63.2 release

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -1,5 +1,11 @@
 name: Protobuf
-on: pull_request
+on:
+  # Exclude feature branches, only run if the PR is targeting main.
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - "main"
 jobs:
   lint:
     name: Lint protobuf
@@ -55,7 +61,7 @@ jobs:
           toolchain: stable
           override: false
 
-      - uses: bufbuild/buf-setup-action@v1.27.1
+      - uses: bufbuild/buf-setup-action@v1
         with:
           buf_api_token: ${{ secrets.BUF_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -55,17 +55,9 @@ jobs:
           location: us-central1
 
       - name: install helmfile
-        run: |
-          helmfile_version="0.157.0"
-          helmfile_url="https://github.com/helmfile/helmfile/releases/download/v${helmfile_version}/helmfile_${helmfile_version}_linux_amd64.tar.gz"
-          mkdir -p /tmp/helmfile-download
-          cd /tmp/helmfile-download || exit 1
-          curl -SfL -O "$helmfile_url"
-          tar -xzf helmfile*.tar.gz
-          mkdir -p "$HOME/bin"
-          cp helmfile "$HOME/bin/"
-          export PATH="$HOME/bin:$PATH"
-          which helmfile
+        uses: mamezou-tech/setup-helmfile@v1.3.0
+        with:
+          helmfile-version: "v0.157.0"
 
       - name: deploy
         run: |-

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -67,6 +67,7 @@ jobs:
       - name: bounce osiris
         shell: bash
         run: |-
+          export PENUMBRA_VERSION='${{ github.event.inputs.image_tag || github.ref_name }}'
           # Set the exact version for the current testnet for Osiris, so deps match.
           kubectl set image deployments \
               -l "app.kubernetes.io/instance=osiris-testnet" \
@@ -78,6 +79,7 @@ jobs:
       - name: bounce galileo
         shell: bash
         run: |-
+          export PENUMBRA_VERSION='${{ github.event.inputs.image_tag || github.ref_name }}'
           # Set the exact version for the current testnet for Galileo, so deps match.
           kubectl set image deployments \
               -l "app.kubernetes.io/instance=galileo" \

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -49,17 +49,9 @@ jobs:
           location: us-central1
 
       - name: install helmfile
-        run: |
-          helmfile_version="0.157.0"
-          helmfile_url="https://github.com/helmfile/helmfile/releases/download/v${helmfile_version}/helmfile_${helmfile_version}_linux_amd64.tar.gz"
-          mkdir -p /tmp/helmfile-download
-          cd /tmp/helmfile-download || exit 1
-          curl -SfL -O "$helmfile_url"
-          tar -xzf helmfile*.tar.gz
-          mkdir -p "$HOME/bin"
-          cp helmfile "$HOME/bin/"
-          export PATH="$HOME/bin:$PATH"
-          which helmfile
+        uses: mamezou-tech/setup-helmfile@v1.3.0
+        with:
+          helmfile-version: "v0.157.0"
 
       - name: deploy
         run: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,143 +1,183 @@
+# Copyright 2022-2023, axodotdev
+# SPDX-License-Identifier: MIT or Apache-2.0
+#
 # CI that:
 #
 # * checks for a Git Tag that looks like a release
-# * creates a Github Release™ and fills in its text
-# * builds artifacts with cargo-dist (executable-zips, installers)
-# * uploads those artifacts to the Github Release™
+# * builds artifacts with cargo-dist (archives, installers, hashes)
+# * uploads those artifacts to temporary workflow zip
+# * on success, uploads the artifacts to a Github Release™
 #
-# Note that the Github Release™ will be created before the artifacts,
-# so there will be a few minutes where the release has no artifacts
-# and then they will slowly trickle in, possibly failing. To make
-# this more pleasant we mark the release as a "draft" until all
-# artifacts have been successfully uploaded. This allows you to
-# choose what to do with partial successes and avoids spamming
-# anyone with notifications before the release is actually ready.
+# Note that the Github Release™ will be created with a generated
+# title/body based on your changelogs.
 name: Release
 
 permissions:
   contents: write
 
 # This task will run whenever you push a git tag that looks like a version
-# like "v1", "v1.2.0", "v0.1.0-prerelease01", "my-app-v1.0.0", etc.
-# The version will be roughly parsed as ({PACKAGE_NAME}-)?v{VERSION}, where
+# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
+# Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
-# must be a Cargo-style SemVer Version.
+# must be a Cargo-style SemVer Version (must have at least major.minor.patch).
 #
-# If PACKAGE_NAME is specified, then we will create a Github Release™ for that
+# If PACKAGE_NAME is specified, then the release will be for that
 # package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
 #
-# If PACKAGE_NAME isn't specified, then we will create a Github Release™ for all
-# (cargo-dist-able) packages in the workspace with that version (this is mode is
+# If PACKAGE_NAME isn't specified, then the release will be for all
+# (cargo-dist-able) packages in the workspace with that version (this mode is
 # intended for workspaces with only one dist-able package, or with all dist-able
 # packages versioned/released in lockstep).
 #
 # If you push multiple tags at once, separate instances of this workflow will
-# spin up, creating an independent Github Release™ for each one.
+# spin up, creating an independent Github Release™ for each one. However Github
+# will hard limit this to 3 tags per commit, as it will assume more tags is a
+# mistake.
 #
-# If there's a prerelease-style suffix to the version then the Github Release™
+# If there's a prerelease-style suffix to the version, then the Github Release™
 # will be marked as a prerelease.
 on:
   push:
     tags:
-      - '*-?v[0-9]+*'
+      - '**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
-  # Create the Github Release™ so the packages have something to be uploaded to
-  create-release:
+  # Run 'cargo dist plan' to determine what tasks we need to do
+  plan:
     runs-on: ubuntu-latest
     outputs:
-      has-releases: ${{ steps.create-release.outputs.has-releases }}
+      val: ${{ steps.plan.outputs.manifest }}
+      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
+      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
+      publishing: ${{ !github.event.pull_request }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Install Rust
-        run: rustup update 1.73.0 --no-self-update && rustup default 1.73.0
+        run: rustup update "1.73" --no-self-update && rustup default "1.73"
       - name: Install cargo-dist
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.5/cargo-dist-v0.0.5-installer.sh | sh
-      - id: create-release
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.2/cargo-dist-installer.sh | sh"
+      - id: plan
         run: |
-          cargo dist manifest --tag=${{ github.ref_name }} --artifacts=all --no-local-paths --output-format=json > dist-manifest.json
-          echo "dist manifest ran successfully"
+          cargo dist plan ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }} --output-format=json > dist-manifest.json
+          echo "cargo dist plan ran successfully"
           cat dist-manifest.json
+          echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
+      - name: "Upload dist-manifest.json"
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: dist-manifest.json
 
-          # Create the Github Release™ based on what cargo-dist thinks it should be
-          ANNOUNCEMENT_TITLE=$(cat dist-manifest.json | jq --raw-output ".announcement_title")
-          IS_PRERELEASE=$(cat dist-manifest.json | jq --raw-output ".announcement_is_prerelease")
-          cat dist-manifest.json | jq --raw-output ".announcement_github_body" > new_dist_announcement.md
-          gh release create ${{ github.ref_name }} --draft --prerelease="$IS_PRERELEASE" --title="$ANNOUNCEMENT_TITLE" --notes-file=new_dist_announcement.md
-          echo "created announcement!"
-
-          # Upload the manifest to the Github Release™
-          gh release upload ${{ github.ref_name }} dist-manifest.json
-          echo "uploaded manifest!"
-
-          # Disable all the upload-artifacts tasks if we have no actual releases
-          HAS_RELEASES=$(cat dist-manifest.json | jq --raw-output ".releases != null")
-          echo "has-releases=$HAS_RELEASES" >> "$GITHUB_OUTPUT"
-
-  # Build and packages all the things
-  upload-artifacts:
+  # Build and packages all the platform-specific things
+  upload-local-artifacts:
     # Let the initial task tell us to not run (currently very blunt)
-    needs: create-release
-    if: ${{ needs.create-release.outputs.has-releases == 'true' }}
+    needs: plan
+    if: ${{ fromJson(needs.plan.outputs.val).releases != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
     strategy:
+      fail-fast: false
+      # We override the generated `matrix` so we can specify custom runners,
+      # for faster build times. This works for Linux & macOS. To generate the base template, run:
+      # `cargo dist plan --output-format json`. That JSON content has been adapted to YAML below.
+      # matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
       matrix:
-        # For Linux, we override with a custom runner, for faster build times.
-        # We don't have a comparable setup for mac/win, so those builds will be
-        # much slower, effectively making the whole matrix run slow. Punting for now.
         include:
-        - os: macos-12-xl
-          dist-args: --artifacts=local --target=aarch64-apple-darwin --target=x86_64-apple-darwin
-          install-dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.5/cargo-dist-v0.0.5-installer.sh | sh
-        - os: buildjet-16vcpu-ubuntu-2004
-          dist-args: --artifacts=local --target=x86_64-unknown-linux-gnu
-          install-dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.5/cargo-dist-v0.0.5-installer.sh | sh
-        - os: windows-2019
-          dist-args: --artifacts=local --target=x86_64-pc-windows-msvc
-          install-dist: irm  https://github.com/axodotdev/cargo-dist/releases/download/v0.0.5/cargo-dist-v0.0.5-installer.ps1 | iex
+        - runner: buildjet-16vcpu-ubuntu-2004
+          dist_args: --artifacts=local --target=x86_64-unknown-linux-gnu
+          install_dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.2/cargo-dist-installer.sh | sh
+          targets:
+            - x86_64-unknown-linux-gnu
+        - runner: macos-12-xl
+          dist_args: --artifacts=local --target=aarch64-apple-darwin
+          install_dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.2/cargo-dist-installer.sh | sh
+          targets:
+            - aarch64-apple-darwin
+        - runner: macos-12-xl
+          dist_args: --artifacts=local --target=x86_64-apple-darwin
+          install_dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.2/cargo-dist-installer.sh | sh
+          targets:
+            - x86_64-apple-darwin
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Setting RUSTFLAGS to duplicate .cargo/config.toml, because cargo-dist doesn't support config.toml.
+      BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
       RUSTFLAGS: "--cfg tokio_unstable"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install Rust
-        run: rustup update 1.73.0 --no-self-update && rustup default 1.73.0
+        run: rustup update "1.73" --no-self-update && rustup default "1.73"
+      - uses: swatinem/rust-cache@v2
       - name: Install cargo-dist
-        run: ${{ matrix.install-dist }}
-      - name: Run cargo-dist
-        # This logic is a bit janky because it's trying to be a polyglot between
-        # powershell and bash since this will run on windows, macos, and linux!
-        # The two platforms don't agree on how to talk about env vars but they
-        # do agree on 'cat' and '$()' so we use that to marshal values between commands.
+        run: ${{ matrix.install_dist }}
+      - name: Install dependencies
+        run: |
+          ${{ matrix.packages_install }}
+      - name: Build artifacts
         run: |
           # Actually do builds and make zips and whatnot
-          cargo dist build --tag=${{ github.ref_name }} --output-format=json ${{ matrix.dist-args }} > dist-manifest.json
-          echo "dist ran successfully"
-          cat dist-manifest.json
-
+          cargo dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
+          echo "cargo dist ran successfully"
+      - id: cargo-dist
+        name: Post-build
+        # We force bash here just because github makes it really hard to get values up
+        # to "real" actions without writing to env-vars, and writing to env-vars has
+        # inconsistent syntax between shell and powershell.
+        shell: bash
+        run: |
           # Parse out what we just built and upload it to the Github Release™
-          cat dist-manifest.json | jq --raw-output ".artifacts[]?.path | select( . != null )" > uploads.txt
-          echo "uploading..."
-          cat uploads.txt
-          gh release upload ${{ github.ref_name }} $(cat uploads.txt)
-          echo "uploaded!"
+          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
+          jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
-  # Mark the Github Release™ as a non-draft now that everything has succeeded!
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
+
+  should-publish:
+    needs:
+      - plan
+      - upload-local-artifacts
+    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: print tag
+        run: echo "ok we're publishing!"
+
+  # Create a Github Release with all the results once everything is done
   publish-release:
-    # Only run after all the other tasks, but it's ok if upload-artifacts was skipped
-    needs: [create-release, upload-artifacts]
-    if: ${{ always() && needs.create-release.result == 'success' && (needs.upload-artifacts.result == 'skipped' || needs.upload-artifacts.result == 'success') }}
+    needs: [plan, should-publish]
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
-      - name: mark release as non-draft
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: "Download artifacts"
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+          path: artifacts
+      - name: Cleanup
         run: |
-          gh release edit ${{ github.ref_name }} --draft=false
+          # Remove the granular manifests
+          rm artifacts/*-dist-manifest.json
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ needs.plan.outputs.tag }}
+          name: ${{ fromJson(needs.plan.outputs.val).announcement_title }}
+          body: ${{ fromJson(needs.plan.outputs.val).announcement_github_body }}
+          prerelease: ${{ fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
+          artifacts: "artifacts/*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,14 +58,19 @@ opt-level = "s"
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.0.5"
-# The preferred Rust toolchain to use in CI (rustup toolchain syntax).
-# We use the same value as the MSRV in crates/bin/pd/Cargo.toml.
+cargo-dist-version = "0.4.2"
+# The preferred Rust toolchain to use in CI (rustup toolchain syntax)
 rust-toolchain-version = "1.73"
-# CI backends to support (see 'cargo dist generate-ci')
+# CI backends to support
 ci = ["github"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
+targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin"]
+# The installers to generate for each app
+installers = []
+# Publish jobs to run in CI
+pr-run-mode = "skip"
+# We override RUSTFLAGS, so we must permit changes from the default template.
+allow-dirty = ["ci"]
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/deployments/ci.sh
+++ b/deployments/ci.sh
@@ -49,8 +49,7 @@ function helm_uninstall() {
 # as necessary. Will *not* replace certain durable resources like
 # the LoadBalancer Service objects, which are annotated with helm.sh/resource-policy=keep.
 function helm_install() {
-    # TODO: make sure helmfile is present in ci environemnt.
-    helmfile sync -f "$HELMFILE_MANIFEST" --args \
+    helmfile apply -f "$HELMFILE_MANIFEST" --args \
         --set="image.tag=${PENUMBRA_VERSION}"
 }
 

--- a/deployments/scripts/gha-repository-dispatch
+++ b/deployments/scripts/gha-repository-dispatch
@@ -2,7 +2,10 @@
 # Utility script to trigger GitHub Action workflows across different repositories [0].
 # Requires a GitHub Personal Access Token (PAT), exported as GITHUB_PAT env var [1].
 #
-# [0] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch
+# Uses event `workflow_dispatch`, rather than `repository_dispatch`, because the latter
+# does not support passing `inputs`, which we need to set a specific version of Penumbra.
+#
+# [0] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
 # [1] https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
 set -euo pipefail
 
@@ -19,11 +22,15 @@ elif [[ -z "$github_pat" ]] ; then
     exit 1
 fi
 
+# The workflow id is the filename containing the job YAML.
+# https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#get-a-workflow
+workflow_id="container.yml"
+
 # Support overriding the upstream version of Penumbra, but default to 'main'.
 penumbra_version="${PENUMBRA_VERSION:-main}"
 
-# Build URL for repository dispatch API endpoint.
-github_repository_url="https://api.github.com/repos/${github_repo}/dispatches"
+# Build URL for workflow dispatch API endpoint.
+github_workflow_url="https://api.github.com/repos/${github_repo}/actions/workflows/${workflow_id}/dispatches"
 
 # Accept arguments for workflow, and emit valid JSON for curl request.
 # Using printf allows us to interpolate bash variables in JSON,
@@ -32,12 +39,15 @@ function format_json_payload() {
     local v
     v="${1:-}"
     shift
-    printf '{"event_type": "container-build", "client_payload": { "penumbra_version": "%s" }}' "$v"
+    # N.B. the "ref" value here is the gitref on the remote repo, not the calling repo.
+    printf '{"ref": "main", "inputs": { "penumbra_version": "%s" }}' "$v"
 }
 
 json_payload="$(format_json_payload "$penumbra_version")"
-curl -f -X POST "$github_repository_url" \
-          -H 'Accept: application/vnd.github.v3+json' \
+>&2 printf 'Sending JSON blob:\n%s\nto URL: %s\n' "$json_payload" "$github_workflow_url"
+curl -f -L -X POST \
+          -H 'Accept: application/vnd.github+json' \
           -H 'Content-Type: application/json' \
           -H "Authorization: token $github_pat" \
+          "$github_workflow_url" \
           --data "$json_payload"


### PR DESCRIPTION
This PR prepares the upcoming `v0.63.2` point release. See context in https://github.com/penumbra-zone/penumbra/issues/3182#issuecomment-1809402338. As described there, most of these changes are CI related, geared toward providing working binary builds again. There are also two (2) QoL pcli improvements. 

After this PR is merged into the `release/0.63.x` branch, the usual `cargo release` steps will be performed on that branch, including a tag, to trigger the point release.