### PR TITLE
refactor(wasm): clean up split-up build

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["console_error_panic_hook"]
+mock-database = []
 
 [dependencies]
 penumbra-asset         = { path = "../core/asset" }
@@ -45,7 +46,7 @@ wasm-bindgen             = "0.2.87"
 wasm-bindgen-futures     = "0.4.37"
 wasm-bindgen-test        = "0.3.37"
 web-sys                  = { version = "0.3.64", features = ["console"] }
-serde_json               = "1.0.107"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.37"
+wasm-bindgen-test        = "0.3.37"
+serde_json               = "1.0.107"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -44,7 +44,6 @@ serde-wasm-bindgen       = "0.5.0"
 thiserror                = "1.0"
 wasm-bindgen             = "0.2.87"
 wasm-bindgen-futures     = "0.4.37"
-wasm-bindgen-test        = "0.3.37"
 web-sys                  = { version = "0.3.64", features = ["console"] }
 
 [dev-dependencies]

--- a/crates/wasm/src/error.rs
+++ b/crates/wasm/src/error.rs
@@ -10,7 +10,6 @@ use web_sys::DomException;
 use penumbra_tct::error::{InsertBlockError, InsertEpochError, InsertError};
 
 pub type WasmResult<T> = Result<T, WasmError>;
-pub type WasmOption<T> = Option<T>;
 
 #[derive(Error, Debug)]
 pub enum WasmError {

--- a/crates/wasm/src/planner.rs
+++ b/crates/wasm/src/planner.rs
@@ -532,8 +532,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
 
         // If there are outputs, we check that a memo has been added. If not, we add a blank memo.
         if self.plan.num_outputs() > 0 && self.plan.memo_plan.is_none() {
-            self.memo(MemoPlaintext::blank_memo(self_address.clone()))
-                .expect("empty string is a valid memo");
+            self.memo(MemoPlaintext::blank_memo(self_address.clone()))?;
         } else if self.plan.num_outputs() == 0 && self.plan.memo_plan.is_some() {
             anyhow::bail!("if no outputs, no memo should be added");
         }

--- a/crates/wasm/src/storage.rs
+++ b/crates/wasm/src/storage.rs
@@ -41,6 +41,7 @@ pub struct IndexedDBStorage {
 
 impl IndexedDBStorage {
     pub async fn new(constants: IndexedDbConstants) -> WasmResult<Self> {
+        #[allow(unused_mut)]
         let mut db_req: OpenDbRequest = IdbDatabase::open_u32(&constants.name, constants.version)?;
 
         // Conditionally mock sample `IdbDatabase` database for testing purposes

--- a/crates/wasm/src/storage.rs
+++ b/crates/wasm/src/storage.rs
@@ -45,7 +45,9 @@ impl IndexedDBStorage {
 
         // Conditionally mock sample `IdbDatabase` database for testing purposes
         #[cfg(feature = "mock-database")]
-        let db_req = IndexedDBStorage::mock_test_database(db_req).into_future().await;
+        let db_req = IndexedDBStorage::mock_test_database(db_req)
+            .into_future()
+            .await;
 
         let db: IdbDatabase = db_req.into_future().await?;
 

--- a/crates/wasm/src/storage.rs
+++ b/crates/wasm/src/storage.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 use std::future::IntoFuture;
 
 use indexed_db_futures::{

--- a/crates/wasm/src/tx.rs
+++ b/crates/wasm/src/tx.rs
@@ -202,22 +202,21 @@ pub fn build_parallel(
 ) -> WasmResult<JsValue> {
     utils::set_panic_hook();
 
-    let plan_proto: pb::TransactionPlan = serde_wasm_bindgen::from_value(transaction_plan)?;
-    let plan: TransactionPlan = plan_proto.try_into()?;
+    let plan: TransactionPlan = serde_wasm_bindgen::from_value(transaction_plan.clone())?;
 
     let witness_data_proto: pb::WitnessData = serde_wasm_bindgen::from_value(witness_data)?;
-    let witness_data_: WitnessData = witness_data_proto.try_into()?;
+    let witness_data: WitnessData = witness_data_proto.try_into()?;
 
     let auth_data_proto: pb::AuthorizationData = serde_wasm_bindgen::from_value(auth_data)?;
-    let auth_data_: AuthorizationData = auth_data_proto.try_into()?;
+    let auth_data: AuthorizationData = auth_data_proto.try_into()?;
 
-    let actions_: Vec<Action> = serde_wasm_bindgen::from_value(actions)?;
+    let actions: Vec<Action> = serde_wasm_bindgen::from_value(actions)?;
 
     let transaction = plan
         .clone()
-        .build_unauth_with_actions(actions_, &witness_data_)?;
+        .build_unauth_with_actions(actions, &witness_data)?;
 
-    let tx = plan.apply_auth_data(&mut OsRng, &auth_data_, transaction)?;
+    let tx = plan.apply_auth_data(&mut OsRng, &auth_data, transaction)?;
 
     let value = serde_wasm_bindgen::to_value(&tx.to_proto())?;
 

--- a/crates/wasm/src/wasm_planner.rs
+++ b/crates/wasm/src/wasm_planner.rs
@@ -3,13 +3,13 @@ use crate::planner::Planner;
 use crate::storage::IndexedDBStorage;
 use crate::swap_record::SwapRecord;
 use crate::utils;
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use ark_ff::UniformRand;
 use decaf377::Fq;
 use penumbra_chain::params::{ChainParameters, FmdParameters};
 use penumbra_dex::swap_claim::SwapClaimPlan;
 
-use penumbra_keys::{symmetric::PayloadKey, FullViewingKey};
+use penumbra_keys::FullViewingKey;
 use penumbra_proto::{
     core::{
         asset::v1alpha1::{DenomMetadata, Value},
@@ -18,7 +18,6 @@ use penumbra_proto::{
         keys::v1alpha1::{Address, AddressIndex},
         transaction::v1alpha1 as pb,
         transaction::v1alpha1::MemoPlaintext,
-        transaction::v1alpha1::TransactionPlan as tp,
     },
     crypto::tct::v1alpha1::StateCommitment,
     DomainType,

--- a/crates/wasm/src/wasm_planner.rs
+++ b/crates/wasm/src/wasm_planner.rs
@@ -83,7 +83,8 @@ impl WasmPlanner {
     ) -> WasmResult<JsValue> {
         utils::set_panic_hook();
 
-        let transaction_plan: TransactionPlan = serde_wasm_bindgen::from_value(transaction_plan.clone())?;
+        let transaction_plan: TransactionPlan =
+            serde_wasm_bindgen::from_value(transaction_plan.clone())?;
 
         let witness_data_proto: pb::WitnessData = serde_wasm_bindgen::from_value(witness_data)?;
         let witness_data: WitnessData = witness_data_proto.try_into()?;
@@ -99,32 +100,21 @@ impl WasmPlanner {
         let action = match action_plan {
             ActionPlan::Spend(spend_plan) => {
                 let spend = ActionPlan::Spend(spend_plan);
-                Some(
-                    spend
-                        .build_unauth(&full_viewing_key, &witness_data, memo_key)?,
-                )
+                Some(spend.build_unauth(&full_viewing_key, &witness_data, memo_key)?)
             }
             ActionPlan::Output(output_plan) => {
                 let output = ActionPlan::Output(output_plan);
-                Some(
-                    output
-                        .build_unauth(&full_viewing_key, &witness_data, memo_key)?,
-                )
+                Some(output.build_unauth(&full_viewing_key, &witness_data, memo_key)?)
             }
 
             // TODO: Other action variants besides 'Spend' and 'Output' still require testing.
             ActionPlan::Swap(swap_plan) => {
                 let swap = ActionPlan::Swap(swap_plan);
-                Some(
-                    swap.build_unauth(&full_viewing_key, &witness_data, memo_key)?,
-                )
+                Some(swap.build_unauth(&full_viewing_key, &witness_data, memo_key)?)
             }
             ActionPlan::SwapClaim(swap_claim_plan) => {
                 let swap_claim = ActionPlan::SwapClaim(swap_claim_plan);
-                Some(
-                    swap_claim
-                        .build_unauth(&full_viewing_key, &witness_data, memo_key)?,
-                )
+                Some(swap_claim.build_unauth(&full_viewing_key, &witness_data, memo_key)?)
             }
             ActionPlan::Delegate(delegation) => Some(Action::Delegate(delegation)),
             ActionPlan::Undelegate(undelegation) => Some(Action::Undelegate(undelegation)),

--- a/crates/wasm/tests/test_build.rs
+++ b/crates/wasm/tests/test_build.rs
@@ -28,7 +28,7 @@ mod tests {
     };
     use penumbra_wasm::{
         error::WasmError,
-        storage::IndexedDBStorage,
+        storage::{IndexedDBStorage, Tables, IndexedDbConstants},
         tx::{authorize, build, build_parallel, witness},
         wasm_planner::WasmPlanner,
     };
@@ -38,23 +38,7 @@ mod tests {
         // Limit the use of Penumbra Rust libraries since we're mocking JS calls
         // that are based on constructing objects according to protobuf definitions.
 
-        // Define database parameters
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        pub struct IndexedDbConstants {
-            name: String,
-            version: u32,
-            tables: Tables,
-        }
-
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        pub struct Tables {
-            assets: String,
-            notes: String,
-            spendable_notes: String,
-            swaps: String,
-        }
-
-        // IndexDB tables and constants.
+        // Define `IndexDB` table parameters and constants.
         let tables: Tables = Tables {
             assets: "ASSETS".to_string(),
             notes: "NOTES".to_string(),
@@ -454,6 +438,7 @@ mod tests {
         .unwrap();
         console_log!("Parallel transaction is: {:?}", parallel_transaction);
 
+        // Execute serial spend transaction and generate proof.
         let serial_transaction = build(
             full_viewing_key,
             transaction_plan.clone(),

--- a/crates/wasm/tests/test_build.rs
+++ b/crates/wasm/tests/test_build.rs
@@ -28,7 +28,7 @@ mod tests {
     };
     use penumbra_wasm::{
         error::WasmError,
-        storage::{IndexedDBStorage, Tables, IndexedDbConstants},
+        storage::{IndexedDBStorage, IndexedDbConstants, Tables},
         tx::{authorize, build, build_parallel, witness},
         wasm_planner::WasmPlanner,
     };


### PR DESCRIPTION
References #3406. 

For testing purposes, we can conditionally mock a sample `IdbDatabase` database using the `mock-database` feature. This enables stripping out unnecessary business logic from the production code. The command to run the test suite is `wasm-pack test --chrome -- --test test_build --target wasm32-unknown-unknown --release --features "mock-database"`
