### PR TITLE
distributions: compute and distribute inflation per epoch

### DIFF
--- a/crates/core/component/chain/src/component/view.rs
+++ b/crates/core/component/chain/src/component/view.rs
@@ -53,6 +53,12 @@ pub trait StateReadExt: StateRead {
             .map(|params| params.epoch_duration)
     }
 
+    async fn get_epoch_for_height(&self, height: u64) -> Result<Epoch> {
+        self.get(&state_key::epoch_by_height(height))
+            .await?
+            .ok_or_else(|| anyhow!("missing epoch for height"))
+    }
+
     /// Gets the chain ID.
     async fn get_chain_id(&self) -> Result<String> {
         // this might be a bit wasteful -- does it matter?  who knows, at this

--- a/crates/core/component/distributions/src/component.rs
+++ b/crates/core/component/distributions/src/component.rs
@@ -4,7 +4,7 @@ mod view;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use penumbra_component::Component;
 // use penumbra_dex::{component::StateReadExt as _, component::StateWriteExt as _};
@@ -40,7 +40,7 @@ impl Component for Distributions {
                 // TODO(erwan): it's not yet totally clear if it is necessary, or even desirable, for the
                 // distributions component to track the total issuance. The shielded pool component
                 // already does that. We do it anyway for now so that we can write the rest of the scaffolding.
-                state.set_total_issued(genesis_issuance);
+                state.set_staking_token_issuance_for_epoch(genesis_issuance);
             }
         };
     }
@@ -59,33 +59,48 @@ impl Component for Distributions {
     ) {
     }
 
-    #[instrument(name = "distributions", skip(_state))]
-    async fn end_epoch<S: StateWrite + 'static>(_state: &mut Arc<S>) -> Result<()> {
-        Ok(())
+    #[instrument(name = "distributions", skip(state))]
+    async fn end_epoch<S: StateWrite + 'static>(state: &mut Arc<S>) -> Result<()> {
+        let state = Arc::get_mut(state).context("state should be unique")?;
+        let new_issuance = state.compute_new_issuance().await?;
+        tracing::debug!(?new_issuance, "computed new issuance for epoch");
+        Ok(state.distribute(new_issuance).await)
     }
 }
 
 #[async_trait]
 trait DistributionManager: StateWriteExt {
     /// Compute the total new issuance of staking tokens for this epoch.
-    /// TODO(erwan): this is a stub implementation.
     async fn compute_new_issuance(&self) -> Result<Amount> {
-        let base_reward_rate: u64 = 0;
-        let total_issued = self
-            .total_issued()
+        use penumbra_chain::component::StateReadExt as _;
+        let current_block_height = self.get_block_height().await?;
+        let current_epoch = self.get_epoch_for_height(current_block_height).await?;
+        let num_blocks = current_block_height
+            .checked_sub(current_epoch.start_height)
+            .expect("epoch start height is less than or equal to current block height");
+
+        let staking_issuance_per_block = self
+            .get_distributions_params()
             .await?
-            .expect("total issuance has been initialized");
-        const BPS_SQUARED: u64 = 1_0000_0000; // reward rate is measured in basis points squared
-        let new_issuance = total_issued * base_reward_rate / BPS_SQUARED;
-        Ok(new_issuance.into())
+            .staking_issuance_per_block;
+
+        tracing::debug!(
+            number_of_blocks_in_epoch = num_blocks,
+            staking_issuance_per_block,
+            "calculating issuance per epoch"
+        );
+
+        let new_issuance_for_epoch = staking_issuance_per_block
+            .checked_mul(num_blocks)
+            .expect("infaillible unless issuance is pathological");
+
+        Ok(Amount::from(new_issuance_for_epoch))
     }
 
     /// Update the object store with the new issuance of staking tokens for this epoch.
-    /// TODO(erwan): this is a stub implementation.
-    async fn distribute(&mut self) -> Result<()> {
-        let new_issuance = self.compute_new_issuance().await?;
-        tracing::debug!(?new_issuance, "computed new issuance for epoch");
-        self.set_total_issued(new_issuance);
-        todo!()
+    async fn distribute(&mut self, new_issuance: Amount) {
+        self.set_staking_token_issuance_for_epoch(new_issuance)
     }
 }
+
+impl<T: StateWrite + ?Sized> DistributionManager for T {}

--- a/crates/core/component/distributions/src/component/state_key.rs
+++ b/crates/core/component/distributions/src/component/state_key.rs
@@ -1,6 +1,6 @@
-// The cumulative total issuance of staking token.
-pub fn total_issued() -> &'static str {
-    "distributions/total_issued"
+// The amount of staking tokens issued for this epoch.
+pub fn staking_token_issuance_for_epoch() -> &'static str {
+    "distributions/staking_token_issuance_for_epoch"
 }
 
 pub fn distributions_parameters() -> &'static str {

--- a/crates/core/component/distributions/src/component/view.rs
+++ b/crates/core/component/distributions/src/component/view.rs
@@ -21,8 +21,8 @@ pub trait StateReadExt: StateRead {
             .ok_or_else(|| anyhow::anyhow!("Missing DistributionsParameters"))
     }
 
-    async fn total_issued(&self) -> Result<Option<u64>> {
-        self.get_proto(&state_key::total_issued()).await
+    fn get_staking_token_issuance_for_epoch(&self) -> Option<Amount> {
+        self.object_get(&state_key::staking_token_issuance_for_epoch())
     }
 }
 
@@ -30,10 +30,9 @@ impl<T: StateRead + ?Sized> StateReadExt for T {}
 #[async_trait]
 
 pub trait StateWriteExt: StateWrite + StateReadExt {
-    /// Set the total amount of staking tokens issued.
-    fn set_total_issued(&mut self, total_issued: Amount) {
-        let total = Amount::from(total_issued);
-        self.put(state_key::total_issued().to_string(), total)
+    /// Set the total amount of staking tokens issued for this epoch.
+    fn set_staking_token_issuance_for_epoch(&mut self, issuance: Amount) {
+        self.object_put(state_key::staking_token_issuance_for_epoch(), issuance);
     }
 
     /// Set the Distributions parameters in the JMT.


### PR DESCRIPTION
Part of #3409, this PR uses the new distributions component chain parameter (`staking_issuance_per_block`) to compute the per-epoch inflation budget and store it in the object store.