### PR TITLE
ci: update checkout actions to v4

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint protobuf
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1
         with:
           buf_api_token: ${{ secrets.BUF_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
     # runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1
         with:
           buf_api_token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
 
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Docker Hub container registry (for pulls)
         uses: docker/login-action@v2
@@ -106,7 +106,7 @@ jobs:
       - penumbra
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # We use the GHA Repository Dispatch functionality to trigger a container
       # build in the penumbra-zone/osiris repo.
       - name: Trigger remote build
@@ -129,7 +129,7 @@ jobs:
       - penumbra
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # We use the GHA Repository Dispatch functionality to trigger a container
       # build in the penumbra-zone/galileo repo.
       - name: Trigger remote build
@@ -155,7 +155,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # We use the GHA Repository Dispatch functionality to trigger a container
       # build in the penumbra-zone/hermes repo.
@@ -178,7 +178,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Docker Hub container registry (for pulls)
         uses: docker/login-action@v2

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -39,7 +39,7 @@ jobs:
     environment: testnet-preview
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: gcloudauth
         uses: google-github-actions/auth@v0

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: gcloudauth
         uses: google-github-actions/auth@v0

--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install rust toolchain

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: ./crates/wasm/publish
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ jobs:
     name: Test Suite
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install rust toolchain
@@ -30,7 +30,7 @@ jobs:
     name: Rustfmt
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -43,7 +43,7 @@ jobs:
     name: Check for warnings
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install rust toolchain
@@ -57,7 +57,7 @@ jobs:
     name: Check that rustdocs build OK
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install rust toolchain
@@ -72,7 +72,7 @@ jobs:
     name: Build WASM
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install rust toolchain

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,7 +13,7 @@ jobs:
       cancel-in-progress: true
     environment: smoke-test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           lfs: true
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/summoner_smoke.yml
+++ b/.github/workflows/summoner_smoke.yml
@@ -16,7 +16,7 @@ jobs:
       cancel-in-progress: true
     environment: smoke-test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           lfs: true
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
We were using checkout v2 & and v3 in a few places, when v4 is the latest. v2 shows a deprecation warning:

  The following actions uses node12 which is deprecated
  and will be forced to run on node16: actions/checkout@v2.
  For more info:
  https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/