### PR TITLE
ci: serialize preview deploys

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -20,7 +20,9 @@ on:
 # that was just merged.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Don't cancel mid-run, as an interrupted `helmfile sync` can create broken release
+  # states in the kube API server that require manual cleanup.
+  cancel-in-progress: false
 
 jobs:
   build-container:


### PR DESCRIPTION
Don't cancel mid-run, as an interrupted `helmfile sync` can create broken release states in the kube API server that require manual cleanup.