### PR TITLE
Update Grafana Dashboards

### DIFF
--- a/deployments/config/grafana/dashboards/ABCI.json
+++ b/deployments/config/grafana/dashboards/ABCI.json
@@ -167,7 +167,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(tendermint_abci_connection_method_timing_count[5m])) by (method)",
+          "expr": "sum(rate(tendermint_abci_connection_method_timing_seconds_count[5m])) by (method)",
           "refId": "A"
         }
       ],
@@ -255,7 +255,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(tendermint_abci_connection_method_timing_bucket{method=\"begin_block\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(tendermint_abci_connection_method_timing_seconds_bucket{method=\"begin_block\"}[5m])))",
           "range": true,
           "refId": "A"
         },
@@ -264,7 +264,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.5, sum by(le) (rate(tendermint_abci_connection_method_timing_bucket{method=\"begin_block\"}[5m])))",
+          "expr": "histogram_quantile(0.5, sum by(le) (rate(tendermint_abci_connection_method_timing_seconds_bucket{method=\"begin_block\"}[5m])))",
           "hide": false,
           "refId": "B"
         }
@@ -353,7 +353,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(tendermint_abci_connection_method_timing_bucket{method=\"deliver_tx\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(tendermint_abci_connection_method_timing_seconds_bucket{method=\"deliver_tx\"}[5m])))",
           "range": true,
           "refId": "A"
         }
@@ -442,7 +442,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(tendermint_abci_connection_method_timing_bucket{method=\"end_block\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(tendermint_abci_connection_method_timing_seconds_bucket{method=\"end_block\"}[5m])))",
           "range": true,
           "refId": "A"
         }
@@ -531,7 +531,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(tendermint_abci_connection_method_timing_bucket{method=\"commit\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(tendermint_abci_connection_method_timing_seconds_bucket{method=\"commit\"}[5m])))",
           "range": true,
           "refId": "A"
         }

--- a/deployments/config/grafana/dashboards/Penumbra.json
+++ b/deployments/config/grafana/dashboards/Penumbra.json
@@ -30,7 +30,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -108,7 +108,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(penumbra_storage_get_raw_duration_seconds_sum[5m]) / rate(penumbra_storage_get_raw_duration_seconds_count[5m])",
@@ -123,7 +123,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -201,7 +201,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "rate(penumbra_storage_nonverifiable_get_raw_duration_seconds_sum[5m]) / rate(penumbra_storage_nonverifiable_get_raw_duration_seconds_count[5m])",
@@ -540,172 +540,6 @@
             }
           },
           "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "Active Validators"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 32
-      },
-      "id": 6,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "group(penumbra_stake_validators_active{worker=\"\\\"consensus\\\"\"}) by (worker)",
-          "interval": "",
-          "legendFormat": "Active Validators",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "group(penumbra_stake_validators_inactive{worker=\"\\\"consensus\\\"\"}) by (worker)",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Inactive Validators",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "group(penumbra_stake_validators_disabled{worker=\"\\\"consensus\\\"\"}) by (worker)",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Disabled Validators",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "group(penumbra_stake_validators_jailed{worker=\"\\\"consensus\\\"\"}) by (worker)",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Jailed Validators",
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": true,
-          "expr": "group(penumbra_stake_validators_tombstoned{worker=\"\\\"consensus\\\"\"}) by (worker)",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "Tombstoned Validators",
-          "refId": "E"
-        }
-      ],
-      "title": "Validators",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -725,8 +559,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 41
+        "x": 12,
+        "y": 16
       },
       "id": 4,
       "options": {
@@ -817,9 +651,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 49
+        "w": 12,
+        "x": 12,
+        "y": 8
       },
       "id": 2,
       "options": {
@@ -841,7 +675,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(penumbra_stake_validators_active{worker=\"\\\"consensus\\\"\"})",
+          "expr": "sum(penumbra_stake_validators_active)",
           "interval": "",
           "legendFormat": "Active Validators",
           "refId": "A"
@@ -852,7 +686,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(penumbra_stake_validators_inactive{worker=\"\\\"consensus\\\"\"})",
+          "expr": "sum(penumbra_stake_validators_inactive)",
           "hide": false,
           "interval": "",
           "legendFormat": "Inactive Validators",
@@ -864,7 +698,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(penumbra_stake_validators_disabled{worker=\"\\\"consensus\\\"\"})",
+          "expr": "sum(penumbra_stake_validators_disabled)",
           "hide": false,
           "interval": "",
           "legendFormat": "Disabled Validators",
@@ -876,10 +710,10 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(penumbra_stake_validators_tombstoned{worker=\"\\\"consensus\\\"\"})",
+          "expr": "sum(penumbra_stake_validators_tombstoned)",
           "hide": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "Tombstoned Validators",
           "refId": "D"
         },
         {
@@ -888,7 +722,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "sum(penumbra_stake_validators_jailed{worker=\"\\\"consensus\\\"\"})",
+          "expr": "sum(penumbra_stake_validators_jailed)",
           "hide": false,
           "interval": "",
           "legendFormat": "Jailed Validators",

--- a/deployments/config/grafana/dashboards/Transactions.json
+++ b/deployments/config/grafana/dashboards/Transactions.json
@@ -1,4 +1,35 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.5.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -30,7 +61,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Time spent searching for paths between two assets, while processing Swaps in the DEX engine.",
       "fieldConfig": {
@@ -86,7 +117,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "histogram_quantile(0.95, sum by(le) (rate(penumbra_dex_path_search_duration_seconds_bucket[$__rate_interval])))",
@@ -101,7 +132,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "The total number of path-search operations. Only shows for val-0, as we expect the number to be the same across all nodes.",
       "fieldConfig": {
@@ -139,9 +170,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -152,7 +181,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "disableTextWrap": false,
           "editorMode": "builder",
@@ -269,21 +298,13 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "Prometheus",
-          "value": "PBFA97CFB590B2093"
-        },
         "hide": 0,
-        "includeAll": false,
         "label": "datasource",
-        "multi": false,
         "name": "DS_PROMETHEUS",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
         "type": "datasource"
       }
     ]

--- a/deployments/config/grafana/dashboards/Validators.json
+++ b/deployments/config/grafana/dashboards/Validators.json
@@ -138,7 +138,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "penumbra_stake_validators_active{role=\"consensus\"}",
+          "expr": "penumbra_stake_validators_active",
           "refId": "A"
         },
         {
@@ -146,7 +146,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "penumbra_stake_validators_disabled{role=\"consensus\"}",
+          "expr": "penumbra_stake_validators_disabled",
           "hide": false,
           "refId": "B"
         },
@@ -155,7 +155,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "penumbra_stake_validators_inactive{role=\"consensus\"}",
+          "expr": "penumbra_stake_validators_inactive",
           "hide": false,
           "refId": "C"
         },
@@ -164,7 +164,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "penumbra_stake_validators_jailed{role=\"consensus\"}",
+          "expr": "penumbra_stake_validators_jailed",
           "hide": false,
           "refId": "D"
         },
@@ -173,7 +173,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "penumbra_stake_validators_tombstoned{role=\"consensus\"}",
+          "expr": "penumbra_stake_validators_tombstoned",
           "hide": false,
           "refId": "E"
         }
@@ -260,7 +260,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "penumbra_stake_missed_blocks{role=\"consensus\"}",
+          "expr": "penumbra_stake_missed_blocks",
           "refId": "A"
         }
       ],

--- a/deployments/config/grafana/dashboards/sync.json
+++ b/deployments/config/grafana/dashboards/sync.json
@@ -1,4 +1,34 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.5.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -25,7 +55,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -102,7 +132,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "rate(penumbra_component_compact_block_compact_block_range_served_total[5m])",
@@ -117,7 +147,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -194,7 +224,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "penumbra_component_compact_block_compact_block_range_active_connections",
@@ -209,7 +239,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -286,7 +316,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "rate(penumbra_storage_nonverifiable_get_raw_duration_seconds_sum[5m]) / rate(penumbra_storage_nonverifiable_get_raw_duration_seconds_count[5m])",
@@ -301,7 +331,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -378,7 +408,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "rate(tendermint_consensus_latest_block_height[5m])",
@@ -393,7 +423,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -470,7 +500,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "rate(penumbra_storage_get_raw_duration_seconds_sum[5m]) / rate(penumbra_storage_get_raw_duration_seconds_count[5m])",
@@ -485,7 +515,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -562,7 +592,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "tendermint_consensus_height",
@@ -577,7 +607,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -654,7 +684,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "rate(penumbra_storage_nonverifiable_get_raw_duration_seconds_count[5m])",
@@ -669,7 +699,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -746,7 +776,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
           "expr": "rate(penumbra_storage_get_raw_duration_seconds_count[5m])",
@@ -765,7 +795,18 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-7d",


### PR DESCRIPTION
Two changes to address issues I had when reusing the Grafana dashboards for a full node and validator:

- The ABCI dashboard relies on a metric that CometBFT emits with a name that now includes the unit (seconds)
- The Sync, Transactions, and Penumbra dashboards have at least some hardcoded Prometheus plugin UID's. Turning this into a parameter makes the dashboard reusable, and is the approach the other dashboards take.
- The Validators dashboards looks for a `role` label with the value `consensus` on the validator counts that is not emitted
- The Penumbra dashboard looks for a `worker` label with the value `consensus` on the validator counts that is not emitted - it also creates a panel that performs a group operation over `workers` filtered to `consensus` value, which, if present, would duplicate the result of calling sum over the metric directly