### PR TITLE
feat(pd): add permissive cors headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,6 +4901,7 @@ dependencies = [
  "tower",
  "tower-abci",
  "tower-actor",
+ "tower-http 0.4.4",
  "tower-service",
  "tracing",
  "tracing-subscriber 0.3.18",

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -81,6 +81,7 @@ tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["compat"] }
 tower = { version = "0.4", features = ["full"] }
 tower-service = "0.3.2"
+tower-http = "0.4"
 tracing = "0.1"
 regex = "1.5"
 reqwest = { version = "0.11", features = ["json"] }

--- a/deployments/charts/penumbra-node/values.yaml
+++ b/deployments/charts/penumbra-node/values.yaml
@@ -86,8 +86,7 @@ ingressRoute:
   secretName: ""
   # Traefik middleware CRDs, to be applied to pd's gRPC service.
   # These config objects must already exist in the API, i.e. create them out of band.
-  middlewares:
-    - name: cors-allow-all
+  middlewares: []
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
We want to enable use of pd's gRPC services in arbitrary web contexts, including between localhost and a published website, for debugging. Refs #3281.