### PR TITLE
fix: circular dependency cleanup

### DIFF
--- a/crates/core/component/stake/Cargo.toml
+++ b/crates/core/component/stake/Cargo.toml
@@ -87,7 +87,6 @@ async-stream = { version = "0.3.5", optional = true }
 [dev-dependencies]
 ed25519-consensus = "2"
 rand_chacha = "0.3"
-# penumbra-transaction = { path = "../../transaction", features = ["parallel"] }
 tracing-subscriber = "0.3"
 proptest = "1"
 

--- a/crates/core/component/stake/Cargo.toml
+++ b/crates/core/component/stake/Cargo.toml
@@ -87,7 +87,7 @@ async-stream = { version = "0.3.5", optional = true }
 [dev-dependencies]
 ed25519-consensus = "2"
 rand_chacha = "0.3"
-penumbra-transaction = { path = "../../transaction", features = ["parallel"] }
+# penumbra-transaction = { path = "../../transaction", features = ["parallel"] }
 tracing-subscriber = "0.3"
 proptest = "1"
 


### PR DESCRIPTION
@conorsch during your cleanup of the commit history, I think one of the dev dependencies in the `penumbra-stake` crate was unnecessarily kept in and snuck into master. To completely resolve the circular dependency bug, that needs to be removed as well. 