### PR TITLE
build: stop using vergen

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,9 +5,6 @@
 !Cargo.toml
 !Cargo.lock
 !.cargo/
-# git directory for vergen. unfortunately, breaks cache
-# on every commit.
-!.git/
 
 # testnets for 'pd testnet generate' defaults
 !testnets/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,26 +2350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
-name = "enum-iterator"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2953d1df47ac0eb70086ccabf0275aa8da8591a28bd358ee2b52bd9f9e3ff9e9"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8958699f9359f0b04e691a13850d48b7de329138023876d07cbd024c2c820598"
-dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,18 +2790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error 1.0.4",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "ghash"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2836,19 +2804,6 @@ name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
-
-[[package]]
-name = "git2"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
-dependencies = [
- "bitflags 2.4.1",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
 
 [[package]]
 name = "glob"
@@ -3879,18 +3834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libgit2-sys"
-version = "0.16.1+1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3951,7 +3894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4257,7 +4199,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "url",
- "vergen",
 ]
 
 [[package]]
@@ -4315,15 +4256,6 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -4758,7 +4690,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "url",
- "vergen",
  "walkdir",
 ]
 
@@ -4814,7 +4745,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.2.25",
  "url",
- "vergen",
 ]
 
 [[package]]
@@ -4906,7 +4836,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "url",
- "vergen",
 ]
 
 [[package]]
@@ -5012,7 +4941,6 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber 0.3.18",
- "vergen",
 ]
 
 [[package]]
@@ -5204,7 +5132,6 @@ dependencies = [
  "toml 0.5.11",
  "tonic",
  "tracing",
- "vergen",
 ]
 
 [[package]]
@@ -5513,7 +5440,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "url",
- "vergen",
 ]
 
 [[package]]
@@ -5782,7 +5708,6 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber 0.3.18",
- "vergen",
 ]
 
 [[package]]
@@ -6053,7 +5978,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.2.25",
  "url",
- "vergen",
 ]
 
 [[package]]
@@ -7989,7 +7913,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "url",
- "vergen",
 ]
 
 [[package]]
@@ -8052,21 +7975,6 @@ dependencies = [
  "quote 1.0.33",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7de153d0438a648bb71e06e300e54fc641685e96af96d49b843f43172d341c"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "doc-comment",
- "libc",
- "ntapi",
- "once_cell",
- "winapi",
 ]
 
 [[package]]
@@ -8950,24 +8858,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vergen"
-version = "5.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf88d94e969e7956d924ba70741316796177fa0c79a2c9f4ab04998d96e966e"
-dependencies = [
- "anyhow",
- "cfg-if",
- "chrono",
- "enum-iterator",
- "getset",
- "git2",
- "rustc_version 0.4.0",
- "rustversion",
- "sysinfo",
- "thiserror",
-]
 
 [[package]]
 name = "version_check"

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -95,10 +95,6 @@ ndarray = "0.15.6"
 dialoguer = "0.10.4"
 # ndarray-linalg = { version = "0.16.0", features = ["openblas-static"] }
 
-[build-dependencies]
-vergen = "5"
-anyhow = "1"
-
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "2.1"

--- a/crates/bin/pcli/build.rs
+++ b/crates/bin/pcli/build.rs
@@ -1,5 +1,0 @@
-use vergen::{vergen, Config};
-
-fn main() {
-    vergen(Config::default()).unwrap()
-}

--- a/crates/bin/pcli/src/command/debug.rs
+++ b/crates/bin/pcli/src/command/debug.rs
@@ -110,7 +110,7 @@ impl DebugInfo {
     }
     /// Return the version for `pcli` baked in at compile time.
     fn get_pcli_version() -> String {
-        env!("VERGEN_GIT_SEMVER").to_string()
+        env!("CARGO_PKG_VERSION").to_string()
     }
     /// Attempt to find `pd` on PATH, and return its version number. Depending on deployment,
     /// `pd` may not be on the path; it may in a container context elsewhere.

--- a/crates/bin/pcli/src/opt.rs
+++ b/crates/bin/pcli/src/opt.rs
@@ -22,11 +22,7 @@ use penumbra_view::ViewService;
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
-#[clap(
-    name = "pcli",
-    about = "The Penumbra command-line interface.",
-    version = env!("VERGEN_GIT_SEMVER"),
-)]
+#[clap(name = "pcli", about = "The Penumbra command-line interface.", version)]
 pub struct Opt {
     #[clap(subcommand)]
     pub cmd: Command,

--- a/crates/bin/pclientd/Cargo.toml
+++ b/crates/bin/pclientd/Cargo.toml
@@ -69,6 +69,3 @@ penumbra-proof-params = { path = "../../crypto/proof-params", features = [
     "bundled-proving-keys",
     "download-proving-keys",
 ] }
-
-[build-dependencies]
-vergen = "5"

--- a/crates/bin/pclientd/build.rs
+++ b/crates/bin/pclientd/build.rs
@@ -1,5 +1,0 @@
-use vergen::{vergen, Config};
-
-fn main() {
-    vergen(Config::default()).unwrap();
-}

--- a/crates/bin/pclientd/src/lib.rs
+++ b/crates/bin/pclientd/src/lib.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::net::SocketAddr;
 use std::path::Path;
 
@@ -71,11 +70,7 @@ fn default_home() -> Utf8PathBuf {
 }
 
 #[derive(Debug, Parser)]
-#[clap(
-    name = "pclientd",
-    about = "The Penumbra view daemon.",
-    version = env!("VERGEN_GIT_SEMVER"),
-)]
+#[clap(name = "pclientd", about = "The Penumbra view daemon.", version)]
 pub struct Opt {
     /// Command to run.
     #[clap(subcommand)]

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -131,7 +131,6 @@ penumbra-proof-params = { path = "../../crypto/proof-params", features = [
 ] }
 
 [build-dependencies]
-vergen = "5"
 anyhow = "1"
 
 [package.metadata.dist]

--- a/crates/bin/pd/build.rs
+++ b/crates/bin/pd/build.rs
@@ -1,10 +1,8 @@
 use std::path::Path;
 
 use anyhow::Context;
-use vergen::{vergen, Config};
 
 fn main() -> anyhow::Result<()> {
-    vergen(Config::default()).unwrap();
     setup_testnet_config()?;
     Ok(())
 }

--- a/crates/bin/pd/src/info.rs
+++ b/crates/bin/pd/src/info.rs
@@ -43,7 +43,7 @@ use tracing::Instrument;
 
 use penumbra_tower_trace::v037::RequestExt;
 
-const ABCI_INFO_VERSION: &str = env!("VERGEN_GIT_SEMVER");
+const ABCI_INFO_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Implements service traits for Tonic gRPC services.
 ///

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -40,11 +40,7 @@ use penumbra_tower_trace::v037::RequestExt;
 use tendermint::v0_37::abci::{ConsensusRequest, MempoolRequest};
 
 #[derive(Debug, Parser)]
-#[clap(
-    name = "pd",
-    about = "The Penumbra daemon.",
-    version = env!("VERGEN_GIT_SEMVER"),
-)]
+#[clap(name = "pd", about = "The Penumbra daemon.", version)]
 struct Opt {
     /// Enable Tokio Console support.
     #[clap(long)]

--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -71,9 +71,6 @@ rand_core = "0.6"
 rand_chacha = "0.3"
 tracing-subscriber = "0.3"
 
-[build-dependencies]
-vergen = "5"
-
 [features]
 default = ["std"]
 std = ["ark-ff/std", "ibc-types/std"]

--- a/crates/core/component/stake/Cargo.toml
+++ b/crates/core/component/stake/Cargo.toml
@@ -89,6 +89,3 @@ ed25519-consensus = "2"
 rand_chacha = "0.3"
 tracing-subscriber = "0.3"
 proptest = "1"
-
-[build-dependencies]
-vergen = "5"

--- a/crates/custody/Cargo.toml
+++ b/crates/custody/Cargo.toml
@@ -26,8 +26,5 @@ rand_core = "0.6"
 ed25519-consensus = "2.1"
 base64 = "0.20"
 
-[build-dependencies]
-vergen = "5"
-
 [dev-dependencies]
 toml = "0.5"

--- a/crates/custody/build.rs
+++ b/crates/custody/build.rs
@@ -1,5 +1,0 @@
-use vergen::{vergen, Config};
-
-fn main() {
-    vergen(Config::default()).unwrap();
-}

--- a/crates/misc/measure/Cargo.toml
+++ b/crates/misc/measure/Cargo.toml
@@ -23,9 +23,6 @@ reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1"
 bytesize = "1.2"
 
-[build-dependencies]
-vergen = "5"
-
 [[bin]]
 name = "measure"
 path = "src/main.rs"

--- a/crates/misc/measure/build.rs
+++ b/crates/misc/measure/build.rs
@@ -1,5 +1,0 @@
-use vergen::{vergen, Config};
-
-fn main() {
-    vergen(Config::default()).unwrap()
-}

--- a/crates/misc/measure/src/main.rs
+++ b/crates/misc/measure/src/main.rs
@@ -28,7 +28,7 @@ use url::Url;
 #[clap(
     name = "penumbra-measure",
     about = "A developer tool for measuring things about Penumbra.",
-    version = env!("VERGEN_GIT_SEMVER"),
+    version
 )]
 pub struct Opt {
     /// The URL for the gRPC endpoint of the remote pd node.

--- a/crates/narsil/narsil/Cargo.toml
+++ b/crates/narsil/narsil/Cargo.toml
@@ -61,5 +61,4 @@ url = "2"
 atty = "0.2"
 
 [build-dependencies]
-vergen = "5"
 anyhow = "1"

--- a/crates/narsil/narsil/build.rs
+++ b/crates/narsil/narsil/build.rs
@@ -1,6 +1,0 @@
-use vergen::{vergen, Config};
-
-fn main() -> anyhow::Result<()> {
-    vergen(Config::default())?;
-    Ok(())
-}

--- a/crates/narsil/narsil/src/bin/narsild.rs
+++ b/crates/narsil/narsil/src/bin/narsild.rs
@@ -30,11 +30,7 @@ use tracing_subscriber::{prelude::*, EnvFilter};
 use url::Url;
 
 #[derive(Debug, Parser)]
-#[clap(
-    name = "narsild",
-    about = "The narsil daemon.",
-    version = env!("VERGEN_GIT_SEMVER"),
-)]
+#[clap(name = "narsild", about = "The narsil daemon.", version)]
 struct Opt {
     /// Enable Tokio Console support.
     #[clap(long)]

--- a/crates/view/Cargo.toml
+++ b/crates/view/Cargo.toml
@@ -75,6 +75,3 @@ r2d2_sqlite = { version = "0.22", git = "https://github.com/penumbra-zone/r2d2-s
 genawaiter = "0.99"
 digest = "0.9"
 once_cell = "1"
-
-[build-dependencies]
-vergen = "5"

--- a/crates/view/build.rs
+++ b/crates/view/build.rs
@@ -1,8 +1,4 @@
-use vergen::{vergen, Config};
-
 fn main() {
-    vergen(Config::default()).expect("able to instantiate vergen");
-
     // Changes to the SQL schema should trigger a rebuild:
     println!("cargo:rerun-if-changed=src/storage/schema.sql");
 }

--- a/crates/view/src/storage.rs
+++ b/crates/view/src/storage.rs
@@ -163,7 +163,7 @@ impl Storage {
                 anyhow::bail!(
                     "can't load view database created by client version {} using client version {}: they have different schemata, so you need to reset your view database and resynchronize",
                     database_client_version,
-                    env!("VERGEN_GIT_SEMVER"),
+                    env!("CARGO_PKG_VERSION"),
                 );
             }
 
@@ -254,7 +254,7 @@ impl Storage {
             // Insert the client version into the database
             tx.execute(
                 "INSERT INTO client_version (client_version) VALUES (?1)",
-                [env!("VERGEN_GIT_SEMVER")],
+                [env!("CARGO_PKG_VERSION")],
             )?;
 
             tx.commit()?;

--- a/deployments/containerfiles/Dockerfile
+++ b/deployments/containerfiles/Dockerfile
@@ -14,13 +14,12 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /usr/src/penumbra
 # Add rust dependency lockfiles first, to cache downloads.
 COPY Cargo.lock Cargo.toml .
+# If any rust code changed, the cache will break on copying `crates/`.
+# Ideally we'd copy in all Cargo.toml files first, fetch, then copy crates.
 COPY crates ./crates
 # Copy in summonerd contribution orchestrator.
 COPY tools ./tools
 RUN cargo fetch
-# Unfortunately, container layer cache is busted copying in the .git
-# dir, which is required for using vergen, so we rebuild the rust
-# code from source fresh.
 COPY . .
 # Build Penumbra binaries
 RUN cargo build --release

--- a/tools/summonerd/Cargo.toml
+++ b/tools/summonerd/Cargo.toml
@@ -54,7 +54,3 @@ r2d2 = "0.8"
 r2d2_sqlite = { version = "0.22", git = "https://github.com/penumbra-zone/r2d2-sqlite.git", features = [
     "bundled",
 ] }
-
-[build-dependencies]
-vergen = "5"
-

--- a/tools/summonerd/build.rs
+++ b/tools/summonerd/build.rs
@@ -1,5 +1,0 @@
-use vergen::{vergen, Config};
-
-fn main() {
-    vergen(Config::default()).unwrap();
-}

--- a/tools/summonerd/src/main.rs
+++ b/tools/summonerd/src/main.rs
@@ -81,7 +81,7 @@ operating the orchestration.
     name = "summonerd",
     about = "Penumbra summoning ceremony coordinator",
     long_about = LONG_HELP,
-    version = env!("VERGEN_GIT_SEMVER"),
+    version,
 )]
 struct Opt {
     /// Enable Tokio Console support.


### PR DESCRIPTION
We remove the `vergen` build dependency from all crates in the workspace, in order to speed up local builds, and slightly improve CI cache performance. The only downside to this change is that version strings are now hardcoded, based on the version specified in `Cargo.toml`,  e.g. `v0.63.2`.

Refs #3436.