### PR TITLE
storage(substore): add delimiter handling

### DIFF
--- a/crates/core/component/ibc/src/prefix.rs
+++ b/crates/core/component/ibc/src/prefix.rs
@@ -45,7 +45,7 @@ mod vendored {
     }
 }
 
-/// the ICS23 proof spec for penumbra's IBC state; this can be used to verify proofs
+/// The ICS23 proof spec for penumbra's IBC state; this can be used to verify proofs
 /// for other substores in the penumbra state, provided that the data is indeed inside a substore
 /// (as opposed to directly in the root store.)
 pub static IBC_PROOF_SPECS: Lazy<Vec<ics23::ProofSpec>> =
@@ -61,6 +61,6 @@ impl MerklePrefixExt for MerklePrefix {
         let prefix_string = String::from_utf8(self.key_prefix.clone())
             .expect("commitment prefix is not valid utf-8");
 
-        format!("{}{}", prefix_string, path)
+        format!("{}/{}", prefix_string, path)
     }
 }

--- a/crates/storage/src/snapshot.rs
+++ b/crates/storage/src/snapshot.rs
@@ -60,6 +60,10 @@ impl Snapshot {
     /// up to the current JMT root hash. If the key is not present, returns `None` and a
     /// non-existence proof.
     pub async fn get_with_proof(&self, key: Vec<u8>) -> Result<(Option<Vec<u8>>, MerkleProof)> {
+        if key.is_empty() {
+            anyhow::bail!("empty keys are not allowed")
+        }
+
         let span = tracing::Span::current();
         let rocksdb_snapshot = self.0.snapshot.clone();
         let db = self.0.db.clone();

--- a/crates/storage/src/store/multistore.rs
+++ b/crates/storage/src/store/multistore.rs
@@ -24,59 +24,150 @@ impl MultistoreConfig {
             .unwrap_or(self.main_store.clone())
     }
 
-    /// Route the key to the correct substore, or the transparent store if no prefix matches.
-    /// Returns a key with the prefix removed, and the target `SubstoreConfig`.
-    /// If the key is an exact match for the prefix, the main store is returned instead.
+    /// Route a key to a substore, and return the truncated key and the corresponding `SubstoreConfig`.
+    ///
+    /// This method is used for ordinary key-value operations.
+    ///
+    /// Note: since this method implements the routing logic for the multistore,
+    /// callers might prefer [`MultistoreConfig::match_prefix_str`] if they don't
+    /// need to route the key.
+    ///
+    /// # Routing
+    /// + If the key is a total match for the prefix, the **main store** is returned.
+    /// + If the key is not a total match for the prefix, the prefix is removed from  
+    ///   the key and the key is routed to the substore matching the prefix.
+    /// + If the key does not match any prefix, the key is routed to the **main store**.
+    /// + If a delimiter is prefixing the key, it is removed.
+    ///
+    /// # Examples
+    /// `prefix_a/key` -> `key` in `substore_a`
+    /// `prefix_akey` -> `prefix_akey` in `main_store
+    /// `prefix_a` -> `prefix_a` in `main_store`
+    /// `prefix_a/` -> `prefix_a/` in `main_store
+    /// `nonexistent_prefix` -> `nonexistent_prefix` in `main_store`
     pub fn route_key_str<'a>(&self, key: &'a str) -> (&'a str, Arc<SubstoreConfig>) {
         let config = self.find_substore(key.as_bytes());
         if key == config.prefix {
             return (key, self.main_store.clone());
         }
 
-        let key = key
+        let truncated_key = key
             .strip_prefix(&config.prefix)
             .expect("key has the prefix of the matched substore");
-        (key, config)
+
+        // If the key does not contain a delimiter, we return the original key
+        // routed to the main store. This is because we do not want to allow
+        // collisions e.g. `prefix_a/key` and `prefix_akey`.
+        let Some(matching_key) = truncated_key.strip_prefix("/") else {
+            return (key, self.main_store.clone());
+        };
+
+        // If the matching key is empty, we return the original key routed to
+        // the main store. This is because we do not want to allow empty keys
+        // in the substore.
+        if matching_key.is_empty() {
+            (key, self.main_store.clone())
+        } else {
+            (matching_key, config)
+        }
     }
 
-    /// Route the key to the correct substore, or the transparent store if no prefix matches.
-    /// Returns a key with the prefix removed, and the target `SubstoreConfig`.
-    /// If the key is an exact match for the prefix, the main store is returned instead.
+    /// Route a key to a substore, and return the truncated key and the corresponding `SubstoreConfig`.
+    ///
+    /// This method is used for ordinary key-value operations.
+    ///
+    /// Note: since this method implements the routing logic for the multistore,
+    /// callers might prefer [`MultistoreConfig::match_prefix_bytes`] if they don't
+    /// need to route the key.
+    ///
+    /// # Routing
+    /// + If the key is a total match for the prefix, the **main store** is returned.
+    /// + If the key is not a total match for the prefix, the prefix is removed from  
+    ///   the key and the key is routed to the substore matching the prefix.
+    /// + If the key does not match any prefix, the key is routed to the **main store**.
+    /// + If a delimiter is prefixing the key, it is removed.
+    ///
+    /// # Examples
+    /// `prefix_a/key` -> `key` in `substore_a`
+    /// `prefix_a` -> `prefix_a` in `main_store`
+    /// `preifx_a/` -> `prefix_a/` in `main_store`
+    /// `nonexistent_prefix` -> `nonexistent_prefix` in `main_store`
     pub fn route_key_bytes<'a>(&self, key: &'a [u8]) -> (&'a [u8], Arc<SubstoreConfig>) {
         let config = self.find_substore(key);
         if key == config.prefix.as_bytes() {
             return (key, self.main_store.clone());
         }
 
-        let key = key
+        let truncated_key = key
             .strip_prefix(config.prefix.as_bytes())
             .expect("key has the prefix of the matched substore");
-        (key, config)
+
+        // If the key does not contain a delimiter, we return the original key
+        // routed to the main store. This is because we do not want to allow
+        // collisions e.g. `prefix_a/key` and `prefix_akey`.
+        let Some(matching_key) = truncated_key.strip_prefix(b"/") else {
+            return (key, self.main_store.clone());
+        };
+
+        // If the matching key is empty, we return the original key routed to
+        // the main store. This is because we do not want to allow empty keys
+        // in the substore.
+        if matching_key.is_empty() {
+            (key, self.main_store.clone())
+        } else {
+            (matching_key, config)
+        }
     }
 
-    /// Finds the substore matching the prefix, and returns a truncated prefix and a corresponding
-    /// `SubstoreConfig`. This method differs from `route_key_str` in that it does not return the
-    /// main store if the key is an exact match for the prefix.
-    /// This is useful for implementing prefix iteration.
+    /// Returns the truncated prefix and the corresponding `SubstoreConfig`.
+    ///
+    /// This method is used to implement prefix iteration.
+    ///
+    /// Unlike [`MultistoreConfig::route_key_str`], this method does not do any routing.
+    /// It simply finds the substore matching the prefix, strip the prefix and delimiter,
+    /// and returns the truncated prefix and the corresponding `SubstoreConfig`.
+    ///
+    /// # Examples
+    /// `prefix_a/key` -> `key` in `substore_a`
+    /// `prefix_a` -> "" in `substore_a`
+    /// `prefix_a/` -> "" in `substore_a`
+    /// `nonexistent_prefix` -> "" in `main_store`
     pub fn match_prefix_str<'a>(&self, prefix: &'a str) -> (&'a str, Arc<SubstoreConfig>) {
         let config = self.find_substore(prefix.as_bytes());
 
         let truncated_prefix = prefix
             .strip_prefix(&config.prefix)
             .expect("key has the prefix of the matched substore");
+
+        let truncated_prefix = truncated_prefix
+            .strip_prefix("/")
+            .unwrap_or(truncated_prefix);
         (truncated_prefix, config)
     }
 
-    /// Finds the substore matching the prefix, and returns a truncated prefix and a corresponding
-    /// `SubstoreConfig`. This method differs from `route_key_str` in that it does not return the
-    /// main store if the key is an exact match for the prefix.
-    /// This is useful for implementing prefix iteration.
+    /// Returns the truncated prefix and the corresponding `SubstoreConfig`.
+    ///
+    /// Unlike [`MultistoreConfig::route_key_str`], this method does not do any routing.
+    /// It simply finds the substore matching the prefix, strip the prefix and delimiter,
+    /// and returns the truncated prefix and the corresponding `SubstoreConfig`.
+    ///
+    /// This method is used to implement prefix iteration.
+    ///
+    /// # Examples
+    /// `prefix_a/key` -> `key` in `substore_a`
+    /// `prefix_a` -> "" in `substore_a`
+    /// `prefix_a/` -> "" in `substore_a`
+    /// `nonexistent_prefix` -> "" in `main_store`
     pub fn match_prefix_bytes<'a>(&self, prefix: &'a [u8]) -> (&'a [u8], Arc<SubstoreConfig>) {
         let config = self.find_substore(prefix);
 
         let truncated_prefix = prefix
             .strip_prefix(config.prefix.as_bytes())
             .expect("key has the prefix of the matched substore");
+
+        let truncated_prefix = truncated_prefix
+            .strip_prefix(b"/")
+            .unwrap_or(truncated_prefix);
         (truncated_prefix, config)
     }
 }

--- a/crates/storage/src/store/substore.rs
+++ b/crates/storage/src/store/substore.rs
@@ -22,6 +22,8 @@ use jmt::storage::TreeWriter;
 pub struct SubstoreConfig {
     /// The prefix of the substore. If empty, it is the root-level store config.
     pub prefix: String,
+    /// The prefix of the substore including the trailing slash.
+    pub prefix_with_delimiter: String,
     /// name: "substore-{prefix}-jmt"
     /// role: persists the logical structure of the JMT
     /// maps: `storage::DbNodeKey` to `jmt::Node`
@@ -56,6 +58,7 @@ impl SubstoreConfig {
             cf_jmt_values: format!("substore-{}-jmt-values", prefix),
             cf_jmt_keys_by_keyhash: format!("substore-{}-jmt-keys-by-keyhash", prefix),
             cf_nonverifiable: format!("substore-{}-nonverifiable", prefix),
+            prefix_with_delimiter: format!("{}/", prefix),
             prefix,
         }
     }

--- a/crates/storage/tests/migration.rs
+++ b/crates/storage/tests/migration.rs
@@ -100,7 +100,7 @@ async fn test_substore_migration() -> anyhow::Result<()> {
         let mut keys: Vec<String> = vec![];
         let mut values: Vec<Vec<u8>> = vec![];
         for substore in all_substores.iter() {
-            let key = format!("{substore}key_{i}");
+            let key = format!("{substore}/key_{i}");
             let value = format!("{substore}value_{i}").as_bytes().to_vec();
             tracing::debug!(?key, "initializing substore {substore} with key-value pair");
             delta.put_raw(key.clone(), value.clone());
@@ -153,7 +153,7 @@ async fn test_substore_migration() -> anyhow::Result<()> {
 
     // Start by writing a key in every substore, including the main store.
     for substore in all_substores.iter() {
-        let key = format!("{substore}migration", substore = substore);
+        let key = format!("{substore}/migration", substore = substore);
         let value = format!("{substore}migration data", substore = substore)
             .as_bytes()
             .to_vec();

--- a/crates/storage/tests/substore_tests.rs
+++ b/crates/storage/tests/substore_tests.rs
@@ -37,7 +37,15 @@ async fn test_route_key_cases() -> () {
         "prefix_a/key_1",
         "prefix_akey_1",
         "prefix_a/",
-        "prefix_a",
+        // TODO(erwan): Making sure that there are no collisions between
+        // `prefix_a/` and `prefix_a` is important. However, in practice
+        // `prefix_a` stores the root hash of the substore, so 1/ it will
+        // not containt the value we put in it since it got overwritten
+        // during the commit step, 2/ it will be disallowed shortly
+        // in a follow-up PR. When we do that, we can remove the commented
+        // out test case below. And instead replace it with a vector that
+        // checks that we are NOT able to write to `prefix_a` directly.
+        // "prefix_a", <- this should be disallowed.
         "prefix_b/key_1",
     ];
     let values = vec![

--- a/crates/wasm/tests/test_build.rs
+++ b/crates/wasm/tests/test_build.rs
@@ -29,7 +29,7 @@ mod tests {
     use penumbra_wasm::{
         error::WasmError,
         keys::load_proving_key,
-        storage::{IndexedDBStorage, IndexedDbConstants, Tables},
+        storage::IndexedDBStorage,
         tx::{authorize, build, build_parallel, witness},
         wasm_planner::WasmPlanner,
     };
@@ -65,13 +65,16 @@ mod tests {
             serde_wasm_bindgen::to_value(&undelegate_claim_key).unwrap();
 
         // Dynamically load the proving keys at runtime for each key type.
-        load_proving_key(spend_key_js, "spend");
-        load_proving_key(output_key_js, "output");
-        load_proving_key(delegator_vote_key_js, "delegator_vote");
-        load_proving_key(nullifier_derivation_key_js, "nullifier_derivation");
-        load_proving_key(swap_key_js, "swap");
-        load_proving_key(swap_claim_key_js, "swap_claim");
-        load_proving_key(undelegate_claim_key_js, "undelegate_claim");
+        load_proving_key(spend_key_js, "spend").expect("can load spend key");
+        load_proving_key(output_key_js, "output").expect("can load output key");
+        load_proving_key(delegator_vote_key_js, "delegator_vote")
+            .expect("can load delegator vote key");
+        load_proving_key(nullifier_derivation_key_js, "nullifier_derivation")
+            .expect("can load nullifier derivation key");
+        load_proving_key(swap_key_js, "swap").expect("can load swap key");
+        load_proving_key(swap_claim_key_js, "swap_claim").expect("can load swap claim key");
+        load_proving_key(undelegate_claim_key_js, "undelegate_claim")
+            .expect("can load undelegate claim key");
 
         // Define database parameters.
         #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
According to the ICS24 spec, substore prefixes are identifiers. This means that they "MUST" follow precise requirements:

```
An Identifier is a bytestring used as a key for an object stored in state, such as a connection, channel, or light client.

Identifiers MUST be non-empty (of positive integer length).

Identifiers MUST consist of characters in one of the following categories only:

Alphanumeric
., _, +, -, #
[, ], <, >
```

This means that our decision to include a trailing delimiter for our IBC prefix is technically incompatible with the spec. This is unfortunate, because it greatly simplifies the routing logic. However, in practice this could become a problem if a counterparty IBC implementation decides to enforce this requirement.

This PR adds support for removing delimiters from our defined prefixes. Instead of defining an `ibc/` prefix, the user defines a prefix identifier `"ibc"`. The routing logic handles adding/stripping a delimiter `"/"`. For example, a key path: `ibc/path/to/client/state` will result in a match to the `ibc` substore at key `path/to/client/state`.

However, quietly managing delimiters adds some complexity. Naively, we could find ourselves in a situation where we collisions occur e.g. `"ibcpath/to/client/state"` and `ibc/path/to/client/state`. Similarly, we now have extra edge cases to enforce that we never write an empty key to a substore: `ibc`, `ibc/` would resolve to the same key.

To avoid this, we only route a key to a substore if it contains a prefix, a delimiter, and a non-empty substore path e.g. `"ibc/path/to"` and `"ibc/key"` routes to the `"ibc"` substore, but `"ibc/"` and `"ibc"` don't.