### PR TITLE
ci: check for uncommitted lockfiles

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,19 @@ jobs:
           # The `-D warnings` option causes an error on warnings;
           # we must duplicate the rustflags from `.cargo/config.toml`.
           RUSTFLAGS: "-D warnings --cfg tokio_unstable"
+
+      # If a dependency was modified, Cargo.lock may flap if not committed.
+      - name: Check for diffs
+        shell: bash
+        run: |
+          s="$(git status --porcelain)"
+          if [[ -n "$s" ]]; then
+              echo "ERROR: found modified files that should be committed:"
+              echo "$s"
+              exit 1
+          else
+              echo "OK: no uncommitted changes detected"
+          fi
       - name: Run tests with nextest
         run: cargo nextest run --release --features migration
         env:
@@ -39,17 +52,6 @@ jobs:
         uses: astriaorg/buildjet-rust-cache@v2.5.1
       - run: cargo fmt --all -- --check
 
-  check:
-    name: Check for warnings
-    runs-on: buildjet-16vcpu-ubuntu-2004
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Load rust cache
-        uses: astriaorg/buildjet-rust-cache@v2.5.1
   docs:
     # We use a custom script to generate the index page for https://rustdoc.penumbra.zone,
     # and refactors to rust deps can break that generation. Let's ensure this script exits 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5769,7 +5769,6 @@ dependencies = [
  "penumbra-shielded-pool",
  "penumbra-storage",
  "penumbra-tct",
- "penumbra-transaction",
  "proptest",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",


### PR DESCRIPTION
Adding a "git diff" check to ci, in an attempt to catch a situtation where dependencies were modified in Cargo.toml files, but the Cargo.lock file wasn't regenerated.

Also prunes an unused "check" job that was modified in #3022.