### PR TITLE
Update transactions.md

### DIFF
--- a/docs/protocol/src/concepts/transactions.md
+++ b/docs/protocol/src/concepts/transactions.md
@@ -1,7 +1,7 @@
 # Transactions
 
 Transactions describe an atomic collection of changes to the ledger state.  Each
-transaction consist of a sequence of *descriptions* for various actions[^1].
+transaction consists of a sequence of *descriptions* for various actions[^1].
 Each description adds or subtracts (typed) value from the transaction's value
 balance, which must net to zero.  Penumbra adapts the *Spend* and *Output* actions from Sapling, and adds many new descriptions to support additional functionality:
 


### PR DESCRIPTION
Hello,

**Description** 
This pull request addresses the correction of the expression "Each transaction consist." The original sentence uses the word "transaction" to denote a singular subject, making the correct form "consists."

**Changes**
Corrected the word "consist" to "consists" in the expression "Each transaction," as the singular subject requires the verb form "consists."

**Additional Notes**
- No additional dependencies or changes are required.
- This fix is straightforward and does not impact any other functionalities.  

Thank you.