### PR TITLE
build: remove unused wasm profile

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -51,5 +51,10 @@ web-sys                  = { version = "0.3.64", features = ["console"] }
 wasm-bindgen-test        = "0.3.37"
 serde_json               = "1.0.107"
 
-[profile.release]
-lto = true
+# Profiles are ignored for crates within a workspace.
+# In order to customize the profile for wasm, we must
+# either break the crate out of the workspace, or set
+# the profile options at the workspace level, affecting
+# all crates.
+# [profile.release]
+# lto = true


### PR DESCRIPTION
Follow-up to #3432. Shutting this customization off, because it was being ignored anyway, and generated a warnig:

    warning: profiles for the non root package will be ignored,
    specify profiles at the workspace root

We should discuss whether keeping the wasm crate inside the workspace is the right move.