### PR TITLE
keys: Align AddressIndex proto serialization

### DIFF
--- a/crates/core/keys/src/keys/diversifier.rs
+++ b/crates/core/keys/src/keys/diversifier.rs
@@ -228,9 +228,16 @@ impl DomainType for AddressIndex {
 
 impl From<AddressIndex> for pb::AddressIndex {
     fn from(d: AddressIndex) -> pb::AddressIndex {
-        pb::AddressIndex {
-            account: d.account,
-            randomizer: d.randomizer.to_vec(),
+        if d.is_ephemeral() {
+            pb::AddressIndex {
+                account: d.account,
+                randomizer: d.randomizer.to_vec(),
+            }
+        } else {
+            pb::AddressIndex {
+                account: d.account,
+                randomizer: Vec::new(),
+            }
         }
     }
 }


### PR DESCRIPTION
This commit changes the Rust code to omit the `randomizer` field if it is zero-valued, so that the protobuf notion of default values aligns with the application-level notion of default values.