### PR TITLE
sct: add ABCI events for SCT roots

### DIFF
--- a/crates/core/component/sct/src/component/view.rs
+++ b/crates/core/component/sct/src/component/view.rs
@@ -8,7 +8,7 @@ use tct::builder::{block, epoch};
 
 // TODO: make epoch management the responsibility of this component
 
-use crate::state_key;
+use crate::{event, state_key};
 
 /// This trait provides read access to common parts of the Penumbra
 /// state store.
@@ -149,6 +149,7 @@ trait StateWriteExt: StateWrite {
     fn set_sct_anchor(&mut self, height: u64, sct_anchor: tct::Root) {
         tracing::debug!(?height, ?sct_anchor, "writing anchor");
 
+        self.record(event::sct_anchor(height, &sct_anchor));
         self.put(state_key::anchor_by_height(height), sct_anchor);
         self.put_proto(state_key::anchor_lookup(sct_anchor), height);
     }
@@ -156,15 +157,17 @@ trait StateWriteExt: StateWrite {
     fn set_sct_block_anchor(&mut self, height: u64, sct_block_anchor: block::Root) {
         tracing::debug!(?height, ?sct_block_anchor, "writing block anchor");
 
+        self.record(event::sct_block_anchor(height, &sct_block_anchor));
         self.put(state_key::block_anchor_by_height(height), sct_block_anchor);
         self.put_proto(state_key::block_anchor_lookup(sct_block_anchor), height);
     }
 
-    fn set_sct_epoch_anchor(&mut self, index: u64, sct_block_anchor: epoch::Root) {
-        tracing::debug!(?index, ?sct_block_anchor, "writing epoch anchor");
+    fn set_sct_epoch_anchor(&mut self, index: u64, sct_epoch_anchor: epoch::Root) {
+        tracing::debug!(?index, ?sct_epoch_anchor, "writing epoch anchor");
 
-        self.put(state_key::epoch_anchor_by_index(index), sct_block_anchor);
-        self.put_proto(state_key::epoch_anchor_lookup(sct_block_anchor), index);
+        self.record(event::sct_epoch_anchor(index, &sct_epoch_anchor));
+        self.put(state_key::epoch_anchor_by_index(index), sct_epoch_anchor);
+        self.put_proto(state_key::epoch_anchor_lookup(sct_epoch_anchor), index);
     }
 
     async fn write_sct(

--- a/crates/core/component/sct/src/event.rs
+++ b/crates/core/component/sct/src/event.rs
@@ -1,1 +1,33 @@
+use penumbra_tct as tct;
+use tct::builder::{block, epoch};
+use tendermint::abci::{Event, EventAttributeIndexExt};
 
+pub fn sct_anchor(height: u64, anchor: &tct::Root) -> Event {
+    Event::new(
+        "sct_anchor",
+        [
+            ("height", height.to_string()).index(),
+            ("anchor", anchor.to_string()).index(),
+        ],
+    )
+}
+
+pub fn sct_block_anchor(height: u64, anchor: &block::Root) -> Event {
+    Event::new(
+        "sct_block_anchor",
+        [
+            ("height", height.to_string()).index(),
+            ("anchor", anchor.to_string()).index(),
+        ],
+    )
+}
+
+pub fn sct_epoch_anchor(index: u64, anchor: &epoch::Root) -> Event {
+    Event::new(
+        "sct_epoch_anchor",
+        [
+            ("index", index.to_string()).index(),
+            ("anchor", anchor.to_string()).index(),
+        ],
+    )
+}


### PR DESCRIPTION
This allows indexers to report on SCT roots and anchors. As a side effect, this also means that there will be at least one event fired in every single `EndBlock`, so every block will have at least one event sent to the indexer.

cc @ejmg