### PR TITLE
refactor(wasm): try_load_unchecked method

### DIFF
--- a/crates/crypto/proof-params/src/lib.rs
+++ b/crates/crypto/proof-params/src/lib.rs
@@ -68,6 +68,18 @@ impl LazyProvingKey {
             Ok(pk)
         })
     }
+
+    /// Attempt to load the proving key from the given bytes.
+    ///
+    /// This method bypasses the validation checks against the hardcoded
+    /// hash of the expected proving key.
+    pub fn try_load_unchecked(&self, bytes: &[u8]) -> Result<&ProvingKey<Bls12_377>> {
+        self.inner.get_or_try_init(|| {
+            let pk = ProvingKey::deserialize_uncompressed_unchecked(bytes)?;
+
+            Ok(pk)
+        })
+    }
 }
 
 impl Deref for LazyProvingKey {

--- a/crates/wasm/src/keys.rs
+++ b/crates/wasm/src/keys.rs
@@ -40,7 +40,7 @@ pub fn load_proving_key(parameters: JsValue, key_type: &str) -> WasmResult<()> {
     };
 
     // Load proving key.
-    proving_key_map.try_load(&parameters_bytes)?;
+    proving_key_map.try_load_unchecked(&parameters_bytes)?;
     Ok(())
 }
 


### PR DESCRIPTION
The purpose of `try_load_unchecked` is to bypass the expensive hash [operation](https://github.com/penumbra-zone/penumbra/pull/3337/commits/cb83595b52d3e58b6aca6d2afcca804f8127ad1d#diff-4d79c375b208fed2ca0ad42ad928b14507df16e1569c0895594b278be7aff0e4R59) used for fingerprinting the proving keys in WASM. This reduces the `load_proving_key` call times by **80%**. 