### PR TITLE
deploy: increase node storage 100G -> 200G

### DIFF
--- a/deployments/helmfile.d/penumbra-testnet.yaml
+++ b/deployments/helmfile.d/penumbra-testnet.yaml
@@ -5,7 +5,7 @@ releases:
     values:
       - persistence:
           enabled: true
-          size: 100G
+          size: 200G
       - preserve_lb_svc: true
       - only_lb_svc: false
       - image:
@@ -38,7 +38,7 @@ releases:
       - penumbra_bootstrap_node_cometbft_rpc_url: "http://penumbra-testnet-val-0:26657"
       - persistence:
           enabled: true
-          size: 100G
+          size: 200G
       - part_of: penumbra-testnet
       # Node config info, including ip address, monikers, and seed-mode status.
       - vars/penumbra-testnet-nodes-ips.yml


### PR DESCRIPTION
After five weeks running Testnet 63 Rhea (#3182), the PL-run nodes filled up their available disk storage, which is 100G per node. (Of that, roughly 90% is pd, 10% cometbft.) To recover, we manually edited the PVCs to grow to 200G, and this change locks that new config into version control, for use in future testnets.