### PR TITLE
feat(pd): custom voting periods testnet generate

### DIFF
--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -183,6 +183,10 @@ enum TestnetCommand {
         /// Testnet name [default: latest testnet].
         #[clap(long)]
         chain_id: Option<String>,
+        /// The duration, in number of blocks, that a governance proposal
+        /// can be voted on.
+        #[clap(long)]
+        proposal_voting_blocks: Option<u64>,
         /// Base hostname for a validator's p2p service. If multiple validators
         /// exist in the genesis, e.g. via `--validators-input-file`, then
         /// numeric suffixes are automatically added, e.g. "-0", "-1", etc.
@@ -605,6 +609,7 @@ async fn main() -> anyhow::Result<()> {
                     chain_id,
                     preserve_chain_id,
                     external_addresses,
+                    proposal_voting_blocks,
                 },
             testnet_dir,
         } => {
@@ -660,6 +665,7 @@ async fn main() -> anyhow::Result<()> {
                 active_validator_limit,
                 epoch_duration,
                 unbonding_epochs,
+                proposal_voting_blocks,
             )?;
             tracing::info!(
                 n_validators = t.validators.len(),

--- a/deployments/charts/penumbra-network/templates/job-generate.yaml
+++ b/deployments/charts/penumbra-network/templates/job-generate.yaml
@@ -74,6 +74,12 @@ spec:
                 {{- if .Values.network.preserve_chain_id }}
                 --preserve-chain-id \
                 {{- end }}
+                {{- if .Values.network.epoch_duration }}
+                --epoch-duration {{ .Values.network.epoch_duration }} \
+                {{- end }}
+                {{- if .Values.network.proposal_voting_blocks }}
+                --proposal-voting-blocks {{ .Values.network.proposal_voting_blocks }} \
+                {{- end }}
                 --validators-input-file /penumbra/validators.json \
                 --external-addresses {{ .Values.network.external_addresses }}
 

--- a/deployments/charts/penumbra-network/values.yaml
+++ b/deployments/charts/penumbra-network/values.yaml
@@ -25,6 +25,9 @@ network:
   # It'd be grand to have a DNS hostname in here, e.g. `veil.petrichor.guru:31888`.
   # external_addresses: veil.petrichor.guru:31888
   external_addresses: ""
+  # Customization of the voting period for governance proposals.
+  # Dial this down if you want faster voting for testing.
+  proposal_voting_blocks:
 
   # How many validators are present at genesis. This number must
   # match the count in the JSON file used to define the validators.


### PR DESCRIPTION
During testing of upgrades, it's been handy to reduce the default, static value of "24h" for voting on a given proposal, so that a proposal can be made, voted on, and passed, all within e.g. 1h. This setting greatly accelerates testing on devnets.

Also includes customization var in deploy scripts for `epoch_duration`, which we're not currently overriding, but now we can if we want to.

Ideally we'd set these customizations by just overriding the `pd testnet generate` command, but given that the cmd requires a storage dir arg that's non-standard, it's more straightforward to stick with the clunky vars-based approach for now.