### PR TITLE
pd(upgrade): create fresh validator state and accept `--genesis-start`

### DIFF
--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -20,7 +20,7 @@ use pd::testnet::{
     generate::TestnetConfig,
     join::testnet_join,
 };
-use pd::upgrade::{self, Upgrade};
+use pd::upgrade;
 use penumbra_app::SUBSTORE_PREFIXES;
 use penumbra_proto::core::component::dex::v1alpha1::simulation_service_server::SimulationServiceServer;
 use penumbra_proto::util::tendermint_proxy::v1alpha1::tendermint_proxy_service_server::TendermintProxyServiceServer;
@@ -152,7 +152,8 @@ enum RootCommand {
         #[clap(long, display_order = 200)]
         upgrade_path: PathBuf,
         #[clap(long, display_order = 300)]
-        /// Timestamp of the genesis file.
+        /// Timestamp of the genesis file in RFC3339 format. If unset, defaults to the current time,
+        /// unless the migration script overrides it.
         genesis_start: Option<tendermint::time::Time>,
     },
 }
@@ -713,7 +714,8 @@ async fn main() -> anyhow::Result<()> {
         } => {
             use upgrade::Upgrade::SimpleUpgrade;
             tracing::info!("upgrading state from {}", upgrade_path.display());
-            SimpleUpgrade::migrate(upgrade_path.clone(), genesis_start)
+            SimpleUpgrade
+                .migrate(upgrade_path.clone(), genesis_start)
                 .await
                 .context("failed to upgrade state")?;
         }

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -151,6 +151,9 @@ enum RootCommand {
         /// The directory containing exported state to which the upgrade will be applied.
         #[clap(long, display_order = 200)]
         upgrade_path: PathBuf,
+        #[clap(long, display_order = 300)]
+        /// Timestamp of the genesis file.
+        genesis_start: Option<tendermint::time::Time>,
     },
 }
 
@@ -704,9 +707,13 @@ async fn main() -> anyhow::Result<()> {
             // - apply checks: root hash, size, etc.
             todo!()
         }
-        RootCommand::Upgrade { upgrade_path } => {
+        RootCommand::Upgrade {
+            upgrade_path,
+            genesis_start,
+        } => {
+            use upgrade::Upgrade::SimpleUpgrade;
             tracing::info!("upgrading state from {}", upgrade_path.display());
-            upgrade::migrate(upgrade_path.clone(), Upgrade::Testnet60)
+            SimpleUpgrade::migrate(upgrade_path.clone(), genesis_start)
                 .await
                 .context("failed to upgrade state")?;
         }

--- a/crates/bin/pd/src/upgrade.rs
+++ b/crates/bin/pd/src/upgrade.rs
@@ -15,79 +15,94 @@ pub enum Upgrade {
     /// No-op migration
     Noop,
     /// A simple migration: adds a key to the consensus state.
-    Testnet60,
+    /// This is useful for testing upgrade mechanisms, including in production.
+    SimpleUpgrade,
+    /// Migrates from testnet-64 to testnet-65.
+    Testnet65,
 }
 
-pub async fn migrate(path_to_export: PathBuf, upgrade: Upgrade) -> anyhow::Result<()> {
-    match upgrade {
-        Upgrade::Noop => (),
-        Upgrade::Testnet60 => {
-            let mut db_path = path_to_export.clone();
-            db_path.push("rocksdb");
-            let storage = Storage::load(db_path, SUBSTORE_PREFIXES.to_vec()).await?;
-            let export_state = storage.latest_snapshot();
-            let root_hash = export_state.root_hash().await.expect("can get root hash");
-            let app_hash_pre_migration: RootHash = root_hash.into();
-            let height = export_state
-                .get_block_height()
-                .await
-                .expect("can get block height");
-            let post_ugprade_height = height.wrapping_add(1);
+impl Upgrade {
+    pub async fn migrate(
+        &self,
+        path_to_export: PathBuf,
+        genesis_start: Option<tendermint::time::Time>,
+    ) -> anyhow::Result<()> {
+        match self {
+            Upgrade::Noop => (),
+            Upgrade::SimpleUpgrade => {
+                let mut db_path = path_to_export.clone();
+                db_path.push("rocksdb");
+                let storage = Storage::load(db_path, SUBSTORE_PREFIXES.to_vec()).await?;
+                let export_state = storage.latest_snapshot();
+                let root_hash = export_state.root_hash().await.expect("can get root hash");
+                let app_hash_pre_migration: RootHash = root_hash.into();
+                let height = export_state
+                    .get_block_height()
+                    .await
+                    .expect("can get block height");
+                let post_ugprade_height = height.wrapping_add(1);
 
-            /* --------- writing to the jmt  ------------ */
-            tracing::info!(?app_hash_pre_migration, "app hash pre-upgrade");
-            let mut delta = StateDelta::new(export_state);
-            delta.put_raw("has_migrated".to_string(), "yes".into());
-            delta.put_block_height(0u64);
-            let root_hash = storage.commit_in_place(delta).await?;
-            let app_hash_post_migration: RootHash = root_hash.into();
-            tracing::info!(?app_hash_post_migration, "app hash post upgrade");
+                /* --------- writing to the jmt  ------------ */
+                tracing::info!(?app_hash_pre_migration, "app hash pre-upgrade");
+                let mut delta = StateDelta::new(export_state);
+                delta.put_raw("has_migrated".to_string(), "yes".into());
+                delta.put_block_height(0u64);
+                let root_hash = storage.commit_in_place(delta).await?;
+                let app_hash_post_migration: RootHash = root_hash.into();
+                tracing::info!(?app_hash_post_migration, "app hash post upgrade");
 
-            /* --------- collecting genesis data -------- */
-            tracing::info!("generating genesis");
-            let migrated_state = storage.latest_snapshot();
-            let root_hash = migrated_state.root_hash().await.expect("can get root hash");
-            let app_hash: RootHash = root_hash.into();
-            tracing::info!(?root_hash, "root hash from snapshot (post-upgrade)");
-            let chain_params = migrated_state
-                .get_chain_params()
-                .await
-                .expect("can get chain params");
+                /* --------- collecting genesis data -------- */
+                tracing::info!("generating genesis");
+                let migrated_state = storage.latest_snapshot();
+                let root_hash = migrated_state.root_hash().await.expect("can get root hash");
+                let app_hash: RootHash = root_hash.into();
+                tracing::info!(?root_hash, "root hash from snapshot (post-upgrade)");
+                let chain_params = migrated_state
+                    .get_chain_params()
+                    .await
+                    .expect("can get chain params");
 
-            /* ---------- genereate genesis ------------  */
-            let validators = migrated_state.validator_list().await?;
-            let app_state = genesis::Content {
-                chain_content: ChainContent { chain_params },
-                stake_content: StakeContent {
-                    validators: validators.into_iter().map(Into::into).collect(),
+                /* ---------- generate genesis ------------  */
+                let validators = migrated_state.validator_list().await?;
+                let app_state = genesis::Content {
+                    chain_content: ChainContent { chain_params },
+                    stake_content: StakeContent {
+                        validators: validators.into_iter().map(Into::into).collect(),
+                        ..Default::default()
+                    },
                     ..Default::default()
-                },
-                ..Default::default()
-            };
-            let mut genesis =
-                TestnetConfig::make_genesis(app_state.clone()).expect("can make genesis");
-            genesis.app_hash = app_hash
-                .0
-                .to_vec()
-                .try_into()
-                .expect("infaillible conversion");
-            genesis.initial_height = post_ugprade_height as i64;
-            genesis.genesis_time = tendermint::time::Time::now();
-            let checkpoint = [32u8; 32].to_vec();
-            let genesis = TestnetConfig::make_checkpoint(genesis, Some(checkpoint));
+                };
+                let mut genesis =
+                    TestnetConfig::make_genesis(app_state.clone()).expect("can make genesis");
+                genesis.app_hash = app_hash
+                    .0
+                    .to_vec()
+                    .try_into()
+                    .expect("infaillible conversion");
+                genesis.initial_height = post_ugprade_height as i64;
+                genesis.genesis_time = genesis_start.unwrap_or_else(|| {
+                    let now = tendermint::time::Time::now();
+                    tracing::info!(%now, "no genesis time provided, detecting a testing setup");
+                    now
+                });
+                let checkpoint = [32u8; 32].to_vec();
+                let genesis = TestnetConfig::make_checkpoint(genesis, Some(checkpoint));
 
-            let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");
-            tracing::info!("genesis: {}", genesis_json);
-            let mut genesis_path = path_to_export.clone();
-            genesis_path.push("genesis.json");
-            std::fs::write(genesis_path, genesis_json).expect("can write genesis");
+                let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");
+                tracing::info!("genesis: {}", genesis_json);
+                let mut genesis_path = path_to_export.clone();
+                genesis_path.push("genesis.json");
+                std::fs::write(genesis_path, genesis_json).expect("can write genesis");
 
-            let mut validator_state_path = path_to_export.clone();
-            validator_state_path.push("priv_validator_state.json");
-            let fresh_validator_state = crate::testnet::generate::TestnetValidator::initial_state();
-            std::fs::write(validator_state_path, fresh_validator_state)
-                .expect("can write validator state");
+                let mut validator_state_path = path_to_export.clone();
+                validator_state_path.push("priv_validator_state.json");
+                let fresh_validator_state =
+                    crate::testnet::generate::TestnetValidator::initial_state();
+                std::fs::write(validator_state_path, fresh_validator_state)
+                    .expect("can write validator state");
+            }
+            Upgrade::Testnet65 => { /* currently a no-op. */ }
         }
+        Ok(())
     }
-    Ok(())
 }


### PR DESCRIPTION
This PR makes the `SimpleUpgrade` migration script generate a fresh validator state file to populate comet's view of the validator data. It also adds an optional `--genesis-start` flag to `pd upgrade` to help testing with multinode setups. 