### PR TITLE
pd(upgrade): use checkpoint in simple upgrade

### DIFF
--- a/crates/bin/pd/src/upgrade.rs
+++ b/crates/bin/pd/src/upgrade.rs
@@ -85,7 +85,7 @@ impl Upgrade {
                     tracing::info!(%now, "no genesis time provided, detecting a testing setup");
                     now
                 });
-                let checkpoint = [32u8; 32].to_vec();
+                let checkpoint = app_hash.0;
                 let genesis = TestnetConfig::make_checkpoint(genesis, Some(checkpoint));
 
                 let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");


### PR DESCRIPTION
After an upgrade, a migrated genesis files contains the root hash of the application's merkle tree, and an arbitrary bytestring which can be used to perform component-specific health checks. Although the field is a no-op in the simple upgrade scenario, it is a bit confusing that it contains `[32u8; 32]` instead of the application hash. This PR fixes this. 