### PR TITLE
ci: upgrade runners ubuntu-2004 -> ubuntu-2204

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -46,7 +46,7 @@ jobs:
 
   protobuf-fresh:
     name: Compile protobuf specs to rust code
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-16vcpu-ubuntu-2204
     # runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   penumbra:
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-16vcpu-ubuntu-2204
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: Render and deploy protocol and API docs
     timeout-minutes: 30
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install Rust
         run: rustup update "1.73" --no-self-update && rustup default "1.73"
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.2/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.5.0/cargo-dist-installer.sh | sh"
       - id: plan
         run: |
           cargo dist plan ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }} --output-format=json > dist-manifest.json
@@ -85,19 +85,19 @@ jobs:
       # matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
       matrix:
         include:
-        - runner: buildjet-16vcpu-ubuntu-2004
+        - runner: buildjet-16vcpu-ubuntu-2204
           dist_args: --artifacts=local --target=x86_64-unknown-linux-gnu
-          install_dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.2/cargo-dist-installer.sh | sh
+          install_dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.5.0/cargo-dist-installer.sh | sh
           targets:
             - x86_64-unknown-linux-gnu
         - runner: macos-12-xl
           dist_args: --artifacts=local --target=aarch64-apple-darwin
-          install_dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.2/cargo-dist-installer.sh | sh
+          install_dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.5.0/cargo-dist-installer.sh | sh
           targets:
             - aarch64-apple-darwin
         - runner: macos-12-xl
           dist_args: --artifacts=local --target=x86_64-apple-darwin
-          install_dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.4.2/cargo-dist-installer.sh | sh
+          install_dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.5.0/cargo-dist-installer.sh | sh
           targets:
             - x86_64-apple-darwin
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on: pull_request
 jobs:
   test:
     name: Test Suite
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,7 +41,7 @@ jobs:
 
   fmt:
     name: Rustfmt
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
       - name: Install rust toolchain
@@ -57,7 +57,7 @@ jobs:
     # and refactors to rust deps can break that generation. Let's ensure this script exits 0
     # on PRs, but we'll still only deploy after merge into main.
     name: Check that rustdocs build OK
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,7 +72,7 @@ jobs:
 
   wasm:
     name: Build WASM
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   smoke_test:
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-16vcpu-ubuntu-2204
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/summoner_smoke.yml
+++ b/.github/workflows/summoner_smoke.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   smoke_test:
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: buildjet-16vcpu-ubuntu-2204
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ opt-level = "s"
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.4.2"
+cargo-dist-version = "0.5.0"
 # The preferred Rust toolchain to use in CI (rustup toolchain syntax)
 rust-toolchain-version = "1.73"
 # CI backends to support


### PR DESCRIPTION
We were building binaries on Ubuntu 20.04, which made using those binaries on newer platforms (e.g. Debian Stable 12 Bookworm) throw ssl shared object errors. A few folks reported this problem in Discord. Building on the new runners resolves this problem, at least for Debian Stable. I haven't done a full matrix of platform compatibility, nor do I plan to: listening to reports in Discord is data enough for now.

Also bumps cargo-dist 0.4.2 -> 0.5.0.
Trying to stay on top of cargo-dist version changes, so we don't get surprised by a large diff. Already tested this version in a private fork and it worked great.