### PR TITLE
lint: fix comma in custody cargo toml

### DIFF
--- a/crates/custody/Cargo.toml
+++ b/crates/custody/Cargo.toml
@@ -17,7 +17,7 @@ decaf377-frost = { path = "../crypto/decaf377-frost" }
 decaf377-ka = { path = "../crypto/decaf377-ka" }
 penumbra-chain = { path = "../core/component/chain" }
 penumbra-keys = { path = "../core/keys" }
-penumbra-proto = { path = "../proto" , features = ["rpc"] }
+penumbra-proto = { path = "../proto", features = ["rpc"] }
 penumbra-transaction = { path = "../core/transaction" }
 
 tokio = { version = "1.21.1", features = ["full"]}


### PR DESCRIPTION
Our CI actions were alleging this was invalid TOML. The consequence was that the crate wasn't being cached, which doens't matter much, but I want to silence the warning so future runs are clean and quiet.

[skip ci]