### PR TITLE
feat: cuiloa-testnet fullnode

### DIFF
--- a/deployments/helmfile.d/penumbra-testnet-cuiloa.yaml
+++ b/deployments/helmfile.d/penumbra-testnet-cuiloa.yaml
@@ -1,0 +1,29 @@
+---
+releases:
+  - name: penumbra-testnet-cuiloa-node
+    chart: ../charts/penumbra-node
+# Disabling the strict dependency on the "testnet" environment,
+# because this release was first deployed manually. Post Testnet 64
+# we plan to retire the CI pipeline for deploying the testnet.
+# If breaking changes are merged to Penumbra or Cuiloa, we'll need
+# to redeploy this node manually.
+#    needs:
+#      - penumbra-testnet
+#      # It's not strictly necessary to wait for node deploys, but doing so allows us to exercise
+#      # the public HTTPS RPC endpoint for joining, which is nice.
+#      - penumbra-testnet-nodes
+    values:
+      - penumbra_bootstrap_node_cometbft_rpc_url: "https://rpc.testnet.penumbra.zone"
+      - ingressRoute:
+          enabled: false
+      - image:
+          tag: main
+      - persistence:
+          enabled: true
+          size: 50G
+      - cometbft:
+          config:
+            indexer: psql
+      - part_of: penumbra-testnet
+      - nodes:
+        - moniker: cuiloa


### PR DESCRIPTION
We've added a new cuiloa [0] deployment for the testnet environment, available at https://cuiloa.testnet.penumbra.zone. This change handles the fullnode and sidecar postgres indexing setup required to back the cuiloa app deployment (config for which is managed elsewhere).

This change has already been deployed.

[0] https://github.com/penumbra-zone/cuiloa