### PR TITLE
fix(proto): update `DomainType::Proto` for `ClientState/ConsensusState`

### DIFF
--- a/crates/proto/src/protobuf.rs
+++ b/crates/proto/src/protobuf.rs
@@ -156,7 +156,6 @@ impl TryFrom<crate::core::keys::v1alpha1::ConsensusKey> for tendermint::PublicKe
 // IBC-rs impls
 extern crate ibc_types;
 
-use ibc_proto::google::protobuf::Any;
 use ibc_proto::ibc::core::channel::v1::Channel as RawChannel;
 use ibc_proto::ibc::core::client::v1::Height as RawHeight;
 use ibc_proto::ibc::core::connection::v1::ClientPaths as RawClientPaths;
@@ -166,6 +165,7 @@ use ibc_types::core::channel::ChannelEnd;
 use ibc_types::core::client::Height;
 use ibc_types::core::connection::{ClientPaths, ConnectionEnd};
 use ibc_types::lightclients::tendermint::client_state::ClientState;
+use ibc_types::lightclients::tendermint::consensus_state::ConsensusState;
 
 impl DomainType for ClientPaths {
     type Proto = RawClientPaths;
@@ -183,10 +183,10 @@ impl DomainType for Height {
 }
 
 impl DomainType for ClientState {
-    type Proto = Any;
+    type Proto = ibc_proto::ibc::lightclients::tendermint::v1::ClientState;
 }
-impl DomainType for ibc_types::lightclients::tendermint::consensus_state::ConsensusState {
-    type Proto = Any;
+impl DomainType for ConsensusState {
+    type Proto = ibc_proto::ibc::lightclients::tendermint::v1::ConsensusState;
 }
 
 impl<T> From<T> for IbcRelay

--- a/proto/penumbra/penumbra/core/component/compact_block/v1alpha1/compact_block.proto
+++ b/proto/penumbra/penumbra/core/component/compact_block/v1alpha1/compact_block.proto
@@ -7,7 +7,6 @@ import "penumbra/core/component/fee/v1alpha1/fee.proto";
 import "penumbra/core/component/sct/v1alpha1/sct.proto";
 import "penumbra/core/component/shielded_pool/v1alpha1/shielded_pool.proto";
 import "penumbra/crypto/tct/v1alpha1/tct.proto";
-import "penumbra/core/transaction/v1alpha1/transaction.proto";
 
 // Contains the minimum data needed to update client state.
 message CompactBlock {

--- a/proto/penumbra/penumbra/core/component/sct/v1alpha1/sct.proto
+++ b/proto/penumbra/penumbra/core/component/sct/v1alpha1/sct.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 package penumbra.core.component.sct.v1alpha1;
 
-import "penumbra/core/component/chain/v1alpha1/chain.proto";
 import "penumbra/crypto/tct/v1alpha1/tct.proto";
 
 // Metadata describing the source of a commitment in the state commitment tree.


### PR DESCRIPTION
Found this bug while testing the IBC implementation with Hermes. Previously it was writing an `Any` type to state at the client_state/consensus_state storage locations, but the type Hermes was expecting was the `ibc_proto` `ClientState`/`ConsensusState`. This resulted in a proto decoding error in these locations:
https://github.com/informalsystems/hermes/blob/master/crates/relayer/src/client_state.rs#L127
https://github.com/informalsystems/hermes/blob/master/crates/relayer/src/consensus_state.rs#L59

These are called in the `Endpoint` `query_client_state`/`query_consensus_state` methods (for example here https://github.com/informalsystems/hermes/blob/b98ca86991fc1cc6d3f6c595918251a34eb6f1db/crates/relayer/src/chain/cosmos.rs#L1238)

specifically the error I got from Hermes was `Error::decode_raw_client_state`:
```
ERROR failed while querying for client 07-tendermint-0 on chain id astria: other error: error decoding raw client state: error decoding buffer into message: failed to decode Protobuf message: Fraction.numerator: ClientState.trust_level: invalid wire type: LengthDelimited (expected Varint)
```

I can give more details on how I was running everything if needed!

also linted the protos cause CI complained 😭