### PR TITLE
Bump ibc-types deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,14 +3261,15 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a8b1356652b9f160f5a010dd6b084675b8a28e163bf2b41ca5abecf27d9701"
+checksum = "4222cfac37f21da28292db0f2673fdb8455284895891ff09979680243efb9a20"
 dependencies = [
  "base64 0.21.5",
  "bytes",
  "flex-error",
  "ics23",
+ "informalsystems-pbjson 0.7.0",
  "prost",
  "serde",
  "subtle-encoding",
@@ -3278,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0a8726baeff64a88d7cbfdba30ecc72f43a4c4f666c62be5ad1e13db16dc42"
+checksum = "345e31ea9be7b5b3e98bcd8a2a3b2376d2ab8663d455ba6ac83e53c1048510d6"
 dependencies = [
  "ibc-types-core-channel",
  "ibc-types-core-client",
@@ -3296,9 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-channel"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "929ed12868a24aee42ad216da8ce644b3197da8a2a99d232325315cc83b95bac"
+checksum = "7dca175f7e461227e22b1978eb65445a4013c233845c2c6aabde5abace557a81"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3329,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-client"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5f2c8a94eba2a1b893254c6e1fed5eaea4d2b782a244c09a9fca6ce327d3d3"
+checksum = "35cb6d632bf050c1891fb9c3958b6ec119cc0e3861954f6f87b332f8687f8d51"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3356,9 +3357,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-commitment"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db7e1100ef3ceab4e9218eae3b999b7e728b377fedbe575419a16dbf97b8ce"
+checksum = "e57ec19137bd7f35724bb130770d695533e67224c0ff5cb98c30ad591f392377"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3391,9 +3392,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-connection"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d891d04932818c943ad26e31e24327089589669e9bbd9eeeadd922fe1c5ec3d0"
+checksum = "f86f9467e70cf1236af7c5d0d475983a2ebcc02622c5ccefb30263f33747ebb5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3421,9 +3422,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-domain-type"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4aa0ca354ac01399b72b2e338224f49709163416c880a1510b15f3e5461cb4"
+checksum = "0ac16371dda10031cb6824352cfaf830da98acc5feacb025e6330f6eb048fd4a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3432,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-identifier"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045d626ba8fd79a0d22c19b55470f19741ef5aab43f47eb3659a1757f965cc66"
+checksum = "99892ea17faa9b38ac172ed996be8f7a1b28f5020729634c52af7c5e1dc24c0a"
 dependencies = [
  "displaydoc",
  "serde",
@@ -3443,9 +3444,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-lightclients-tendermint"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e016b4520121e1917d4fbb35aa353864c0ec88225652d581a408f59ebd0736"
+checksum = "fbfb501b8c9c97d54b6368ff70ac0804af94a0668805e822bb303cc76f6f1aa0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3480,9 +3481,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-path"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4c25c82d976ead3dd925bb4fabdcf7862e9305ef2ffc50c8a9ba9463b1e005"
+checksum = "7121ab67e172915d20d9bdebcb54fb41e940461ddcd37cd108e233df2f898bb9"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3503,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-timestamp"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773c0b6f0cc6d9cec8b04e78fd9fcafbea14ce56ce36d0b4cf5386e4dd171c93"
+checksum = "e9f46394de8d492afc1bc43b83bddeffe086c93270b7f89fddf04f046adbaeba"
 dependencies = [
  "bytes",
  "displaydoc",
@@ -3522,9 +3523,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-transfer"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139137fac90c907ccaed4b191844f71347c29ff93e9adf724e5dfc0595b1a60a"
+checksum = "c9352195987055fde11c32c1f5ed238e452d96b1fa021d642c3c2b12c05963dc"
 dependencies = [
  "displaydoc",
  "serde",
@@ -3552,7 +3553,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "hex",
- "informalsystems-pbjson",
+ "informalsystems-pbjson 0.6.0",
  "prost",
  "ripemd",
  "serde",
@@ -3720,6 +3721,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4eecd90f87bea412eac91c6ef94f6b1e390128290898cbe14f2b926787ae1fb"
 dependencies = [
  "base64 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "informalsystems-pbjson"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa4a0980c8379295100d70854354e78df2ee1c6ca0f96ffe89afeb3140e3a3d"
+dependencies = [
+ "base64 0.21.5",
  "serde",
 ]
 

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -59,9 +59,9 @@ tendermint = { version = "0.34.0", features = ["rust-crypto"] }
 jmt = "0.9"
 
 # External dependencies
-ibc-types = { version = "0.10.0", features = ["std", "with_serde"] }
+ibc-types = { version = "0.11.0", features = ["std", "with_serde"] }
 
-ibc-proto = { version = "0.39.0" }
+ibc-proto = { version = "0.40.0" }
 ark-ff = { version = "0.4", default-features = false }
 atty = "0.2"
 ed25519-consensus = "2"

--- a/crates/bin/pclientd/Cargo.toml
+++ b/crates/bin/pclientd/Cargo.toml
@@ -63,8 +63,8 @@ directories = "4.0.1"
 tempfile = "3.3.0"
 assert_cmd = "2.0"
 base64 = "0.20"
-ibc-types = { version = "0.10.0" }
-ibc-proto = { version = "0.39.0", default-features = false, features = ["server"] }
+ibc-types = { version = "0.11.0" }
+ibc-proto = { version = "0.40.0", default-features = false, features = ["server"] }
 penumbra-proof-params = { path = "../../crypto/proof-params", features = [
     "bundled-proving-keys",
     "download-proving-keys",

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -57,9 +57,9 @@ tendermint-config = "0.34.0"
 tendermint-proto = "0.34.0"
 tendermint = "0.34.0"
 tendermint-light-client-verifier = "0.34.0"
-ibc-types = { version = "0.10.0" }
+ibc-types = { version = "0.11.0" }
 
-ibc-proto = { version = "0.39.0", default-features = false, features = [
+ibc-proto = { version = "0.40.0", default-features = false, features = [
     "server",
 ] }
 prost = "0.12.3"

--- a/crates/cnidarium/Cargo.toml
+++ b/crates/cnidarium/Cargo.toml
@@ -25,7 +25,7 @@ metrics = { version = "0.19.0", optional = true }
 parking_lot = "0.12"
 pin-project = "1.0.12"
 smallvec = { version = "1.10", features = ["union", "const_generics"] }
-ibc-types = { version = "0.10.0", default-features = false, features = ["std"] }
+ibc-types = { version = "0.11.0", default-features = false, features = ["std"] }
 once_cell = "1"
 
 # Tendermint/IBC crates
@@ -39,7 +39,7 @@ tonic = { version = "0.10", optional = true }
 prost = { version = "0.12.3", optional = true }
 serde = { version = "1", optional = true }
 pbjson = { version = "0.5", optional = true }
-ibc-proto = { version = "0.39.0", default-features = false, features = ["serde"], optional = true }
+ibc-proto = { version = "0.40.0", default-features = false, features = ["serde"], optional = true }
 regex = "1.10.2"
 
 [dev-dependencies]

--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -65,8 +65,8 @@ parking_lot = "0.12"
 tendermint = "0.34.0"
 tendermint-proto = "0.34.0"
 tendermint-light-client-verifier = "0.34.0"
-ibc-types = { version = "0.10.0", default-features = false }
-ibc-proto = { version = "0.39.0", default-features = false, features = [
+ibc-types = { version = "0.11.0", default-features = false }
+ibc-proto = { version = "0.40.0", default-features = false, features = [
     "server",
 ] }
 

--- a/crates/core/component/chain/Cargo.toml
+++ b/crates/core/component/chain/Cargo.toml
@@ -18,7 +18,7 @@ penumbra-num = { path = "../../../core/num", default-features = false }
 decaf377 = "0.5"
 
 tendermint = "0.34.0"
-ibc-types = { version = "0.10.0", default-features = false }
+ibc-types = { version = "0.11.0", default-features = false }
 ics23 = "0.11.0"
 
 # Crates.io deps

--- a/crates/core/component/ibc/Cargo.toml
+++ b/crates/core/component/ibc/Cargo.toml
@@ -29,8 +29,8 @@ penumbra-keys = { path = "../../../core/keys", default-features = false }
 penumbra-effecthash = { path = "../../../core/effecthash", default-features = false }
 
 # Penumbra dependencies
-ibc-types = { version = "0.10.0", default-features = false }
-ibc-proto = { version = "0.39.0", default-features = false }
+ibc-types = { version = "0.11.0", default-features = false }
+ibc-proto = { version = "0.40.0", default-features = false }
 
 # Crates.io deps
 ics23 = "0.11.0"

--- a/crates/core/component/shielded-pool/Cargo.toml
+++ b/crates/core/component/shielded-pool/Cargo.toml
@@ -48,7 +48,7 @@ decaf377-ka = { path = "../../../crypto/decaf377-ka/" }
 decaf377-fmd = { path = "../../../crypto/decaf377-fmd/" }
 
 # Penumbra dependencies
-ibc-types = { version = "0.10.0", default-features = false }
+ibc-types = { version = "0.11.0", default-features = false }
 decaf377-rdsa = { version = "0.7" }
 decaf377 = { version = "0.5", features = ["r1cs"] }
 poseidon377 = { version = "0.6", features = ["r1cs"] }

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -25,10 +25,10 @@ penumbra-keys = { path = "../keys", default-features = false }
 penumbra-effecthash = { path = "../effecthash", default-features = false }
 
 # Git deps
-ibc-types = { version = "0.10.0", default-features = false }
+ibc-types = { version = "0.11.0", default-features = false }
 
 # Crates.io deps
-ibc-proto = { version = "0.39.0", default-features = false }
+ibc-proto = { version = "0.40.0", default-features = false }
 decaf377 = "0.5"
 decaf377-rdsa = { version = "0.7" }
 poseidon377 = { version = "0.6", features = ["r1cs"] }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0"
 subtle-encoding = "0.5"
 bech32 = "0.8"
 cnidarium = { path = "../cnidarium", optional = true }
-ibc-types = { version = "0.10.0", features = ["std"] }
+ibc-types = { version = "0.11.0", features = ["std"] }
 pin-project = "1"
 async-trait = "0.1.52"
 async-stream = "0.2.0"
@@ -27,7 +27,7 @@ futures = "0.3"
 pbjson = "0.6"
 pbjson-types = "0.6"
 
-ibc-proto = { version = "0.39.0", default-features = false, features = [
+ibc-proto = { version = "0.40.0", default-features = false, features = [
     "std",
     "serde",
 ] }

--- a/crates/view/Cargo.toml
+++ b/crates/view/Cargo.toml
@@ -39,7 +39,7 @@ penumbra-compact-block = { path = "../core/component/compact-block", default-fea
 penumbra-app = { path = "../core/app" }
 penumbra-transaction = { path = "../core/transaction" }
 
-ibc-types = { version = "0.10.0", default-features = false }
+ibc-types = { version = "0.11.0", default-features = false }
 
 ark-std = { version = "0.4", default-features = false }
 decaf377 = { version = "0.5", features = ["r1cs"] }

--- a/crates/wasm/tests/test_deserialize.rs
+++ b/crates/wasm/tests/test_deserialize.rs
@@ -1,0 +1,35 @@
+use penumbra_proto::core::component::ibc::v1alpha1::Ics20Withdrawal as PbIcs20Withdrawal;
+use penumbra_shielded_pool::Ics20Withdrawal;
+
+#[test]
+fn height_properly_serializes_from_json() {
+    let data = r#"
+        {
+          "amount": {
+            "lo": "12000000"
+          },
+          "denom": {
+            "denom": "upenumbra"
+          },
+          "destinationChainAddress": "xyz",
+          "returnAddress": {
+            "inner": "by+DwROtdzWZu+W+gQ+e7pJ328aBf4Lng1dtnnkH971ebSC4O1+fQE+QmMNQ0iEg1/ARaF6yop4BurwW0Z1B7v0/o3AYchf6IEMYBxGyN18="
+          },
+          "timeoutHeight": {
+            "revisionNumber": "5",
+            "revisionHeight": "3928271"
+          },
+          "timeoutTime": "1701471437169",
+          "sourceChannel": "channel-0"
+        }
+    "#;
+
+    let withdrawal_proto: PbIcs20Withdrawal = serde_json::from_str(data).unwrap();
+    let height = withdrawal_proto.clone().timeout_height.unwrap();
+    assert_eq!(height.revision_number, 5u64);
+    assert_eq!(height.revision_height, 3928271u64);
+
+    let domain_type: Ics20Withdrawal = withdrawal_proto.try_into().unwrap();
+    assert_eq!(domain_type.timeout_height.revision_number, 5u64);
+    assert_eq!(domain_type.timeout_height.revision_height, 3928271u64);
+}

--- a/tools/proto-compiler/Cargo.toml
+++ b/tools/proto-compiler/Cargo.toml
@@ -15,5 +15,5 @@ pbjson-types = "0.6"
 pbjson-build = "0.6"
 tempfile = "3"
 
-ibc-proto = { version = "0.39.0" }
+ibc-proto = { version = "0.40.0" }
 ics23 = "0.11.0"


### PR DESCRIPTION
Unblocks: https://github.com/penumbra-zone/web/issues/248 which requires the updated protojson serialization methods