### PR TITLE
ci: add moons of mars to testnet names

### DIFF
--- a/deployments/helmfile.d/vars/penumbra-devnet-nodes-ips.yml
+++ b/deployments/helmfile.d/vars/penumbra-devnet-nodes-ips.yml
@@ -1,8 +1,8 @@
 nodes:
   - external_address: 35.202.100.199:26656
-    moniker: phobos-seed
+    moniker: ceres-seed
     seed_mode: true
   - external_address: 34.16.34.194:26656
-    moniker: deimos
+    moniker: vesta
   - external_address: 34.173.166.32:26656
-    moniker: naiad
+    moniker: pallas

--- a/deployments/helmfile.d/vars/penumbra-preview-nodes-ips.yml
+++ b/deployments/helmfile.d/vars/penumbra-preview-nodes-ips.yml
@@ -1,10 +1,10 @@
 nodes:
   - external_address: 34.135.6.235:26656
-    moniker: phobos-seed
+    moniker: ceres-seed
     seed_mode: true
   - external_address: 34.28.180.178:26656
-    moniker: deimos
+    moniker: vesta
   - external_address: 34.42.196.153:26656
-    moniker: naiad
+    moniker: pallas
   - external_address: 35.239.76.154:26656
-    moniker: thalassa
+    moniker: hygiea

--- a/deployments/helmfile.d/vars/penumbra-testnet-nodes-ips.yml
+++ b/deployments/helmfile.d/vars/penumbra-testnet-nodes-ips.yml
@@ -1,10 +1,10 @@
 nodes:
   - external_address: 35.225.116.144:26656
-    moniker: phobos-seed
+    moniker: ceres-seed
     seed_mode: true
   - external_address: 35.224.80.161:26656
-    moniker: deimos
+    moniker: vesta
   - external_address: 34.68.200.112:26656
-    moniker: naiad
+    moniker: pallas
   - external_address: 35.192.219.42:26656
-    moniker: thalassa
+    moniker: hygiea

--- a/deployments/scripts/get-lb-ips
+++ b/deployments/scripts/get-lb-ips
@@ -13,8 +13,9 @@ fi
 
 # Declare monikers for nodes on the network.
 # These monikers will be added to the generated vars file,
-# alongside the IP info.
-node_names=(phobos-seed deimos naiad thalassa)
+# alongside the IP info. Here we use notable asteroids,
+# reserving moons for testnet names.
+node_names=(ceres-seed vesta pallas hygiea)
 
 HELM_RELEASE="${1:-}"
 shift 1

--- a/testnets/names.txt
+++ b/testnets/names.txt
@@ -62,3 +62,5 @@ Dione
 Iapetus
 Rhea
 Titan
+Deimos
+Phobos


### PR DESCRIPTION
We've shipped testnets for the Jovian and Saturnine moons. Now, we add the Mars of moons, only two (2). If we need more than this, we can follow up with the moons of Neptune for more headroom.

Also updates the names of fullnodes in the CI deployment, which were previously set to moons of Mars and Neptune. Now moon names are only used to refer to testnets, and the fullnode monikers are notable asteroids.