### PR TITLE
ci: disable osiris handling

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -71,14 +71,3 @@ jobs:
 
       - name: bounce grpcui
         run: kubectl rollout restart deployment grpcui-preview
-
-      - name: bounce osiris
-        run: kubectl rollout restart deployment osiris-preview
-
-      # We only run one (1) relayer instance, and re-deploy it as part of the preview update.
-      # The other end of the configured path is the long-running testnet.
-      # We ignore errors on the bounce, because we may have removed the deployment out of band:
-      # we're still working on reliable packet relaying between test chains.
-      - name: bounce relayer
-        run: |-
-          kubectl rollout restart deployment relayer-preview || true

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -64,18 +64,6 @@ jobs:
       - name: bounce grpcui
         run: kubectl rollout restart deployment grpcui-testnet
 
-      - name: bounce osiris
-        shell: bash
-        run: |-
-          export PENUMBRA_VERSION='${{ github.event.inputs.image_tag || github.ref_name }}'
-          # Set the exact version for the current testnet for Osiris, so deps match.
-          kubectl set image deployments \
-              -l "app.kubernetes.io/instance=osiris-testnet" \
-              "osiris=ghcr.io/penumbra-zone/osiris:penumbra-${PENUMBRA_VERSION}"
-          # Wait for rollout to complete. Will block until pods are marked Ready.
-          kubectl rollout status deployment \
-              -l "app.kubernetes.io/instance=osiris-testnet"
-
       - name: bounce galileo
         shell: bash
         run: |-


### PR DESCRIPTION
We've disabled Osiris, likely indefinitely, so let's remove it from the CI workflows. Otherwise, preview deploys report as failed, even though the preview environment was created succesfully. In the medium term, we hope to have a Hummingbot service running, which will serve a similar role to Osiris.

Also removes the unused relayer reboot, as we're using Hermes for IBC now.