### PR TITLE
docs: add more talk urls

### DIFF
--- a/docs/guide/src/resources.md
+++ b/docs/guide/src/resources.md
@@ -35,7 +35,10 @@ The protobuf documentation is rendered at [buf.build/penumbra-zone/penumbra][pro
 These talks were given at various conferences and events,
 describing different aspects of the Penumbra ecosystem.
 
-* [DevCon 2022: Building a Private DEX with ZKPs and Threshold Cryptography](https://www.youtube.com/watch?v=JjmOelgfqNo)
+* [DevCon 2022: Building a Private DEX with ZKPs and Threshold Cryptography](https://archive.devcon.org/archive/watch/6/penumbra-building-a-private-dex-with-zkps-and-threshold-cryptography/?tab=YouTube)
 * [ZK8: How to build a private DEX](https://www.youtube.com/watch?v=-ap9ja36EYU)
 * [ZK8: Tiered Merkle Topiary in Rust](https://www.youtube.com/watch?v=mHoe7lQMcxU)
 * [ZK Whiteboard Session: ZK Swaps](https://www.youtube.com/watch?v=ziUZyQmHh4c)
+* [MEV Day: Minimizing MEV with sealed-input batch swaps](https://www.youtube.com/watch?v=oPIOIW2tvL4)
+* [Nebular Summit: Creating Performant Interchain Privacy At Scale](https://www.youtube.com/watch?v=EEUKPrno3u4)
+* [Interchain FM: Penumbra, Zero-Knowledge Decentralized Exchange](https://interchain.fm/episodes/penumbra-zero-knowledge-decentralized-exchange/transcript)


### PR DESCRIPTION
Consolidating talk URLs from a few different places, such as onboarding docs, Discord, and of course this guide.