### PR TITLE
docs: update testnet name for ibc 63 -> 64

### DIFF
--- a/docs/guide/src/pcli/transaction.md
+++ b/docs/guide/src/pcli/transaction.md
@@ -181,7 +181,7 @@ has been configured between the Osmosis testnet and the *current* Penumbra testn
 
 Penumbra aims to implement full IBC support for cross-chain asset transfers. For now, however,
 we're only running a relayer between the Penumbra testnet and the [Osmosis testnet] chains.
-For Testnet 63 Rhea, the channel information is:
+For Testnet 64 Titan, the channel information is:
 
 <!--
 To update the information below, update the Hermes config, then run:


### PR DESCRIPTION
Follow up to 41345e5958840fd2e8a0b7f16f2a8fd7181bcbd6, which updated the IBC info, but didn't update the testnet name from Rhea to Titan.