### PR TITLE
ci: increase cuiloa testnet storage

### DIFF
--- a/deployments/helmfile.d/penumbra-testnet-cuiloa.yaml
+++ b/deployments/helmfile.d/penumbra-testnet-cuiloa.yaml
@@ -17,10 +17,10 @@ releases:
       - ingressRoute:
           enabled: false
       - image:
-          tag: main
+          tag: "v0.64.1"
       - persistence:
           enabled: true
-          size: 50G
+          size: 200G
       - cometbft:
           config:
             indexer: psql


### PR DESCRIPTION
The testnet fullnodes had their storage increased in [0], and the fullnode backing the testnet cuiloa instance should have the same allotment. Also pinning a specific version of penumbra container, so that newer (and incompatible) versions aren't pulled on restart.

[0] bff43e609e7a2a1730728ee7a310e4c8eeb603d4