### PR TITLE
chore: cargo lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,13 +15,14 @@ jobs:
         uses: taiki-e/install-action@nextest
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
-      - name: Run cargo check
+      - name: Run cargo check, failing on warnings
+        # The benchmarks don't pass lint; soon!
+        # run: cargo check --release --all-targets
         run: cargo check --release
         env:
           # The `-D warnings` option causes an error on warnings;
-          # but it caused apparently spurious warnings, so it was disabled.
           # we must duplicate the rustflags from `.cargo/config.toml`.
-          RUSTFLAGS: "--cfg tokio_unstable"
+          RUSTFLAGS: "-D warnings --cfg tokio_unstable"
 
       # If a dependency was modified, Cargo.lock may flap if not committed.
       - name: Check for diffs

--- a/crates/core/component/governance/src/metrics.rs
+++ b/crates/core/component/governance/src/metrics.rs
@@ -11,6 +11,7 @@
 //! This trick is probably good to avoid in general, because it could be
 //! confusing, but in this limited case, it seems like a clean option.
 
+#[allow(unused_imports)]
 pub use metrics::*;
 
 /// Registers all metrics used by this crate.

--- a/crates/core/component/ibc/src/component/metrics.rs
+++ b/crates/core/component/ibc/src/component/metrics.rs
@@ -11,6 +11,7 @@
 //! This trick is probably good to avoid in general, because it could be
 //! confusing, but in this limited case, it seems like a clean option.
 
+#[allow(unused_imports)]
 pub use metrics::*;
 
 /// Registers all metrics used by this crate.

--- a/crates/core/component/shielded-pool/src/component/metrics.rs
+++ b/crates/core/component/shielded-pool/src/component/metrics.rs
@@ -11,6 +11,7 @@
 //! This trick is probably good to avoid in general, because it could be
 //! confusing, but in this limited case, it seems like a clean option.
 
+#[allow(unused_imports)]
 pub use metrics::*;
 
 /// Registers all metrics used by this crate.

--- a/crates/crypto/decaf377-frost/src/traits.rs
+++ b/crates/crypto/decaf377-frost/src/traits.rs
@@ -1,6 +1,6 @@
 use ark_ff::{Field as _, One, UniformRand, Zero};
 use decaf377::{Element, FieldExt, Fr};
-pub use frost_core::{frost, Ciphersuite, Field, FieldError, Group, GroupError};
+pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
 use rand_core;
 
 use crate::hash::Hasher;

--- a/crates/crypto/tct/src/internal.rs
+++ b/crates/crypto/tct/src/internal.rs
@@ -115,7 +115,7 @@ pub mod frontier {
         item::Item,
         leaf::Leaf,
         node::Node,
-        tier::{Nested, Tier},
+        tier::Tier,
         top::{Top, TrackForgotten},
     };
 }

--- a/crates/view/src/metrics.rs
+++ b/crates/view/src/metrics.rs
@@ -11,6 +11,7 @@
 //! This trick is probably good to avoid in general, because it could be
 //! confusing, but in this limited case, it seems like a clean option.
 
+#[allow(unused_imports)]
 pub use metrics::*;
 
 /// Registers all metrics used by this crate.


### PR DESCRIPTION
Satisfies the latest cargo lints. I took the easy way out, preserving the existing function sigs, rather than performing a deeper refactor. Ignored the checks on the re-export of metrics code across components.
    
Holding off on adding `--all-targets` to the check command, because there's some cleanup to do in the benchmarks, related to #3556.
    
Revert "ci: disable -D warnings"
This reverts commit 4e7c77b7404e69ab279d8d273a56935e7dba53c7.
    
Refs #3543.
