### PR TITLE
docs: update testnet 64 ibc channel

### DIFF
--- a/deployments/relayer/configs/penumbra-preview.json
+++ b/deployments/relayer/configs/penumbra-preview.json
@@ -2,9 +2,9 @@
   "type": "penumbra",
   "value": {
     "key": "default",
-    "chain-id": "penumbra-testnet-tethys-cc6f18f4",
+    "chain-id": "penumbra-testnet-titan-da6576af",
     "rpc-addr": "https://rpc.testnet-preview.penumbra.zone:443",
-    "account-prefix": "penumbrav2t",
+    "account-prefix": "penumbra",
     "keyring-backend": "test",
     "gas-adjustment": 1.0,
     "gas-prices": "0.00upenumbra",

--- a/deployments/relayer/configs/penumbra-testnet.json
+++ b/deployments/relayer/configs/penumbra-testnet.json
@@ -2,9 +2,9 @@
   "type": "penumbra",
   "value": {
     "key": "default",
-    "chain-id": "penumbra-testnet-pasiphae",
+    "chain-id": "penumbra-testnet-titan",
     "rpc-addr": "https://rpc.testnet.penumbra.zone:443",
-    "account-prefix": "penumbrav2t",
+    "account-prefix": "penumbra",
     "keyring-backend": "test",
     "gas-adjustment": 1.0,
     "gas-prices": "0.00upenumbra",

--- a/docs/guide/src/pcli/transaction.md
+++ b/docs/guide/src/pcli/transaction.md
@@ -195,14 +195,14 @@ during setup.
   "ordering": 1,
   "counterparty": {
     "port_id": "transfer",
-    "channel_id": "channel-4544"
+    "channel_id": "channel-4687"
   },
   "connection_hops": [
-    "connection-0"
+    "connection-1"
   ],
   "version": "ics20-1",
   "port_id": "transfer",
-  "channel_id": "channel-0"
+  "channel_id": "channel-1"
 }
 ```
 


### PR DESCRIPTION
Intentionally created a second channel via Hermes, still on Testnet 64 Titan, in an attempt to restore relaying functionality.