### PR TITLE
refactor: Use Placeholder for Validator Identity Key in Documentation

### DIFF
--- a/docs/guide/src/pd/validator.md
+++ b/docs/guide/src/pd/validator.md
@@ -140,7 +140,7 @@ pcli validator identity
 And then delegate some amount of `penumbra` to it:
 
 ```console
-pcli tx delegate 1penumbra --to penumbravalid1g2huds8klwypzczfgx67j7zp6ntq2m5fxmctkf7ja96zn49d6s9qz72hu3
+pcli tx delegate 1penumbra --to [YOUR_VALIDATOR_IDENTITY_KEY]
 ```
 
 You should then see your balance of `penumbra` decreased and that you have received some amount of delegation tokens for your validator:


### PR DESCRIPTION
I've been following the instructions for running a full node and setting up a validator. During this process, I noticed that in the section for delegating to a validator, the documentation provides an example command with a specific address. Here is the current command:

```console
pcli tx delegate 1penumbra --to penumbravalid1g2huds8klwypzczfgx67j7zp6ntq2m5fxmctkf7ja96zn49d6s9qz72hu3
```

While executing these steps quickly, I inadvertently used the example address in the command without realizing it. This might be a common oversight for others who are also setting up their nodes and validators in a similar manner.

To prevent such mistakes, I propose we use a placeholder for the validator's identity key, similar to how it's done in the governance section of the Penumbra guide: https://guide.penumbra.zone/main/pcli/governance.html#getting-proposal-information

The revised command would look like this:

```console
pcli tx delegate 1penumbra --to [YOUR_VALIDATOR_IDENTITY_KEY]
```

Using `[YOUR_VALIDATOR_IDENTITY_KEY]` in caps lock as a placeholder makes it clear that users need to replace this part with their specific validator's identity key. This format is more user-friendly and minimizes the risk of users accidentally using the example address.

Thank you for considering this suggestion.