### PR TITLE
ci: fix buf workflow on PRs

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -1,12 +1,12 @@
 name: Protobuf
 on:
   # Exclude feature branches, only run if the PR is targeting main.
-  pull_request_target:
-    types:
-      - opened
+  pull_request:
     branches:
       - "main"
 jobs:
+  # Ensure there are no breaking changes to the protocol specs,
+  # by running the "buf lint" action against the changes in this PR.
   lint:
     name: Lint protobuf
     runs-on: ubuntu-latest
@@ -16,7 +16,6 @@ jobs:
         with:
           buf_api_token: ${{ secrets.BUF_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # input: 'proto'
 
       - uses: bufbuild/buf-lint-action@v1
         with:
@@ -44,10 +43,11 @@ jobs:
           # The 'main' branch of the GitHub repository that defines the module.
           against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=main,subdir=proto"
 
+  # Run our bespoke tooling for codegen, consuming the protocol buffer definitions
+  # and emitting generated code. Afterward, there should be no uncommitted changes.
   protobuf-fresh:
     name: Compile protobuf specs to rust code
     runs-on: buildjet-16vcpu-ubuntu-2204
-    # runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v4


### PR DESCRIPTION
Follow up to #3292, which incorrectly used `pull_request_target` rather than `pull_request` to restrict workflow runs to PRs targeting main. We still want to skip the buf workflows if the PR is targeting a feature branch.

Closes #3570.