### PR TITLE
Fix unused variable / import warnings in pcli

### DIFF
--- a/crates/bin/pcli/src/command/ceremony.rs
+++ b/crates/bin/pcli/src/command/ceremony.rs
@@ -22,7 +22,7 @@ use penumbra_proto::{
     view::v1alpha1::GasPricesRequest,
 };
 use penumbra_transaction::memo::MemoPlaintext;
-use penumbra_view::{Planner, ViewClient};
+use penumbra_view::Planner;
 
 use crate::App;
 

--- a/crates/bin/pcli/src/command/view/balance.rs
+++ b/crates/bin/pcli/src/command/view/balance.rs
@@ -17,7 +17,7 @@ impl BalanceCmd {
         false
     }
 
-    pub async fn exec<V: ViewClient>(&self, fvk: &FullViewingKey, view: &mut V) -> Result<()> {
+    pub async fn exec<V: ViewClient>(&self, _fvk: &FullViewingKey, view: &mut V) -> Result<()> {
         let asset_cache = view.assets().await?;
 
         // Initialize the table

--- a/crates/bin/pcli/src/command/view/staked.rs
+++ b/crates/bin/pcli/src/command/view/staked.rs
@@ -23,7 +23,7 @@ impl StakedCmd {
 
     pub async fn exec(
         &self,
-        full_viewing_key: &FullViewingKey,
+        _fvk: &FullViewingKey,
         view_client: &mut impl ViewClient,
         pd_channel: Channel,
     ) -> Result<()> {


### PR DESCRIPTION
I don't quite know when this regression was introduced, but it's related to unused variables and imports.