### PR TITLE
ci: cargo check all targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,9 +16,7 @@ jobs:
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
       - name: Run cargo check, failing on warnings
-        # The benchmarks don't pass lint; soon!
-        # run: cargo check --release --all-targets
-        run: cargo check --release
+        run: cargo check --release --all-targets
         env:
           # The `-D warnings` option causes an error on warnings;
           # we must duplicate the rustflags from `.cargo/config.toml`.


### PR DESCRIPTION
As of #3579 we can now enable `cargo check --all-targets` to ensure that even benchmarks are included in `cargo check`.

Closes #3543.