### PR TITLE
MemoPlaintext string length enforced, TransactionPlan panic avoided

### DIFF
--- a/crates/core/app/src/action_handler/actions/submit.rs
+++ b/crates/core/app/src/action_handler/actions/submit.rs
@@ -353,7 +353,7 @@ static COMMUNITY_POOL_FULL_VIEWING_KEY: Lazy<FullViewingKey> = Lazy::new(|| {
 async fn build_community_pool_transaction(
     transaction_plan: TransactionPlan,
 ) -> Result<Transaction> {
-    let effect_hash = transaction_plan.effect_hash(&COMMUNITY_POOL_FULL_VIEWING_KEY);
+    let effect_hash = transaction_plan.effect_hash(&COMMUNITY_POOL_FULL_VIEWING_KEY)?;
     transaction_plan.build(
         &COMMUNITY_POOL_FULL_VIEWING_KEY,
         &WitnessData {

--- a/crates/core/app/src/action_handler/transaction.rs
+++ b/crates/core/app/src/action_handler/transaction.rs
@@ -170,7 +170,7 @@ mod tests {
         // Build the transaction.
         let fvk = &test_keys::FULL_VIEWING_KEY;
         let sk = &test_keys::SPEND_KEY;
-        let auth_data = plan.authorize(OsRng, sk);
+        let auth_data = plan.authorize(OsRng, sk)?;
         let witness_data = WitnessData {
             anchor: sct.root(),
             state_commitment_proofs: plan
@@ -233,7 +233,7 @@ mod tests {
         // Build the transaction.
         let fvk = &test_keys::FULL_VIEWING_KEY;
         let sk = &test_keys::SPEND_KEY;
-        let auth_data = plan.authorize(OsRng, sk);
+        let auth_data = plan.authorize(OsRng, sk)?;
         let witness_data = WitnessData {
             anchor: sct.root(),
             state_commitment_proofs: plan

--- a/crates/core/transaction/src/memo.rs
+++ b/crates/core/transaction/src/memo.rs
@@ -8,6 +8,7 @@ use anyhow::anyhow;
 use decaf377_ka as ka;
 use penumbra_asset::balance;
 use penumbra_keys::{
+    address::ADDRESS_LEN_BYTES,
     keys::OutgoingViewingKey,
     symmetric::{OvkWrappedKey, PayloadKey, PayloadKind, WrappedMemoKey},
     Address,
@@ -57,6 +58,12 @@ impl TryFrom<Vec<u8>> for MemoPlaintext {
         let text = String::from_utf8_lossy(&bytes[80..])
             .trim_end_matches(0u8 as char)
             .to_string();
+        if (text).len() > MEMO_LEN_BYTES - ADDRESS_LEN_BYTES {
+            anyhow::bail!(
+                "provided memo text exceeds {} bytes",
+                MEMO_LEN_BYTES - ADDRESS_LEN_BYTES
+            );
+        }
 
         Ok(MemoPlaintext {
             return_address,
@@ -222,6 +229,12 @@ impl TryFrom<pbt::MemoPlaintext> for MemoPlaintext {
             .return_address
             .ok_or_else(|| anyhow::anyhow!("message missing return address"))?
             .try_into()?;
+        if (msg.text).len() > MEMO_LEN_BYTES - ADDRESS_LEN_BYTES {
+            anyhow::bail!(
+                "provided memo text exceeds {} bytes",
+                MEMO_LEN_BYTES - ADDRESS_LEN_BYTES
+            );
+        }
         Ok(Self {
             return_address: sender,
             text: msg.text,

--- a/crates/core/transaction/src/plan.rs
+++ b/crates/core/transaction/src/plan.rs
@@ -511,9 +511,9 @@ mod tests {
 
         println!("{}", serde_json::to_string_pretty(&plan).unwrap());
 
-        let plan_effect_hash = plan.effect_hash(fvk);
+        let plan_effect_hash = plan.effect_hash(fvk).unwrap();
 
-        let auth_data = plan.authorize(rng, &sk);
+        let auth_data = plan.authorize(rng, &sk).unwrap();
         let witness_data = WitnessData {
             anchor: sct.root(),
             state_commitment_proofs: plan

--- a/crates/core/transaction/src/plan/auth.rs
+++ b/crates/core/transaction/src/plan/auth.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use penumbra_keys::keys::SpendKey;
 use rand::{CryptoRng, RngCore};
 
@@ -11,8 +12,8 @@ impl TransactionPlan {
         &self,
         mut rng: R,
         sk: &SpendKey,
-    ) -> AuthorizationData {
-        let effect_hash = self.effect_hash(sk.full_viewing_key());
+    ) -> Result<AuthorizationData> {
+        let effect_hash = self.effect_hash(sk.full_viewing_key())?;
         let mut spend_auths = Vec::new();
         let mut delegator_vote_auths = Vec::new();
 
@@ -28,10 +29,10 @@ impl TransactionPlan {
             let auth_sig = rsk.sign(&mut rng, effect_hash.as_ref());
             delegator_vote_auths.push(auth_sig);
         }
-        AuthorizationData {
+        Ok(AuthorizationData {
             effect_hash,
             spend_auths,
             delegator_vote_auths,
-        }
+        })
     }
 }

--- a/crates/custody/src/soft_kms.rs
+++ b/crates/custody/src/soft_kms.rs
@@ -33,7 +33,7 @@ impl SoftKms {
             policy.check(request)?;
         }
 
-        Ok(request.plan.authorize(OsRng, &self.config.spend_key))
+        Ok(request.plan.authorize(OsRng, &self.config.spend_key)?)
     }
 }
 

--- a/crates/custody/src/threshold.rs
+++ b/crates/custody/src/threshold.rs
@@ -579,7 +579,7 @@ mod test {
                 pre_authorizations: Vec::new(),
             })
             .await?;
-        assert_eq!(plan.effect_hash(&fvk), authorization_data.effect_hash);
+        assert_eq!(plan.effect_hash(&fvk)?, authorization_data.effect_hash);
         // The transaction plan only has spends
         for (randomizer, sig) in plan
             .spend_plans()

--- a/crates/custody/src/threshold/sign.rs
+++ b/crates/custody/src/threshold/sign.rs
@@ -348,7 +348,7 @@ pub fn coordinator_round2(
     let reply = CoordinatorRound2 { all_commitments };
 
     let my_round2_reply = follower_round2(config, state.my_round1_state, reply.clone())?;
-    let effect_hash = state.plan.effect_hash(config.fvk());
+    let effect_hash = state.plan.effect_hash(config.fvk())?;
     let signing_packages = {
         reply
             .all_commitments
@@ -432,7 +432,7 @@ pub fn follower_round2(
     state: FollowerState,
     coordinator: CoordinatorRound2,
 ) -> Result<FollowerRound2> {
-    let effect_hash = state.plan.effect_hash(config.fvk());
+    let effect_hash = state.plan.effect_hash(config.fvk())?;
     let signing_packages = coordinator
         .all_commitments
         .into_iter()

--- a/crates/wasm/src/tx.rs
+++ b/crates/wasm/src/tx.rs
@@ -79,7 +79,7 @@ pub fn authorize(spend_key_str: &str, transaction_plan: JsValue) -> WasmResult<J
     let spend_key = SpendKey::from_str(spend_key_str)?;
     let plan: TransactionPlan = plan_proto.try_into()?;
 
-    let auth_data: AuthorizationData = plan.authorize(OsRng, &spend_key);
+    let auth_data: AuthorizationData = plan.authorize(OsRng, &spend_key)?;
     let result = serde_wasm_bindgen::to_value(&auth_data.to_proto())?;
     Ok(result)
 }


### PR DESCRIPTION
identified a panic when working on web transactions.

added checks to verify text length is under maximum when deserializing from `pbt::MemoPlaintext` or `Vec<u8>`, to prevent the creation of impossible memos. perhaps `MemoPlaintext` should use private fields and a constructor to enforce format limitations that cannot be specified by protobuf, but this is a smaller change.

ultimately the source of the panic was an `expect` used in `TransactionPlan::effect_hash` to unwrap a potential error, this is now bubbled as `anyhow::Result`