### PR TITLE
feat: 📝 implement mock-cometbft crate (work-in-progress)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5477,6 +5477,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-mock-cometbft"
+version = "0.64.1"
+
+[[package]]
 name = "penumbra-num"
 version = "0.64.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
   "crates/bin/pcli",
   "crates/wasm",
   "crates/test/tct-property-test",
+  "crates/test/mock-cometbft",
   "crates/misc/measure",
   "crates/misc/tct-visualize",
   "crates/bench",

--- a/crates/test/mock-cometbft/Cargo.toml
+++ b/crates/test/mock-cometbft/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "penumbra-mock-cometbft"
+version = "0.64.1"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/test/mock-cometbft/src/lib.rs
+++ b/crates/test/mock-cometbft/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
this commit introduces a new library, in `crates/test/`. this library contains a mock implementation of cometbft, for use in cargo integration tests.

* this does NOT add the `penumbra-mock-cometbft` crate to the list of crates included in the rust documentation in `deployments/scripts/rust-docs`. the `penumbra-tct-property-test` crate was also not included in that list at the time of writing.

/!\ ------------------------------------------------------- /!\
/!\ NOTE: this is a rolling work-in-progress.               /!\
/!\ this branch will be force-pushed frequently until it is /!\
/!\ ready for review. proceed accordingly!                  /!\
/!\ ------------------------------------------------------- /!\