### PR TITLE
ibc: ⛅ hoist ics02 validation out of client_counter

### DIFF
--- a/crates/core/component/ibc/src/component.rs
+++ b/crates/core/component/ibc/src/component.rs
@@ -4,6 +4,7 @@ mod client;
 mod client_counter;
 mod connection;
 mod connection_counter;
+mod ics02_validation;
 
 #[cfg(feature = "rpc")]
 pub mod rpc;

--- a/crates/core/component/ibc/src/component/client_counter.rs
+++ b/crates/core/component/ibc/src/component/client_counter.rs
@@ -1,8 +1,5 @@
-use crate::{component::ics02_validation, IBC_PROOF_SPECS};
-use ibc_proto::google::protobuf::Any;
 use ibc_types::core::client::Height;
-use ibc_types::core::connection::{ChainId, ConnectionId};
-use ibc_types::lightclients::tendermint::TrustThreshold;
+use ibc_types::core::connection::ConnectionId;
 use penumbra_proto::{penumbra::core::component::ibc::v1alpha1 as pb, DomainType};
 
 #[derive(Clone, Debug)]
@@ -88,83 +85,4 @@ impl From<ClientConnections> for pb::ClientConnections {
                 .collect(),
         }
     }
-}
-
-// Check that the trust threshold is:
-//
-// a) non-zero
-// b) greater or equal to 1/3
-// c) strictly less than 1
-fn validate_trust_threshold(trust_threshold: TrustThreshold) -> anyhow::Result<()> {
-    if trust_threshold.denominator() == 0 {
-        anyhow::bail!("trust threshold denominator cannot be zero");
-    }
-
-    if trust_threshold.numerator() * 3 < trust_threshold.denominator() {
-        anyhow::bail!("trust threshold must be greater than 1/3");
-    }
-
-    if trust_threshold.numerator() >= trust_threshold.denominator() {
-        anyhow::bail!("trust threshold must be strictly less than 1");
-    }
-
-    Ok(())
-}
-
-// validate the parameters of an AnyClientState, verifying that it is a valid Penumbra client
-// state.
-pub fn validate_penumbra_client_state(
-    client_state: Any,
-    chain_id: &str,
-    current_height: u64,
-) -> anyhow::Result<()> {
-    let tm_client_state = ics02_validation::get_tendermint_client_state(client_state)?;
-
-    if tm_client_state.frozen_height.is_some() {
-        anyhow::bail!("invalid client state: frozen");
-    }
-
-    // NOTE: Chain ID validation is actually not standardized yet. see
-    // https://github.com/informalsystems/ibc-rs/pull/304#discussion_r503917283
-    let chain_id = ChainId::from_string(chain_id);
-    if chain_id != tm_client_state.chain_id {
-        anyhow::bail!("invalid client state: chain id does not match");
-    }
-
-    // check that the revision number is the same as our chain ID's version
-    if tm_client_state.latest_height().revision_number() != chain_id.version() {
-        anyhow::bail!("invalid client state: revision number does not match");
-    }
-
-    // check that the latest height isn't gte the current block height
-    if tm_client_state.latest_height().revision_height() >= current_height {
-        anyhow::bail!(
-            "invalid client state: latest height is greater than or equal to the current block height"
-        );
-    }
-
-    // check client proof specs match penumbra proof specs
-    if IBC_PROOF_SPECS.clone() != tm_client_state.proof_specs {
-        // allow legacy proof specs without prehash_key_before_comparison
-        let mut spec_with_prehash_key = tm_client_state.proof_specs.clone();
-        spec_with_prehash_key[0].prehash_key_before_comparison = true;
-        spec_with_prehash_key[1].prehash_key_before_comparison = true;
-        if IBC_PROOF_SPECS.clone() != spec_with_prehash_key {
-            anyhow::bail!("invalid client state: proof specs do not match");
-        }
-    }
-
-    // check that the trust level is correct
-    validate_trust_threshold(tm_client_state.trust_level)?;
-
-    // TODO: check that the unbonding period is correct
-    //
-    // - check unbonding period is greater than trusting period
-    if tm_client_state.unbonding_period < tm_client_state.trusting_period {
-        anyhow::bail!("invalid client state: unbonding period is less than trusting period");
-    }
-
-    // TODO: check upgrade path
-
-    Ok(())
 }

--- a/crates/core/component/ibc/src/component/client_counter.rs
+++ b/crates/core/component/ibc/src/component/client_counter.rs
@@ -1,4 +1,4 @@
-use crate::IBC_PROOF_SPECS;
+use crate::{component::ics02_validation, IBC_PROOF_SPECS};
 use ibc_proto::google::protobuf::Any;
 use ibc_types::core::client::Height;
 use ibc_types::core::connection::{ChainId, ConnectionId};
@@ -86,91 +86,6 @@ impl From<ClientConnections> for pb::ClientConnections {
                 .into_iter()
                 .map(|h| h.as_str().to_string())
                 .collect(),
-        }
-    }
-}
-
-pub(crate) mod ics02_validation {
-    use anyhow::{anyhow, Result};
-    use ibc_proto::google::protobuf::Any;
-    use ibc_types::lightclients::tendermint::client_state::{
-        ClientState as TendermintClientState, TENDERMINT_CLIENT_STATE_TYPE_URL,
-    };
-    use ibc_types::lightclients::tendermint::consensus_state::{
-        ConsensusState as TendermintConsensusState, TENDERMINT_CONSENSUS_STATE_TYPE_URL,
-    };
-    use ibc_types::lightclients::tendermint::header::{
-        Header as TendermintHeader, TENDERMINT_HEADER_TYPE_URL,
-    };
-    use ibc_types::lightclients::tendermint::misbehaviour::{
-        Misbehaviour as TendermintMisbehavior, TENDERMINT_MISBEHAVIOUR_TYPE_URL,
-    };
-
-    pub fn is_tendermint_header_state(header: &Any) -> bool {
-        header.type_url.as_str() == TENDERMINT_HEADER_TYPE_URL
-    }
-    pub fn is_tendermint_consensus_state(consensus_state: &Any) -> bool {
-        consensus_state.type_url.as_str() == TENDERMINT_CONSENSUS_STATE_TYPE_URL
-    }
-    pub fn is_tendermint_client_state(client_state: &Any) -> bool {
-        client_state.type_url.as_str() == TENDERMINT_CLIENT_STATE_TYPE_URL
-    }
-    pub fn is_tendermint_misbehavior(misbehavior: &Any) -> bool {
-        misbehavior.type_url.as_str() == TENDERMINT_MISBEHAVIOUR_TYPE_URL
-    }
-
-    pub fn get_tendermint_misbehavior(misbehavior: Any) -> Result<TendermintMisbehavior> {
-        if is_tendermint_misbehavior(&misbehavior) {
-            TendermintMisbehavior::try_from(misbehavior)
-                .map_err(|e| anyhow!(format!("failed to deserialize tendermint misbehavior: {e}")))
-        } else {
-            anyhow::bail!(format!(
-                "expected a tendermint light client misbehavior, got: {}",
-                misbehavior.type_url.as_str()
-            ))
-        }
-    }
-
-    pub fn get_tendermint_header(header: Any) -> Result<TendermintHeader> {
-        if is_tendermint_header_state(&header) {
-            TendermintHeader::try_from(header)
-                .map_err(|e| anyhow!(format!("failed to deserialize tendermint header: {e}")))
-        } else {
-            anyhow::bail!(format!(
-                "expected a tendermint light client header, got: {}",
-                header.type_url.as_str()
-            ))
-        }
-    }
-
-    pub fn get_tendermint_consensus_state(
-        consensus_state: Any,
-    ) -> Result<TendermintConsensusState> {
-        if is_tendermint_consensus_state(&consensus_state) {
-            TendermintConsensusState::try_from(consensus_state).map_err(|e| {
-                anyhow!(format!(
-                    "failed to deserialize tendermint consensus state: {e}"
-                ))
-            })
-        } else {
-            anyhow::bail!(format!(
-                "expected tendermint consensus state, got: {}",
-                consensus_state.type_url.as_str()
-            ))
-        }
-    }
-    pub fn get_tendermint_client_state(client_state: Any) -> Result<TendermintClientState> {
-        if is_tendermint_client_state(&client_state) {
-            TendermintClientState::try_from(client_state).map_err(|e| {
-                anyhow!(format!(
-                    "failed to deserialize tendermint client state: {e}"
-                ))
-            })
-        } else {
-            anyhow::bail!(format!(
-                "expected tendermint client state, got: {}",
-                client_state.type_url.as_str()
-            ))
         }
     }
 }

--- a/crates/core/component/ibc/src/component/ics02_validation.rs
+++ b/crates/core/component/ibc/src/component/ics02_validation.rs
@@ -1,0 +1,80 @@
+use anyhow::{anyhow, Result};
+use ibc_proto::google::protobuf::Any;
+use ibc_types::lightclients::tendermint::client_state::{
+    ClientState as TendermintClientState, TENDERMINT_CLIENT_STATE_TYPE_URL,
+};
+use ibc_types::lightclients::tendermint::consensus_state::{
+    ConsensusState as TendermintConsensusState, TENDERMINT_CONSENSUS_STATE_TYPE_URL,
+};
+use ibc_types::lightclients::tendermint::header::{
+    Header as TendermintHeader, TENDERMINT_HEADER_TYPE_URL,
+};
+use ibc_types::lightclients::tendermint::misbehaviour::{
+    Misbehaviour as TendermintMisbehavior, TENDERMINT_MISBEHAVIOUR_TYPE_URL,
+};
+
+pub fn is_tendermint_header_state(header: &Any) -> bool {
+    header.type_url.as_str() == TENDERMINT_HEADER_TYPE_URL
+}
+pub fn is_tendermint_consensus_state(consensus_state: &Any) -> bool {
+    consensus_state.type_url.as_str() == TENDERMINT_CONSENSUS_STATE_TYPE_URL
+}
+pub fn is_tendermint_client_state(client_state: &Any) -> bool {
+    client_state.type_url.as_str() == TENDERMINT_CLIENT_STATE_TYPE_URL
+}
+pub fn is_tendermint_misbehavior(misbehavior: &Any) -> bool {
+    misbehavior.type_url.as_str() == TENDERMINT_MISBEHAVIOUR_TYPE_URL
+}
+
+pub fn get_tendermint_misbehavior(misbehavior: Any) -> Result<TendermintMisbehavior> {
+    if is_tendermint_misbehavior(&misbehavior) {
+        TendermintMisbehavior::try_from(misbehavior)
+            .map_err(|e| anyhow!(format!("failed to deserialize tendermint misbehavior: {e}")))
+    } else {
+        anyhow::bail!(format!(
+            "expected a tendermint light client misbehavior, got: {}",
+            misbehavior.type_url.as_str()
+        ))
+    }
+}
+
+pub fn get_tendermint_header(header: Any) -> Result<TendermintHeader> {
+    if is_tendermint_header_state(&header) {
+        TendermintHeader::try_from(header)
+            .map_err(|e| anyhow!(format!("failed to deserialize tendermint header: {e}")))
+    } else {
+        anyhow::bail!(format!(
+            "expected a tendermint light client header, got: {}",
+            header.type_url.as_str()
+        ))
+    }
+}
+
+pub fn get_tendermint_consensus_state(consensus_state: Any) -> Result<TendermintConsensusState> {
+    if is_tendermint_consensus_state(&consensus_state) {
+        TendermintConsensusState::try_from(consensus_state).map_err(|e| {
+            anyhow!(format!(
+                "failed to deserialize tendermint consensus state: {e}"
+            ))
+        })
+    } else {
+        anyhow::bail!(format!(
+            "expected tendermint consensus state, got: {}",
+            consensus_state.type_url.as_str()
+        ))
+    }
+}
+pub fn get_tendermint_client_state(client_state: Any) -> Result<TendermintClientState> {
+    if is_tendermint_client_state(&client_state) {
+        TendermintClientState::try_from(client_state).map_err(|e| {
+            anyhow!(format!(
+                "failed to deserialize tendermint client state: {e}"
+            ))
+        })
+    } else {
+        anyhow::bail!(format!(
+            "expected tendermint client state, got: {}",
+            client_state.type_url.as_str()
+        ))
+    }
+}

--- a/crates/core/component/ibc/src/component/ics02_validation.rs
+++ b/crates/core/component/ibc/src/component/ics02_validation.rs
@@ -1,16 +1,17 @@
+use crate::IBC_PROOF_SPECS;
 use anyhow::{anyhow, Result};
 use ibc_proto::google::protobuf::Any;
-use ibc_types::lightclients::tendermint::client_state::{
-    ClientState as TendermintClientState, TENDERMINT_CLIENT_STATE_TYPE_URL,
-};
-use ibc_types::lightclients::tendermint::consensus_state::{
-    ConsensusState as TendermintConsensusState, TENDERMINT_CONSENSUS_STATE_TYPE_URL,
-};
-use ibc_types::lightclients::tendermint::header::{
-    Header as TendermintHeader, TENDERMINT_HEADER_TYPE_URL,
-};
-use ibc_types::lightclients::tendermint::misbehaviour::{
-    Misbehaviour as TendermintMisbehavior, TENDERMINT_MISBEHAVIOUR_TYPE_URL,
+use ibc_types::{
+    core::connection::ChainId,
+    lightclients::tendermint::{
+        client_state::{ClientState as TendermintClientState, TENDERMINT_CLIENT_STATE_TYPE_URL},
+        consensus_state::{
+            ConsensusState as TendermintConsensusState, TENDERMINT_CONSENSUS_STATE_TYPE_URL,
+        },
+        header::{Header as TendermintHeader, TENDERMINT_HEADER_TYPE_URL},
+        misbehaviour::{Misbehaviour as TendermintMisbehavior, TENDERMINT_MISBEHAVIOUR_TYPE_URL},
+        TrustThreshold,
+    },
 };
 
 pub fn is_tendermint_header_state(header: &Any) -> bool {
@@ -77,4 +78,83 @@ pub fn get_tendermint_client_state(client_state: Any) -> Result<TendermintClient
             client_state.type_url.as_str()
         ))
     }
+}
+
+// validate the parameters of an AnyClientState, verifying that it is a valid Penumbra client
+// state.
+pub fn validate_penumbra_client_state(
+    client_state: Any,
+    chain_id: &str,
+    current_height: u64,
+) -> anyhow::Result<()> {
+    let tm_client_state = get_tendermint_client_state(client_state)?;
+
+    if tm_client_state.frozen_height.is_some() {
+        anyhow::bail!("invalid client state: frozen");
+    }
+
+    // NOTE: Chain ID validation is actually not standardized yet. see
+    // https://github.com/informalsystems/ibc-rs/pull/304#discussion_r503917283
+    let chain_id = ChainId::from_string(chain_id);
+    if chain_id != tm_client_state.chain_id {
+        anyhow::bail!("invalid client state: chain id does not match");
+    }
+
+    // check that the revision number is the same as our chain ID's version
+    if tm_client_state.latest_height().revision_number() != chain_id.version() {
+        anyhow::bail!("invalid client state: revision number does not match");
+    }
+
+    // check that the latest height isn't gte the current block height
+    if tm_client_state.latest_height().revision_height() >= current_height {
+        anyhow::bail!(
+            "invalid client state: latest height is greater than or equal to the current block height"
+        );
+    }
+
+    // check client proof specs match penumbra proof specs
+    if IBC_PROOF_SPECS.clone() != tm_client_state.proof_specs {
+        // allow legacy proof specs without prehash_key_before_comparison
+        let mut spec_with_prehash_key = tm_client_state.proof_specs.clone();
+        spec_with_prehash_key[0].prehash_key_before_comparison = true;
+        spec_with_prehash_key[1].prehash_key_before_comparison = true;
+        if IBC_PROOF_SPECS.clone() != spec_with_prehash_key {
+            anyhow::bail!("invalid client state: proof specs do not match");
+        }
+    }
+
+    // check that the trust level is correct
+    validate_trust_threshold(tm_client_state.trust_level)?;
+
+    // TODO: check that the unbonding period is correct
+    //
+    // - check unbonding period is greater than trusting period
+    if tm_client_state.unbonding_period < tm_client_state.trusting_period {
+        anyhow::bail!("invalid client state: unbonding period is less than trusting period");
+    }
+
+    // TODO: check upgrade path
+
+    Ok(())
+}
+
+// Check that the trust threshold is:
+//
+// a) non-zero
+// b) greater or equal to 1/3
+// c) strictly less than 1
+fn validate_trust_threshold(trust_threshold: TrustThreshold) -> anyhow::Result<()> {
+    if trust_threshold.denominator() == 0 {
+        anyhow::bail!("trust threshold denominator cannot be zero");
+    }
+
+    if trust_threshold.numerator() * 3 < trust_threshold.denominator() {
+        anyhow::bail!("trust threshold must be greater than 1/3");
+    }
+
+    if trust_threshold.numerator() >= trust_threshold.denominator() {
+        anyhow::bail!("trust threshold must be strictly less than 1");
+    }
+
+    Ok(())
 }

--- a/crates/core/component/ibc/src/component/msg_handler/connection_open_ack.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/connection_open_ack.rs
@@ -12,8 +12,8 @@ use penumbra_chain::component::StateReadExt as _;
 use crate::{
     component::{
         client::StateReadExt as _,
-        client_counter::validate_penumbra_client_state,
         connection::{StateReadExt as _, StateWriteExt as _},
+        ics02_validation::validate_penumbra_client_state,
         proof_verification, MsgHandler,
     },
     IBC_COMMITMENT_PREFIX,

--- a/crates/core/component/ibc/src/component/msg_handler/connection_open_try.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/connection_open_try.rs
@@ -17,9 +17,9 @@ use penumbra_chain::component::StateReadExt as _;
 
 use crate::component::{
     client::StateReadExt as _,
-    client_counter::validate_penumbra_client_state,
     connection::{StateReadExt as _, StateWriteExt as _},
     connection_counter::SUPPORTED_VERSIONS,
+    ics02_validation::validate_penumbra_client_state,
     MsgHandler,
 };
 

--- a/crates/core/component/ibc/src/component/msg_handler/create_client.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/create_client.rs
@@ -8,8 +8,8 @@ use ibc_types::{
 
 use crate::component::{
     client::{StateReadExt as _, StateWriteExt as _},
-    client_counter::{ics02_validation, ClientCounter},
-    MsgHandler,
+    client_counter::ClientCounter,
+    ics02_validation, MsgHandler,
 };
 
 #[async_trait]

--- a/crates/core/component/ibc/src/component/msg_handler/misbehavior.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/misbehavior.rs
@@ -13,12 +13,9 @@ use tendermint_light_client_verifier::{
     ProdVerifier, Verdict, Verifier,
 };
 
-use crate::component::client::StateWriteExt as _;
-use crate::component::client_counter::ics02_validation;
-use crate::component::ClientStateReadExt as _;
-
 use super::update_client::verify_header_validator_set;
 use super::MsgHandler;
+use crate::component::{client::StateWriteExt as _, ics02_validation, ClientStateReadExt as _};
 
 #[async_trait]
 impl MsgHandler for MsgSubmitMisbehaviour {

--- a/crates/core/component/ibc/src/component/msg_handler/update_client.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/update_client.rs
@@ -18,8 +18,7 @@ use tendermint_light_client_verifier::{
 
 use crate::component::{
     client::{Ics2ClientExt as _, StateReadExt as _, StateWriteExt as _},
-    client_counter::ics02_validation,
-    MsgHandler,
+    ics02_validation, MsgHandler,
 };
 
 #[async_trait]


### PR DESCRIPTION
nb: this branch strictly contains plain code motion. it does not make any
changes to the code being moved.

this branch performs two simple transformations, broken into two commits:

#### ⛅ hoist ics02 validation out of client_counter
    
`ics02_validation` contains some important code for interfacing with
tendermint/cometbft. while this submodule lives beneath the client counter
logic, its contents are used in our message handling code related to e.g.
misbehavior.

this hoists this submodule up one level, to be a child of
`penumbra_ibc::component`.

#### ⛅ place `validate_penumbra_client_state` in ics02_validation

while validate_penumbra_client_state was not originally placed in the ics02_validation submodule,
it feels like it is more connected to that validation logic than the
surrounding client counter types.

this bears out to be true; it is `pub`, the client counter code isn't changed,
and affected imports are in the message handler area.

