### PR TITLE
test: add negative proptest strategies for first three circuits

### DIFF
--- a/crates/core/component/governance/src/delegator_vote/proof.rs
+++ b/crates/core/component/governance/src/delegator_vote/proof.rs
@@ -487,6 +487,8 @@ mod tests {
     }
 
     prop_compose! {
+        // This strategy generates a delegator vote statement that votes on a proposal with
+        // a non-zero position commitment index. The circuit should be unsatisfiable in this case.
         fn arb_invalid_delegator_vote_statement_nonzero_start()(v_blinding in fr_strategy(), spend_auth_randomizer in fr_strategy(), asset_id64 in any::<u64>(), address_index in any::<u32>(), amount in any::<u64>(), seed_phrase_randomness in any::<[u8; 32]>(), rseed_randomness in any::<[u8; 32]>(), num_commitments in 0..100) -> (DelegatorVoteProofPublic, DelegatorVoteProofPrivate) {
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));

--- a/crates/core/component/shielded-pool/src/nullifier_derivation.rs
+++ b/crates/core/component/shielded-pool/src/nullifier_derivation.rs
@@ -266,6 +266,10 @@ mod tests {
     }
 
     prop_compose! {
+        // An invalid nullifier derivation statement is derived here by
+        // adding a random value to the nullifier key. The circuit should
+        // be unsatisfiable if the witnessed nullifier key is incorrect, i.e.
+        // does not match the nullifier key used to derive the nullifier.
         fn arb_invalid_nullifier_derivation_statement()(amount in any::<u64>(), address_index in any::<u32>(), position in any::<(u16, u16, u16)>(), invalid_nk_randomness in any::<[u8; 32]>(), asset_id64 in any::<u64>(), seed_phrase_randomness in any::<[u8; 32]>(), rseed_randomness in any::<[u8; 32]>()) -> (NullifierDerivationProofPublic, NullifierDerivationProofPrivate) {
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));

--- a/crates/core/component/shielded-pool/src/spend/proof.rs
+++ b/crates/core/component/shielded-pool/src/spend/proof.rs
@@ -662,75 +662,71 @@ mod tests {
         }
     }
 
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(2))]
-    #[test]
-    /// Check that the `SpendProof` verification fails when using balance
-    /// commitments with different blinding factors.
-    fn spend_proof_verification_balance_commitment_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy(), incorrect_blinding_factor in fr_strategy()) {
-        let mut rng = OsRng;
-        let (pk, vk) = generate_prepared_test_parameters::<SpendCircuit>(&mut rng);
+    prop_compose! {
+        fn arb_invalid_spend_statement_v_blinding_factor()(v_blinding in fr_strategy(), incorrect_v_blinding in fr_strategy(), spend_auth_randomizer in fr_strategy(), asset_id64 in any::<u64>(), address_index in any::<u32>(), amount in any::<u64>(), seed_phrase_randomness in any::<[u8; 32]>(), rseed_randomness in any::<[u8; 32]>(), num_commitments in 0..100) -> (SpendProofPublic, SpendProofPrivate) {
+            let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
+            let sk_sender = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));
+            let fvk_sender = sk_sender.full_viewing_key();
+            let ivk_sender = fvk_sender.incoming();
+            let (sender, _dtk_d) = ivk_sender.payment_address(address_index.into());
+            let value_to_send = Value {
+                amount: Amount::from(amount),
+                asset_id: asset::Id(Fq::from(asset_id64)),
+            };
+            let note = Note::from_parts(
+                sender,
+                value_to_send,
+                Rseed(rseed_randomness),
+            ).expect("should be able to create note");
+            let note_commitment = note.commit();
+            let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
+            let nk = *sk_sender.nullifier_key();
+            let ak: VerificationKey<SpendAuth> = sk_sender.spend_auth_key().into();
 
-        let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-        let sk_sender = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));
-        let fvk_sender = sk_sender.full_viewing_key();
-        let ivk_sender = fvk_sender.incoming();
-        let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());
+            let mut sct = tct::Tree::new();
 
-        let value_to_send = Value {
-            amount: value_amount.into(),
-            asset_id: asset::Cache::with_known_assets().get_unit("upenumbra").unwrap().id(),
-        };
+            // Next, we simulate the case where the SCT is not empty by adding `num_commitments`
+            // unrelated items in the SCT.
+            for i in 0..num_commitments {
+                // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
+                let rseed = Rseed([i as u8; 32]);
+                let dummy_note_commitment = Note::from_parts(sender, value_to_send, rseed).expect("can create note").commit();
+                sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
+            }
 
-        let note = Note::generate(&mut rng, &sender, value_to_send);
-        let note_commitment = note.commit();
-        let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
-        let nk = *sk_sender.nullifier_key();
-        let ak = sk_sender.spend_auth_key().into();
-        let mut sct = tct::Tree::new();
-        sct.insert(tct::Witness::Keep, note_commitment).unwrap();
-        let anchor = sct.root();
-        let state_commitment_proof = sct.witness(note_commitment).unwrap();
-        let balance_commitment = value_to_send.commit(v_blinding);
-        let rk: VerificationKey<SpendAuth> = rsk.into();
-        let nf = Nullifier::derive(&nk, 0.into(), &note_commitment);
+            sct.insert(tct::Witness::Keep, note_commitment).expect("should be able to insert note commitments into the SCT");
+            let anchor = sct.root();
+            let state_commitment_proof = sct.witness(note_commitment).expect("can witness note commitment");
+            let balance_commitment = value_to_send.commit(v_blinding);
+            let rk: VerificationKey<SpendAuth> = rsk.into();
+            let nullifier = Nullifier::derive(&nk, state_commitment_proof.position(), &note_commitment);
 
-        let blinding_r = Fq::rand(&mut OsRng);
-        let blinding_s = Fq::rand(&mut OsRng);
-        let public = SpendProofPublic {
-            anchor,
-            balance_commitment,
-            nullifier: nf,
-            rk,
-        };
-        let private = SpendProofPrivate {
-            state_commitment_proof,
-            note,
-            v_blinding,
-            spend_auth_randomizer,
-            ak,
-            nk,
-        };
-        let proof = SpendProof::prove(
-            blinding_r,
-            blinding_s,
-            &pk,
-            public, private
-
-        )
-        .expect("can create proof");
-
-        let incorrect_balance_commitment = value_to_send.commit(incorrect_blinding_factor);
-        let incorrect_public = SpendProofPublic {
-            anchor,
-            balance_commitment: incorrect_balance_commitment,
-            nullifier: nf,
-            rk,
-        };
-
-        let proof_result = proof.verify(&vk, incorrect_public);
-        assert!(proof_result.is_err());
+            let public = SpendProofPublic {
+                anchor,
+                balance_commitment,
+                nullifier,
+                rk,
+            };
+            let private = SpendProofPrivate {
+                state_commitment_proof,
+                note,
+                v_blinding: incorrect_v_blinding,
+                spend_auth_randomizer,
+                ak,
+                nk,
+            };
+            (public, private)
+        }
     }
+
+    proptest! {
+        #[test]
+        /// Check that the `SpendProof` is not satisifed when using balance
+        /// commitments with different blinding factors.
+        fn spend_proof_verification_balance_commitment_integrity_failure((public, private) in arb_invalid_spend_statement_v_blinding_factor()) {
+            assert!(check_satisfaction(&public, &private).is_err());
+            assert!(check_circuit_satisfaction(public, private).is_err());
+        }
     }
 
     proptest! {

--- a/crates/core/component/shielded-pool/src/spend/proof.rs
+++ b/crates/core/component/shielded-pool/src/spend/proof.rs
@@ -460,73 +460,70 @@ mod tests {
         }
     }
 
+    prop_compose! {
+        fn arb_invalid_spend_statement_incorrect_anchor()(v_blinding in fr_strategy(), spend_auth_randomizer in fr_strategy(), asset_id64 in any::<u64>(), address_index in any::<u32>(), amount in any::<u64>(), seed_phrase_randomness in any::<[u8; 32]>(), rseed_randomness in any::<[u8; 32]>(), num_commitments in 0..100) -> (SpendProofPublic, SpendProofPrivate) {
+            let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
+            let sk_sender = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));
+            let fvk_sender = sk_sender.full_viewing_key();
+            let ivk_sender = fvk_sender.incoming();
+            let (sender, _dtk_d) = ivk_sender.payment_address(address_index.into());
+            let value_to_send = Value {
+                amount: Amount::from(amount),
+                asset_id: asset::Id(Fq::from(asset_id64)),
+            };
+            let note = Note::from_parts(
+                sender,
+                value_to_send,
+                Rseed(rseed_randomness),
+            ).expect("should be able to create note");
+            let note_commitment = note.commit();
+            let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
+            let nk = *sk_sender.nullifier_key();
+            let ak: VerificationKey<SpendAuth> = sk_sender.spend_auth_key().into();
+
+            let mut sct = tct::Tree::new();
+
+            // Next, we simulate the case where the SCT is not empty by adding `num_commitments`
+            // unrelated items in the SCT.
+            for i in 0..num_commitments {
+                // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
+                let rseed = Rseed([i as u8; 32]);
+                let dummy_note_commitment = Note::from_parts(sender, value_to_send, rseed).expect("can create note").commit();
+                sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
+            }
+            let incorrect_anchor = sct.root();
+
+            sct.insert(tct::Witness::Keep, note_commitment).expect("should be able to insert note commitments into the SCT");
+            let state_commitment_proof = sct.witness(note_commitment).expect("can witness note commitment");
+            let balance_commitment = value_to_send.commit(v_blinding);
+            let rk: VerificationKey<SpendAuth> = rsk.into();
+            let nullifier = Nullifier::derive(&nk, state_commitment_proof.position(), &note_commitment);
+
+            let public = SpendProofPublic {
+                anchor: incorrect_anchor,
+                balance_commitment,
+                nullifier,
+                rk,
+            };
+            let private = SpendProofPrivate {
+                state_commitment_proof,
+                note,
+                v_blinding,
+                spend_auth_randomizer,
+                ak,
+                nk,
+            };
+            (public, private)
+        }
+    }
+
     proptest! {
-        #![proptest_config(ProptestConfig::with_cases(2))]
     #[test]
     /// Check that the `SpendProof` verification fails when using an incorrect
     /// TCT root (`anchor`).
-    fn spend_proof_verification_merkle_path_integrity_failure(seed_phrase_randomness in any::<[u8; 32]>(), spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy()) {
-        let mut rng = OsRng;
-        let (pk, vk) = generate_prepared_test_parameters::<SpendCircuit>(&mut rng);
-
-        let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
-        let sk_sender = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));
-        let fvk_sender = sk_sender.full_viewing_key();
-        let ivk_sender = fvk_sender.incoming();
-        let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());
-
-        let value_to_send = Value {
-            amount: value_amount.into(),
-            asset_id: asset::Cache::with_known_assets().get_unit("upenumbra").unwrap().id(),
-        };
-
-        let note = Note::generate(&mut rng, &sender, value_to_send);
-        let note_commitment = note.commit();
-        let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
-        let nk = *sk_sender.nullifier_key();
-        let ak: VerificationKey<SpendAuth> = sk_sender.spend_auth_key().into();
-        let mut sct = tct::Tree::new();
-        let incorrect_anchor = sct.root();
-        sct.insert(tct::Witness::Keep, note_commitment).unwrap();
-        let anchor = sct.root();
-        let state_commitment_proof = sct.witness(note_commitment).unwrap();
-        let balance_commitment = value_to_send.commit(v_blinding);
-        let rk: VerificationKey<SpendAuth> = rsk.into();
-        let nf = Nullifier::derive(&nk, 0.into(), &note_commitment);
-
-        let blinding_r = Fq::rand(&mut OsRng);
-        let blinding_s = Fq::rand(&mut OsRng);
-        let public = SpendProofPublic {
-            anchor,
-            balance_commitment,
-            nullifier: nf,
-            rk,
-        };
-        let private = SpendProofPrivate {
-            state_commitment_proof,
-            note,
-            v_blinding,
-            spend_auth_randomizer,
-            ak,
-            nk,
-        };
-        let proof = SpendProof::prove(
-            blinding_r,
-            blinding_s,
-            &pk,
-            public,
-            private
-        )
-        .expect("can create proof");
-
-        let incorrect_public = SpendProofPublic {
-            anchor: incorrect_anchor,
-            balance_commitment,
-            nullifier: nf,
-            rk,
-        };
-        let proof_result = proof.verify(&vk, incorrect_public);
-        assert!(proof_result.is_err());
+    fn spend_proof_verification_merkle_path_integrity_failure((public, private) in arb_invalid_spend_statement_incorrect_anchor()) {
+        assert!(check_satisfaction(&public, &private).is_err());
+            assert!(check_circuit_satisfaction(public, private).is_err());
     }
     }
 

--- a/crates/core/component/shielded-pool/src/spend/proof.rs
+++ b/crates/core/component/shielded-pool/src/spend/proof.rs
@@ -729,50 +729,54 @@ mod tests {
         }
     }
 
-    proptest! {
-            #![proptest_config(ProptestConfig::with_cases(2))]
-        #[test]
-        /// Check that the `SpendProof` verification fails when the incorrect randomizable verification key is used.
-        fn spend_proof_verification_fails_rk_integrity(seed_phrase_randomness in any::<[u8; 32]>(), spend_auth_randomizer in fr_strategy(), value_amount in 2..200u64, v_blinding in fr_strategy(), incorrect_spend_auth_randomizer in fr_strategy()) {
-            let mut rng = OsRng;
-            let (pk, vk) = generate_prepared_test_parameters::<SpendCircuit>(&mut rng);
-
+    prop_compose! {
+        fn arb_invalid_spend_statement_rk_integrity()(v_blinding in fr_strategy(), spend_auth_randomizer in fr_strategy(), asset_id64 in any::<u64>(), address_index in any::<u32>(), amount in any::<u64>(), seed_phrase_randomness in any::<[u8; 32]>(), rseed_randomness in any::<[u8; 32]>(), num_commitments in 0..100, incorrect_spend_auth_randomizer in fr_strategy()) -> (SpendProofPublic, SpendProofPrivate) {
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));
             let fvk_sender = sk_sender.full_viewing_key();
             let ivk_sender = fvk_sender.incoming();
-            let (sender, _dtk_d) = ivk_sender.payment_address(0u32.into());
-
+            let (sender, _dtk_d) = ivk_sender.payment_address(address_index.into());
             let value_to_send = Value {
-                amount: value_amount.into(),
-                asset_id: asset::Cache::with_known_assets().get_unit("upenumbra").unwrap().id(),
+                amount: Amount::from(amount),
+                asset_id: asset::Id(Fq::from(asset_id64)),
             };
-
-            let note = Note::generate(&mut rng, &sender, value_to_send);
+            let note = Note::from_parts(
+                sender,
+                value_to_send,
+                Rseed(rseed_randomness),
+            ).expect("should be able to create note");
             let note_commitment = note.commit();
             let rsk = sk_sender.spend_auth_key().randomize(&spend_auth_randomizer);
             let nk = *sk_sender.nullifier_key();
-            let ak = sk_sender.spend_auth_key().into();
+            let ak: VerificationKey<SpendAuth> = sk_sender.spend_auth_key().into();
+
             let mut sct = tct::Tree::new();
-            sct.insert(tct::Witness::Keep, note_commitment).unwrap();
+
+            // Next, we simulate the case where the SCT is not empty by adding `num_commitments`
+            // unrelated items in the SCT.
+            for i in 0..num_commitments {
+                // To avoid duplicate note commitments, we use the `i` counter as the Rseed randomness
+                let rseed = Rseed([i as u8; 32]);
+                let dummy_note_commitment = Note::from_parts(sender, value_to_send, rseed).expect("can create note").commit();
+                sct.insert(tct::Witness::Keep, dummy_note_commitment).expect("should be able to insert note commitments into the SCT");
+            }
+
+            sct.insert(tct::Witness::Keep, note_commitment).expect("should be able to insert note commitments into the SCT");
             let anchor = sct.root();
-            let state_commitment_proof = sct.witness(note_commitment).unwrap();
+            let state_commitment_proof = sct.witness(note_commitment).expect("can witness note commitment");
             let balance_commitment = value_to_send.commit(v_blinding);
-            let rk: VerificationKey<SpendAuth> = rsk.into();
-            let nf = Nullifier::derive(&nk, 0.into(), &note_commitment);
+            let nullifier = Nullifier::derive(&nk, state_commitment_proof.position(), &note_commitment);
 
             let incorrect_rsk = sk_sender
                 .spend_auth_key()
                 .randomize(&incorrect_spend_auth_randomizer);
             let incorrect_rk: VerificationKey<SpendAuth> = incorrect_rsk.into();
 
-            let blinding_r = Fq::rand(&mut OsRng);
-            let blinding_s = Fq::rand(&mut OsRng);
             let public = SpendProofPublic {
                 anchor,
                 balance_commitment,
-                nullifier: nf,
-                rk,
+                nullifier,
+                rk: incorrect_rk,
             };
             let private = SpendProofPrivate {
                 state_commitment_proof,
@@ -782,22 +786,16 @@ mod tests {
                 ak,
                 nk,
             };
-            let proof = SpendProof::prove(
-                blinding_r,
-                blinding_s,
-                &pk,
-                public, private
-            )
-            .expect("should be able to form proof");
+            (public, private)
+        }
+    }
 
-            let incorrect_public = SpendProofPublic {
-                anchor,
-                balance_commitment,
-                nullifier: nf,
-                rk: incorrect_rk,
-            };
-            let proof_result = proof.verify(&vk, incorrect_public);
-            assert!(proof_result.is_err());
+    proptest! {
+        #[test]
+        /// Check that the `SpendProof` is not satisfied when the incorrect randomizable verification key is used.
+        fn spend_proof_verification_fails_rk_integrity((public, private) in arb_invalid_spend_statement_rk_integrity()) {
+            assert!(check_satisfaction(&public, &private).is_err());
+            assert!(check_circuit_satisfaction(public, private).is_err());
         }
     }
 

--- a/crates/core/component/shielded-pool/src/spend/proof.rs
+++ b/crates/core/component/shielded-pool/src/spend/proof.rs
@@ -460,6 +460,10 @@ mod tests {
     }
 
     prop_compose! {
+        // This strategy generates a spend statement that uses a Merkle root
+        // from prior to the note commitment being added to the SCT. The Merkle
+        // path should not verify using this invalid root, and as such the circuit
+        // should be unsatisfiable.
         fn arb_invalid_spend_statement_incorrect_anchor()(v_blinding in fr_strategy(), spend_auth_randomizer in fr_strategy(), asset_id64 in any::<u64>(), address_index in any::<u32>(), amount in any::<u64>(), seed_phrase_randomness in any::<[u8; 32]>(), rseed_randomness in any::<[u8; 32]>(), num_commitments in 0..100) -> (SpendProofPublic, SpendProofPrivate) {
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));
@@ -527,6 +531,17 @@ mod tests {
     }
 
     prop_compose! {
+        // Recall: The transmission key `pk_d` is derived as:
+        //
+        // `pk_d ​= [ivk] B_d`
+        //
+        // where `B_d` is the diversified basepoint and `ivk` is the incoming
+        // viewing key.
+        //
+        // This strategy generates a spend statement that is spending a note
+        // that corresponds to a diversified address associated with a different
+        // IVK, i.e. the prover cannot demonstrate the transmission key `pk_d`
+        // was derived as above and the circuit should be unsatisfiable.
         fn arb_invalid_spend_statement_diversified_address()(v_blinding in fr_strategy(), spend_auth_randomizer in fr_strategy(), asset_id64 in any::<u64>(), address_index in any::<u32>(), amount in any::<u64>(), seed_phrase_randomness in any::<[u8; 32]>(), incorrect_seed_phrase_randomness in any::<[u8; 32]>(), rseed_randomness in any::<[u8; 32]>()) -> (SpendProofPublic, SpendProofPrivate) {
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));
@@ -590,6 +605,8 @@ mod tests {
     }
 
     prop_compose! {
+        // This strategy generates a spend statement that derives a nullifier
+        // using a different position.
         fn arb_invalid_spend_statement_nullifier()(v_blinding in fr_strategy(), spend_auth_randomizer in fr_strategy(), asset_id64 in any::<u64>(), address_index in any::<u32>(), amount in any::<u64>(), seed_phrase_randomness in any::<[u8; 32]>(), rseed_randomness in any::<[u8; 32]>(), num_commitments in 0..100) -> (SpendProofPublic, SpendProofPrivate) {
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));
@@ -662,6 +679,8 @@ mod tests {
     }
 
     prop_compose! {
+        // This statement uses a randomly generated incorrect value blinding factor for deriving the
+        // balance commitment.
         fn arb_invalid_spend_statement_v_blinding_factor()(v_blinding in fr_strategy(), incorrect_v_blinding in fr_strategy(), spend_auth_randomizer in fr_strategy(), asset_id64 in any::<u64>(), address_index in any::<u32>(), amount in any::<u64>(), seed_phrase_randomness in any::<[u8; 32]>(), rseed_randomness in any::<[u8; 32]>(), num_commitments in 0..100) -> (SpendProofPublic, SpendProofPrivate) {
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));
@@ -729,6 +748,8 @@ mod tests {
     }
 
     prop_compose! {
+        // This statement uses a randomly generated incorrect spend auth randomizer for deriving the
+        // randomized verification key.
         fn arb_invalid_spend_statement_rk_integrity()(v_blinding in fr_strategy(), spend_auth_randomizer in fr_strategy(), asset_id64 in any::<u64>(), address_index in any::<u32>(), amount in any::<u64>(), seed_phrase_randomness in any::<[u8; 32]>(), rseed_randomness in any::<[u8; 32]>(), num_commitments in 0..100, incorrect_spend_auth_randomizer in fr_strategy()) -> (SpendProofPublic, SpendProofPrivate) {
             let seed_phrase = SeedPhrase::from_randomness(&seed_phrase_randomness);
             let sk_sender = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));


### PR DESCRIPTION
This adds negative proptest strategies for the `SpendCircuit`, `DelegatorVoteCircuit`, and `NullifierDerivationCircuit` towards #3565