### PR TITLE
typo: PRF takes input 1 (not 0) when deriving `nk`

### DIFF
--- a/docs/protocol/src/protocol/addresses_keys/spend_key.md
+++ b/docs/protocol/src/protocol/addresses_keys/spend_key.md
@@ -55,7 +55,7 @@ personalization `label`, key `key`, and input `input`.  Define
 integer in little-endian order.  Then
 ```
 ask = from_le_bytes(prf_expand("Penumbra_ExpndSd", spend_key_bytes, 0)) mod r
-nk  = from_le_bytes(prf_expand("Penumbra_ExpndSd", spend_key_bytes, 0)) mod q
+nk  = from_le_bytes(prf_expand("Penumbra_ExpndSd", spend_key_bytes, 1)) mod q
 ```
 
 The *spending key* consists of `spend_key_bytes` and `ask`.  (Since `ask` is


### PR DESCRIPTION
Quick typo fix in docs (surmised based on [the official implementation](https://github.com/penumbra-zone/penumbra/blob/main/crates/core/keys/src/keys/spend.rs#L67-L75)).