### PR TITLE
ci: use cargo clippy optimize code

### DIFF
--- a/crates/cnidarium/src/store/multistore.rs
+++ b/crates/cnidarium/src/store/multistore.rs
@@ -58,7 +58,7 @@ impl MultistoreConfig {
         // If the key does not contain a delimiter, we return the original key
         // routed to the main store. This is because we do not want to allow
         // collisions e.g. `prefix_a/key` and `prefix_akey`.
-        let Some(matching_key) = truncated_key.strip_prefix("/") else {
+        let Some(matching_key) = truncated_key.strip_prefix('/') else {
             return (key, self.main_store.clone());
         };
 
@@ -140,7 +140,7 @@ impl MultistoreConfig {
             .expect("key has the prefix of the matched substore");
 
         let truncated_prefix = truncated_prefix
-            .strip_prefix("/")
+            .strip_prefix('/')
             .unwrap_or(truncated_prefix);
         (truncated_prefix, config)
     }

--- a/crates/cnidarium/src/store/substore.rs
+++ b/crates/cnidarium/src/store/substore.rs
@@ -75,42 +75,52 @@ impl SubstoreConfig {
 
     pub fn cf_jmt<'s>(&self, db_handle: &'s Arc<rocksdb::DB>) -> &'s ColumnFamily {
         let column = self.cf_jmt.as_str();
-        db_handle.cf_handle(column).expect(&format!(
-            "jmt column family not found for prefix: {}, substore: {}",
-            column, self.prefix
-        ))
+        db_handle.cf_handle(column).unwrap_or_else(|| {
+            panic!(
+                "jmt column family not found for prefix: {}, substore: {}",
+                column, self.prefix
+            )
+        })
     }
 
     pub fn cf_jmt_values<'s>(&self, db_handle: &'s Arc<rocksdb::DB>) -> &'s ColumnFamily {
         let column = self.cf_jmt_values.as_str();
-        db_handle.cf_handle(column).expect(&format!(
-            "jmt-values column family not found for prefix: {}, substore: {}",
-            column, self.prefix
-        ))
+        db_handle.cf_handle(column).unwrap_or_else(|| {
+            panic!(
+                "jmt-values column family not found for prefix: {}, substore: {}",
+                column, self.prefix
+            )
+        })
     }
 
     pub fn cf_jmt_keys_by_keyhash<'s>(&self, db_handle: &'s Arc<rocksdb::DB>) -> &'s ColumnFamily {
         let column = self.cf_jmt_keys_by_keyhash.as_str();
-        db_handle.cf_handle(column).expect(&format!(
-            "jmt-keys-by-keyhash column family not found for prefix: {}, substore: {}",
-            column, self.prefix
-        ))
+        db_handle.cf_handle(column).unwrap_or_else(|| {
+            panic!(
+                "jmt-keys-by-keyhash column family not found for prefix: {}, substore: {}",
+                column, self.prefix
+            )
+        })
     }
 
     pub fn cf_jmt_keys<'s>(&self, db_handle: &'s Arc<rocksdb::DB>) -> &'s ColumnFamily {
         let column = self.cf_jmt_keys.as_str();
-        db_handle.cf_handle(column).expect(&format!(
-            "jmt-keys column family not found for prefix: {}, substore: {}",
-            column, self.prefix
-        ))
+        db_handle.cf_handle(column).unwrap_or_else(|| {
+            panic!(
+                "jmt-keys column family not found for prefix: {}, substore: {}",
+                column, self.prefix
+            )
+        })
     }
 
     pub fn cf_nonverifiable<'s>(&self, db_handle: &'s Arc<rocksdb::DB>) -> &'s ColumnFamily {
         let column = self.cf_nonverifiable.as_str();
-        db_handle.cf_handle(column).expect(&format!(
-            "nonverifiable column family not found for prefix: {}, substore: {}",
-            column, self.prefix
-        ))
+        db_handle.cf_handle(column).unwrap_or_else(|| {
+            panic!(
+                "nonverifiable column family not found for prefix: {}, substore: {}",
+                column, self.prefix
+            )
+        })
     }
 
     pub fn latest_version_from_db(

--- a/crates/core/asset/src/asset/cache.rs
+++ b/crates/core/asset/src/asset/cache.rs
@@ -203,10 +203,7 @@ impl Deref for Cache {
 
 impl From<Cache> for BTreeMap<Id, DenomMetadata> {
     fn from(cache: Cache) -> Self {
-        cache
-            .cache
-            .into_iter()
-            .collect()
+        cache.cache.into_iter().collect()
     }
 }
 

--- a/crates/core/asset/src/asset/cache.rs
+++ b/crates/core/asset/src/asset/cache.rs
@@ -206,7 +206,6 @@ impl From<Cache> for BTreeMap<Id, DenomMetadata> {
         cache
             .cache
             .into_iter()
-            .map(|(id, denom)| (id, denom))
             .collect()
     }
 }

--- a/crates/core/asset/src/balance.rs
+++ b/crates/core/asset/src/balance.rs
@@ -335,7 +335,7 @@ impl BalanceVar {
         // Access constraint system ref from one of the balance contributions
         let cs = self
             .inner
-            .get(0)
+            .first()
             .expect("at least one contribution to balance")
             .0
             .asset_id

--- a/crates/core/component/distributions/src/component.rs
+++ b/crates/core/component/distributions/src/component.rs
@@ -46,7 +46,8 @@ impl Component for Distributions {
         let state = Arc::get_mut(state).context("state should be unique")?;
         let new_issuance = state.compute_new_issuance().await?;
         tracing::debug!(?new_issuance, "computed new issuance for epoch");
-        Ok(state.distribute(new_issuance).await)
+        state.distribute(new_issuance).await;
+        Ok(())
     }
 }
 

--- a/crates/core/component/distributions/src/component/view.rs
+++ b/crates/core/component/distributions/src/component/view.rs
@@ -22,7 +22,7 @@ pub trait StateReadExt: StateRead {
     }
 
     fn get_staking_token_issuance_for_epoch(&self) -> Option<Amount> {
-        self.object_get(&state_key::staking_token_issuance_for_epoch())
+        self.object_get(state_key::staking_token_issuance_for_epoch())
     }
 }
 

--- a/crates/core/component/distributions/src/genesis.rs
+++ b/crates/core/component/distributions/src/genesis.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::params::DistributionsParameters;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Default, Clone)]
 #[serde(try_from = "pb::GenesisContent", into = "pb::GenesisContent")]
 pub struct Content {
     /// The initial configuration parameters for the distributions component.
@@ -34,12 +34,4 @@ impl TryFrom<pb::GenesisContent> for Content {
 
 impl DomainType for Content {
     type Proto = pb::GenesisContent;
-}
-
-impl Default for Content {
-    fn default() -> Self {
-        Self {
-            distributions_params: DistributionsParameters::default(),
-        }
-    }
 }

--- a/crates/core/component/ibc/src/component/client.rs
+++ b/crates/core/component/ibc/src/component/client.rs
@@ -319,7 +319,7 @@ pub trait StateReadExt: StateRead {
         if let Some(next_height) = verified_heights
             .heights
             .iter()
-            .find(|&verified_height| verified_height > &height)
+            .find(|&verified_height| verified_height > height)
         {
             let next_cons_state = self
                 .get_verified_consensus_state(next_height, client_id)
@@ -350,7 +350,7 @@ pub trait StateReadExt: StateRead {
         if let Some(prev_height) = verified_heights
             .heights
             .iter()
-            .find(|&verified_height| verified_height < &height)
+            .find(|&verified_height| verified_height < height)
         {
             let prev_cons_state = self
                 .get_verified_consensus_state(prev_height, client_id)

--- a/crates/core/component/ibc/src/component/msg_handler/connection_open_ack.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/connection_open_ack.rs
@@ -235,7 +235,7 @@ async fn verify_previous_connection<S: StateRead>(
     let state_is_consistent = connection.state_matches(&State::Init)
         && connection.versions.contains(&msg.version)
         || connection.state_matches(&State::TryOpen)
-            && connection.versions.get(0).eq(&Some(&msg.version));
+            && connection.versions.first().eq(&Some(&msg.version));
 
     if !state_is_consistent {
         anyhow::bail!("connection is not in the correct state");

--- a/crates/core/component/ibc/src/component/msg_handler/misbehavior.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/misbehavior.rs
@@ -119,7 +119,7 @@ async fn verify_misbehavior_header<S: StateRead>(
 ) -> Result<()> {
     let trusted_height = mb_header.trusted_height;
     let last_trusted_consensus_state = state
-        .get_verified_consensus_state(&trusted_height, &client_id)
+        .get_verified_consensus_state(&trusted_height, client_id)
         .await?;
 
     let trusted_height = trusted_height

--- a/crates/core/component/ibc/src/component/proof_verification.rs
+++ b/crates/core/component/ibc/src/component/proof_verification.rs
@@ -126,10 +126,7 @@ pub trait ClientUpgradeProofVerifier: StateReadExt {
             anyhow::bail!("upgrade path is not set");
         };
 
-        let upgrade_path_prefix = MerklePrefix::try_from(upgrade_path[0].clone().into_bytes())
-            .map_err(|_| {
-                anyhow::anyhow!("couldnt create commitment prefix from client upgrade path")
-            })?;
+        let upgrade_path_prefix = MerklePrefix::from(upgrade_path[0].clone().into_bytes());
 
         // check if the client is frozen
         if trusted_client_state.is_frozen() {

--- a/crates/core/component/ibc/src/component/rpc/client_query.rs
+++ b/crates/core/component/ibc/src/component/rpc/client_query.rs
@@ -279,7 +279,7 @@ async fn get_latest_verified_height(
     client_id: &ClientId,
 ) -> Result<Height, tonic::Status> {
     let verified_heights = snapshot
-        .get_verified_heights(&client_id)
+        .get_verified_heights(client_id)
         .await
         .map_err(|e| tonic::Status::aborted(format!("couldn't get verified heights: {e}")))?;
 

--- a/crates/core/component/ibc/src/component/rpc/consensus_query.rs
+++ b/crates/core/component/ibc/src/component/rpc/consensus_query.rs
@@ -217,7 +217,7 @@ impl ConsensusQuery for IbcQuery {
                 ))
             })?;
 
-        let connection = snapshot.get_connection(&connection_id).await.map_err(|e| {
+        let connection = snapshot.get_connection(connection_id).await.map_err(|e| {
             tonic::Status::aborted(format!(
                 "couldn't get connection {connection_id} for channel {channel_id} for port {port_id}: {e}"
             ))
@@ -302,7 +302,7 @@ impl ConsensusQuery for IbcQuery {
                 ))
             })?;
 
-        let connection = snapshot.get_connection(&connection_id).await.map_err(|e| {
+        let connection = snapshot.get_connection(connection_id).await.map_err(|e| {
             tonic::Status::aborted(format!(
                 "couldn't get connection {connection_id} for channel {channel_id} for port {port_id}: {e}"
             ))

--- a/crates/core/component/sct/src/component/view.rs
+++ b/crates/core/component/sct/src/component/view.rs
@@ -95,7 +95,7 @@ pub trait StateReadExt: StateRead {
             anyhow::bail!(
                 "nullifier {} was already spent in {:?}",
                 nullifier,
-                hex::encode(&info.id),
+                hex::encode(info.id),
             );
         }
         Ok(())

--- a/crates/core/component/stake/src/funding_stream.rs
+++ b/crates/core/component/stake/src/funding_stream.rs
@@ -192,6 +192,6 @@ impl<'a> IntoIterator for &'a FundingStreams {
     type IntoIter = std::slice::Iter<'a, FundingStream>;
 
     fn into_iter(self) -> Self::IntoIter {
-        (&self.funding_streams).into_iter()
+        (&self.funding_streams).iter()
     }
 }

--- a/crates/core/num/src/fixpoint.rs
+++ b/crates/core/num/src/fixpoint.rs
@@ -652,7 +652,7 @@ impl U128x128Var {
         let bits = self.limbs[2]
             .to_bits_le()
             .into_iter()
-            .chain(self.limbs[3].to_bits_le().into_iter())
+            .chain(self.limbs[3].to_bits_le())
             .collect::<Vec<Boolean<Fq>>>();
         Ok(AmountVar {
             amount: Boolean::<Fq>::le_bits_to_fp_var(&bits)?,

--- a/crates/crypto/decaf377-frost/src/lib.rs
+++ b/crates/crypto/decaf377-frost/src/lib.rs
@@ -223,7 +223,7 @@ pub fn aggregate(
 ) -> Result<Signature<SpendAuth>, Error> {
     let signature_shares = signature_shares
         .iter()
-        .map(|(a, b)| (*a, b.0.clone()))
+        .map(|(a, b)| (*a, b.0))
         .collect();
     let frost_sig = frost::aggregate(&signing_package.0, &signature_shares, pubkeys)?;
     Ok(TryInto::<[u8; 64]>::try_into(frost_sig.serialize())
@@ -241,7 +241,7 @@ pub fn aggregate_randomized(
 ) -> Result<Signature<SpendAuth>, Error> {
     let signature_shares = signature_shares
         .iter()
-        .map(|(a, b)| (*a, b.0.clone()))
+        .map(|(a, b)| (*a, b.0))
         .collect();
     let frost_sig = frost_rerandomized::aggregate(
         &signing_package.0,

--- a/crates/crypto/decaf377-frost/src/lib.rs
+++ b/crates/crypto/decaf377-frost/src/lib.rs
@@ -221,10 +221,7 @@ pub fn aggregate(
     signature_shares: &HashMap<Identifier, round2::SignatureShare>,
     pubkeys: &keys::PublicKeyPackage,
 ) -> Result<Signature<SpendAuth>, Error> {
-    let signature_shares = signature_shares
-        .iter()
-        .map(|(a, b)| (*a, b.0))
-        .collect();
+    let signature_shares = signature_shares.iter().map(|(a, b)| (*a, b.0)).collect();
     let frost_sig = frost::aggregate(&signing_package.0, &signature_shares, pubkeys)?;
     Ok(TryInto::<[u8; 64]>::try_into(frost_sig.serialize())
         .expect("serialization is valid")
@@ -239,10 +236,7 @@ pub fn aggregate_randomized(
     pubkeys: &keys::PublicKeyPackage,
     randomizer: decaf377::Fr,
 ) -> Result<Signature<SpendAuth>, Error> {
-    let signature_shares = signature_shares
-        .iter()
-        .map(|(a, b)| (*a, b.0))
-        .collect();
+    let signature_shares = signature_shares.iter().map(|(a, b)| (*a, b.0)).collect();
     let frost_sig = frost_rerandomized::aggregate(
         &signing_package.0,
         &signature_shares,

--- a/crates/crypto/decaf377-frost/src/traits.rs
+++ b/crates/crypto/decaf377-frost/src/traits.rs
@@ -1,7 +1,6 @@
 use ark_ff::{Field as _, One, UniformRand, Zero};
 use decaf377::{Element, FieldExt, Fr};
 pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
-use rand_core;
 
 use crate::hash::Hasher;
 

--- a/crates/proto/src/event.rs
+++ b/crates/proto/src/event.rs
@@ -8,7 +8,7 @@ pub trait ProtoEvent: Message + Name + Serialize + DeserializeOwned + Sized {
     fn into_event(&self) -> abci::Event {
         let kind = Self::full_name();
 
-        let event_json = serde_json::to_value(&self)
+        let event_json = serde_json::to_value(self)
             .expect("ProtoEvent constrained values should be JSON serializeable.");
 
         // WARNING: Assuming that Rust value will always serialize into a valid JSON Object value. This falls apart the moment that isn't true, so we fail hard if that turns out to be the case.
@@ -27,7 +27,7 @@ pub trait ProtoEvent: Message + Name + Serialize + DeserializeOwned + Sized {
         // [0]: https://github.com/cosmos/cosmos-sdk/blob/8fb62054c59e580c0ae0c898751f8dc46044499a/types/events.go#L102-L104
         attributes.sort_by(|a, b| (&a.key).cmp(&b.key));
 
-        return abci::Event::new(kind, attributes);
+        abci::Event::new(kind, attributes)
     }
 
     fn from_event(event: &abci::Event) -> anyhow::Result<Self> {
@@ -51,9 +51,7 @@ pub trait ProtoEvent: Message + Name + Serialize + DeserializeOwned + Sized {
         let json = serde_json::to_value(attributes)
             .expect("HashMap of String, serde_json::Value should be serializeable.");
 
-        return Ok(
-            serde_json::from_value(json).context("could not deserialise ProtoJSON into event")?
-        );
+        serde_json::from_value(json).context("could not deserialise ProtoJSON into event")
     }
 }
 


### PR DESCRIPTION
I found there are many warnings when we run `cargo clippy`, we should use `cargo clippy` to check the code and optimize it.

And i found the `std::collections::HashMap` is marked disallowed, but there are many `HashMap` inside this project, it looks not easy to simple remove all of it. Should we remove this from `clippy.toml` or just let the warning exists?

This PR try to optimize a part of those warnings.