### PR TITLE
staking: length-limit validator definition strings

### DIFF
--- a/crates/core/component/stake/src/action_handler/validator_definition.rs
+++ b/crates/core/component/stake/src/action_handler/validator_definition.rs
@@ -16,7 +16,22 @@ use crate::{
 impl ActionHandler for validator::Definition {
     type CheckStatelessContext = ();
     async fn check_stateless(&self, _context: ()) -> Result<()> {
-        // First, check the signature:
+        // First, we check that the validator website/name/description does not
+        // exceed 70, 140, and 280 characters respectively. We use guard statements
+        // so that clients can display actionable error messages.
+        if self.validator.website.len() > 70 {
+            anyhow::bail!("validator website field must be less than 70 characters")
+        }
+
+        if self.validator.name.len() > 140 {
+            anyhow::bail!("validator name must be less than 140 characters")
+        }
+
+        if self.validator.description.len() > 280 {
+            anyhow::bail!("validator description must be less than 280 characters")
+        }
+
+        // Then, we check the signature:
         let definition_bytes = self.validator.encode_to_vec();
         self.validator
             .identity_key

--- a/crates/core/component/stake/src/validator.rs
+++ b/crates/core/component/stake/src/validator.rs
@@ -39,12 +39,15 @@ pub struct Validator {
     pub consensus_key: tendermint::PublicKey,
 
     /// The validator's (human-readable) name.
+    /// Length: <= 140 characters.
     pub name: String,
 
     /// The validator's website URL.
+    /// Length: <= 70 characters.
     pub website: String,
 
     /// The validator's description.
+    /// Length: <= 280 characters.
     pub description: String,
 
     /// Whether the validator is enabled or not.


### PR DESCRIPTION
Close #2066, adds a 70, 140, and 280 characters limit on website/name/description respectively. 