### PR TITLE
Handle change note fees

### DIFF
--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -297,7 +297,6 @@ impl TxCmd {
 
                 let mut planner = Planner::new(OsRng);
 
-                println!("gas prices at time of tx plan: {:#?}", gas_prices);
                 planner.set_gas_prices(gas_prices);
                 for value in values.iter().cloned() {
                     planner.output(value, to);
@@ -312,7 +311,6 @@ impl TxCmd {
                     )
                     .await
                     .context("can't build send transaction")?;
-                println!("plan: {:?}", plan);
                 app.build_and_submit_transaction(plan).await?;
             }
             TxCmd::CommunityPoolDeposit { values, source } => {

--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -269,6 +269,7 @@ impl TxCmd {
             .gas_prices
             .expect("gas prices must be available")
             .try_into()?;
+        println!("current gas prices: {:#?}", gas_prices);
 
         match self {
             TxCmd::Send {

--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -296,6 +296,8 @@ impl TxCmd {
                     MemoPlaintext::new(return_address, memo.clone().unwrap_or_default())?;
 
                 let mut planner = Planner::new(OsRng);
+
+                println!("gas prices at time of tx plan: {:#?}", gas_prices);
                 planner.set_gas_prices(gas_prices);
                 for value in values.iter().cloned() {
                     planner.output(value, to);
@@ -310,6 +312,7 @@ impl TxCmd {
                     )
                     .await
                     .context("can't build send transaction")?;
+                println!("plan: {:?}", plan);
                 app.build_and_submit_transaction(plan).await?;
             }
             TxCmd::CommunityPoolDeposit { values, source } => {

--- a/crates/bin/pcli/src/command/tx/liquidity_position.rs
+++ b/crates/bin/pcli/src/command/tx/liquidity_position.rs
@@ -19,9 +19,6 @@ pub enum PositionCmd {
     Order(OrderCmd),
     /// Debits an all opened position NFTs associated with a specific source and credits closed position NFTs.
     CloseAll {
-        /// The transaction fee (paid in upenumbra).
-        #[clap(long, default_value = "0")]
-        fee: u64,
         /// Only spend funds originally received by the given address index.
         #[clap(long, default_value = "0")]
         source: u32,
@@ -31,9 +28,6 @@ pub enum PositionCmd {
     },
     /// Debits an opened position NFT and credits a closed position NFT.
     Close {
-        /// The transaction fee (paid in upenumbra).
-        #[clap(long, default_value = "0")]
-        fee: u64,
         /// Only spend funds originally received by the given address index.
         #[clap(long, default_value = "0")]
         source: u32,
@@ -42,9 +36,6 @@ pub enum PositionCmd {
     },
     /// Debits all closed position NFTs associated with a specific account and credits withdrawn position NFTs and the final reserves.
     WithdrawAll {
-        /// The transaction fee (paid in upenumbra).
-        #[clap(long, default_value = "0")]
-        fee: u64,
         /// Only spend funds originally received by the given address index.
         #[clap(long, default_value = "0")]
         source: u32,
@@ -54,9 +45,6 @@ pub enum PositionCmd {
     },
     /// Debits a closed position NFT and credits a withdrawn position NFT and the final reserves.
     Withdraw {
-        /// The transaction fee (paid in upenumbra).
-        #[clap(long, default_value = "0")]
-        fee: u64,
         /// Only spend funds originally received by the given address index.
         #[clap(long, default_value = "0")]
         source: u32,
@@ -95,9 +83,6 @@ pub enum OrderCmd {
         /// An optional suffix of the form `/10bps` may be added to specify a fee spread for the
         /// resulting position, though this is less useful for buy/sell orders than passive LPs.
         buy_order: String,
-        /// The transaction fee (paid in upenumbra).
-        #[clap(long, default_value = "0")]
-        fee: u64,
         /// Only spend funds originally received by the given address index.
         #[clap(long, default_value = "0")]
         source: u32,
@@ -112,9 +97,6 @@ pub enum OrderCmd {
         /// An optional suffix of the form `/10bps` may be added to specify a fee spread for the
         /// resulting position, though this is less useful for buy/sell orders than passive LPs.
         sell_order: String,
-        /// The transaction fee (paid in upenumbra).
-        #[clap(long, default_value = "0")]
-        fee: u64,
         /// Only spend funds originally received by the given address index.
         #[clap(long, default_value = "0")]
         source: u32,
@@ -125,13 +107,6 @@ pub enum OrderCmd {
 }
 
 impl OrderCmd {
-    pub fn fee(&self) -> u64 {
-        match self {
-            OrderCmd::Buy { fee, .. } => *fee,
-            OrderCmd::Sell { fee, .. } => *fee,
-        }
-    }
-
     pub fn source(&self) -> u32 {
         match self {
             OrderCmd::Buy { source, .. } => *source,

--- a/crates/bin/pcli/src/network.rs
+++ b/crates/bin/pcli/src/network.rs
@@ -36,7 +36,9 @@ impl App {
         let fee = gas_prices.price(&gas_cost);
         assert!(
             transaction.transaction_parameters().fee.amount() >= fee,
-            "paid fee must be greater than minimum fee"
+            "paid fee {} must be greater than minimum fee {}",
+            transaction.transaction_parameters().fee.amount(),
+            fee
         );
         self.submit_transaction(transaction).await
     }

--- a/crates/bin/pcli/src/network.rs
+++ b/crates/bin/pcli/src/network.rs
@@ -31,23 +31,9 @@ impl App {
             .gas_prices
             .expect("gas prices must be available")
             .try_into()?;
-        println!("tx plan gas cost: {:#?}", plan.gas_cost());
-        println!("plan required fee: {}", gas_prices.price(&plan.gas_cost()));
-        println!("actions in planned tx 2: {}", plan.actions.len());
-        println!(
-            "number of output actions in planned tx 2: {}",
-            plan.num_outputs()
-        );
-        println!(
-            "number of spend actions in planned tx 2: {}",
-            plan.num_spends()
-        );
         let transaction = self.build_transaction(plan).await?;
         let gas_cost = transaction.gas_cost();
-        println!("tx gas cost: {:#?}", gas_cost);
-        println!("gas prices at time of tx submission: {:#?}", gas_prices);
         let fee = gas_prices.price(&gas_cost);
-        println!("transaction required fee: {}", fee);
         assert!(
             transaction.transaction_parameters().fee.amount() >= fee,
             "paid fee must be greater than minimum fee"
@@ -60,7 +46,6 @@ impl App {
         plan: TransactionPlan,
     ) -> impl Future<Output = anyhow::Result<Transaction>> + '_ {
         println!("building transaction...");
-        println!("plan: {:#?}", plan);
         let start = std::time::Instant::now();
         let tx = penumbra_wallet::build_transaction(
             &self.config.full_viewing_key,

--- a/crates/bin/pcli/tests/network_integration.rs
+++ b/crates/bin/pcli/tests/network_integration.rs
@@ -543,7 +543,7 @@ fn lp_management() {
 /// Address 0 swaps 1gm for 1penumbra.
 /// Validate:
 /// Address 0 has 99gm and some penumbra.
-/// Address 1 has 1gm and 1000penumbra.
+/// Address 1 has 1gm and 999penumbra.
 fn swap() {
     let tmpdir = load_wallet_into_tmpdir();
 
@@ -596,8 +596,8 @@ fn swap() {
         )
         // Address 0 has some penumbra.
         .stdout(predicate::str::is_match(r"0\s*.*penumbra").unwrap())
-        // Address 1 has 1000penumbra.
-        .stdout(predicate::str::is_match(r"1\s*1000(\.[0-9]+)?penumbra").unwrap());
+        // Address 1 has 999penumbra.
+        .stdout(predicate::str::is_match(r"1\s*999(\.[0-9]+)?penumbra").unwrap());
 
     // Address 1: swaps 1gm for 1penumbra.
     let mut swap_cmd = Command::cargo_bin("pcli").unwrap();
@@ -635,8 +635,8 @@ fn swap() {
         )
         // Address 0 has some penumbra.
         .stdout(predicate::str::is_match(r"0\s*.*penumbra").unwrap())
-        // Address 1 has 1000penumbra.
-        .stdout(predicate::str::is_match(r"1\s*1000(\.[0-9]+)?penumbra").unwrap());
+        // Address 1 has 999penumbra.
+        .stdout(predicate::str::is_match(r"1\s*999(\.[0-9]+)?penumbra").unwrap());
 
     // Close and withdraw any existing liquidity positions.
     let mut close_cmd = Command::cargo_bin("pcli").unwrap();

--- a/crates/bin/pcli/tests/network_integration.rs
+++ b/crates/bin/pcli/tests/network_integration.rs
@@ -683,8 +683,8 @@ fn swap() {
         .stdout(predicate::str::is_match(r"1\s*1gm").unwrap())
         // Address 0 has some penumbra.
         .stdout(predicate::str::is_match(r"0\s*.*penumbra").unwrap())
-        // Address 1 has 1000penumbra.
-        .stdout(predicate::str::is_match(r"1\s*1000(\.[0-9]+)?penumbra").unwrap());
+        // Address 1 has 999penumbra.
+        .stdout(predicate::str::is_match(r"1\s*999(\.[0-9]+)?penumbra").unwrap());
 }
 
 // Note: As part of #2589, we changed the way DEX calculations are performed. In particular,

--- a/crates/core/app/src/action_handler/transaction/stateful.rs
+++ b/crates/core/app/src/action_handler/transaction/stateful.rs
@@ -84,6 +84,15 @@ pub(super) async fn fee_greater_than_base_fee<S: StateRead>(
     {
         Ok(())
     } else {
+        println!(
+            "paid transaction fee: {}",
+            transaction
+                .transaction_body()
+                .transaction_parameters
+                .fee
+                .amount()
+        );
+        println!("base price: {}", transaction_base_price);
         Err(anyhow::anyhow!(
             "consensus rule violated: paid transaction fee must be greater than or equal to transaction's base fee"
         ))

--- a/crates/core/app/src/action_handler/transaction/stateful.rs
+++ b/crates/core/app/src/action_handler/transaction/stateful.rs
@@ -84,15 +84,6 @@ pub(super) async fn fee_greater_than_base_fee<S: StateRead>(
     {
         Ok(())
     } else {
-        println!(
-            "paid transaction fee: {}",
-            transaction
-                .transaction_body()
-                .transaction_parameters
-                .fee
-                .amount()
-        );
-        println!("base price: {}", transaction_base_price);
         Err(anyhow::anyhow!(
             "consensus rule violated: paid transaction fee must be greater than or equal to transaction's base fee"
         ))

--- a/crates/core/component/fee/src/gas.rs
+++ b/crates/core/component/fee/src/gas.rs
@@ -67,10 +67,10 @@ impl GasPrices {
     /// denominator of 1,000 to the gas prices.
     pub fn price(&self, gas: &Gas) -> Amount {
         Amount::from(
-            self.block_space_price * gas.block_space / 1_000
-                + self.compact_block_space_price * gas.compact_block_space / 1_000
-                + self.verification_price * gas.verification / 1_000
-                + self.execution_price * gas.execution / 1_000,
+            self.block_space_price * (gas.block_space * 1_000) / 1_000
+                + self.compact_block_space_price * (gas.compact_block_space * 1_000) / 1_000
+                + self.verification_price * (gas.verification * 1_000) / 1_000
+                + self.execution_price * (gas.execution * 1_000) / 1_000,
         )
     }
 }

--- a/crates/core/component/fee/src/gas.rs
+++ b/crates/core/component/fee/src/gas.rs
@@ -6,6 +6,7 @@ use penumbra_proto::{core::component::fee::v1alpha1 as pb, DomainType};
 /// Represents the different resources that a transaction can consume,
 /// for purposes of calculating multidimensional fees based on real
 /// transaction resource consumption.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Gas {
     pub block_space: u64,
     pub compact_block_space: u64,

--- a/crates/core/component/fee/src/genesis.rs
+++ b/crates/core/component/fee/src/genesis.rs
@@ -48,10 +48,10 @@ impl Default for Content {
         Self {
             fee_params: FeeParameters::default(),
             gas_prices: GasPrices {
-                block_space_price: 0,
-                compact_block_space_price: 0,
-                verification_price: 0,
-                execution_price: 0,
+                block_space_price: 1,
+                compact_block_space_price: 2,
+                verification_price: 3,
+                execution_price: 4,
             },
         }
     }

--- a/crates/core/component/fee/src/genesis.rs
+++ b/crates/core/component/fee/src/genesis.rs
@@ -48,10 +48,10 @@ impl Default for Content {
         Self {
             fee_params: FeeParameters::default(),
             gas_prices: GasPrices {
-                block_space_price: 1,
-                compact_block_space_price: 2,
-                verification_price: 3,
-                execution_price: 4,
+                block_space_price: 3_000,
+                compact_block_space_price: 30_000,
+                verification_price: 1_000,
+                execution_price: 1_000,
             },
         }
     }

--- a/crates/core/component/fee/src/genesis.rs
+++ b/crates/core/component/fee/src/genesis.rs
@@ -48,10 +48,10 @@ impl Default for Content {
         Self {
             fee_params: FeeParameters::default(),
             gas_prices: GasPrices {
-                block_space_price: 3_000,
-                compact_block_space_price: 30_000,
-                verification_price: 1_000,
-                execution_price: 1_000,
+                block_space_price: 30,
+                compact_block_space_price: 300,
+                verification_price: 10,
+                execution_price: 10,
             },
         }
     }

--- a/crates/core/transaction/src/gas.rs
+++ b/crates/core/transaction/src/gas.rs
@@ -49,7 +49,7 @@ fn spend_gas_cost() -> Gas {
     }
 }
 
-fn output_gas_cost() -> Gas {
+pub fn output_gas_cost() -> Gas {
     Gas {
         // Each [`Action`] has a `0` `block_space` cost, since the [`Transaction`] itself
         // will use the encoded size of the complete transaction to calculate the block space.

--- a/crates/core/transaction/src/gas.rs
+++ b/crates/core/transaction/src/gas.rs
@@ -33,7 +33,7 @@ pub trait GasCost {
     fn gas_cost(&self) -> Gas;
 }
 
-fn spend_gas_cost() -> Gas {
+pub fn spend_gas_cost() -> Gas {
     Gas {
         // Each [`Action`] has a `0` `block_space` cost, since the [`Transaction`] itself
         // will use the encoded size of the complete transaction to calculate the block space.

--- a/crates/core/transaction/src/plan.rs
+++ b/crates/core/transaction/src/plan.rs
@@ -325,6 +325,11 @@ impl TransactionPlan {
         self.output_plans().count()
     }
 
+    /// Convenience method to get the number of `SpendPlan`s in this transaction.
+    pub fn num_spends(&self) -> usize {
+        self.spend_plans().count()
+    }
+
     /// Method to populate the detection data for this transaction plan.
     pub fn populate_detection_data<R: CryptoRng + Rng>(
         &mut self,

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -175,7 +175,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
         // copying the exact fees to the real transaction.
         let fee = Fee::from_staking_token_amount(minimum_fee * Amount::from(8u32));
         self.balance -= fee.0;
-        self.plan.transaction_parameters.fee = fee;
+        self.plan.transaction_parameters.fee = fee.clone();
         println!("Adding fee: {:?} to transaction", fee);
         self
     }

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -35,7 +35,7 @@ use penumbra_stake::{rate::RateData, validator};
 use penumbra_stake::{IdentityKey, UndelegateClaimPlan};
 use penumbra_tct as tct;
 use penumbra_transaction::{
-    gas::GasCost,
+    gas::{self, GasCost},
     memo::MemoPlaintext,
     plan::{ActionPlan, MemoPlan, TransactionPlan},
 };
@@ -162,13 +162,17 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     #[instrument(skip(self))]
     pub fn add_gas_fees(&mut self) -> &mut Self {
         let minimum_fee = self.gas_prices.price(&self.plan.gas_cost());
+        println!("minimum_fee: {:?}", minimum_fee);
 
         // Since paying the fee possibly requires adding an additional Spend to the
         // transaction, which would then change the fee calculation, we multiply the
-        // fee here by a factor of 2 and then recalculate and capture the excess as
+        // fee here by a factor of 16 and then recalculate and capture the excess as
         // change outputs.
-        let fee = Fee::from_staking_token_amount(minimum_fee * Amount::from(2u32));
-        self.balance += fee.0;
+        let fee = Fee::from_staking_token_amount(minimum_fee * Amount::from(64u32));
+        println!("fee: {:?}", fee);
+        println!("balance before fee: {:?}", self.balance);
+        self.balance -= fee.0;
+        println!("balance after fee: {:?}", self.balance);
         self.plan.transaction_parameters.fee = fee;
         self
     }
@@ -179,8 +183,9 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     /// the view service when the plan is [`finish`](Planner::finish)ed.
     #[instrument(skip(self))]
     pub fn spend(&mut self, note: Note, position: tct::Position) -> &mut Self {
-        let spend = SpendPlan::new(&mut self.rng, note, position).into();
-        self.action(spend);
+        let spend: SpendPlan = SpendPlan::new(&mut self.rng, note, position).into();
+        println!("spend balance: {:?}", spend.balance());
+        self.action(penumbra_transaction::ActionPlan::Spend(spend));
         self
     }
 
@@ -589,9 +594,40 @@ impl<R: RngCore + CryptoRng> Planner<R> {
         // for the cost of any additional `Spend` actions necessary to pay the fee, we need
         // to now calculate the transaction's fee again and capture the excess as change
         // by subtracting the excess from the required value balance.
-        let tx_real_fee = self.gas_prices.price(&self.plan.gas_cost());
+        println!("tx_plan_gas_cost: {:?}", self.plan.gas_cost());
+        println!("actions in planned tx 1: {}", self.plan.actions.len());
+        println!(
+            "number of output actions in planned tx 1: {}",
+            self.plan.num_outputs()
+        );
+        println!(
+            "number of spend actions in planned tx 1: {}",
+            self.plan.num_spends()
+        );
+        let mut tx_real_fee = self.gas_prices.price(&self.plan.gas_cost());
+
+        // Since the excess fee paid will create an additional Output action, we need to
+        // account for the necessary fee for that action as well.
+        println!("fee prior to adding output price: {:?}", tx_real_fee);
+        tx_real_fee += self.gas_prices.price(&gas::output_gas_cost());
+
+        // For any remaining provided balance, add the necessary fee for collecting:
+        for value in self.balance.provided().collect::<Vec<_>>() {
+            tx_real_fee += self.gas_prices.price(&gas::output_gas_cost());
+        }
+
+        assert!(
+            tx_real_fee <= self.plan.transaction_parameters.fee.amount(),
+            "tx real fee must be less than planned fee"
+        );
+        println!("tx_real_fee: {:?}", tx_real_fee);
+        println!(
+            "planned fee: {:?}",
+            self.plan.transaction_parameters.fee.amount()
+        );
         let excess_fee_spent = self.plan.transaction_parameters.fee.amount() - tx_real_fee;
-        self.balance -= Value {
+        println!("excess fee spent: {:?}", excess_fee_spent);
+        self.balance += Value {
             amount: excess_fee_spent,
             asset_id: *STAKING_TOKEN_ASSET_ID,
         };

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -176,6 +176,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
         let fee = Fee::from_staking_token_amount(minimum_fee * Amount::from(8u32));
         self.balance -= fee.0;
         self.plan.transaction_parameters.fee = fee;
+        println!("Adding fee: {:?} to transaction", fee);
         self
     }
 
@@ -615,6 +616,10 @@ impl<R: RngCore + CryptoRng> Planner<R> {
             asset_id: *STAKING_TOKEN_ASSET_ID,
         };
         self.plan.transaction_parameters.fee = Fee::from_staking_token_amount(tx_real_fee);
+        println!(
+            "planning with fee: {:?}",
+            self.plan.transaction_parameters.fee
+        );
 
         // For any remaining provided balance, make a single change note for each
         for value in self.balance.provided().collect::<Vec<_>>() {

--- a/crates/view/src/service.rs
+++ b/crates/view/src/service.rs
@@ -407,6 +407,7 @@ impl ViewProtocolService for ViewService {
                 tonic::Status::internal(format!("could not get app params: {:#}", e))
             })?;
 
+        // TODO: handle gas costs here
         let mut planner = Planner::new(OsRng);
         planner
             .fee(

--- a/crates/wasm/src/planner.rs
+++ b/crates/wasm/src/planner.rs
@@ -513,7 +513,9 @@ impl<R: RngCore + CryptoRng> Planner<R> {
 
         assert!(
             tx_real_fee <= self.plan.transaction_parameters.fee.amount(),
-            "tx real fee must be less than planned fee"
+            "tx real fee {:?} must be less than planned fee {:?}",
+            tx_real_fee,
+            self.plan.transaction_parameters.fee.amount()
         );
         let excess_fee_spent = self.plan.transaction_parameters.fee.amount() - tx_real_fee;
         self.balance += Value {


### PR DESCRIPTION
This fixes some issues discovered when end-to-end testing fees in the extension and pcli.

* Fee signs were flipped
* Change notes were not properly accounted for

There are potential footguns in this implementation that are commented and should be addressed in a followup issue:

```rust
        // Since paying the fee possibly requires adding additional Spends and Outputs
        // to the transaction, which would then change the fee calculation, we multiply
        // the fee here by a factor of 8 and then recalculate and capture the excess as
        // change outputs.
        //
        // TODO: this is gross and depending on gas costs could make the gas overpayment
        // ridiculously large (so large that the account may not have notes available to cover it)
        // or too small. We may need a cyclical calculation of fees on the transaction plan,
        // or a "simulated" transaction plan with infinite assets to calculate fees on before
        // copying the exact fees to the real transaction.
        let fee = Fee::from_staking_token_amount(minimum_fee * Amount::from(8u32));
```