### PR TITLE
Set the value_name for the pclientd --view option

### DIFF
--- a/crates/bin/pclientd/src/lib.rs
+++ b/crates/bin/pclientd/src/lib.rs
@@ -85,7 +85,7 @@ pub enum Command {
     /// Generate configs for `pclientd` in view or custody mode.
     Init {
         /// If provided, initialize in view mode with the given full viewing key.
-        #[clap(long, display_order = 100)]
+        #[clap(long, display_order = 100, value_name = "FULL_VIEWING_KEY")]
         view: Option<String>,
         /// If provided, initialize in custody mode with the given seed phrase.
         ///


### PR DESCRIPTION
The `--help` docs are a bit unclear about what should be passed to the `--view` option. This change makes it clear that the argument should be a full viewing key.

## Before
```
$ cargo run --bin pclientd init --help
...
pclientd-init
Generate configs for `pclientd` in view or custody mode

USAGE:
    pclientd init [OPTIONS]

OPTIONS:
        --view <VIEW>
            If provided, initialize in view mode with the given full viewing key

        --custody <CUSTODY>
            If provided, initialize in custody mode with the given seed phrase.

            If the value '-' is provided, the seed phrase will be read from stdin.

        --bind-addr <BIND_ADDR>
            Sets the address to bind to to serve gRPC

            [default: 127.0.0.1:8081]

        --grpc-url <GRPC_URL>
            Sets the URL of the gRPC endpoint used to talk to pd

            [default: https://grpc.testnet.penumbra.zone]

    -h, --help
            Print help information
```

## After
```
$ cargo run --bin pclientd init --help
...
pclientd-init
Generate configs for `pclientd` in view or custody mode

USAGE:
    pclientd init [OPTIONS]

OPTIONS:
        --view <FULL_VIEWING_KEY>
            If provided, initialize in view mode with the given full viewing key

        --custody <CUSTODY>
            If provided, initialize in custody mode with the given seed phrase.

            If the value '-' is provided, the seed phrase will be read from stdin.

        --bind-addr <BIND_ADDR>
            Sets the address to bind to to serve gRPC

            [default: 127.0.0.1:8081]

        --grpc-url <GRPC_URL>
            Sets the URL of the gRPC endpoint used to talk to pd

            [default: https://grpc.testnet.penumbra.zone]

    -h, --help
            Print help information
```