### PR TITLE
ci: re-enable transaction sweep test

### DIFF
--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -345,15 +345,11 @@ impl TxCmd {
 
                 for (i, plan) in plans.into_iter().enumerate() {
                     println!("building sweep {i} of {num_plans}");
-                    let tx = app.build_transaction(plan).await?;
-                    app.submit_transaction_unconfirmed(tx).await?;
+                    app.build_and_submit_transaction(plan).await?;
                 }
                 if num_plans == 0 {
                     println!("finished sweeping");
                     break;
-                } else {
-                    println!("awaiting confirmations...");
-                    tokio::time::sleep(std::time::Duration::from_secs(6)).await;
                 }
             },
             TxCmd::Swap {

--- a/crates/bin/pcli/tests/network_integration.rs
+++ b/crates/bin/pcli/tests/network_integration.rs
@@ -217,18 +217,17 @@ fn transaction_send_from_addr_0_to_addr_1() {
         .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS));
 }
 
-// Temporarily disabling the sweep test, pending resolution of GH3621.
-// #[ignore]
-// #[test]
-//fn transaction_sweep() {
-//    let tmpdir = load_wallet_into_tmpdir();
-//
-//    let mut sweep_cmd = Command::cargo_bin("pcli").unwrap();
-//    sweep_cmd
-//        .args(["--home", tmpdir.path().to_str().unwrap(), "tx", "sweep"])
-//        .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS));
-//    sweep_cmd.assert().success();
-//}
+#[ignore]
+#[test]
+fn transaction_sweep() {
+    let tmpdir = load_wallet_into_tmpdir();
+
+    let mut sweep_cmd = Command::cargo_bin("pcli").unwrap();
+    sweep_cmd
+        .args(["--home", tmpdir.path().to_str().unwrap(), "tx", "sweep"])
+        .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS));
+    sweep_cmd.assert().success();
+}
 
 #[ignore]
 #[test]


### PR DESCRIPTION
  Turns out the spooky failure of the tx sweep integration test was just that sweeping was taking slightly longer, and `pcli tx sweep`was still using a naive sleep, rather than the more robust await-confirmation logic that we've built into the planner.
    
This reverts commit 5b4fb169266e5bd46052ae53a0d29321859a73a5.
    
Closes #3621.

