### PR TITLE
fee: fix regression in #3624

### DIFF
--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -381,7 +381,7 @@ impl TxCmd {
                 // part of the `SwapPlaintext`), we can't use the planner to estimate the fee and need to
                 // call the helper method directly.
                 let estimated_claim_fee = Fee::from_staking_token_amount(
-                    Amount::from(2u32) * gas_prices.price(&swap_claim_gas_cost()),
+                    Amount::from(2u32) * gas_prices.fee(&swap_claim_gas_cost()),
                 );
                 planner.swap(input, into.id(), estimated_claim_fee, claim_address)?;
 

--- a/crates/bin/pcli/src/network.rs
+++ b/crates/bin/pcli/src/network.rs
@@ -33,7 +33,7 @@ impl App {
             .try_into()?;
         let transaction = self.build_transaction(plan).await?;
         let gas_cost = transaction.gas_cost();
-        let fee = gas_prices.price(&gas_cost);
+        let fee = gas_prices.fee(&gas_cost);
         assert!(
             transaction.transaction_parameters().fee.amount() >= fee,
             "paid fee {} must be greater than minimum fee {}",

--- a/crates/core/app/src/action_handler/transaction/stateful.rs
+++ b/crates/core/app/src/action_handler/transaction/stateful.rs
@@ -73,7 +73,7 @@ pub(super) async fn fee_greater_than_base_fee<S: StateRead>(
         .await
         .expect("gas prices must be present in state");
 
-    let transaction_base_price = current_gas_prices.price(&transaction.gas_cost());
+    let transaction_base_price = current_gas_prices.fee(&transaction.gas_cost());
 
     if transaction
         .transaction_body()

--- a/crates/core/component/fee/src/gas.rs
+++ b/crates/core/component/fee/src/gas.rs
@@ -45,7 +45,11 @@ impl Sum for Gas {
 }
 
 /// Expresses the price of each unit of gas in terms of the staking token.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+///
+/// These prices have an implicit denominator of 1,000 relative to the base unit
+/// of the staking token, so gas price 1,000 times 1 unit of gas is 1 base unit
+/// of staking token.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub struct GasPrices {
     pub block_space_price: u64,
     pub compact_block_space_price: u64,
@@ -55,22 +59,16 @@ pub struct GasPrices {
 
 impl GasPrices {
     pub fn zero() -> Self {
-        Self {
-            block_space_price: 0,
-            compact_block_space_price: 0,
-            verification_price: 0,
-            execution_price: 0,
-        }
+        Self::default()
     }
 
-    /// Calculates the price based on given gas schedule. Applies an implicit
-    /// denominator of 1,000 to the gas prices.
-    pub fn price(&self, gas: &Gas) -> Amount {
+    /// Use these gas prices to calculate the fee for a given gas vector.
+    pub fn fee(&self, gas: &Gas) -> Amount {
         Amount::from(
-            self.block_space_price * (gas.block_space * 1_000) / 1_000
-                + self.compact_block_space_price * (gas.compact_block_space * 1_000) / 1_000
-                + self.verification_price * (gas.verification * 1_000) / 1_000
-                + self.execution_price * (gas.execution * 1_000) / 1_000,
+            self.block_space_price * gas.block_space / 1_000
+                + self.compact_block_space_price * gas.compact_block_space / 1_000
+                + self.verification_price * gas.verification / 1_000
+                + self.execution_price * gas.execution / 1_000,
         )
     }
 }

--- a/crates/core/component/fee/src/gas.rs
+++ b/crates/core/component/fee/src/gas.rs
@@ -65,10 +65,10 @@ impl GasPrices {
     /// Use these gas prices to calculate the fee for a given gas vector.
     pub fn fee(&self, gas: &Gas) -> Amount {
         Amount::from(
-            self.block_space_price * gas.block_space / 1_000
-                + self.compact_block_space_price * gas.compact_block_space / 1_000
-                + self.verification_price * gas.verification / 1_000
-                + self.execution_price * gas.execution / 1_000,
+            (self.block_space_price * gas.block_space) / 1_000
+                + (self.compact_block_space_price * gas.compact_block_space) / 1_000
+                + (self.verification_price * gas.verification) / 1_000
+                + (self.execution_price * gas.execution) / 1_000,
         )
     }
 }

--- a/crates/core/component/fee/src/genesis.rs
+++ b/crates/core/component/fee/src/genesis.rs
@@ -47,12 +47,7 @@ impl Default for Content {
     fn default() -> Self {
         Self {
             fee_params: FeeParameters::default(),
-            gas_prices: GasPrices {
-                block_space_price: 30,
-                compact_block_space_price: 300,
-                verification_price: 10,
-                execution_price: 10,
-            },
+            gas_prices: GasPrices::default(),
         }
     }
 }

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -164,7 +164,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
         // Add a single Spend + Output to the minimum fee to cover paying the fee
         let minimum_fee = self
             .gas_prices
-            .price(&(self.plan.gas_cost() + gas::output_gas_cost() + gas::spend_gas_cost()));
+            .fee(&(self.plan.gas_cost() + gas::output_gas_cost() + gas::spend_gas_cost()));
 
         // Since paying the fee possibly requires adding additional Spends and Outputs
         // to the transaction, which would then change the fee calculation, we multiply
@@ -598,15 +598,15 @@ impl<R: RngCore + CryptoRng> Planner<R> {
         // for the cost of any additional `Spend` and `Output` actions necessary to pay the fee,
         // we need to now calculate the transaction's fee again and capture the excess as change
         // by subtracting the excess from the required value balance.
-        let mut tx_real_fee = self.gas_prices.price(&self.plan.gas_cost());
+        let mut tx_real_fee = self.gas_prices.fee(&self.plan.gas_cost());
 
         // Since the excess fee paid will create an additional Output action, we need to
         // account for the necessary fee for that action as well.
-        tx_real_fee += self.gas_prices.price(&gas::output_gas_cost());
+        tx_real_fee += self.gas_prices.fee(&gas::output_gas_cost());
 
         // For any remaining provided balance, add the necessary fee for collecting:
         tx_real_fee += Amount::from(self.balance.provided().count() as u64)
-            * self.gas_prices.price(&gas::output_gas_cost());
+            * self.gas_prices.fee(&gas::output_gas_cost());
 
         assert!(
             tx_real_fee <= self.plan.transaction_parameters.fee.amount(),

--- a/crates/wasm/src/planner.rs
+++ b/crates/wasm/src/planner.rs
@@ -153,7 +153,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     ///
     /// This function should be called once.
     pub fn add_gas_fees(&mut self) -> &mut Self {
-        let minimum_fee = self.gas_prices.price(&self.plan.gas_cost());
+        let minimum_fee = self.gas_prices.fee(&self.plan.gas_cost());
 
         // Since paying the fee possibly requires adding an additional Spend to the
         // transaction, which would then change the fee calculation, we multiply the
@@ -501,15 +501,15 @@ impl<R: RngCore + CryptoRng> Planner<R> {
         // for the cost of any additional `Spend` and `Output` actions necessary to pay the fee,
         // we need to now calculate the transaction's fee again and capture the excess as change
         // by subtracting the excess from the required value balance.
-        let mut tx_real_fee = self.gas_prices.price(&self.plan.gas_cost());
+        let mut tx_real_fee = self.gas_prices.fee(&self.plan.gas_cost());
 
         // Since the excess fee paid will create an additional Output action, we need to
         // account for the necessary fee for that action as well.
-        tx_real_fee += self.gas_prices.price(&gas::output_gas_cost());
+        tx_real_fee += self.gas_prices.fee(&gas::output_gas_cost());
 
         // For any remaining provided balance, add the necessary fee for collecting:
         tx_real_fee += Amount::from(self.balance.provided().count() as u64)
-            * self.gas_prices.price(&gas::output_gas_cost());
+            * self.gas_prices.fee(&gas::output_gas_cost());
 
         assert!(
             tx_real_fee <= self.plan.transaction_parameters.fee.amount(),


### PR DESCRIPTION
In #3624, the default gas prices were changed to have nonzero values, in order to test client functionality with nonzero fees. However, we *don't* want to make this the default until we've ported all the client software over, and even then, we should make the gas price setting be part of the `AppParameter`s, rather than changing the default value. (We want the default value for `GasPrices` to align with the proto default value).