### PR TITLE
feat(pcli) default to phase 2 for ceremony

### DIFF
--- a/crates/bin/pcli/src/command/ceremony.rs
+++ b/crates/bin/pcli/src/command/ceremony.rs
@@ -80,12 +80,21 @@ async fn handle_bid(app: &mut App, to: Address, from: AddressIndex, bid: &str) -
 pub enum CeremonyCmd {
     /// Contribute to the ceremony
     Contribute {
-        #[clap(long)]
+        /// The phase of the summoning ceremony that's currently active. Must match that of the remote
+        /// coordinator.
+        #[clap(long, default_value = "2")]
         phase: u8,
+        /// The URL for the public coordination server.
         #[clap(long, default_value = "https://summoning.penumbra.zone")]
         coordinator_url: Url,
+        /// The Penumbra wallet address of the coordination server. Bids will be sent to this
+        /// address, so the coordinator can compute the contributor's place in the queue.
         #[clap(long)]
         coordinator_address: Address,
+        /// Amount to spend during bid. Must be specified typed values, e.g. '50penumbra'.
+        /// Only the 'penumbra' token is accepted for contributions. Bids are additive,
+        /// so if you're disconnected, you can bid '0penumbra' and your previous bids
+        /// will be still be counted when computing your place in the queue.
         #[clap(long)]
         bid: String,
     },


### PR DESCRIPTION
As plan to transition to phase 2 of the summoning ceremony along with the release of Testnet 65. Here we update the default value for `pcli ceremony contribute --phase` to be `2`, rather than a required arg. The summoning website already displays an explicit example command, and the value for "phase" is determined by the phase of the coordinator server, so no changes needed there.