### PR TITLE
chore: prune unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,18 +54,6 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
-dependencies = [
- "cfg-if",
- "cipher 0.3.0",
- "cpufeatures",
- "opaque-debug",
-]
-
-[[package]]
-name = "aes"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
@@ -2619,20 +2607,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "frost377"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb50dd922b56e36d8d6ab99d098757b8f9facb17d96da183692690203f6b4a"
-dependencies = [
- "anyhow",
- "ark-ff",
- "ark-poly",
- "blake2b_simd 0.5.11",
- "decaf377 0.4.0",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4698,7 +4672,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "url",
- "walkdir",
 ]
 
 [[package]]
@@ -4956,37 +4929,27 @@ dependencies = [
 name = "penumbra-asset"
 version = "0.64.1"
 dependencies = [
- "aes 0.8.3",
  "anyhow",
  "ark-ff",
- "ark-groth16",
  "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
- "ark-snark",
  "ark-std",
  "base64 0.20.0",
  "bech32",
  "blake2b_simd 0.5.11",
  "bytes",
- "chacha20poly1305",
  "decaf377 0.5.0",
  "decaf377-fmd",
- "decaf377-ka",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
- "f4jumble",
- "frost377",
  "hex",
- "hmac 0.12.1",
  "ibig",
  "num-bigint",
  "once_cell",
- "pbkdf2",
  "penumbra-num",
  "penumbra-proto",
- "penumbra-tct",
  "poseidon377",
  "proptest",
  "rand 0.8.5",
@@ -5050,21 +5013,14 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "bincode",
  "bytes",
  "cnidarium",
- "cnidarium-component",
  "decaf377 0.5.0",
  "hex",
  "ibc-types",
  "ics23",
  "once_cell",
- "penumbra-asset",
- "penumbra-keys",
- "penumbra-num",
  "penumbra-proto",
- "penumbra-tct",
- "penumbra-txhash",
  "serde",
  "sha2 0.9.9",
  "tendermint",
@@ -5244,11 +5200,9 @@ dependencies = [
  "async-trait",
  "cnidarium",
  "cnidarium-component",
- "penumbra-asset",
  "penumbra-chain",
  "penumbra-num",
  "penumbra-proto",
- "penumbra-shielded-pool",
  "serde",
  "tendermint",
  "tracing",
@@ -5279,7 +5233,6 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "bincode",
  "blake2b_simd 0.5.11",
  "bytes",
  "cnidarium",
@@ -5361,7 +5314,6 @@ dependencies = [
  "base64 0.20.0",
  "blake2b_simd 0.5.11",
  "cnidarium",
- "cnidarium-component",
  "hex",
  "ibc-proto",
  "ibc-types",
@@ -5372,7 +5324,6 @@ dependencies = [
  "pbjson-types",
  "penumbra-asset",
  "penumbra-chain",
- "penumbra-keys",
  "penumbra-num",
  "penumbra-proto",
  "penumbra-txhash",
@@ -5395,11 +5346,9 @@ dependencies = [
  "aes 0.8.3",
  "anyhow",
  "ark-ff",
- "ark-groth16",
  "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
- "ark-snark",
  "ark-std",
  "base64 0.20.0",
  "bech32",
@@ -5414,7 +5363,6 @@ dependencies = [
  "derivative",
  "ethnum",
  "f4jumble",
- "frost377",
  "hex",
  "hmac 0.12.1",
  "ibig",
@@ -5449,7 +5397,6 @@ dependencies = [
  "penumbra-chain",
  "penumbra-compact-block",
  "penumbra-proto",
- "reqwest",
  "serde_json",
  "tokio",
  "tonic",
@@ -5462,7 +5409,6 @@ dependencies = [
 name = "penumbra-num"
 version = "0.64.1"
 dependencies = [
- "aes 0.8.3",
  "anyhow",
  "ark-ff",
  "ark-groth16",
@@ -5475,24 +5421,16 @@ dependencies = [
  "bech32",
  "blake2b_simd 0.5.11",
  "bytes",
- "chacha20poly1305",
  "decaf377 0.5.0",
  "decaf377-fmd",
- "decaf377-ka",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
- "f4jumble",
- "frost377",
  "hex",
- "hmac 0.12.1",
  "ibig",
  "num-bigint",
  "once_cell",
- "pbkdf2",
  "penumbra-proto",
- "penumbra-tct",
- "poseidon377",
  "proptest",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -5518,11 +5456,7 @@ dependencies = [
  "ark-snark",
  "ark-std",
  "bech32",
- "criterion 0.4.0",
  "decaf377 0.5.0",
- "decaf377-fmd",
- "decaf377-ka",
- "decaf377-rdsa",
  "hex",
  "lazy_static",
  "num-bigint",
@@ -5570,7 +5504,6 @@ name = "penumbra-proto"
 version = "0.64.1"
 dependencies = [
  "anyhow",
- "async-stream 0.2.1",
  "async-trait",
  "bech32",
  "bytes",
@@ -5608,7 +5541,6 @@ dependencies = [
  "blake2b_simd 0.5.11",
  "bytes",
  "cnidarium",
- "cnidarium-component",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "hex",
@@ -5771,7 +5703,6 @@ dependencies = [
  "penumbra-tct",
  "proptest",
  "proptest-derive",
- "static_assertions",
  "tokio",
 ]
 
@@ -5861,7 +5792,6 @@ dependencies = [
 name = "penumbra-transaction"
 version = "0.64.1"
 dependencies = [
- "aes 0.7.5",
  "anyhow",
  "ark-ff",
  "ark-serialize",
@@ -5870,7 +5800,6 @@ dependencies = [
  "blake2b_simd 0.5.11",
  "bytes",
  "chacha20poly1305",
- "clap 3.2.25",
  "decaf377 0.5.0",
  "decaf377-fmd",
  "decaf377-ka",
@@ -5910,7 +5839,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -5935,7 +5863,6 @@ dependencies = [
  "async-trait",
  "bytes",
  "camino",
- "clap 3.2.25",
  "decaf377 0.5.0",
  "digest 0.9.0",
  "ed25519-consensus",
@@ -6013,7 +5940,6 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "serde_with 1.14.0",
  "tokio",
  "tonic",
  "tower",
@@ -7882,7 +7808,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tonic-web",
  "tower",
  "tracing",
  "tracing-subscriber 0.3.18",

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -45,7 +45,7 @@ penumbra-dex = { path = "../../core/component/dex", default-features = false }
 penumbra-community-pool = { path = "../../core/component/community-pool", default-features = false }
 penumbra-ibc = { path = "../../core/component/ibc", default-features = false }
 penumbra-compact-block = { path = "../../core/component/compact-block", default-features = false }
-penumbra-transaction = { path = "../../core/transaction", features = ["clap"] }
+penumbra-transaction = { path = "../../core/transaction" }
 penumbra-proof-setup = { path = "../../crypto/proof-setup" }
 penumbra-app = { path = "../../core/app" }
 penumbra-wallet = { path = "../../wallet" }
@@ -100,7 +100,6 @@ camino = "1"
 url = { version = "2", features = ["serde"] }
 colored_json = "2.1"
 toml = { version = "0.7", features = ["preserve_order"] }
-walkdir = "2"
 once_cell = "1"
 ndarray = "0.15.6"
 dialoguer = "0.10.4"

--- a/crates/core/asset/Cargo.toml
+++ b/crates/core/asset/Cargo.toml
@@ -7,17 +7,14 @@ edition = "2021"
 
 [dependencies]
 # Workspace deps
-decaf377-ka = { path = "../../crypto/decaf377-ka/" }
 decaf377-fmd = { path = "../../crypto/decaf377-fmd/" }
 penumbra-num = { path = "../num/" }
 penumbra-proto = { path = "../../proto/" }
-penumbra-tct = { path = "../../crypto/tct/", features = ["r1cs"] }
 
 # Git deps
 decaf377 = {version = "0.5", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.7" }
 poseidon377 = { version = "0.6", features = ["r1cs"] }
-f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps
 base64 = "0.20"
@@ -27,13 +24,11 @@ ark-serialize = "0.4"
 regex = "1.5"
 sha2 = "0.10.1"
 bech32 = "0.8.1"
-aes = "0.8.1"
 anyhow = "1"
 thiserror = "1"
 bytes = "1"
 derivative = "2.2"
 hex = "0.4"
-hmac = "0.12.0"
 # Not enabling js feature for getrandom, which is a transitive dep of rand_core,
 # because the docs recommend against doing it in libraries: https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 # Downstream client projects can modify their Cargo.toml files to enable it.
@@ -41,26 +36,21 @@ hmac = "0.12.0"
 blake2b_simd = "0.5"
 serde = { version = "1", features = ["derive"] }
 once_cell = "1.8"
-pbkdf2 = "0.12.0"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand = "0.8"
-chacha20poly1305 = "0.9.0"
 ethnum = "1.3"
 # temporary -- only used for division
 ibig = "0.3"
 # only needed because ark-ff doesn't display correctly
 num-bigint = "0.4"
 tracing = "0.1"
-ark-groth16 = {version = "0.4", default-features = false}
-ark-snark = "0.4"
 ark-r1cs-std = {version = "0.4", default-features = false }
 ark-relations = "0.4"
 
 [dev-dependencies]
 proptest = "1"
 serde_json = "1"
-frost377 = { version = "0.2", default-features=false }
 
 [features]
 default = []
-parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "poseidon377/parallel", "decaf377-rdsa/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel", "frost377/parallel"]
+parallel = ["ark-ff/parallel", "poseidon377/parallel", "decaf377-rdsa/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]

--- a/crates/core/component/chain/Cargo.toml
+++ b/crates/core/component/chain/Cargo.toml
@@ -6,13 +6,7 @@ edition = "2021"
 [dependencies]
 # Workspace dependencies
 cnidarium = { path = "../../../cnidarium", optional = true }
-cnidarium-component = { path = "../../../cnidarium-component", optional = true }
-penumbra-asset = { path = "../../../core/asset", default-features = false }
 penumbra-proto = { path = "../../../proto", default-features = false }
-penumbra-tct = { path = "../../../crypto/tct" }
-penumbra-keys = { path = "../../../core/keys", default-features = false }
-penumbra-txhash = { path = "../../../core/txhash", default-features = false }
-penumbra-num = { path = "../../../core/num", default-features = false }
 
 # Penumbra dependencies
 decaf377 = "0.5"
@@ -24,7 +18,6 @@ ics23 = "0.11.0"
 # Crates.io deps
 ark-ff = { version = "0.4", default_features = false }
 anyhow = "1"
-bincode = "1.3.3"
 bytes = "1"
 hex = "0.4"
 once_cell = "1.8"
@@ -39,7 +32,6 @@ tokio = { version = "1", optional = true }
 
 [features]
 component = [
-    "cnidarium-component",
     "cnidarium",
     "penumbra-proto/cnidarium",
     "penumbra-proto/rpc",

--- a/crates/core/component/distributions/Cargo.toml
+++ b/crates/core/component/distributions/Cargo.toml
@@ -11,7 +11,6 @@ component = [
     "cnidarium",
     "penumbra-proto/cnidarium",
     "penumbra-chain/component",
-    "penumbra-shielded-pool/component",
 ]
 default = ["component"]
 docsrs = []
@@ -19,12 +18,10 @@ docsrs = []
 [dependencies]
 
 # Workspace dependencies
-penumbra-asset = { path = "../../asset" }
 cnidarium-component = { path = "../../../cnidarium-component", optional = true }
 penumbra-chain = { path = "../chain", default-features = false }
 penumbra-num = { path = "../../../core/num", default-features = false }
 penumbra-proto = { path = "../../../proto", default-features = false }
-penumbra-shielded-pool = { path = "../shielded-pool", default-features = false }
 cnidarium = { path = "../../../cnidarium", optional = true }
 
 # Crates.io deps

--- a/crates/core/component/fee/Cargo.toml
+++ b/crates/core/component/fee/Cargo.toml
@@ -35,4 +35,3 @@ blake2b_simd = "0.5"
 bytes = "1"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand = "0.8"
-bincode = "1.3.3"

--- a/crates/core/component/ibc/Cargo.toml
+++ b/crates/core/component/ibc/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [features]
 component = [
     "cnidarium",
-    "cnidarium-component",
     "penumbra-proto/cnidarium",
     "penumbra-chain/component",
 ]
@@ -21,11 +20,9 @@ rpc = ["dep:tonic", "ibc-proto/client", "ibc-proto/server"]
 # Workspace dependencies
 penumbra-proto = { path = "../../../proto", default-features = false }
 cnidarium = { path = "../../../cnidarium", optional = true }
-cnidarium-component = { path = "../../../cnidarium-component", optional = true }
 penumbra-chain = { path = "../chain", default-features = false }
 penumbra-asset = { path = "../../../core/asset", default-features = false }
 penumbra-num = { path = "../../../core/num", default-features = false }
-penumbra-keys = { path = "../../../core/keys", default-features = false }
 penumbra-txhash = { path = "../../../core/txhash", default-features = false }
 
 # Penumbra dependencies

--- a/crates/core/component/sct/Cargo.toml
+++ b/crates/core/component/sct/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 
 [features]
 component = [
-    "cnidarium-component",
     "cnidarium",
     "penumbra-proto/cnidarium",
     "penumbra-chain/component",
@@ -21,7 +20,6 @@ docsrs = []
 [dependencies]
 # Workspace dependencies
 cnidarium = { path = "../../../cnidarium", optional = true }
-cnidarium-component = { path = "../../../cnidarium-component", optional = true }
 penumbra-proto = { path = "../../../proto", default-features = false }
 penumbra-tct = { path = "../../../crypto/tct" }
 penumbra-chain = { path = "../chain", default-features = false }

--- a/crates/core/keys/Cargo.toml
+++ b/crates/core/keys/Cargo.toml
@@ -52,17 +52,14 @@ ibig = "0.3"
 # only needed because ark-ff doesn't display correctly
 num-bigint = "0.4"
 tracing = "0.1"
-ark-groth16 = {version = "0.4", default-features = false}
-ark-snark = "0.4"
 ark-r1cs-std = {version = "0.4", default-features = false }
 ark-relations = "0.4"
 
 [dev-dependencies]
 proptest = "1"
 serde_json = "1"
-frost377 = { version = "0.2", default-features=false }
 num-traits = "0.2"
 
 [features]
 default = []
-parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "poseidon377/parallel", "decaf377-rdsa/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel", "frost377/parallel"]
+parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "poseidon377/parallel", "decaf377-rdsa/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]

--- a/crates/core/num/Cargo.toml
+++ b/crates/core/num/Cargo.toml
@@ -7,16 +7,12 @@ edition = "2021"
 
 [dependencies]
 # Workspace deps
-decaf377-ka = { path = "../../crypto/decaf377-ka/" }
 decaf377-fmd = { path = "../../crypto/decaf377-fmd/" }
 penumbra-proto = { path = "../../proto/" }
-penumbra-tct = { path = "../../crypto/tct/", features = ["r1cs"] }
 
 # Git deps
 decaf377 = {version = "0.5", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.7" }
-poseidon377 = { version = "0.6", features = ["r1cs"] }
-f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
 
 # Crates.io deps
 base64 = "0.20"
@@ -26,13 +22,11 @@ ark-serialize = "0.4"
 regex = "1.5"
 sha2 = "0.10.1"
 bech32 = "0.8.1"
-aes = "0.8.1"
 anyhow = "1"
 thiserror = "1"
 bytes = "1"
 derivative = "2.2"
 hex = "0.4"
-hmac = "0.12.0"
 # Not enabling js feature for getrandom, which is a transitive dep of rand_core,
 # because the docs recommend against doing it in libraries: https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 # Downstream client projects can modify their Cargo.toml files to enable it.
@@ -40,10 +34,8 @@ hmac = "0.12.0"
 blake2b_simd = "0.5"
 serde = { version = "1", features = ["derive"] }
 once_cell = "1.8"
-pbkdf2 = "0.12.0"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand = "0.8"
-chacha20poly1305 = "0.9.0"
 ethnum = "1.3"
 # temporary -- only used for division
 ibig = "0.3"
@@ -58,8 +50,7 @@ ark-relations = "0.4"
 [dev-dependencies]
 proptest = "1"
 serde_json = "1"
-frost377 = { version = "0.2", default-features=false }
 
 [features]
 default = []
-parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "poseidon377/parallel", "decaf377-rdsa/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel", "frost377/parallel"]
+parallel = ["ark-ff/parallel", "decaf377-rdsa/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -38,7 +38,6 @@ ark-serialize = "0.4"
 regex = "1.5"
 sha2 = "0.9"
 bech32 = "0.8.1"
-aes = "0.7"
 anyhow = "1"
 thiserror = "1"
 bytes = "1"
@@ -56,8 +55,6 @@ num-bigint = "0.4"
 serde_json = "1"
 tracing = "0.1"
 tokio = { version = "1.21.1", features = ["full"], optional = true }
-clap = { version = "3", features = ["derive"], optional = true }
-wasm-bindgen-test = "0.3.37"
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/crypto/proof-params/Cargo.toml
+++ b/crates/crypto/proof-params/Cargo.toml
@@ -30,12 +30,6 @@ sha2 = "0.10.1"
 bech32 = "0.8.1"
 lazy_static = "1.4.0"
 
-[dev-dependencies]
-criterion = { version = "0.4", features = ["html_reports"] }
-decaf377-fmd = { path = "../decaf377-fmd/" }
-decaf377-ka = { path = "../decaf377-ka/" }
-decaf377-rdsa = "0.7"
-
 [build-dependencies]
 regex = { version = "1", optional = true }
 reqwest = { version = "0.11.14", optional = true, features = [

--- a/crates/misc/measure/Cargo.toml
+++ b/crates/misc/measure/Cargo.toml
@@ -19,7 +19,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2.2"
 indicatif = "0.16"
-reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1"
 bytesize = "1.2"
 

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -21,7 +21,6 @@ cnidarium = { path = "../cnidarium", optional = true }
 ibc-types = { version = "0.11.0", features = ["std"] }
 pin-project = "1"
 async-trait = "0.1.52"
-async-stream = "0.2.0"
 tracing = "0.1"
 futures = "0.3"
 pbjson = "0.6"

--- a/crates/test/tct-property-test/Cargo.toml
+++ b/crates/test/tct-property-test/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 penumbra-tct = { path = "../../crypto/tct", features = ["arbitrary"] }
 
 anyhow = "1"
-static_assertions = "1"
 proptest = "1"
 proptest-derive = "0.3"
 tokio = { version = "1.21.1", features = ["full"] }

--- a/crates/view/Cargo.toml
+++ b/crates/view/Cargo.toml
@@ -61,7 +61,6 @@ hex = "0.4"
 metrics = "0.19.0"
 async-stream = "0.2"
 parking_lot = "0.12"
-clap = { version = "3", features = ["derive"] }
 camino = "1"
 async-trait = "0.1"
 tendermint = "0.34.0"

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -40,7 +40,6 @@ tracing = "0.1"
 pin-project = "1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-serde_with = { version = "1.11", features = ["hex"] }
 anyhow = "1"
 hex = "0.4"
 rand_core = { version = "0.6.3", features = ["getrandom"] }

--- a/tools/summonerd/Cargo.toml
+++ b/tools/summonerd/Cargo.toml
@@ -44,7 +44,6 @@ rand_core = "0.6.4"
 tokio = { version = "1.22", features = ["full"] }
 tokio-stream = "0.1"
 tonic = "0.10"
-tonic-web = "0.10"
 tower = "0.4"
 tracing = "0.1"
 tracing-subscriber = "0.3"


### PR DESCRIPTION
The command used to generate the list of unused deps was:

  cargo +nightly udeps --all-targets --all-features --workspace

Trimmed things back accordingly, including some light feature pruning.