### PR TITLE
fix(wallet): update non-parallel tx building

### DIFF
--- a/crates/wallet/src/build.rs
+++ b/crates/wallet/src/build.rs
@@ -32,8 +32,7 @@ where
     // ... and then build the transaction:
     #[cfg(not(feature = "parallel"))]
     {
-        let unauth_tx = plan.build(fvk, witness_data)?;
-        let tx = unauth_tx.authorize(&mut rng, &auth_data)?;
+        let tx = plan.build(fvk, &witness_data, &auth_data)?;
         return Ok(tx);
     }
 


### PR DESCRIPTION
This change was necessary in order to build `penumbra-wallet` directly, e.g. via `cargo build -p penumbra-wallet -r`. After this change, the entire workspace can be built across all feature combinations. Verify this with:

    cargo check-all-features --workspace --all-targets

That command will take ~30m wall time, depending on specs, and somewhere between 50-100GB on disk. We don't run this task in CI, see #2210 for context.