### PR TITLE
ci: fix ingress svc name

### DIFF
--- a/deployments/charts/penumbra-node/templates/ingressroute.yaml
+++ b/deployments/charts/penumbra-node/templates/ingressroute.yaml
@@ -26,8 +26,8 @@ Otherwise, RPC can return surprising results, like very low numbers of peers.
 {{- $seed_mode := (index $.Values.nodes $i).seed_mode | default false }}
 {{- if $seed_mode }}
 {{- else }}
-{{ $fn_name := printf "%s-%d" $.Release.Name $i }}
-    - name: {{ $fn_name }}
+{{ $rpc_svc_name := printf "%s-fn-%d" $.Release.Name $i }}
+    - name: {{ $rpc_svc_name }}
       port: 8080
       scheme: h2c
 {{- end }}
@@ -39,8 +39,8 @@ Otherwise, RPC can return surprising results, like very low numbers of peers.
 {{- $seed_mode := (index $.Values.nodes $i).seed_mode | default false }}
 {{- if $seed_mode }}
 {{- else }}
-{{ $fn_name := printf "%s-%d" $.Release.Name $i }}
-    - name: {{ $fn_name }}
+{{ $rpc_svc_name := printf "%s-fn-%d" $.Release.Name $i }}
+    - name: {{ $rpc_svc_name }}
       port: 26657
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Follow-up to 1d688c2d1ebc18fab4cf2172d9078513e05be37b, observed post-deploy that the public HTTPS endpoints weren't responding. We're preserving the old service names for convenience's sake, so let's reuse them throughout.

Other than this fix, the only manual interaction required for the preview deployment to heal after the rewrite was to remove the `app=` selector label from each p2p lb. Will do that manually on testnet when the time comes, as well.