### PR TITLE
🩹 pd: fix auto-https default grpc address

### DIFF
--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -286,7 +286,7 @@ async fn main() -> anyhow::Result<()> {
             // Unpack grpc bind option, defaulting to localhost, but setting 0.0.0.0:443
             // if auto https is enabled. We unpack the option outside of the conditional
             // below, in order to report the bind address in error handling.
-            let grpc_bind = if grpc_bind.is_some() {
+            let grpc_bind = if grpc_auto_https.is_some() {
                 grpc_bind.unwrap_or(
                     "0.0.0.0:443"
                         .parse()

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -1,12 +1,11 @@
 #![allow(clippy::clone_on_copy)]
 #![deny(clippy::unwrap_used)]
 #![recursion_limit = "512"]
-use std::{net::SocketAddr, path::PathBuf};
+use std::{error::Error, net::SocketAddr, path::PathBuf};
 
 use console_subscriber::ConsoleLayer;
 use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 use metrics_util::layers::Stack;
-use std::error::Error;
 
 use anyhow::Context;
 use clap::{Parser, Subcommand};


### PR DESCRIPTION
while working on #3627, i found that a conditional hinges on the wrong option.

this changes pd to follow what the comments and documentation state as the
intent of this code: change the default grpc address based on whether we
have an auto-managed https domain.

a second commit refactors the control flow for the default address. the `parse`
calls only refer to hardcoded values defined in the source. let's define our
defaults as constants, so that we do not have error-handling logic that only
refers to what ought to be known-good addresses.