### PR TITLE
staking: validator state transition fix

### DIFF
--- a/crates/core/component/stake/src/action_handler/undelegate_claim.rs
+++ b/crates/core/component/stake/src/action_handler/undelegate_claim.rs
@@ -31,9 +31,7 @@ impl ActionHandler for UndelegateClaim {
 
     async fn check_stateful<S: StateRead + 'static>(&self, state: Arc<S>) -> Result<()> {
         // We need to check two things:
-
         // 1. That we're past the specified unbonding end epoch.
-
         let current_epoch = state.epoch().await?;
         let end_epoch_index = state
             .unbonding_end_epoch_for(&self.body.validator_identity, self.body.start_epoch_index)

--- a/crates/core/component/stake/src/params.rs
+++ b/crates/core/component/stake/src/params.rs
@@ -69,7 +69,7 @@ impl Default for StakeParameters {
         Self {
             unbonding_epochs: 2,
             active_validator_limit: 80,
-            // copied from cosmos hub
+            // Copied from cosmos hub
             signed_blocks_window_len: 10000,
             missed_blocks_maximum: 9500,
             // 1000 basis points = 10%


### PR DESCRIPTION
This PR fixes an issue with a missing transition (`Active` -> `Defined`) and adds context for each transition case. With that said, writing this code makes me think that we might be better off by limiting the amount of possible transitions, removing `Active -> Defined` and `Jailed -> Defined` transition, and use end-epoch processing to "sweep" inactive validators into the precursor `Defined` state.

Since I am in the middle of an assurance blitz for #3640, I will abstain from making more changes. But this is currently top-of-mind for me. Moreover, manual testing seems to surface issues with Unbonded/Unbonding (observed on `v0.64.0` as well) so I plan to look into that as well. 