### PR TITLE
docs: update ibc channel for testnet 64

### DIFF
--- a/docs/guide/src/pcli/transaction.md
+++ b/docs/guide/src/pcli/transaction.md
@@ -195,18 +195,18 @@ during setup.
   "ordering": 1,
   "counterparty": {
     "port_id": "transfer",
-    "channel_id": "channel-4687"
+    "channel_id": "channel-5077"
   },
   "connection_hops": [
-    "connection-1"
+    "connection-6"
   ],
   "version": "ics20-1",
   "port_id": "transfer",
-  "channel_id": "channel-1"
+  "channel_id": "channel-2"
 }
 ```
 
-The output above shows that the IBC channel id on Penumbra is 0, and on Osmosis it's 4544.
+The output above shows that the IBC channel id on Penumbra is 2, and on Osmosis it's 5077.
 There's one more piece of information we need to make an IBC withdrawal: the appropriate IBC
 timeout height, which is composed of two values: `<counterparty_chain_id_revision>-<counterparty_chain_block_height>`.
 For the Osmosis testnet, as of 2023Q4, the chain id is `osmo-test-5`, meaning the chain id revision is `5`.


### PR DESCRIPTION
Hermes stopped relaying. One problem is that we needed to raise the gas limits, the diff for which in the Hermes config.toml looks like:

```diff
-gas_price = { price = 0.0026, denom = 'uosmo' }
+gas_price = { price = 0.2, denom = 'uosmo' }
 gas_multiplier = 1.1
 clock_drift = '20s'
+max_gas = 900000
```

Hermes is up and running on this new info.