### PR TITLE
ci: improve smoke test logging

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -30,5 +30,22 @@ jobs:
         run: |
           export PATH="$HOME/bin:$PATH"
           ./deployments/scripts/smoke-test.sh
+
+       - name: Display comet logs
+         if: always()
+         run: cat comet.log
+
+       - name: Display pd logs
+         if: always()
+         run: cat pd.log
+
+       - name: Display pclientd logs
+         if: always()
+         run: cat pclientd.log
+
+       - name: Display pcli logs
+         if: always()
+         run: cat pcli.log
+
         env:
           TESTNET_RUNTIME: 2m

--- a/deployments/scripts/smoke-test.sh
+++ b/deployments/scripts/smoke-test.sh
@@ -27,7 +27,12 @@ if ! hash cometbft > /dev/null 2>&1 ; then
     exit 1
 fi
 
-export RUST_LOG="pclientd=debug,pcli=debug,pd=info,penumbra=info"
+# If the action is running in debugging mode, then show me *everything*
+if [ -n "$RUNNER_DEBUG" ]; then
+    export RUST_LOG=debug
+else
+    export RUST_LOG="info,network_integration=debug,pclientd=debug,pcli=info,pd=info,penumbra=info"
+fi
 
 # Duration that the network will be left running before script exits.
 TESTNET_RUNTIME="${TESTNET_RUNTIME:-120}"


### PR DESCRIPTION
This PR change the smoke test workflow to independently capture and display logs produced by `cometbft`, `pd`, and the `pcli`/`pclientd` integration tests. This makes it easy to visualize and isolate the source of a smoke test failure.

It also sets a baseline of `info` level debugging for tracing statements, and `debug` level for `network_integration` tests.

Finally, it offers the opportunity for users to run the integration tests with maximum logging level by detecting if debug mode is enabled for this action run (see screenshot).

<img width="659" alt="Screenshot 2024-01-24 at 11 37 50 AM" src="https://github.com/penumbra-zone/penumbra/assets/7871622/e18551e1-7006-4da0-baca-665a35c3c410">
