### PR TITLE
[wasm] Compute position_id

### DIFF
--- a/crates/wasm/src/dex.rs
+++ b/crates/wasm/src/dex.rs
@@ -1,0 +1,17 @@
+use crate::utils;
+use penumbra_dex::lp::position::Position;
+use serde_wasm_bindgen::Error;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::JsValue;
+
+/// compute position id
+/// Arguments:
+///     position: `Position`
+/// Returns: `PositionId`
+#[wasm_bindgen]
+pub fn compute_position_id(position: JsValue) -> Result<JsValue, Error> {
+    utils::set_panic_hook();
+
+    let position: Position = serde_wasm_bindgen::from_value(position)?;
+    serde_wasm_bindgen::to_value(&position.id())
+}

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate core;
 
 pub mod build;
-mod dex;
+pub mod dex;
 pub mod error;
 pub mod keys;
 pub mod note_record;

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate core;
 
 pub mod build;
+mod dex;
 pub mod error;
 pub mod keys;
 pub mod note_record;


### PR DESCRIPTION
Related to https://github.com/penumbra-zone/web/pull/367 
We need a function to compute `PositionId` since `PositionId` is not stored in `Position` (most likely to optimize on-chain storage). 
`PositionId` is needed as a unique position identifier and is also used to update `PositionState` ( see usage https://github.com/penumbra-zone/web/pull/367/files#diff-ccb0493c986b958cf859e773170457e5ff59a4a2e0d742698492247f6ae872da. )

discussion 
https://discord.com/channels/824484045370818580/938328380917559326/1199461586927112283
