### PR TITLE
distributions: add dep to `penumbra_asset`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5200,6 +5200,7 @@ dependencies = [
  "async-trait",
  "cnidarium",
  "cnidarium-component",
+ "penumbra-asset",
  "penumbra-chain",
  "penumbra-num",
  "penumbra-proto",

--- a/crates/core/component/distributions/Cargo.toml
+++ b/crates/core/component/distributions/Cargo.toml
@@ -20,7 +20,8 @@ docsrs = []
 # Workspace dependencies
 cnidarium-component = { path = "../../../cnidarium-component", optional = true }
 penumbra-chain = { path = "../chain", default-features = false }
-penumbra-num = { path = "../../../core/num", default-features = false }
+penumbra-asset = { path = "../../asset", default-features = false }
+penumbra-num = { path = "../../num", default-features = false }
 penumbra-proto = { path = "../../../proto", default-features = false }
 cnidarium = { path = "../../../cnidarium", optional = true }
 


### PR DESCRIPTION
Adds `penumbra-asset` to the distributions component deps. It's not totally clear why CI didn't catch that, I'll circle back when I'm done with more urgent tasks. 