### PR TITLE
Bump display limit to 50k in summoning ceremony

### DIFF
--- a/tools/summonerd/src/web.rs
+++ b/tools/summonerd/src/web.rs
@@ -13,7 +13,7 @@ use crate::{config::Config, PhaseMarker};
 use crate::{queue::ParticipantQueue, storage::Storage};
 
 /// The number of previous contributions to display
-const LAST_N: u64 = 10_000;
+const LAST_N: u64 = 50_000;
 
 /// Represents the storage used by the web application.
 pub struct WebAppState {


### PR DESCRIPTION
We've passed 10k, we'll never pass 50, seems alright