### PR TITLE
Add execution circuit breaker

### DIFF
--- a/crates/core/component/dex/src/circuit_breaker/execution.rs
+++ b/crates/core/component/dex/src/circuit_breaker/execution.rs
@@ -1,0 +1,36 @@
+const MAX_PATH_SEARCHES: u32 = 64;
+const MAX_EXECUTIONS: u32 = 64;
+
+/// Holds the state of the execution circuit breaker.
+/// Responsible for managing the conditions of halting execution of
+/// a single batch swap. All execution circuit breaker triggers are
+/// non-fatal and will allow the swap to be partially fulfilled up
+/// to the search and execution limits managed by the circuit breaker.
+///
+/// The circuit breaker ensures the swap will not use unbounded time complexity.
+struct ExecutionCircuitBreaker {
+    /// The maximum number of times to perform path searches before stopping.
+    pub max_path_searches: u32,
+    /// The number of times path searches have been performed.
+    pub current_path_searches: u32,
+    /// The maximum number of times to execute against liquidity positions before stopping.
+    pub max_executions: u32,
+    /// The number of times liquidity positions have been executed against.
+    pub current_executions: u32,
+}
+
+impl ExecutionCircuitBreaker {
+    pub fn new() -> Self {
+        Self {
+            max_path_searches: MAX_PATH_SEARCHES,
+            current_path_searches: 0,
+            max_executions: MAX_EXECUTIONS,
+            current_executions: 0,
+        }
+    }
+
+    pub fn exceeded_limits(&self) -> bool {
+        self.current_path_searches > self.max_path_searches
+            || self.current_executions > self.max_executions
+    }
+}

--- a/crates/core/component/dex/src/circuit_breaker/execution.rs
+++ b/crates/core/component/dex/src/circuit_breaker/execution.rs
@@ -8,6 +8,7 @@ const MAX_EXECUTIONS: u32 = 64;
 /// to the search and execution limits managed by the circuit breaker.
 ///
 /// The circuit breaker ensures the swap will not use unbounded time complexity.
+#[derive(Debug, Clone)]
 pub(crate) struct ExecutionCircuitBreaker {
     /// The maximum number of times to perform path searches before stopping.
     pub max_path_searches: u32,
@@ -20,11 +21,11 @@ pub(crate) struct ExecutionCircuitBreaker {
 }
 
 impl ExecutionCircuitBreaker {
-    pub fn new() -> Self {
+    pub fn new(max_path_searches: u32, max_executions: u32) -> Self {
         Self {
-            max_path_searches: MAX_PATH_SEARCHES,
+            max_path_searches,
             current_path_searches: 0,
-            max_executions: MAX_EXECUTIONS,
+            max_executions,
             current_executions: 0,
         }
     }
@@ -32,5 +33,16 @@ impl ExecutionCircuitBreaker {
     pub fn exceeded_limits(&self) -> bool {
         self.current_path_searches > self.max_path_searches
             || self.current_executions > self.max_executions
+    }
+}
+
+impl Default for ExecutionCircuitBreaker {
+    fn default() -> Self {
+        Self {
+            max_path_searches: MAX_PATH_SEARCHES,
+            current_path_searches: 0,
+            max_executions: MAX_EXECUTIONS,
+            current_executions: 0,
+        }
     }
 }

--- a/crates/core/component/dex/src/circuit_breaker/execution.rs
+++ b/crates/core/component/dex/src/circuit_breaker/execution.rs
@@ -8,7 +8,7 @@ const MAX_EXECUTIONS: u32 = 64;
 /// to the search and execution limits managed by the circuit breaker.
 ///
 /// The circuit breaker ensures the swap will not use unbounded time complexity.
-struct ExecutionCircuitBreaker {
+pub(crate) struct ExecutionCircuitBreaker {
     /// The maximum number of times to perform path searches before stopping.
     pub max_path_searches: u32,
     /// The number of times path searches have been performed.

--- a/crates/core/component/dex/src/circuit_breaker/mod.rs
+++ b/crates/core/component/dex/src/circuit_breaker/mod.rs
@@ -1,0 +1,3 @@
+mod execution;
+
+pub(crate) use execution::ExecutionCircuitBreaker;

--- a/crates/core/component/dex/src/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/circuit_breaker/value.rs
@@ -1,0 +1,69 @@
+use std::collections::BTreeMap;
+
+use penumbra_asset::{asset, Value};
+use penumbra_num::Amount;
+use penumbra_proto::{core::component::dex::v1alpha1 as pb, DomainType, TypeUrl};
+
+#[derive(Debug, Clone, Default)]
+pub struct AssetTallies {
+    tallies: BTreeMap<asset::Id, Amount>,
+}
+
+impl AssetTallies {
+    pub fn tally(&mut self, value: Value) {
+        *self.tallies.entry(value.asset_id).or_default() += value.amount;
+    }
+}
+
+impl From<AssetTallies> for pb::AssetTallies {
+    fn from(inner: AssetTallies) -> Self {
+        pb::AssetTallies {
+            tallies: inner
+                .tallies
+                .iter()
+                .map(|(k, v)| pb::AssetTally {
+                    asset_id: Some(
+                        Into::<penumbra_proto::core::asset::v1alpha1::AssetId>::into(*k),
+                    ),
+                    amount: Some(Into::<penumbra_proto::core::num::v1alpha1::Amount>::into(
+                        *v,
+                    )),
+                })
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<pb::AssetTallies> for AssetTallies {
+    type Error = anyhow::Error;
+
+    fn try_from(value: pb::AssetTallies) -> Result<Self, Self::Error> {
+        Ok(Self {
+            tallies: value
+                .tallies
+                .iter()
+                .map(|pb_tally| {
+                    (
+                        // TODO: remove expects, return results
+                        pb_tally
+                            .asset_id
+                            .clone()
+                            .expect("asset ID should be present in tally")
+                            .try_into()
+                            .expect("invalid protobuf"),
+                        pb_tally
+                            .amount
+                            .clone()
+                            .expect("amount should be present in tally")
+                            .try_into()
+                            .expect("invalid protobuf"),
+                    )
+                })
+                .collect(),
+        })
+    }
+}
+
+impl DomainType for AssetTallies {
+    type Proto = pb::AssetTallies;
+}

--- a/crates/core/component/dex/src/component/arb.rs
+++ b/crates/core/component/dex/src/component/arb.rs
@@ -7,7 +7,7 @@ use penumbra_asset::{asset, Value};
 use penumbra_chain::component::StateReadExt;
 use tracing::instrument;
 
-use crate::SwapExecution;
+use crate::{ExecutionCircuitBreaker, SwapExecution};
 
 use super::{
     router::{RouteAndFill, RoutingParams},
@@ -50,8 +50,15 @@ pub trait Arbitrage: StateWrite + Sized {
             amount: u64::MAX.into(),
         };
 
+        let execution_circuit_breaker = ExecutionCircuitBreaker::default();
         let swap_execution = this
-            .route_and_fill(arb_token, arb_token, flash_loan.amount, params)
+            .route_and_fill(
+                arb_token,
+                arb_token,
+                flash_loan.amount,
+                params,
+                execution_circuit_breaker,
+            )
             .await?;
         let filled_input = swap_execution.input.amount;
         let output = swap_execution.output.amount;

--- a/crates/core/component/dex/src/component/router/path_search.rs
+++ b/crates/core/component/dex/src/component/router/path_search.rs
@@ -9,7 +9,7 @@ use penumbra_num::fixpoint::U128x128;
 use tokio::task::JoinSet;
 use tracing::{instrument, Instrument};
 
-use crate::component::PositionManager;
+use crate::{component::PositionManager, ExecutionCircuitBreaker};
 
 use super::{Path, PathCache, PathEntry, RoutingParams, SharedPathCache};
 
@@ -113,7 +113,6 @@ async fn relax_path<S: StateRead + 'static>(
     });
 
     let mut js = JoinSet::new();
-    // while let Some(new_end) = candidates {
 
     while let Some(new_end) = candidates.inner_mut().next().await {
         let new_path = path.fork();

--- a/crates/core/component/dex/src/component/router/path_search.rs
+++ b/crates/core/component/dex/src/component/router/path_search.rs
@@ -9,7 +9,7 @@ use penumbra_num::fixpoint::U128x128;
 use tokio::task::JoinSet;
 use tracing::{instrument, Instrument};
 
-use crate::{component::PositionManager, ExecutionCircuitBreaker};
+use crate::component::PositionManager;
 
 use super::{Path, PathCache, PathEntry, RoutingParams, SharedPathCache};
 

--- a/crates/core/component/dex/src/lib.rs
+++ b/crates/core/component/dex/src/lib.rs
@@ -7,10 +7,12 @@ pub mod event;
 pub mod state_key;
 
 mod batch_swap_output_data;
+mod circuit_breaker;
 mod swap_execution;
 mod trading_pair;
 
 pub use batch_swap_output_data::BatchSwapOutputData;
+pub(crate) use circuit_breaker::ExecutionCircuitBreaker;
 pub use swap_execution::SwapExecution;
 pub use trading_pair::{DirectedTradingPair, DirectedUnitPair, TradingPair, TradingPairVar};
 


### PR DESCRIPTION
This adds a circuit break mechanism to the DEX that bounds the maximum number of path searches and position executions for any given batch swap during a block, to prevent potentially unbounded looping.

Closes #3303 