### PR TITLE
Allow dead code for currently unused ExecutionCircuitBreaker constructor

### DIFF
--- a/crates/core/component/dex/src/circuit_breaker/execution.rs
+++ b/crates/core/component/dex/src/circuit_breaker/execution.rs
@@ -21,6 +21,7 @@ pub(crate) struct ExecutionCircuitBreaker {
 }
 
 impl ExecutionCircuitBreaker {
+    #[allow(dead_code)]
     pub fn new(max_path_searches: u32, max_executions: u32) -> Self {
         Self {
             max_path_searches,


### PR DESCRIPTION
The constructor may eventually be used by tests