### PR TITLE
smoke-test: 🐚 use `env` to find bash path

### DIFF
--- a/deployments/scripts/smoke-test.sh
+++ b/deployments/scripts/smoke-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wrapper script to bottle up logic for running "smoke tests" in CI,
 # supporting backgrounding tasks and checking on their status later.
 # The execution plan is:


### PR DESCRIPTION
this is a small cross-platform compatibility change needed to run the smoke tests locally on my machine.