### PR TITLE
Implement value circuit breaker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3659,6 +3659,7 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -4960,6 +4961,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_with 3.5.1",
  "sha2 0.10.8",
  "thiserror",
  "tracing",
@@ -7436,6 +7438,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c"
+dependencies = [
+ "base64 0.21.6",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.1.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros 3.5.1",
+ "time 0.3.19",
+]
+
+[[package]]
 name = "serde_with_macros"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7452,6 +7471,18 @@ name = "serde_with_macros"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2 1.0.76",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,6 +5150,7 @@ dependencies = [
  "async-stream 0.2.1",
  "async-trait",
  "base64 0.20.0",
+ "bincode",
  "blake2b_simd 0.5.11",
  "cnidarium",
  "cnidarium-component",

--- a/crates/core/asset/Cargo.toml
+++ b/crates/core/asset/Cargo.toml
@@ -12,7 +12,7 @@ penumbra-num = { path = "../num/" }
 penumbra-proto = { path = "../../proto/" }
 
 # Git deps
-decaf377 = {version = "0.5", features = ["r1cs"] }
+decaf377 = { version = "0.5", features = ["r1cs"] }
 decaf377-rdsa = { version = "0.7" }
 poseidon377 = { version = "0.6", features = ["r1cs"] }
 
@@ -35,6 +35,7 @@ hex = "0.4"
 # getrandom = { version = "0.2", features = ["js"] }
 blake2b_simd = "0.5"
 serde = { version = "1", features = ["derive"] }
+serde_with = "3.5.1"
 once_cell = "1.8"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
 rand = "0.8"
@@ -44,7 +45,7 @@ ibig = "0.3"
 # only needed because ark-ff doesn't display correctly
 num-bigint = "0.4"
 tracing = "0.1"
-ark-r1cs-std = {version = "0.4", default-features = false }
+ark-r1cs-std = { version = "0.4", default-features = false }
 ark-relations = "0.4"
 
 [dev-dependencies]
@@ -53,4 +54,11 @@ serde_json = "1"
 
 [features]
 default = []
-parallel = ["ark-ff/parallel", "poseidon377/parallel", "decaf377-rdsa/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]
+parallel = [
+    "ark-ff/parallel",
+    "poseidon377/parallel",
+    "decaf377-rdsa/parallel",
+    "ark-std/parallel",
+    "ark-r1cs-std/parallel",
+    "decaf377/parallel",
+]

--- a/crates/core/asset/src/balance.rs
+++ b/crates/core/asset/src/balance.rs
@@ -2,6 +2,7 @@ use ark_r1cs_std::prelude::*;
 use ark_r1cs_std::uint8::UInt8;
 use ark_relations::r1cs::SynthesisError;
 use penumbra_num::{Amount, AmountVar};
+use serde::{Deserialize, Serialize};
 use std::{
     collections::{btree_map, BTreeMap},
     fmt::{self, Debug, Formatter},
@@ -30,7 +31,7 @@ use self::commitment::BalanceCommitmentVar;
 
 /// A `Balance` is a "vector of [`Value`]s", where some values may be required, while others may be
 /// provided. For a transaction to be valid, its balance must be zero.
-#[derive(Clone, Eq, Default)]
+#[derive(Clone, Eq, Default, Serialize, Deserialize)]
 pub struct Balance {
     negated: bool,
     balance: BTreeMap<Id, Imbalance<NonZeroU128>>,

--- a/crates/core/asset/src/balance.rs
+++ b/crates/core/asset/src/balance.rs
@@ -3,6 +3,7 @@ use ark_r1cs_std::uint8::UInt8;
 use ark_relations::r1cs::SynthesisError;
 use penumbra_num::{Amount, AmountVar};
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use std::{
     collections::{btree_map, BTreeMap},
     fmt::{self, Debug, Formatter},
@@ -31,9 +32,11 @@ use self::commitment::BalanceCommitmentVar;
 
 /// A `Balance` is a "vector of [`Value`]s", where some values may be required, while others may be
 /// provided. For a transaction to be valid, its balance must be zero.
+#[serde_as]
 #[derive(Clone, Eq, Default, Serialize, Deserialize)]
 pub struct Balance {
     negated: bool,
+    #[serde_as(as = "Vec<(_, _)>")]
     balance: BTreeMap<Id, Imbalance<NonZeroU128>>,
 }
 

--- a/crates/core/asset/src/balance/imbalance.rs
+++ b/crates/core/asset/src/balance/imbalance.rs
@@ -5,10 +5,12 @@ use std::{
     ops::{Add, Neg, Sub},
 };
 
+use serde::{Deserialize, Serialize};
+
 /// An imbalance is either a required amount or a provided amount.
 ///
 /// This is used exclusively when the type contained is non-zero.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Imbalance<T> {
     /// Something is required, i.e. it must be cancelled out by a provided thing.
     Required(T),

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -61,6 +61,7 @@ ark-groth16 = { version = "0.4", default-features = false }
 ark-snark = "0.4"
 async-trait = "0.1.52"
 async-stream = "0.2"
+bincode = "1.3.3"
 hex = "0.4"
 thiserror = "1"
 anyhow = "1"

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -68,6 +68,7 @@ anyhow = "1"
 tracing = "0.1"
 prost = "0.12.3"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1.0.96"
 metrics = "0.19.0"
 pbjson-types = "0.6.0"
 tendermint = "0.34.0"
@@ -89,7 +90,6 @@ tonic = { version = "0.10", optional = true }
 [dev-dependencies]
 proptest = "1"
 rand = "0.8.5"
-serde_json = "1.0.96"
 tracing-subscriber = "0.3.17"
 rand_chacha = "0.3"
 itertools = "0.11"

--- a/crates/core/component/dex/src/circuit_breaker/mod.rs
+++ b/crates/core/component/dex/src/circuit_breaker/mod.rs
@@ -1,3 +1,5 @@
 mod execution;
+mod value;
 
 pub(crate) use execution::ExecutionCircuitBreaker;
+pub(crate) use value::ValueCircuitBreaker;

--- a/crates/core/component/dex/src/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/circuit_breaker/value.rs
@@ -1,69 +1,102 @@
-use std::collections::BTreeMap;
+use penumbra_asset::{asset, Balance, Value};
+use serde::{Deserialize, Serialize};
 
-use penumbra_asset::{asset, Value};
-use penumbra_num::Amount;
-use penumbra_proto::{core::component::dex::v1alpha1 as pb, DomainType, TypeUrl};
-
-#[derive(Debug, Clone, Default)]
-pub struct AssetTallies {
-    tallies: BTreeMap<asset::Id, Amount>,
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ValueCircuitBreaker {
+    balance: Balance,
 }
 
-impl AssetTallies {
-    pub fn tally(&mut self, value: Value) {
-        *self.tallies.entry(value.asset_id).or_default() += value.amount;
+impl ValueCircuitBreaker {
+    pub fn tally(&mut self, balance: Balance) {
+        self.balance += balance;
     }
-}
 
-impl From<AssetTallies> for pb::AssetTallies {
-    fn from(inner: AssetTallies) -> Self {
-        pb::AssetTallies {
-            tallies: inner
-                .tallies
-                .iter()
-                .map(|(k, v)| pb::AssetTally {
-                    asset_id: Some(
-                        Into::<penumbra_proto::core::asset::v1alpha1::AssetId>::into(*k),
-                    ),
-                    amount: Some(Into::<penumbra_proto::core::num::v1alpha1::Amount>::into(
-                        *v,
-                    )),
-                })
-                .collect(),
+    pub fn check(&self) -> anyhow::Result<()> {
+        // No assets should ever be "required" by the circuit breaker's
+        // internal balance tracking, only "provided".
+        if let Some(r) = self.balance.required().next() {
+            return Err(anyhow::anyhow!(
+                "balance for asset {} is negative: -{}",
+                r.asset_id,
+                r.amount
+            ));
         }
+
+        Ok(())
     }
 }
 
-impl TryFrom<pb::AssetTallies> for AssetTallies {
-    type Error = anyhow::Error;
+#[cfg(test)]
+mod tests {
+    use penumbra_num::Amount;
+    use rand_core::OsRng;
 
-    fn try_from(value: pb::AssetTallies) -> Result<Self, Self::Error> {
-        Ok(Self {
-            tallies: value
-                .tallies
-                .iter()
-                .map(|pb_tally| {
-                    (
-                        // TODO: remove expects, return results
-                        pb_tally
-                            .asset_id
-                            .clone()
-                            .expect("asset ID should be present in tally")
-                            .try_into()
-                            .expect("invalid protobuf"),
-                        pb_tally
-                            .amount
-                            .clone()
-                            .expect("amount should be present in tally")
-                            .try_into()
-                            .expect("invalid protobuf"),
-                    )
-                })
-                .collect(),
-        })
+    use crate::{
+        lp::{position::Position, Reserves},
+        DirectedTradingPair,
+    };
+
+    use super::*;
+
+    // Ideally the update_position_aggregate_value in the PositionManager would be used
+    // but this is simpler for a quick unit test.
+
+    #[test]
+    fn value_circuit_breaker() {
+        let mut value_circuit_breaker = ValueCircuitBreaker::default();
+
+        let gm = asset::Cache::with_known_assets().get_unit("gm").unwrap();
+        let gn = asset::Cache::with_known_assets().get_unit("gn").unwrap();
+
+        let pair = DirectedTradingPair::new(gm.id(), gn.id());
+        let reserves_1 = Reserves {
+            r1: 0u64.into(),
+            r2: 120_000u64.into(),
+        };
+
+        // A position with 120_000 gn and 0 gm.
+        let position_1 = Position::new(
+            OsRng,
+            pair,
+            9u32,
+            1_200_000u64.into(),
+            1_000_000u64.into(),
+            reserves_1,
+        );
+
+        // Track the position in the circuit breaker.
+        let pair = position_1.phi.pair;
+        let new_a = position_1
+            .reserves_for(pair.asset_1)
+            .expect("specified position should match provided trading pair");
+        let new_b = position_1
+            .reserves_for(pair.asset_2)
+            .expect("specified position should match provided trading pair");
+
+        let new_a = Balance::from(Value {
+            asset_id: pair.asset_1,
+            amount: new_a,
+        });
+        let new_b = Balance::from(Value {
+            asset_id: pair.asset_2,
+            amount: new_b,
+        });
+        value_circuit_breaker.tally(new_a);
+        value_circuit_breaker.tally(new_b.clone());
+
+        // The circuit breaker should not trip.
+        assert!(value_circuit_breaker.check().is_ok());
+
+        // If the same amount of gn is taken out of the position, the circuit breaker should not trip.
+        value_circuit_breaker.tally(-new_b);
+        assert!(value_circuit_breaker.check().is_ok());
+
+        // But if there's ever a negative amount of gn in the position, the circuit breaker should trip.
+        let one_b = Balance::from(Value {
+            asset_id: pair.asset_2,
+            amount: Amount::from(1u64),
+        });
+        value_circuit_breaker.tally(-one_b);
+        assert!(value_circuit_breaker.check().is_err());
     }
-}
-
-impl DomainType for AssetTallies {
-    type Proto = pb::AssetTallies;
 }

--- a/crates/core/component/dex/src/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/circuit_breaker/value.rs
@@ -1,4 +1,4 @@
-use penumbra_asset::{asset, Balance, Value};
+use penumbra_asset::Balance;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -28,6 +28,7 @@ impl ValueCircuitBreaker {
 
 #[cfg(test)]
 mod tests {
+    use penumbra_asset::{asset, Value};
     use penumbra_num::Amount;
     use rand_core::OsRng;
 

--- a/crates/core/component/dex/src/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/circuit_breaker/value.rs
@@ -12,16 +12,18 @@ impl ValueCircuitBreaker {
         self.balance += balance;
     }
 
-    pub fn assert_balance_invariant(&self) {
+    pub fn check(&self) -> anyhow::Result<()> {
         // No assets should ever be "required" by the circuit breaker's
         // internal balance tracking, only "provided".
         if let Some(r) = self.balance.required().next() {
-            assert!(
-                false,
+            return Err(anyhow::anyhow!(
                 "balance for asset {} is negative: -{}",
-                r.asset_id, r.amount
-            );
+                r.asset_id,
+                r.amount
+            ));
         }
+
+        Ok(())
     }
 
     pub fn available(&self, asset_id: Id) -> Value {
@@ -39,13 +41,19 @@ impl ValueCircuitBreaker {
 mod tests {
     use std::sync::Arc;
 
+    use crate::component::position_manager::Inner as _;
+    use crate::component::router::{HandleBatchSwaps as _, RoutingParams};
+    use crate::component::{StateReadExt as _, StateWriteExt as _};
     use crate::{
         component::{router::limit_buy, tests::TempStorageExt, PositionManager as _},
-        DirectedUnitPair,
+        state_key, DirectedUnitPair,
     };
-    use cnidarium::{ArcStateDeltaExt as _, StateDelta, TempStorage};
+    use cnidarium::{
+        ArcStateDeltaExt as _, StateDelta, StateRead as _, StateWrite as _, TempStorage,
+    };
     use penumbra_asset::{asset, Value};
     use penumbra_num::Amount;
+    use penumbra_proto::StateWriteProto as _;
     use rand_core::OsRng;
 
     use crate::{
@@ -105,13 +113,11 @@ mod tests {
         assert!(value_circuit_breaker.available(pair.asset_2).amount == 120_000u64.into());
 
         // The circuit breaker should not trip.
-        let result = std::panic::catch_unwind(|| value_circuit_breaker.assert_balance_invariant());
-        assert!(result.is_ok());
+        assert!(value_circuit_breaker.check().is_ok());
 
         // If the same amount of gn is taken out of the position, the circuit breaker should not trip.
         value_circuit_breaker.tally(-new_b);
-        let result = std::panic::catch_unwind(|| value_circuit_breaker.assert_balance_invariant());
-        assert!(result.is_ok());
+        assert!(value_circuit_breaker.check().is_ok());
 
         assert!(value_circuit_breaker.available(pair.asset_1).amount == 0u64.into());
         assert!(value_circuit_breaker.available(pair.asset_2).amount == 0u64.into());
@@ -122,8 +128,7 @@ mod tests {
             amount: Amount::from(1u64),
         });
         value_circuit_breaker.tally(-one_b);
-        let result = std::panic::catch_unwind(|| value_circuit_breaker.assert_balance_invariant());
-        assert!(result.is_err());
+        assert!(value_circuit_breaker.check().is_err());
         assert!(value_circuit_breaker.available(pair.asset_1).amount == 0u64.into());
         assert!(value_circuit_breaker.available(pair.asset_2).amount == 0u64.into());
     }
@@ -155,15 +160,90 @@ mod tests {
         buy_1.reserves.r1 = 2u64.into();
         buy_1.reserves.r2 = 0u64.into();
 
-        // This should not panic, the circuit breaker should not trip.
+        // This should not error, the circuit breaker should not trip.
         state_tx.put_position(buy_1.clone()).await.unwrap();
 
         // Pretend the position was overfilled.
-        buy_1.reserves.r1 = 0u64.into();
-        buy_1.reserves.r2 = 0u64.into();
-        // This should panic
-        state_tx.put_position(buy_1.clone()).await.unwrap();
+        let mut value_circuit_breaker: ValueCircuitBreaker = match state_tx
+            .nonverifiable_get_raw(state_key::aggregate_value().as_bytes())
+            .await
+            .expect("able to retrieve value circuit breaker from nonverifiable storage")
+        {
+            Some(bytes) => serde_json::from_slice(&bytes).expect(
+                "able to deserialize stored value circuit breaker from nonverifiable storage",
+            ),
+            None => panic!("should have a circuit breaker present"),
+        };
+
+        // Wipe out the value in the circuit breaker, so that any outflows should trip it.
+        value_circuit_breaker.balance = Balance::default();
+        state_tx.nonverifiable_put_raw(
+            state_key::aggregate_value().as_bytes().to_vec(),
+            serde_json::to_vec(&value_circuit_breaker)
+                .expect("able to serialize value circuit breaker for nonverifiable storage"),
+        );
+
+        // This should error, since there is no balance available to close out the position.
+        buy_1.state = crate::lp::position::State::Closed;
+        assert!(state_tx.put_position(buy_1).await.is_err());
 
         Ok(())
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "balance for asset")]
+    async fn batch_swap_circuit_breaker() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let storage = TempStorage::new()
+            .await
+            .expect("able to create storage")
+            .apply_minimal_genesis()
+            .await
+            .expect("able to apply genesis");
+        let mut state = Arc::new(StateDelta::new(storage.latest_snapshot()));
+        let mut state_tx = state.try_begin_transaction().unwrap();
+
+        let gm = asset::Cache::with_known_assets().get_unit("gm").unwrap();
+        let gn = asset::Cache::with_known_assets().get_unit("gn").unwrap();
+
+        let pair_1 = DirectedUnitPair::new(gm.clone(), gn.clone());
+
+        // Manually put a position without calling `put_position` so that the
+        // circuit breaker is not aware of the position's value. Then, handling a batch
+        // swap that fills against this position should result in an error.
+        let one = 1u64.into();
+        let price1 = one;
+        // Create a position buying 1 gm with 1 gn (i.e. reserves will be 1gn).
+        let buy_1 = limit_buy(pair_1.clone(), 1u64.into(), price1);
+
+        let id = buy_1.id();
+
+        let position = state_tx.handle_limit_order(&None, buy_1);
+        state_tx.index_position_by_price(&position);
+        state_tx
+            .update_available_liquidity(&position, &None)
+            .await
+            .expect("able to update liquidity");
+        state_tx.put(state_key::position_by_id(&id), position);
+
+        // Now there's a position in the state, but the circuit breaker is not aware of it.
+        let trading_pair = pair_1.into_directed_trading_pair().into();
+        let mut swap_flow = state_tx.swap_flow(&trading_pair);
+
+        assert!(trading_pair.asset_1() == gm.id());
+
+        // Add the amount of each asset being swapped to the batch swap flow.
+        swap_flow.0 += gm.value(5u32.into()).amount;
+        swap_flow.1 += 0u32.into();
+
+        // Set the batch swap flow for the trading pair.
+        state_tx.put_swap_flow(&trading_pair, swap_flow.clone());
+        state_tx.apply();
+
+        // This call should panic due to the outflow of gn not being covered by the circuit breaker.
+        state
+            .handle_batch_swaps(trading_pair, swap_flow, 0, 0, RoutingParams::default())
+            .await
+            .expect("unable to process batch swaps");
     }
 }

--- a/crates/core/component/dex/src/component/mod.rs
+++ b/crates/core/component/dex/src/component/mod.rs
@@ -20,4 +20,4 @@ pub use position_manager::{PositionManager, PositionRead};
 pub use swap_manager::SwapManager;
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/crates/core/component/dex/src/component/mod.rs
+++ b/crates/core/component/dex/src/component/mod.rs
@@ -10,7 +10,7 @@ mod action_handler;
 mod arb;
 mod dex;
 mod flow;
-mod position_manager;
+pub(crate) mod position_manager;
 mod swap_manager;
 
 pub use self::metrics::register_metrics;

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -249,7 +249,7 @@ pub trait PositionManager: StateWrite + PositionRead {
 impl<T: StateWrite + ?Sized> PositionManager for T {}
 
 #[async_trait]
-pub(super) trait Inner: StateWrite {
+pub(crate) trait Inner: StateWrite {
     fn index_position_by_price(&mut self, position: &position::Position) {
         let (pair, phi) = (position.phi.pair, &position.phi);
         let id = position.id();
@@ -584,7 +584,7 @@ pub(super) trait Inner: StateWrite {
 
         // Confirm that the value circuit breaker is still within the limits.
         // This call will panic if the value circuit breaker detects inflation.
-        value_circuit_breaker.assert_balance_invariant();
+        value_circuit_breaker.check()?;
 
         // Store the value circuit breaker back to nonconsensus storage with the updated tallies.
         self.nonverifiable_put_raw(

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -572,7 +572,7 @@ pub(super) trait Inner: StateWrite {
             .await
             .expect("able to retrieve value circuit breaker from nonverifiable storage")
         {
-            Some(bytes) => bincode::deserialize(&bytes).expect(
+            Some(bytes) => serde_json::from_slice(&bytes).expect(
                 "able to deserialize stored value circuit breaker from nonverifiable storage",
             ),
             None => ValueCircuitBreaker::default(),
@@ -588,7 +588,7 @@ pub(super) trait Inner: StateWrite {
         // Store the value circuit breaker back to nonconsensus storage with the updated tallies.
         self.nonverifiable_put_raw(
             state_key::aggregate_value().as_bytes().to_vec(),
-            bincode::serialize(&value_circuit_breaker)
+            serde_json::to_vec(&value_circuit_breaker)
                 .expect("able to serialize value circuit breaker for nonverifiable storage"),
         );
 

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -583,7 +583,8 @@ pub(super) trait Inner: StateWrite {
         value_circuit_breaker.tally(delta_b);
 
         // Confirm that the value circuit breaker is still within the limits.
-        value_circuit_breaker.check()?;
+        // This call will panic if the value circuit breaker detects inflation.
+        value_circuit_breaker.assert_balance_invariant();
 
         // Store the value circuit breaker back to nonconsensus storage with the updated tallies.
         self.nonverifiable_put_raw(

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -568,7 +568,7 @@ pub(super) trait Inner: StateWrite {
         );
 
         let mut value_circuit_breaker: ValueCircuitBreaker = match self
-            .nonverifiable_get_raw(&state_key::aggregate_value().as_bytes())
+            .nonverifiable_get_raw(state_key::aggregate_value().as_bytes())
             .await
             .expect("able to retrieve value circuit breaker from nonverifiable storage")
         {
@@ -587,7 +587,7 @@ pub(super) trait Inner: StateWrite {
 
         // Store the value circuit breaker back to nonconsensus storage with the updated tallies.
         self.nonverifiable_put_raw(
-            (&state_key::aggregate_value().as_bytes()).to_vec(),
+            state_key::aggregate_value().as_bytes().to_vec(),
             bincode::serialize(&value_circuit_breaker)
                 .expect("able to serialize value circuit breaker for nonverifiable storage"),
         );

--- a/crates/core/component/dex/src/state_key.rs
+++ b/crates/core/component/dex/src/state_key.rs
@@ -59,6 +59,10 @@ pub fn pending_outputs() -> &'static str {
     "dex/pending_outputs"
 }
 
+pub fn aggregate_value() -> &'static str {
+    "dex/aggregate_value"
+}
+
 /// Encompasses non-consensus state keys.
 pub(crate) mod internal {
     use super::*;


### PR DESCRIPTION
This adds a value circuit breaker to the `PositionManager` logic.

Whenever a position is stored, the total reserve amounts (across _all_ positions) are tracked by the `ValueCircuitBreaker`. If after storing a position the reserve balance ever becomes negative ("required"), this implies that more value was taken out of positions than was stored in them, and an error is bubbled up.

Closes #2986