### PR TITLE
feat(pd): allow use of staging api for letsencrypt

### DIFF
--- a/crates/bin/pd/src/auto_https.rs
+++ b/crates/bin/pd/src/auto_https.rs
@@ -23,13 +23,6 @@ const ALPN_PROTOCOLS: [&[u8]; 2] = [b"h2", b"http/1.1"];
 //  NB: this must not be an absolute path see [Path::join].
 const CACHE_DIR: &str = "tokio_rustls_acme_cache";
 
-/// If true, use the production Let's Encrypt environment.
-///
-/// If false, the ACME resolver will use the [staging environment].
-///
-/// [staging environment]: https://letsencrypt.org/docs/staging-environment/
-const PRODUCTION_LETS_ENCRYPT: bool = true;
-
 /// Use ACME to resolve certificates and handle new connections.
 ///
 /// This returns a tuple containing an [`AxumAcceptor`] that may be used with [`axum_server`], and
@@ -38,6 +31,7 @@ const PRODUCTION_LETS_ENCRYPT: bool = true;
 pub fn axum_acceptor(
     home: PathBuf,
     domain: String,
+    production_api: bool,
 ) -> (AxumAcceptor, impl Future<Output = Result<(), Error>>) {
     // Use a file-based cache located within the home directory.
     let cache = home.join(CACHE_DIR);
@@ -46,7 +40,7 @@ pub fn axum_acceptor(
     // Create an ACME client, which we will use to resolve certificates.
     let state = AcmeConfig::new(vec![domain])
         .cache(cache)
-        .directory_lets_encrypt(PRODUCTION_LETS_ENCRYPT)
+        .directory_lets_encrypt(production_api)
         .state();
 
     // Define our server configuration, using the ACME certificate resolver.

--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -52,9 +52,17 @@ pub enum RootCommand {
         /// Let's Encrypt and caches them in the `home` directory.  The
         /// production LE CA has rate limits, so be careful using this option
         /// with `pd testnet unsafe-reset-all`, which will delete the certificates
-        /// and force re-issuance, possibly hitting the rate limit.
+        /// and force re-issuance, possibly hitting the rate limit. See the
+        /// `--acme-staging` option.
         #[clap(long, value_name = "DOMAIN", display_order = 200)]
         grpc_auto_https: Option<String>,
+        /// Enable use of the LetsEncrypt ACME staging API (https://letsencrypt.org/docs/staging-environment/),
+        /// which is more forgiving of ratelimits. Set this option to `true`
+        /// if you're trying out the `--grpc-auto-https` option for the first time,
+        /// to validate your configuration, before subjecting yourself to production
+        /// ratelimits. This option has no effect if `--grpc-auto-https` is not set.
+        #[clap(long, display_order = 201, default_value = "false")]
+        acme_staging: bool,
         /// Bind the metrics endpoint to this socket.
         #[clap(
             short,

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> anyhow::Result<()> {
             abci_bind,
             grpc_bind,
             grpc_auto_https,
+            acme_staging,
             metrics_bind,
             cometbft_addr,
             enable_expensive_rpc,
@@ -296,7 +297,8 @@ async fn main() -> anyhow::Result<()> {
             let grpc_server = axum_server::bind(grpc_bind);
             let grpc_server = match grpc_auto_https {
                 Some(domain) => {
-                    let (acceptor, acme_worker) = pd::auto_https::axum_acceptor(pd_home, domain);
+                    let (acceptor, acme_worker) =
+                        pd::auto_https::axum_acceptor(pd_home, domain, !acme_staging);
                     // TODO(kate): we should eventually propagate errors from the ACME worker task.
                     tokio::spawn(acme_worker);
                     spawn_grpc_server!(grpc_server.acceptor(acceptor))


### PR DESCRIPTION
Closes #3681.

To test, I provisioned a machine on with DNS on a test domain (to reduce side-effects in case it was broken, and the requested domain got ratelimited):

```
❯ curl -I https://cert-1.plinfra.net
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.

❯ curl -I https://cert-1.plinfra.net -k
HTTP/2 200 
grpc-status: 12
content-type: application/grpc
content-length: 0
date: Tue, 30 Jan 2024 18:11:46 GMT
```

I also confirmed that when run as a normal user, the bind to 443 fails with an error message:

```
2024-01-30T18:21:24.968644Z  INFO pd: starting pd abci_bind=127.0.0.1:26658 grpc_bind=0.0.0.0:443 grpc_auto_https=Some("cert-1.plinfra.net") metrics_bind=127.0.0.1:9000 cometbft_addr=http://127.0.0.1:26657/ enable_expensive_rpc=false
2024-01-30T18:21:24.968852Z DEBUG penumbra_app::app: initializing App instance
2024-01-30T18:21:24.968873Z DEBUG penumbra_app::app: initializing App instance
2024-01-30T18:21:24.968965Z  INFO tower_abci::v037::server: ABCI server starting on tcp socket addr=127.0.0.1:26658
2024-01-30T18:21:24.978605Z DEBUG acme_worker: pd::auto_https: received acme event: AccountCacheStore
2024-01-30T18:21:24.979077Z ERROR pd: grpc server on 0.0.0.0:443 failed: Permission denied (os error 13)
Error: grpc server on 0.0.0.0:443 failed: Permission denied (os error 13)
```

That logic hasn't changed in this PR, but the new output validates that https://github.com/penumbra-zone/penumbra/pull/3555 is working as expected.