### PR TITLE
Fix a few mistakes in the Penumbra Protocol docs

### DIFF
--- a/docs/protocol/src/concepts/addresses_keys.md
+++ b/docs/protocol/src/concepts/addresses_keys.md
@@ -62,5 +62,4 @@ addresses, allowing fine-grained control of delegation.
 
 This diagram shows only the user-visible parts of the key hierarchy.
 Internally, each of these keys has different components, described in detail in
-the [Addresses and Keys](../protocol/addresses_keys.md) section of the
-[Cryptographic Protocol](../protocol.md) chapter.
+the [Addresses and Keys](../protocol/addresses_keys.md) chapter.

--- a/docs/protocol/src/concepts/transactions.md
+++ b/docs/protocol/src/concepts/transactions.md
@@ -35,10 +35,6 @@ pool](../stake/undelegation.md), consuming delegation tokens from the
 transaction's value balance and producing new notes recording the appropriate
 amount of unbonded stake;
 
-- **Commission** descriptions are used by validators to [claim commission on
-staking rewards](../stake/validator-rewards.md) into shielded notes,
-adding unbonded stake to the transaction's value balance;
-
 #### Governance
 
 - **CreateProposal** descriptions are used to [propose measures for on-chain

--- a/docs/protocol/src/concepts/transactions.md
+++ b/docs/protocol/src/concepts/transactions.md
@@ -3,13 +3,13 @@
 Transactions describe an atomic collection of changes to the ledger state.  Each
 transaction consists of a sequence of *descriptions* for various actions[^1].
 Each description adds or subtracts (typed) value from the transaction's value
-balance, which must net to zero.  Penumbra adapts the *Spend* and *Output* actions from Sapling, and adds many new descriptions to support additional functionality:
+balance, which must net to zero.
 
 Penumbra adapts Sapling's *Spend*, which
 spends a note and adds to the transaction's value balance, and
 *Output*, which creates a new note and subtracts from the
-transaction's value balance, and adds many new descriptions to support
-additional functionality:
+transaction's value balance. Penumbra also adds many new descriptions
+to support additional functionality:
 
 #### Transfers
 

--- a/docs/protocol/src/concepts/transactions.md
+++ b/docs/protocol/src/concepts/transactions.md
@@ -35,7 +35,7 @@ pool](../stake/undelegation.md), consuming delegation tokens from the
 transaction's value balance and producing new notes recording the appropriate
 amount of unbonded stake;
 
-- **Commission** descriptions are used by validators to [sweep commission on
+- **Commission** descriptions are used by validators to [claim commission on
 staking rewards](../stake/validator-rewards.md) into shielded notes,
 adding unbonded stake to the transaction's value balance;
 
@@ -61,7 +61,7 @@ description leaves the value balance unchanged.
 transaction's value balance, burning them, and producing a swap commitment for
 use in the second stage;
 
-- **Sweep** descriptions perform the second phase of
+- **SwapClaim** descriptions perform the second phase of
 [ZSwap](../zswap.md), allowing a user who burned tokens of one
 type to mint tokens of the other type at the chain-specified clearing price, and
 adding the new tokens to a transaction's value balance;

--- a/docs/protocol/src/protocol.md
+++ b/docs/protocol/src/protocol.md
@@ -3,8 +3,6 @@
 This chapter describes the cryptographic design of the Penumbra protocol,
 described in more detail in the following sections:
 
-- The [Addresses and Keys](./protocol/addresses_keys.md) section describes the Penumbra key hierarchy and diversified addresses.
-
 - The [Notes](./protocol/notes/note_ciphertexts.md) section describes Penumbra's private notes and their contents.
 
 - The [Transaction Cryptography](./protocol/transaction_crypto.md) section describes the symmetric keys used at the level of an individual transaction.


### PR DESCRIPTION
Just a couple things I noticed while reading the Penumbra protocol.