### PR TITLE
proto: move box_grpc_svc to proto crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5542,6 +5542,7 @@ dependencies = [
  "decaf377-rdsa",
  "futures",
  "hex",
+ "http-body",
  "ibc-proto",
  "ibc-types",
  "ics23",
@@ -5554,6 +5555,7 @@ dependencies = [
  "subtle-encoding",
  "tendermint",
  "tonic",
+ "tower",
  "tracing",
 ]
 

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -30,7 +30,7 @@ parallel = [
 
 [dependencies]
 # Workspace dependencies
-penumbra-proto = { path = "../../proto", features = ["rpc"] }
+penumbra-proto = { path = "../../proto", features = ["rpc", "box-grpc"] }
 penumbra-tct = { path = "../../crypto/tct" }
 penumbra-num = { path = "../../core/num", default-features = false }
 penumbra-asset = { path = "../../core/asset", default-features = false }

--- a/crates/bin/pcli/src/main.rs
+++ b/crates/bin/pcli/src/main.rs
@@ -7,17 +7,16 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use futures::StreamExt;
 
-use box_grpc_svc::BoxGrpcService;
 use command::*;
 use config::PcliConfig;
 use opt::Opt;
+use penumbra_proto::box_grpc_svc::BoxGrpcService;
 use penumbra_proto::{
     custody::v1alpha1::custody_protocol_service_client::CustodyProtocolServiceClient,
     view::v1alpha1::view_protocol_service_client::ViewProtocolServiceClient,
 };
 use penumbra_view::ViewClient;
 
-mod box_grpc_svc;
 mod command;
 mod config;
 mod dex_utils;

--- a/crates/bin/pcli/src/opt.rs
+++ b/crates/bin/pcli/src/opt.rs
@@ -1,5 +1,4 @@
 use crate::{
-    box_grpc_svc,
     config::{CustodyConfig, PcliConfig},
     terminal::ActualTerminal,
     App, Command,
@@ -9,6 +8,7 @@ use camino::Utf8PathBuf;
 use clap::Parser;
 use directories::ProjectDirs;
 use penumbra_custody::soft_kms::SoftKms;
+use penumbra_proto::box_grpc_svc;
 use penumbra_proto::{
     custody::v1alpha1::{
         custody_protocol_service_client::CustodyProtocolServiceClient,

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -11,6 +11,8 @@ decaf377-rdsa = { version = "0.7" }
 bytes = { version = "1", features = ["serde"] }
 prost = "0.12.3"
 tonic = { version = "0.10", optional = true }
+tower = { version = "0.4", features = ["full"], optional = true }
+http-body = { version = "0.4.5", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hex = "0.4"
@@ -39,4 +41,5 @@ anyhow = "1"
 
 [features]
 rpc = ["dep:tonic", "ibc-proto/client"]
+box-grpc = ["dep:http-body", "dep:tonic", "dep:tower"]
 cnidarium = ["dep:cnidarium"]

--- a/crates/proto/src/box_grpc_svc.rs
+++ b/crates/proto/src/box_grpc_svc.rs
@@ -8,16 +8,16 @@ use tonic::{
 use tower::{util::BoxCloneService, Service, ServiceBuilder};
 
 /// A type-erased gRPC service.
-pub(crate) type BoxGrpcService =
+pub type BoxGrpcService =
     BoxCloneService<grpc::Request<ReqBody>, grpc::Response<RspBody>, BoxError>;
 
-pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// A type-erased gRPC response [`Body`].
-pub(crate) type RspBody = UnsyncBoxBody<Bytes, BoxError>;
+pub type RspBody = UnsyncBoxBody<Bytes, BoxError>;
 
 /// Connects to the provided tonic [`Endpoint`], returning a [`BoxGrpcService`].
-pub(crate) async fn connect(ep: Endpoint) -> anyhow::Result<BoxGrpcService> {
+pub async fn connect(ep: Endpoint) -> anyhow::Result<BoxGrpcService> {
     let conn = ep.connect().await?;
     let svc = ServiceBuilder::new()
         .map_response(|rsp: grpc::Response<transport::Body>| rsp.map(box_rsp_body))
@@ -28,7 +28,7 @@ pub(crate) async fn connect(ep: Endpoint) -> anyhow::Result<BoxGrpcService> {
 
 /// Constructs a [`BoxGrpcService`] by erasing the type of an `S`-typed local
 /// (in-process) service instance.
-pub(crate) fn local<S, B>(svc: S) -> BoxGrpcService
+pub fn local<S, B>(svc: S) -> BoxGrpcService
 where
     S: Service<grpc::Request<ReqBody>, Response = grpc::Response<B>>,
     S: Clone + Send + Sync + 'static,

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -28,6 +28,9 @@ pub use prost::{Message, Name};
 /// Helper methods used for shaping the JSON (and other Serde) formats derived from the protos.
 pub mod serializers;
 
+#[cfg(feature = "box-grpc")]
+pub mod box_grpc_svc;
+
 /// Helper trait for using Protobuf messages as ABCI events.
 pub mod event;
 mod protobuf;


### PR DESCRIPTION
We want to make this utility accessible, in order to make interacting with the grpc services easier for callers, in particular the Hermes relayer