### PR TITLE
chore: 🧹 remove dangling references to `penumbra-chain`

### DIFF
--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -35,7 +35,6 @@ penumbra-tct = { path = "../../crypto/tct" }
 penumbra-num = { path = "../../core/num", default-features = false }
 penumbra-asset = { path = "../../core/asset", default-features = false }
 penumbra-keys = { path = "../../core/keys", default-features = false }
-#penumbra-chain = { path = "../../core/component/chain", default-features = false }
 penumbra-shielded-pool = { path = "../../core/component/shielded-pool", default-features = false }
 penumbra-governance = { path = "../../core/component/governance", default-features = false }
 penumbra-stake = { path = "../../core/component/stake", default-features = false }

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -38,7 +38,6 @@ penumbra-governance = { path = "../../core/component/governance", features = [
 ] }
 penumbra-ibc = { path = "../../core/component/ibc", features = ["rpc"] }
 penumbra-compact-block = { path = "../../core/component/compact-block" }
-#penumbra-chain = { path = "../../core/component/chain" }
 penumbra-transaction = { path = "../../core/transaction" }
 penumbra-app = { path = "../../core/app" }
 penumbra-custody = { path = "../../custody" }

--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -16,7 +16,6 @@ penumbra-asset = { path = "../asset" }
 penumbra-keys = { path = "../keys" }
 penumbra-txhash = { path = "../txhash" }
 penumbra-num = { path = "../num" }
-#penumbra-chain = { path = "../component/chain", features = ["component"] }
 penumbra-shielded-pool = { path = "../component/shielded-pool", features = [
     "component",
 ] }

--- a/crates/core/component/community-pool/Cargo.toml
+++ b/crates/core/component/community-pool/Cargo.toml
@@ -20,7 +20,6 @@ docsrs = []
 cnidarium = { path = "../../../cnidarium", optional = true }
 cnidarium-component = { path = "../../../cnidarium-component", optional = true }
 penumbra-proto = { path = "../../../proto", default-features = false }
-#penumbra-chain = { path = "../chain", default-features = false }
 penumbra-shielded-pool = { path = "../shielded-pool", default-features = false }
 penumbra-sct = { path = "../sct", default-features = false }
 penumbra-asset = { path = "../../../core/asset", default-features = false }

--- a/crates/core/component/compact-block/Cargo.toml
+++ b/crates/core/component/compact-block/Cargo.toml
@@ -26,7 +26,6 @@ cnidarium = { path = "../../../cnidarium", optional = true }
 penumbra-tct = { path = "../../../crypto/tct" }
 penumbra-proof-params = { path = "../../../crypto/proof-params", default-features = false }
 cnidarium-component = { path = "../../../cnidarium-component", optional = true }
-#penumbra-chain = { path = "../chain", default-features = false }
 penumbra-shielded-pool = { path = "../shielded-pool", default-features = false }
 penumbra-dex = { path = "../dex", default-features = false }
 penumbra-ibc = { path = "../ibc", default-features = false }

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -32,7 +32,6 @@ parallel = [
 # Workspace dependencies
 penumbra-proto = { path = "../../../proto", default-features = false }
 cnidarium = { path = "../../../cnidarium", optional = true }
-#penumbra-chain = { path = "../chain", default-features = false }
 cnidarium-component = { path = "../../../cnidarium-component", optional = true }
 penumbra-shielded-pool = { path = "../shielded-pool", default-features = false }
 penumbra-sct = { path = "../sct", default-features = false }

--- a/crates/core/component/distributions/Cargo.toml
+++ b/crates/core/component/distributions/Cargo.toml
@@ -21,7 +21,6 @@ docsrs = []
 cnidarium = { path = "../../../cnidarium", optional = true }
 cnidarium-component = { path = "../../../cnidarium-component", optional = true }
 penumbra-asset = { path = "../../../core/asset", default-features = false }
-#penumbra-chain = { path = "../chain", default-features = false }
 penumbra-num = { path = "../../../core/num", default-features = false }
 penumbra-proto = { path = "../../../proto", default-features = false }
 penumbra-sct = { path = "../sct", default-features = false }

--- a/crates/core/component/funding/Cargo.toml
+++ b/crates/core/component/funding/Cargo.toml
@@ -25,7 +25,6 @@ docsrs = []
 # Workspace dependencies
 cnidarium-component = { path = "../../../cnidarium-component", optional = true }
 penumbra-asset = { path = "../../asset" }
-#penumbra-chain = { path = "../chain", default-features = false }
 penumbra-community-pool = { path = "../community-pool", default-features = false }
 penumbra-distributions = { path = "../distributions", default-features = false }
 penumbra-proto = { path = "../../../proto", default-features = false }

--- a/crates/core/component/governance/Cargo.toml
+++ b/crates/core/component/governance/Cargo.toml
@@ -43,7 +43,6 @@ penumbra-fee = { path = "../fee", default-features = false }
 penumbra-funding = { path = "../funding", default-features = false }
 penumbra-ibc = { path = "../ibc", default-features = false }
 penumbra-distributions = { path = "../distributions", default-features = false }
-#penumbra-chain = { path = "../chain", default-features = false }
 penumbra-asset = { path = "../../../core/asset", default-features = false }
 penumbra-keys = { path = "../../../core/keys", default-features = false }
 penumbra-txhash = { path = "../../../core/txhash", default-features = false }

--- a/crates/core/component/ibc/src/component/client.rs
+++ b/crates/core/component/ibc/src/component/client.rs
@@ -489,7 +489,7 @@ mod tests {
         // equivalent.
         let mut state = Arc::new(StateDelta::new(()));
         {
-            // TODO: this is copied out of App::init_chain, can we put it in penumbra-chain or sth?
+            // TODO: this is copied out of App::init_chain, can we put it somewhere else?
             let mut state_tx = state.try_begin_transaction().unwrap();
             state_tx.put_block_height(0);
             state_tx.put_epoch_by_height(

--- a/crates/core/component/shielded-pool/Cargo.toml
+++ b/crates/core/component/shielded-pool/Cargo.toml
@@ -38,7 +38,6 @@ penumbra-proof-params = { path = "../../../crypto/proof-params", default-feature
 penumbra-sct = { path = "../sct", default-features = false }
 cnidarium-component = { path = "../../../cnidarium-component", optional = true }
 penumbra-ibc = { path = "../ibc", default-features = false }
-#penumbra-chain = { path = "../chain", default-features = false }
 penumbra-asset = { path = "../../../core/asset", default-features = false }
 penumbra-num = { path = "../../../core/num", default-features = false }
 penumbra-keys = { path = "../../../core/keys", default-features = false }

--- a/crates/core/component/stake/Cargo.toml
+++ b/crates/core/component/stake/Cargo.toml
@@ -40,7 +40,6 @@ parallel = [
 cnidarium = { path = "../../../cnidarium", default-features = false, optional = true }
 cnidarium-component = { path = "../../../cnidarium-component", default-features = false, optional = true }
 penumbra-asset = { path = "../../../core/asset", default-features = false }
-#penumbra-chain = { path = "../chain", default-features = false }
 penumbra-community-pool = { path = "../community-pool", default-features = false }
 penumbra-distributions = { path = "../distributions", default-features = false }
 penumbra-keys = { path = "../../../core/keys", default-features = false }

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -10,7 +10,6 @@ decaf377-ka = { path = "../../crypto/decaf377-ka/" }
 decaf377-fmd = { path = "../../crypto/decaf377-fmd/" }
 penumbra-tct = { path = "../../crypto/tct" }
 penumbra-proof-params = { path = "../../crypto/proof-params/" }
-#penumbra-chain = { path = "../component/chain/", default-features = false }
 penumbra-governance = { path = "../component/governance/", default-features = false }
 penumbra-shielded-pool = { path = "../component/shielded-pool/", default-features = false }
 penumbra-sct = { path = "../component/sct/", default-features = false }

--- a/crates/custody/Cargo.toml
+++ b/crates/custody/Cargo.toml
@@ -15,7 +15,6 @@ decaf377 = "0.5"
 decaf377-rdsa = "0.7"
 decaf377-frost = { path = "../crypto/decaf377-frost" }
 decaf377-ka = { path = "../crypto/decaf377-ka" }
-#penumbra-chain = { path = "../core/component/chain" }
 penumbra-keys = { path = "../core/keys" }
 penumbra-txhash = { path = "../core/txhash" }
 penumbra-proto = { path = "../proto", features = ["rpc"] }

--- a/crates/misc/measure/Cargo.toml
+++ b/crates/misc/measure/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 penumbra-proto = { path = "../../proto", features = ["rpc"] }
-#penumbra-chain = { path = "../../core/component/chain" }
 penumbra-app = { path = "../../core/app" }
 penumbra-compact-block = { path = "../../core/component/compact-block", default-features = false }
 

--- a/crates/view/Cargo.toml
+++ b/crates/view/Cargo.toml
@@ -25,7 +25,6 @@ penumbra-tct = { path = "../crypto/tct" }
 penumbra-num = { path = "../core/num" }
 penumbra-keys = { path = "../core/keys" }
 penumbra-asset = { path = "../core/asset" }
-#penumbra-chain = { path = "../core/component/chain" }
 penumbra-shielded-pool = { path = "../core/component/shielded-pool", default-features = false }
 penumbra-governance = { path = "../core/component/governance", default-features = false }
 penumbra-stake = { path = "../core/component/stake", default-features = false }

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -18,7 +18,6 @@ penumbra-tct = { path = "../crypto/tct" }
 penumbra-num = { path = "../core/num" }
 penumbra-asset = { path = "../core/asset" }
 penumbra-keys = { path = "../core/keys" }
-# penumbra-chain = { path = "../core/component/chain" }
 penumbra-dex = { path = "../core/component/dex" }
 penumbra-transaction = { path = "../core/transaction" }
 penumbra-app = { path = "../core/app" }


### PR DESCRIPTION
cleanup, related to #3703.