### PR TITLE
ci: remove hermes build

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -146,30 +146,6 @@ jobs:
           cd deployments/
           ./scripts/gha-repository-dispatch penumbra-zone/galileo
 
-  hermes:
-    runs-on: ubuntu-latest
-    needs:
-      - penumbra
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      # We use the GHA Repository Dispatch functionality to trigger a container
-      # build in the penumbra-zone/hermes repo.
-      - name: Trigger remote build
-        shell: bash
-        env:
-          GITHUB_PAT: ${{ secrets.GH_PAT }}
-        run: |-
-          export PENUMBRA_VERSION='${{ github.event.inputs.image_tag || github.ref_name }}'
-          # Hermes only runs against public testnets, so we need only build tags, but for now
-          # we build even on main, to ensure a working build as ibc code changes.
-          cd deployments/
-          ./scripts/gha-repository-dispatch penumbra-zone/hermes
-
   relayer:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The fork repo for hermes was reset, so the referenced workflow no longer exists. This was causing an HTTP 422 in the build logic. Removing hermes references to sidestep the problem and unbreak preview deploys.