### PR TITLE
chore(app): 🏴 organize `lib.rs`, metadata for `Cargo.toml`

### DIFF
--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "penumbra-app"
 version = "0.65.0-alpha.1"
+authors = ["Penumbra Labs <team@penumbra.zone>"]
 edition = "2021"
+repository = "https://github.com/penumbra-zone/penumbra/"
+homepage = "https://penumbra.zone"
+license = "MIT OR Apache-2.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/core/app/src/lib.rs
+++ b/crates/core/app/src/lib.rs
@@ -1,20 +1,30 @@
 #![deny(clippy::unwrap_used)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+pub mod app;
+pub mod genesis;
+pub mod metrics;
+pub mod params;
+pub mod rpc;
+
 mod action_handler;
 mod community_pool_ext;
 mod mock_client;
 mod penumbra_host_chain;
 mod temp_storage_ext;
 
-pub use action_handler::ActionHandler;
-pub use app::StateWriteExt;
-pub use community_pool_ext::CommunityPoolStateReadExt;
-pub use mock_client::MockClient;
-pub use penumbra_host_chain::PenumbraHost;
-pub use temp_storage_ext::TempStorageExt;
+#[cfg(test)]
+mod tests;
+
+pub use crate::{
+    action_handler::ActionHandler, app::StateWriteExt,
+    community_pool_ext::CommunityPoolStateReadExt, metrics::register_metrics,
+    mock_client::MockClient, penumbra_host_chain::PenumbraHost, temp_storage_ext::TempStorageExt,
+};
 
 use once_cell::sync::Lazy;
+
+pub const APP_VERSION: u64 = 1;
 
 pub static SUBSTORE_PREFIXES: Lazy<Vec<String>> = Lazy::new(|| {
     vec![
@@ -23,20 +33,8 @@ pub static SUBSTORE_PREFIXES: Lazy<Vec<String>> = Lazy::new(|| {
     ]
 });
 
-pub mod app;
-pub mod genesis;
-pub mod params;
-
-pub mod metrics;
-pub mod rpc;
-pub use self::metrics::register_metrics;
-
-pub const APP_VERSION: u64 = 1;
 /// The substore prefix used for storing histori CometBFT block data.
 pub static COMETBFT_SUBSTORE_PREFIX: &'static str = "cometbft-data";
-
-#[cfg(test)]
-mod tests;
 
 /// Temporary compat wrapper for duplicate trait impls
 pub struct Compat<'a, T>(&'a T);


### PR DESCRIPTION
this is a small bit of cleanup, as i've been reading through the app crate. add crate metadata present elsewhere in our workspace, and polish the top-level `lib.rs` file.