### PR TITLE
fix(pd): acme-staging flag should default to false

### DIFF
--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -61,7 +61,7 @@ pub enum RootCommand {
         /// if you're trying out the `--grpc-auto-https` option for the first time,
         /// to validate your configuration, before subjecting yourself to production
         /// ratelimits. This option has no effect if `--grpc-auto-https` is not set.
-        #[clap(long, display_order = 201, default_value = "false")]
+        #[clap(long, display_order = 201)]
         acme_staging: bool,
         /// Bind the metrics endpoint to this socket.
         #[clap(

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -123,6 +123,7 @@ async fn main() -> anyhow::Result<()> {
                 ?abci_bind,
                 ?grpc_bind,
                 ?grpc_auto_https,
+                ?acme_staging,
                 ?metrics_bind,
                 %cometbft_addr,
                 ?enable_expensive_rpc,


### PR DESCRIPTION
Follow up to https://github.com/penumbra-zone/penumbra/pull/3705, which was subtly broken: the `--acme-staging` flag was *always* set to true, so I was getting staging certs even when I wanted prod ones. The problem was mistaken use of `default_value` in the clap derive markers. Simply setting the arg type as bool is sufficient; neither `default_value` nor `default_value_t` are appropriate here.