### PR TITLE
shielded-pool(component): simplify tracking of fmd parameters

### DIFF
--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -254,7 +254,9 @@ impl App {
                 state_tx.put_ibc_params(ibc_params);
             }
             if let Some(shielded_pool_params) = app_params.new.shielded_pool_params {
-                state_tx.put_shielded_pool_params(shielded_pool_params);
+                state_tx
+                    .put_shielded_pool_params(shielded_pool_params)
+                    .await;
             }
             if let Some(sct_params) = app_params.new.sct_params {
                 state_tx.put_sct_params(sct_params);


### PR DESCRIPTION
Close #3713, a follow-up to #3617. Now that we have shielded pool parameters, we do not want to have a separate code path to update the FMD parameters without also updating the shielded pool params. 