### PR TITLE
feat(pcli): default coordinator address for ceremony

### DIFF
--- a/crates/bin/pcli/src/command/ceremony.rs
+++ b/crates/bin/pcli/src/command/ceremony.rs
@@ -89,7 +89,10 @@ pub enum CeremonyCmd {
         coordinator_url: Url,
         /// The Penumbra wallet address of the coordination server. Bids will be sent to this
         /// address, so the coordinator can compute the contributor's place in the queue.
-        #[clap(long)]
+        #[clap(
+            long,
+            default_value = "penumbra1qvqr8cvqyf4pwrl6svw9kj8eypf3fuunrcs83m30zxh57y2ytk94gygmtq5k82cjdq9y3mlaa3fwctwpdjr6fxnwuzrsy4ezm0u2tqpzw0sed82shzcr42sju55en26mavjnw4"
+        )]
         coordinator_address: Address,
         /// Amount to spend during bid. Must be specified typed values, e.g. '50penumbra'.
         /// Only the 'penumbra' token is accepted for contributions. Bids are additive,

--- a/tools/summonerd/src/web.rs
+++ b/tools/summonerd/src/web.rs
@@ -17,7 +17,7 @@ const LAST_N: u64 = 50_000;
 
 /// Represents the storage used by the web application.
 pub struct WebAppState {
-    address: Address,
+    _address: Address,
     config: Config,
     phase: PhaseMarker,
     queue: ParticipantQueue,
@@ -67,14 +67,14 @@ async fn serve_woff2(filename: &str) -> impl IntoResponse {
 }
 
 pub fn web_app(
-    address: Address,
+    _address: Address,
     config: Config,
     phase: PhaseMarker,
     queue: ParticipantQueue,
     storage: Storage,
 ) -> Router {
     let shared_state = Arc::new(WebAppState {
-        address,
+        _address,
         config,
         phase,
         queue,
@@ -122,7 +122,7 @@ pub async fn main_page(State(state): State<Arc<WebAppState>>) -> impl IntoRespon
         .unwrap_or(0);
 
     let template = MainTemplate {
-        address: state.address.to_string(),
+        _address: state._address.to_string(),
         min_bid: format!("{}penumbra", state.config.min_bid_u64),
         phase_number,
         phase_1_completed,
@@ -205,7 +205,7 @@ pub async fn phase_2(State(state): State<Arc<WebAppState>>) -> impl IntoResponse
 #[derive(Template)]
 #[template(path = "main.html")]
 struct MainTemplate {
-    address: String,
+    _address: String,
     min_bid: String,
     phase_number: u64,
     phase_1_completed: u64,

--- a/tools/summonerd/templates/main.html
+++ b/tools/summonerd/templates/main.html
@@ -118,7 +118,7 @@
           To join the queue, use <span class="font-mono">pcli ceremony contribute</span> to place a bid:
         </p>
         <pre
-          class="text-sm my-8 p-4 bg-charcoal rounded-lg overflow-x-auto">pcli ceremony contribute --phase {{ phase_number }} --bid {{ min_bid }} --coordinator-address {{ address }}</pre>
+          class="text-sm my-8 p-4 bg-charcoal rounded-lg overflow-x-auto">pcli ceremony contribute --phase {{ phase_number }} --bid {{ min_bid }}</pre>
         <p>
           The minimum bid for this ceremony is {{ min_bid }}.
         </p>


### PR DESCRIPTION
During Phase 1 of the summoning ceremony, some contributors were confused about the `--coordinator-address` flag, and incorrectly overrode it to a wallet address they control. Let's set a sane default value for that arg, and remove its display from the web page.