### PR TITLE
fix(metrics): rename tendermint -> cometbft

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -69,5 +69,8 @@ jobs:
           export HELM_RELEASE='penumbra-preview'
           ./ci.sh
 
+      - name: bounce metrics
+        run: kubectl rollout restart deployment penumbra-preview-metrics
+
       - name: bounce grpcui
         run: kubectl rollout restart deployment grpcui-preview

--- a/deployments/charts/penumbra-metrics/templates/configmap.yaml
+++ b/deployments/charts/penumbra-metrics/templates/configmap.yaml
@@ -15,37 +15,29 @@ data:
       editable: false
   prometheus_scrape_configs: |
     scrape_configs:
+
+      - job_name: 'Penumbra Fullnode'
+        scrape_interval: 10s
+        scheme: http
+        metrics_path: metrics
+        static_configs:
 {{ $count := (.Values.scrape_configs.numFullNodes | int) }}
 {{ range $i,$e := until $count }}
+          - targets:
 {{ $fn_name := printf $.Values.scrape_configs.fmtFullNodeSvc $i }}
-
-      - job_name: 'Tendermint Fullnode {{ $i }}'
-        scrape_interval: 10s
-        scheme: http
-        metrics_path: metrics
-        static_configs:
-          - targets: ['{{ $fn_name }}:26660']
-
-      - job_name: 'Penumbra Daemon Fullnode {{ $i }}'
-        scrape_interval: 10s
-        scheme: http
-        metrics_path: metrics
-        static_configs:
-          - targets: ['{{ $fn_name }}:9000']
+            - '{{ $fn_name }}:9000'
+            - '{{ $fn_name }}:26660'
 {{ end }}
+
+      - job_name: 'Penumbra Validator'
+        scrape_interval: 10s
+        scheme: http
+        metrics_path: metrics
+        static_configs:
+          - targets:
 {{ $count := (.Values.scrape_configs.numValidators | int) }}
 {{ range $i,$e := until $count }}
 {{ $val_name := printf $.Values.scrape_configs.fmtValidatorSvc $i }}
-      - job_name: 'Tendermint Validator {{ $i }}'
-        scrape_interval: 10s
-        scheme: http
-        metrics_path: metrics
-        static_configs:
-          - targets: ['{{ $val_name }}:26660']
-      - job_name: 'Penumbra Daemon Validator {{ $i }}'
-        scrape_interval: 10s
-        scheme: http
-        metrics_path: metrics
-        static_configs:
-          - targets: ['{{ $val_name }}:9000']
+            - '{{ $val_name }}:9000'
+            - '{{ $val_name }}:26660'
 {{ end }}

--- a/deployments/config/grafana/dashboards/ABCI.json
+++ b/deployments/config/grafana/dashboards/ABCI.json
@@ -167,7 +167,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(tendermint_abci_connection_method_timing_seconds_count[5m])) by (method)",
+          "expr": "sum(rate(cometbft_abci_connection_method_timing_seconds_count[5m])) by (method)",
           "refId": "A"
         }
       ],
@@ -255,7 +255,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(tendermint_abci_connection_method_timing_seconds_bucket{method=\"begin_block\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(cometbft_abci_connection_method_timing_seconds_bucket{method=\"begin_block\"}[5m])))",
           "range": true,
           "refId": "A"
         },
@@ -264,7 +264,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.5, sum by(le) (rate(tendermint_abci_connection_method_timing_seconds_bucket{method=\"begin_block\"}[5m])))",
+          "expr": "histogram_quantile(0.5, sum by(le) (rate(cometbft_abci_connection_method_timing_seconds_bucket{method=\"begin_block\"}[5m])))",
           "hide": false,
           "refId": "B"
         }
@@ -353,7 +353,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(tendermint_abci_connection_method_timing_seconds_bucket{method=\"deliver_tx\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(cometbft_abci_connection_method_timing_seconds_bucket{method=\"deliver_tx\"}[5m])))",
           "range": true,
           "refId": "A"
         }
@@ -442,7 +442,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(tendermint_abci_connection_method_timing_seconds_bucket{method=\"end_block\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(cometbft_abci_connection_method_timing_seconds_bucket{method=\"end_block\"}[5m])))",
           "range": true,
           "refId": "A"
         }
@@ -531,7 +531,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(tendermint_abci_connection_method_timing_seconds_bucket{method=\"commit\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(cometbft_abci_connection_method_timing_seconds_bucket{method=\"commit\"}[5m])))",
           "range": true,
           "refId": "A"
         }

--- a/deployments/config/grafana/dashboards/Consensus.json
+++ b/deployments/config/grafana/dashboards/Consensus.json
@@ -139,7 +139,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "tendermint_consensus_missing_validators",
+          "expr": "cometbft_consensus_missing_validators",
           "legendFormat": "Missing Validators",
           "range": true,
           "refId": "A"
@@ -150,7 +150,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "tendermint_consensus_validators",
+          "expr": "cometbft_consensus_validators",
           "hide": false,
           "legendFormat": "Validators",
           "range": true,
@@ -240,7 +240,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(tendermint_consensus_latest_block_height[5m])",
+          "expr": "rate(cometbft_consensus_latest_block_height[5m])",
           "refId": "A"
         }
       ],
@@ -326,7 +326,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "tendermint_consensus_rounds",
+          "expr": "cometbft_consensus_rounds",
           "refId": "A"
         }
       ],

--- a/deployments/config/grafana/dashboards/P2P.json
+++ b/deployments/config/grafana/dashboards/P2P.json
@@ -138,7 +138,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "tendermint_p2p_peers",
+          "expr": "cometbft_p2p_peers",
           "refId": "A"
         }
       ],
@@ -225,7 +225,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(tendermint_p2p_peer_send_bytes_total[1m])) by (peer_id)",
+          "expr": "sum(rate(cometbft_p2p_peer_send_bytes_total[1m])) by (peer_id)",
           "refId": "A"
         },
         {
@@ -233,7 +233,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(tendermint_p2p_peer_receive_bytes_total[1m])) by(peer_id)",
+          "expr": "sum(rate(cometbft_p2p_peer_receive_bytes_total[1m])) by(peer_id)",
           "hide": false,
           "refId": "B"
         }

--- a/deployments/config/grafana/dashboards/sync.json
+++ b/deployments/config/grafana/dashboards/sync.json
@@ -411,7 +411,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "rate(tendermint_consensus_latest_block_height[5m])",
+          "expr": "rate(cometbft_consensus_latest_block_height[5m])",
           "instant": false,
           "range": true,
           "refId": "A"
@@ -595,7 +595,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "builder",
-          "expr": "tendermint_consensus_height",
+          "expr": "cometbft_consensus_height",
           "instant": false,
           "range": true,
           "refId": "A"

--- a/testnets/cometbft_config_template.toml
+++ b/testnets/cometbft_config_template.toml
@@ -482,4 +482,4 @@ prometheus_listen_addr = ":26660"
 max_open_connections = 3
 
 # Instrumentation namespace
-namespace = "tendermint"
+namespace = "cometbft"


### PR DESCRIPTION
Updates the generated CometBFT config to use the "cometbft" namespace for emitted metrics. Accordingly, updates the Grafana panels that incorporate those metrics.

Also attempts to make the grafana panels more legible, by bundling up the pd & cometbft scrape points into a single job, either "Fullnode" or "Validator". We'll still have the ability to discriminate by "instance" which includes the address scraped, e.g. "penumbra-testnet-fn-0:9000" for pd.