### PR TITLE
Make all crates use workspace dependencies when shared

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,34 +747,13 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
-dependencies = [
- "async-stream-impl 0.2.1",
- "futures-core",
-]
-
-[[package]]
-name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
- "async-stream-impl 0.3.5",
+ "async-stream-impl",
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
-dependencies = [
- "proc-macro2 1.0.76",
- "quote 1.0.35",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -848,12 +827,12 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core 0.2.9",
+ "axum-core",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -862,38 +841,7 @@ dependencies = [
  "http-body",
  "hyper",
  "itoa",
- "matchit 0.5.0",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http 0.3.5",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -906,22 +854,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
  "tower-layer",
  "tower-service",
 ]
@@ -995,12 +927,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -1435,17 +1361,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags 1.3.2",
- "textwrap 0.11.0",
- "unicode-width",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
@@ -1458,7 +1373,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -1499,7 +1414,7 @@ dependencies = [
  "metrics 0.22.0",
  "once_cell",
  "parking_lot 0.12.1",
- "pbjson 0.5.1",
+ "pbjson",
  "pin-project",
  "prost",
  "regex",
@@ -1716,32 +1631,6 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
-dependencies = [
- "atty",
- "cast",
- "clap 2.34.0",
- "criterion-plot 0.4.5",
- "csv",
- "itertools 0.10.5",
- "lazy_static",
- "num-traits",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_cbor",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
@@ -1750,8 +1639,8 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap 3.2.25",
- "criterion-plot 0.5.0",
+ "clap",
+ "criterion-plot",
  "itertools 0.10.5",
  "lazy_static",
  "num-traits",
@@ -1764,16 +1653,6 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
-dependencies = [
- "cast",
- "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1934,36 +1813,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2 1.0.76",
- "quote 1.0.35",
- "strsim",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1982,22 +1837,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core 0.13.4",
- "quote 1.0.35",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core",
  "quote 1.0.35",
  "syn 2.0.48",
 ]
@@ -2073,8 +1917,8 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "bitvec",
- "blake2b_simd 0.5.11",
- "criterion 0.3.6",
+ "blake2b_simd 1.0.2",
+ "criterion",
  "decaf377 0.5.0",
  "proptest",
  "rand_core 0.6.4",
@@ -2087,7 +1931,7 @@ version = "0.65.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "frost-core",
@@ -4014,12 +3858,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
-
-[[package]]
-name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
@@ -4552,16 +4390,6 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pbjson"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048f9ac93c1eab514f9470c4bc8d97ca2a0a236b84f45cc19d69a59fc11467f6"
-dependencies = [
- "base64 0.13.1",
- "serde",
-]
-
-[[package]]
-name = "pbjson"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1030c719b0ec2a2d25a5df729d6cff1acf3cc230bf766f4f97833591f7577b90"
@@ -4590,7 +4418,7 @@ checksum = "18f596653ba4ac51bdecbb4ef6773bc7f56042dc13927910de1684ad3d32aa12"
 dependencies = [
  "bytes",
  "chrono",
- "pbjson 0.6.0",
+ "pbjson",
  "pbjson-build",
  "prost",
  "prost-build",
@@ -4614,14 +4442,14 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "assert_cmd",
- "async-stream 0.2.1",
+ "async-stream",
  "atty",
  "base64 0.21.6",
  "bincode",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "bytes",
  "camino",
- "clap 3.2.25",
+ "clap",
  "colored_json",
  "comfy-table",
  "decaf377 0.5.0",
@@ -4668,8 +4496,8 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
- "serde_with 1.14.0",
- "sha2 0.9.9",
+ "serde_with",
+ "sha2 0.10.8",
  "simple-base64",
  "tempfile",
  "tendermint",
@@ -4690,13 +4518,13 @@ version = "0.65.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "async-stream 0.2.1",
+ "async-stream",
  "async-trait",
  "atty",
- "base64 0.20.0",
+ "base64 0.21.6",
  "bytes",
  "camino",
- "clap 3.2.25",
+ "clap",
  "directories",
  "ed25519-consensus",
  "futures",
@@ -4721,19 +4549,19 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "serde_with 1.14.0",
+ "serde_with",
  "sha2 0.10.8",
  "tempfile",
  "tendermint",
  "tokio",
  "tokio-stream",
- "toml 0.5.11",
+ "toml 0.7.8",
  "tonic",
  "tonic-reflection",
  "tonic-web",
  "tower",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.18",
  "url",
 ]
 
@@ -4743,16 +4571,16 @@ version = "0.65.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
- "async-stream 0.2.1",
+ "async-stream",
  "async-trait",
  "atty",
  "axum-server",
- "base64 0.20.0",
+ "base64 0.21.6",
  "bincode",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "bytes",
  "chrono",
- "clap 3.2.25",
+ "clap",
  "cnidarium",
  "console-subscriber",
  "csv",
@@ -4804,8 +4632,8 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
- "serde_with 1.14.0",
- "sha2 0.9.9",
+ "serde_with",
+ "sha2 0.10.8",
  "tempfile",
  "tendermint",
  "tendermint-config",
@@ -4815,14 +4643,14 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.10",
- "toml 0.5.11",
+ "toml 0.7.8",
  "tonic",
  "tonic-reflection",
  "tonic-web",
  "tower",
  "tower-abci",
  "tower-actor",
- "tower-http 0.4.4",
+ "tower-http",
  "tower-service",
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -4878,11 +4706,11 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "base64 0.20.0",
+ "base64 0.21.6",
  "bech32",
  "bincode",
  "bitvec",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "cnidarium",
  "cnidarium-component",
  "decaf377 0.5.0",
@@ -4923,8 +4751,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_unit_struct",
- "serde_with 2.3.3",
- "sha2 0.9.9",
+ "serde_with",
+ "sha2 0.10.8",
  "tempfile",
  "tendermint",
  "tendermint-light-client-verifier",
@@ -4945,9 +4773,9 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-std",
- "base64 0.20.0",
+ "base64 0.21.6",
  "bech32",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "bytes",
  "decaf377 0.5.0",
  "decaf377-fmd",
@@ -4967,7 +4795,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_with 3.5.1",
+ "serde_with",
  "sha2 0.10.8",
  "thiserror",
  "tracing",
@@ -4999,7 +4827,7 @@ dependencies = [
  "ark-snark",
  "ark-std",
  "bech32",
- "criterion 0.4.0",
+ "criterion",
  "decaf377 0.5.0",
  "decaf377-fmd",
  "decaf377-ka",
@@ -5036,8 +4864,8 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "base64 0.20.0",
- "blake2b_simd 0.5.11",
+ "base64 0.21.6",
+ "blake2b_simd 1.0.2",
  "cnidarium",
  "cnidarium-component",
  "futures",
@@ -5068,7 +4896,7 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "bytes",
  "cnidarium",
  "cnidarium-component",
@@ -5104,8 +4932,8 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "ark-serialize",
- "base64 0.20.0",
- "blake2b_simd 0.5.11",
+ "base64 0.21.6",
+ "blake2b_simd 1.0.2",
  "bytes",
  "chacha20poly1305",
  "decaf377 0.5.0",
@@ -5123,9 +4951,9 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "serde_with 2.3.3",
+ "serde_with",
  "tokio",
- "toml 0.5.11",
+ "toml 0.7.8",
  "tonic",
  "tracing",
 ]
@@ -5141,11 +4969,11 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "async-stream 0.2.1",
+ "async-stream",
  "async-trait",
- "base64 0.20.0",
+ "base64 0.21.6",
  "bincode",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "cnidarium",
  "cnidarium-component",
  "decaf377 0.5.0",
@@ -5231,7 +5059,7 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "bytes",
  "cnidarium",
  "cnidarium-component",
@@ -5281,10 +5109,10 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "async-stream 0.2.1",
+ "async-stream",
  "async-trait",
  "base64 0.21.6",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "bytes",
  "cnidarium",
  "cnidarium-component",
@@ -5331,8 +5159,8 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
- "base64 0.20.0",
- "blake2b_simd 0.5.11",
+ "base64 0.21.6",
+ "blake2b_simd 1.0.2",
  "cnidarium",
  "hex",
  "ibc-proto",
@@ -5370,10 +5198,10 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-std",
- "base64 0.20.0",
+ "base64 0.21.6",
  "bech32",
  "bip32",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "bytes",
  "chacha20poly1305",
  "decaf377 0.5.0",
@@ -5411,7 +5239,7 @@ version = "0.65.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytesize",
- "clap 3.2.25",
+ "clap",
  "indicatif",
  "penumbra-app",
  "penumbra-compact-block",
@@ -5436,9 +5264,9 @@ dependencies = [
  "ark-serialize",
  "ark-snark",
  "ark-std",
- "base64 0.20.0",
+ "base64 0.21.6",
  "bech32",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "bytes",
  "decaf377 0.5.0",
  "decaf377-fmd",
@@ -5503,8 +5331,8 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "blake2b_simd 0.5.11",
- "criterion 0.4.0",
+ "blake2b_simd 1.0.2",
+ "criterion",
  "decaf377 0.5.0",
  "penumbra-community-pool",
  "penumbra-dex",
@@ -5535,7 +5363,7 @@ dependencies = [
  "ibc-proto",
  "ibc-types",
  "ics23",
- "pbjson 0.6.0",
+ "pbjson",
  "pbjson-types",
  "pin-project",
  "prost",
@@ -5559,7 +5387,7 @@ dependencies = [
  "ark-serialize",
  "async-trait",
  "bincode",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "bytes",
  "cnidarium",
  "cnidarium-component",
@@ -5593,8 +5421,8 @@ dependencies = [
  "ark-serialize",
  "ark-snark",
  "async-trait",
- "base64 0.20.0",
- "blake2b_simd 0.5.11",
+ "base64 0.21.6",
+ "blake2b_simd 1.0.2",
  "bytes",
  "chacha20poly1305",
  "cnidarium",
@@ -5641,9 +5469,9 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "async-stream 0.3.5",
+ "async-stream",
  "async-trait",
- "base64 0.20.0",
+ "base64 0.21.6",
  "bech32",
  "bitvec",
  "cnidarium",
@@ -5673,8 +5501,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_unit_struct",
- "serde_with 2.3.3",
- "sha2 0.9.9",
+ "serde_with",
+ "sha2 0.10.8",
  "tendermint",
  "tokio",
  "tonic",
@@ -5730,10 +5558,10 @@ name = "penumbra-tct-visualize"
 version = "0.65.0-alpha.1"
 dependencies = [
  "anyhow",
- "axum 0.5.17",
+ "axum",
  "axum-server",
  "bytes",
- "clap 3.2.25",
+ "clap",
  "decaf377 0.5.0",
  "futures",
  "hex",
@@ -5751,7 +5579,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.10",
  "tonic",
- "tower-http 0.3.5",
+ "tower-http",
  "tracing-subscriber 0.3.18",
 ]
 
@@ -5770,7 +5598,7 @@ dependencies = [
  "penumbra-transaction",
  "pin-project",
  "pin-project-lite",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "tendermint",
  "tendermint-config",
  "tendermint-light-client-verifier",
@@ -5795,7 +5623,7 @@ dependencies = [
  "http",
  "pin-project",
  "pin-project-lite",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "tendermint",
  "tendermint-proto",
  "tokio",
@@ -5816,7 +5644,7 @@ dependencies = [
  "ark-serialize",
  "base64 0.21.6",
  "bech32",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "bytes",
  "chacha20poly1305",
  "decaf377 0.5.0",
@@ -5853,7 +5681,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
  "tokio",
  "tracing",
@@ -5864,7 +5692,7 @@ name = "penumbra-txhash"
 version = "0.65.0-alpha.1"
 dependencies = [
  "anyhow",
- "blake2b_simd 0.5.11",
+ "blake2b_simd 1.0.2",
  "hex",
  "penumbra-proto",
  "penumbra-tct",
@@ -5877,7 +5705,7 @@ version = "0.65.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-std",
- "async-stream 0.2.1",
+ "async-stream",
  "async-trait",
  "bytes",
  "camino",
@@ -5922,7 +5750,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.18",
  "url",
 ]
 
@@ -6548,10 +6376,12 @@ dependencies = [
 [[package]]
 name = "r2d2_sqlite"
 version = "0.22.0"
-source = "git+https://github.com/penumbra-zone/r2d2-sqlite.git#bcb4957c9bba34d0f22a4e84422edf8d29568e5f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f31323d6161385f385046738df520e0e8694fa74852d35891fc0be08348ddc"
 dependencies = [
  "r2d2",
  "rusqlite",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -7297,16 +7127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7403,33 +7223,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "hex",
- "serde",
- "serde_with_macros 1.5.2",
-]
-
-[[package]]
-name = "serde_with"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "serde",
- "serde_json",
- "serde_with_macros 2.3.3",
- "time 0.3.19",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c"
@@ -7441,32 +7234,8 @@ dependencies = [
  "indexmap 2.1.0",
  "serde",
  "serde_json",
- "serde_with_macros 3.5.1",
+ "serde_with_macros",
  "time 0.3.19",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling 0.13.4",
- "proc-macro2 1.0.76",
- "quote 1.0.35",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling 0.20.3",
- "proc-macro2 1.0.76",
- "quote 1.0.35",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -7475,7 +7244,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298"
 dependencies = [
- "darling 0.20.3",
+ "darling",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "syn 2.0.48",
@@ -7837,11 +7606,11 @@ dependencies = [
  "askama",
  "async-trait",
  "atty",
- "axum 0.6.20",
+ "axum",
  "bytes",
  "camino",
  "chrono",
- "clap 3.2.25",
+ "clap",
  "console-subscriber",
  "decaf377 0.5.0",
  "futures",
@@ -8090,15 +7859,6 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "textwrap"
@@ -8403,9 +8163,9 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
- "async-stream 0.3.5",
+ "async-stream",
  "async-trait",
- "axum 0.6.20",
+ "axum",
  "base64 0.21.6",
  "bytes",
  "h2",
@@ -8455,7 +8215,7 @@ dependencies = [
  "pin-project",
  "tokio-stream",
  "tonic",
- "tower-http 0.4.4",
+ "tower-http",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -8518,26 +8278,6 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
-dependencies = [
- "bitflags 1.3.2",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
@@ -8552,6 +8292,7 @@ dependencies = [
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -8802,6 +8543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom 0.2.12",
+ "rand 0.8.5",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,131 @@ publish = false
 tag = true
 # Don't push, since we're still evaluating the new release workflow.
 push = false
+
+[workspace.package]
+authors = ["Penumbra Labs <team@penumbra.zone>"]
+edition = "2021"
+version = "0.65.0-alpha.1"
+repository = "https://github.com/penumbra-zone/penumbra"
+homepage = "https://penumbra.zone"
+license = "MIT OR Apache-2.0"
+
+[workspace.dependencies]
+anyhow = {version = "1.0.75"}
+ark-ec = {default-features = false, version = "0.4.2"}
+ark-ff = {default-features = false, version = "0.4.2"}
+ark-groth16 = {default-features = false, version = "0.4.0"}
+ark-r1cs-std = {default-features = false, version = "0.4.0"}
+ark-relations = {version = "0.4"}
+ark-serialize = {version = "0.4.2"}
+ark-snark = {version = "0.4.0"}
+ark-std = {default-features = false, version = "0.4"}
+assert_cmd = {version = "2.0"}
+async-stream = {version = "0.3.5"}
+async-trait = {version = "0.1.52"}
+atty = {version = "0.2"}
+axum = {version = "0.6"}
+axum-server = {version = "0.4.7"}
+base64 = {version = "0.21.2"}
+bech32 = {version = "0.8.1"}
+bincode = {version = "1.3.3"}
+bitvec = {version = "1"}
+blake2b_simd = {version = "1"}
+bytes = {version = "1.2"}
+camino = {version = "1"}
+chacha20poly1305 = {version = "0.9.0"}
+chrono = {default-features = false, version = "0.4"}
+clap = {version = "3.2"}
+cnidarium = {default-features = false, path = "crates/cnidarium"}
+cnidarium-component = {default-features = false, path = "crates/cnidarium-component"}
+console-subscriber = {version = "0.2"}
+criterion = {version = "0.4"}
+decaf377 = {default-features = false, version = "0.5"}
+decaf377-fmd = {path = "crates/crypto/decaf377-fmd"}
+decaf377-ka = {path = "crates/crypto/decaf377-ka"}
+decaf377-rdsa = {version = "0.7"}
+derivative = {version = "2.2"}
+directories = {version = "4.0.1"}
+ed25519-consensus = {version = "2.1"}
+ethnum = {version = "1.3"}
+futures = {version = "0.3.28"}
+hex = {version = "0.4.3"}
+http = {version = "0.2.9"}
+http-body = {version = "0.4.5"}
+ibc-proto = {default-features = false, version = "0.40.0"}
+ibc-types = {default-features = false, version = "0.11.0"}
+ibig = {version = "0.3"}
+ics23 = {version = "0.11.0"}
+im = {version = "^15.1.0"}
+indicatif = {version = "0.16"}
+jmt = {version = "0.9"}
+metrics = {version = "0.22"}
+metrics-tracing-context = {version = "0.11.0"}
+num-bigint = {version = "0.4"}
+num-traits = {default-features = false, version = "0.2.15"}
+once_cell = {version = "1.8"}
+parking_lot = {version = "0.12.1"}
+pbjson = {version = "0.6"}
+pbjson-types = {version = "0.6.0"}
+penumbra-app = {path = "crates/core/app"}
+penumbra-asset = {default-features = false, path = "crates/core/asset"}
+penumbra-community-pool = {default-features = false, path = "crates/core/component/community-pool"}
+penumbra-compact-block = {default-features = false, path = "crates/core/component/compact-block"}
+penumbra-custody = {path = "crates/custody"}
+penumbra-dex = {default-features = false, path = "crates/core/component/dex"}
+penumbra-distributions = {default-features = false, path = "crates/core/component/distributions"}
+penumbra-fee = {default-features = false, path = "crates/core/component/fee"}
+penumbra-funding = {default-features = false, path = "crates/core/component/funding"}
+penumbra-governance = {default-features = false, path = "crates/core/component/governance"}
+penumbra-ibc = {default-features = false, path = "crates/core/component/ibc"}
+penumbra-keys = {default-features = false, path = "crates/core/keys"}
+penumbra-num = {default-features = false, path = "crates/core/num"}
+penumbra-proof-params = {default-features = false, path = "crates/crypto/proof-params"}
+penumbra-proof-setup = {path = "crates/crypto/proof-setup"}
+penumbra-proto = {default-features = false, path = "crates/proto"}
+penumbra-sct = {default-features = false, path = "crates/core/component/sct"}
+penumbra-shielded-pool = {default-features = false, path = "crates/core/component/shielded-pool"}
+penumbra-stake = {default-features = false, path = "crates/core/component/stake"}
+penumbra-tct = {default-features = false, path = "crates/crypto/tct"}
+penumbra-transaction = {default-features = false, path = "crates/core/transaction"}
+penumbra-txhash = {default-features = false, path = "crates/core/txhash"}
+penumbra-view = {path = "crates/view"}
+pin-project = {version = "1.0.12"}
+pin-project-lite = {version = "0.2.9"}
+poseidon377 = {version = "0.6"}
+proptest = {version = "1"}
+proptest-derive = {version = "0.3"}
+prost = {version = "0.12.3"}
+prost-types = {version = "0.12"}
+r2d2 = {version = "0.8"}
+r2d2_sqlite = {version = "0.22"}
+rand = {version = "0.8.5"}
+rand_chacha = {version = "0.3.1"}
+rand_core = {version = "0.6.4"}
+regex = {version = "1.8.1"}
+rocksdb = {version = "0.21.0"}
+serde = {version = "1.0.186"}
+serde_json = {version = "1.0.96"}
+serde_unit_struct = {version = "0.1"}
+serde_with = {version = "3.5.1"}
+sha2 = {version = "0.10"}
+tempfile = {version = "3.3.0"}
+tendermint = {default-features = false, version = "0.34.0"}
+tendermint-config = {version = "0.34.0"}
+tendermint-light-client-verifier = {version = "0.34.0"}
+tendermint-proto = {version = "0.34.0"}
+tendermint-rpc = {version = "0.34.0"}
+thiserror = {version = "1.0"}
+tokio = {version = "1.3"}
+tokio-stream = {version = "0.1.8"}
+tokio-util = {version = "0.7"}
+toml = {version = "0.7"}
+tonic = {version = "0.10"}
+tonic-reflection = {version = "0.10.0"}
+tonic-web = {version = "0.10.0"}
+tower = {version = "0.4.0"}
+tower-http = {version = "0.4"}
+tower-service = {version = "0.3.2"}
+tracing = {version = "0.1"}
+tracing-subscriber = {version = "0.3.17"}
+url = {version = "2.2"}

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -1,55 +1,7 @@
 [package]
 name = "penumbra-bench"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-# Workspace deps
-penumbra-num = { path = "../core/num/" }
-penumbra-asset = { path = "../core/asset/" }
-penumbra-keys = { path = "../core/keys/" }
-
-# Git deps
-decaf377 = { version = "0.5", features = ["r1cs"] }
-
-# Crates.io deps
-ark-ec = "0.4.2"
-ark-ff = { version = "0.4", default-features = false }
-ark-std = { version = "0.4", default-features = false }
-ark-serialize = "0.4"
-serde = { version = "1", features = ["derive"] }
-once_cell = "1.8"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-# only needed because ark-ff doesn't display correctly
-num-bigint = "0.4"
-tracing = "0.1"
-ark-groth16 = { version = "0.4", default-features = false }
-ark-snark = "0.4"
-ark-r1cs-std = { version = "0.4", default-features = false }
-ark-relations = "0.4"
-sha2 = "0.10.1"
-bech32 = "0.8.1"
-
-[dev-dependencies]
-penumbra-tct = { path = "../crypto/tct/", features = ["r1cs"] }
-criterion = { version = "0.4", features = ["html_reports"] }
-penumbra-dex = { path = "../core/component/dex/" }
-penumbra-community-pool = { path = "../core/component/community-pool/" }
-penumbra-stake = { path = "../core/component/stake/" }
-penumbra-shielded-pool = { path = "../core/component/shielded-pool/" }
-penumbra-governance = { path = "../core/component/governance/" }
-penumbra-fee = { path = "../core/component/fee/" }
-penumbra-sct = { path = "../core/component/sct/" }
-decaf377-fmd = { path = "../crypto/decaf377-fmd/" }
-decaf377-ka = { path = "../crypto/decaf377-ka/" }
-decaf377-rdsa = "0.7"
-penumbra-proof-params = { path = "../crypto/proof-params", features = [
-    "bundled-proving-keys",
-    "download-proving-keys",
-] }
+version = {workspace = true}
+edition = {workspace = true}
 
 [build-dependencies]
 regex = { version = "1", optional = true }
@@ -99,3 +51,43 @@ harness = false
 [[bench]]
 name = "convert"
 harness = false
+
+[dependencies]
+penumbra-num = {workspace = true, default-features = true}
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-keys = {workspace = true, default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+ark-ec = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-std = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+once_cell = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+num-bigint = {workspace = true}
+tracing = {workspace = true}
+ark-groth16 = {workspace = true, default-features = false}
+ark-snark = {workspace = true}
+ark-r1cs-std = {workspace = true, default-features = false}
+ark-relations = {workspace = true}
+sha2 = {workspace = true}
+bech32 = {workspace = true}
+
+[dev-dependencies]
+penumbra-tct = {workspace = true, features = ["r1cs"], default-features = true}
+criterion = {workspace = true, features = ["html_reports"]}
+penumbra-dex = {workspace = true, default-features = true}
+penumbra-community-pool = {workspace = true, default-features = true}
+penumbra-stake = {workspace = true, default-features = true}
+penumbra-shielded-pool = {workspace = true, default-features = true}
+penumbra-governance = {workspace = true, default-features = true}
+penumbra-fee = {workspace = true, default-features = true}
+penumbra-sct = {workspace = true, default-features = true}
+decaf377-fmd = {workspace = true}
+decaf377-ka = {workspace = true}
+decaf377-rdsa = {workspace = true}
+penumbra-proof-params = {workspace = true, features = [
+    "bundled-proving-keys",
+    "download-proving-keys",
+], default-features = true}

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "pcli"
-version = "0.65.0-alpha.1"
-authors = ["Penumbra Labs <team@penumbra.zone>"]
-edition = "2021"
+version = {workspace = true}
+authors = {workspace = true}
+edition = {workspace = true}
 description = "The command-line interface for the Penumbra Zone"
-repository = "https://github.com/penumbra-zone/penumbra/"
-homepage = "https://penumbra.zone"
-license = "MIT OR Apache-2.0"
+repository = {workspace = true}
+homepage = {workspace = true}
+license = {workspace = true}
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.dist]
+dist = true
 
 [features]
 default = ["std", "parallel", "download-proving-keys"]
@@ -29,91 +30,81 @@ parallel = [
 ]
 
 [dependencies]
-# Workspace dependencies
-penumbra-proto = { path = "../../proto", features = ["rpc", "box-grpc"] }
-penumbra-tct = { path = "../../crypto/tct" }
-penumbra-num = { path = "../../core/num", default-features = false }
-penumbra-asset = { path = "../../core/asset", default-features = false }
-penumbra-keys = { path = "../../core/keys", default-features = false }
-penumbra-shielded-pool = { path = "../../core/component/shielded-pool", default-features = false }
-penumbra-governance = { path = "../../core/component/governance", default-features = false }
-penumbra-stake = { path = "../../core/component/stake", default-features = false }
-penumbra-sct = { path = "../../core/component/sct", default-features = false }
-penumbra-fee = { path = "../../core/component/fee", default-features = false }
-penumbra-dex = { path = "../../core/component/dex", default-features = false }
-penumbra-community-pool = { path = "../../core/component/community-pool", default-features = false }
-penumbra-ibc = { path = "../../core/component/ibc", default-features = false }
-penumbra-compact-block = { path = "../../core/component/compact-block", default-features = false }
-penumbra-transaction = { path = "../../core/transaction" }
-penumbra-proof-setup = { path = "../../crypto/proof-setup" }
-penumbra-app = { path = "../../core/app" }
+penumbra-proto = {workspace = true, features = ["rpc", "box-grpc"], default-features = true}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-governance = {workspace = true, default-features = false}
+penumbra-stake = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-fee = {workspace = true, default-features = false}
+penumbra-dex = {workspace = true, default-features = false}
+penumbra-community-pool = {workspace = true, default-features = false}
+penumbra-ibc = {workspace = true, default-features = false}
+penumbra-compact-block = {workspace = true, default-features = false}
+penumbra-transaction = {workspace = true, default-features = true}
+penumbra-proof-setup = {workspace = true}
+penumbra-app = {workspace = true}
 penumbra-wallet = { path = "../../wallet" }
-penumbra-custody = { path = "../../custody" }
-penumbra-view = { path = "../../view" }
-
-# Penumbra dependencies
-decaf377 = { version = "0.5" }
-decaf377-rdsa = { version = "0.7" }
-tendermint = { version = "0.34.0", features = ["rust-crypto"] }
-jmt = "0.9"
-
-# External dependencies
-ibc-types = { version = "0.11.0", features = ["std", "with_serde"] }
-
-ibc-proto = { version = "0.40.0" }
-ark-ff = { version = "0.4", default-features = false }
-atty = "0.2"
-ed25519-consensus = "2"
-futures = "0.3"
-async-stream = "0.2"
-bincode = "1.3.3"
-blake2b_simd = "0.5"
-base64 = "0.21"
+penumbra-custody = {workspace = true}
+penumbra-view = {workspace = true}
+decaf377 = {workspace = true, default-features = true}
+decaf377-rdsa = {workspace = true}
+tendermint = {workspace = true, features = ["rust-crypto"], default-features = true}
+jmt = {workspace = true}
+ibc-types = {workspace = true, features = ["std", "with_serde"], default-features = true}
+ibc-proto = {workspace = true, default-features = true}
+ark-ff = {workspace = true, default-features = false}
+atty = {workspace = true}
+ed25519-consensus = {workspace = true}
+futures = {workspace = true}
+async-stream = {workspace = true}
+bincode = {workspace = true}
+blake2b_simd = {workspace = true}
+base64 = {workspace = true}
 simple-base64 = "0.23"
-bytes = "1"
+bytes = {workspace = true}
 comfy-table = "5"
-directories = "4.0.1"
-tokio = { version = "1.22", features = ["full"] }
-tokio-stream = "0.1"
-tokio-util = "0.7"
-tower = { version = "0.4", features = ["full"] }
-tracing = "0.1"
-tonic = { version = "0.10", features = ["tls-webpki-roots", "tls"] }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
-pin-project = "1"
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
-regex = "1.6.0"
-serde_with = { version = "1.11", features = ["hex"] }
-sha2 = "0.9"
-anyhow = "1"
-hex = "0.4"
-rand = "0.8"
-rand_chacha = "0.3.1"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
+directories = {workspace = true}
+tokio = {workspace = true, features = ["full"]}
+tokio-stream = {workspace = true}
+tokio-util = {workspace = true}
+tower = {workspace = true, features = ["full"]}
+tracing = {workspace = true}
+tonic = {workspace = true, features = ["tls-webpki-roots", "tls"]}
+tracing-subscriber = {workspace = true, features = ["env-filter", "ansi"]}
+pin-project = {workspace = true}
+serde_json = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+regex = {workspace = true}
+serde_with = {workspace = true, features = ["hex"]}
+sha2 = {workspace = true}
+anyhow = {workspace = true}
+hex = {workspace = true}
+rand = {workspace = true}
+rand_chacha = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
 rpassword = "7"
-indicatif = "0.16"
-http-body = "0.4.5"
-clap = { version = "3", features = ["derive", "env"] }
-camino = "1"
-url = { version = "2", features = ["serde"] }
+indicatif = {workspace = true}
+http-body = {workspace = true}
+clap = {workspace = true, features = ["derive", "env"]}
+camino = {workspace = true}
+url = {workspace = true, features = ["serde"]}
 colored_json = "2.1"
-toml = { version = "0.7", features = ["preserve_order"] }
-once_cell = "1"
+toml = {workspace = true, features = ["preserve_order"]}
+once_cell = {workspace = true}
 ndarray = "0.15.6"
 dialoguer = "0.10.4"
-# ndarray-linalg = { version = "0.16.0", features = ["openblas-static"] }
 
 [dev-dependencies]
-assert_cmd = "2.0"
+assert_cmd = {workspace = true}
 predicates = "2.1"
-tempfile = "3.3.0"
-regex = "1.6.0"
-penumbra-governance = { path = "../../core/component/governance", default-features = false }
-penumbra-proof-params = { path = "../../crypto/proof-params", features = [
+tempfile = {workspace = true}
+regex = {workspace = true}
+penumbra-governance = {workspace = true, default-features = false}
+penumbra-proof-params = {workspace = true, features = [
     "bundled-proving-keys",
     "download-proving-keys",
-] }
-
-[package.metadata.dist]
-dist = true
+], default-features = true}

--- a/crates/bin/pclientd/Cargo.toml
+++ b/crates/bin/pclientd/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "pclientd"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 default = ["std", "download-proving-keys"]
@@ -14,57 +12,55 @@ parallel = ["penumbra-transaction/parallel"]
 download-proving-keys = ["penumbra-proof-params/download-proving-keys"]
 
 [dependencies]
-# Workspace dependencies
-penumbra-proto            = { path = "../../proto", features = ["rpc"] }
-penumbra-tct              = { path = "../../crypto/tct" }
-penumbra-asset           = { path = "../../core/asset" }
-penumbra-keys           = { path = "../../core/keys" }
-penumbra-transaction      = { path = "../../core/transaction" }
-penumbra-app              = { path = "../../core/app" }
-penumbra-custody          = { path = "../../custody" }
-penumbra-view             = { path = "../../view" }
-
-tokio = { version = "1.22", features = ["full"] }
-tokio-stream = { version = "0.1.8", features = ["sync"] }
-anyhow = "1"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
-serde_with = { version = "1.11", features = ["hex"] }
-tracing = "0.1"
-tracing-subscriber = "0.2"
-url = { version = "2", features = ["serde"] }
-http = "0.2.9"
-http-body = "0.4.5"
-tower = "0.4.0"
-tonic = "0.10"
-tonic-web = "0.10.0"
-tonic-reflection = "0.10.0"
-bytes = { version = "1", features = ["serde"] }
-prost = "0.12.3"
-futures = "0.3"
-hex = "0.4"
-metrics = "0.22"
-async-stream = "0.2"
-parking_lot = "0.12"
-clap = { version = "3", features = ["derive", "env"] }
-camino = "1"
-async-trait = "0.1"
-tendermint = "0.34.0"
-sha2 = "0.10.1"
-toml = "0.5"
-ed25519-consensus = "2.1"
-atty = "0.2"
-directories = "4.0.1"
+penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-transaction = {workspace = true, default-features = true}
+penumbra-app = {workspace = true}
+penumbra-custody = {workspace = true}
+penumbra-view = {workspace = true}
+tokio = {workspace = true, features = ["full"]}
+tokio-stream = {workspace = true, features = ["sync"]}
+anyhow = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+serde_json = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_with = {workspace = true, features = ["hex"]}
+tracing = {workspace = true}
+tracing-subscriber = {workspace = true, features = ["env-filter"]}
+url = {workspace = true, features = ["serde"]}
+http = {workspace = true}
+http-body = {workspace = true}
+tower = {workspace = true}
+tonic = {workspace = true}
+tonic-web = {workspace = true}
+tonic-reflection = {workspace = true}
+bytes = {workspace = true, features = ["serde"]}
+prost = {workspace = true}
+futures = {workspace = true}
+hex = {workspace = true}
+metrics = {workspace = true}
+async-stream = {workspace = true}
+parking_lot = {workspace = true}
+clap = {workspace = true, features = ["derive", "env"]}
+camino = {workspace = true}
+async-trait = {workspace = true}
+tendermint = {workspace = true}
+sha2 = {workspace = true}
+toml = {workspace = true}
+ed25519-consensus = {workspace = true}
+atty = {workspace = true}
+directories = {workspace = true}
 
 [dev-dependencies]
-tempfile = "3.3.0"
-assert_cmd = "2.0"
-base64 = "0.20"
-ibc-types = { version = "0.11.0" }
-ibc-proto = { version = "0.40.0", default-features = false, features = ["server"] }
-penumbra-proof-params = { path = "../../crypto/proof-params", features = [
+tempfile = {workspace = true}
+assert_cmd = {workspace = true}
+base64 = {workspace = true}
+ibc-types = {workspace = true, default-features = true}
+ibc-proto = {workspace = true, default-features = false, features = ["server"]}
+penumbra-proof-params = {workspace = true, features = [
     "bundled-proving-keys",
     "download-proving-keys",
-] }
+], default-features = true}

--- a/crates/bin/pclientd/tests/network_integration.rs
+++ b/crates/bin/pclientd/tests/network_integration.rs
@@ -10,6 +10,7 @@ use std::process::Command as StdCommand;
 
 use anyhow::Context;
 use assert_cmd::cargo::CommandCargoExt;
+use base64::prelude::*;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use tempfile::tempdir;
 use tokio::process::Command as TokioCommand;
@@ -103,11 +104,12 @@ async fn transaction_send_flow() -> anyhow::Result<()> {
     // base64 encoded MsgCreateClient that was used to create the currently in-use Stargaze
     // light client on the cosmos hub:
     // https://cosmos.bigdipper.live/transactions/13C1ECC54F088473E2925AD497DDCC092101ADE420BC64BADE67D34A75769CE9
-    let msg_create_client_stargaze_raw = base64::decode(
-        include_str!("../../../core/component/ibc/src/component/test/create_client.msg")
-            .replace('\n', ""),
-    )
-    .unwrap();
+    let msg_create_client_stargaze_raw = BASE64_STANDARD
+        .decode(
+            include_str!("../../../core/component/ibc/src/component/test/create_client.msg")
+                .replace('\n', ""),
+        )
+        .unwrap();
     use ibc_types::core::client::msgs::MsgCreateClient;
     use ibc_types::DomainType;
     let msg_create_stargaze_client =

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -1,141 +1,14 @@
 [package]
 name = "pd"
-version = "0.65.0-alpha.1"
-authors = ["Penumbra Labs <team@penumbra.zone>"]
-edition = "2021"
+version = {workspace = true}
+authors = {workspace = true}
+edition = {workspace = true}
 description = "The node software for the Penumbra Zone"
-repository = "https://github.com/penumbra-zone/penumbra/"
-homepage = "https://penumbra.zone"
-license = "MIT OR Apache-2.0"
+repository = {workspace = true}
+homepage = {workspace = true}
+license = {workspace = true}
 publish = false
-# Pin a MSRV. Anything more recent than this value is OK.
-# If a lower version is used for build, the build will fail.
 rust-version = "1.73"
-
-[features]
-default = ["download-proving-keys"]
-std = ["ibc-types/std"]
-download-proving-keys = ["penumbra-proof-params/download-proving-keys"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-# Workspace dependencies
-penumbra-proto = { path = "../../proto" }
-cnidarium = { path = "../../cnidarium", features = ["migration", "rpc"] }
-penumbra-asset = { path = "../../core/asset" }
-penumbra-keys = { path = "../../core/keys" }
-penumbra-shielded-pool = { path = "../../core/component/shielded-pool", features = [
-    "parallel",
-] }
-penumbra-stake = { path = "../../core/component/stake", features = [
-    "parallel",
-] }
-penumbra-sct = { path = "../../core/component/sct" }
-penumbra-fee = { path = "../../core/component/fee" }
-penumbra-dex = { path = "../../core/component/dex", features = ["parallel"] }
-penumbra-governance = { path = "../../core/component/governance", features = [
-    "parallel",
-] }
-penumbra-ibc = { path = "../../core/component/ibc", features = ["rpc"] }
-penumbra-compact-block = { path = "../../core/component/compact-block" }
-penumbra-transaction = { path = "../../core/transaction" }
-penumbra-app = { path = "../../core/app" }
-penumbra-custody = { path = "../../custody" }
-penumbra-tower-trace = { path = "../../util/tower-trace" }
-penumbra-tendermint-proxy = { path = "../../util/tendermint-proxy" }
-penumbra-auto-https = { path = "../../util/auto-https" }
-
-# Penumbra dependencies
-decaf377 = { version = "0.5", features = ["parallel"] }
-decaf377-rdsa = { version = "0.7" }
-tower-abci = "0.11"
-jmt = "0.9"
-tower-actor = "0.1.0"
-
-# External dependencies
-tendermint-config = "0.34.0"
-tendermint-proto = "0.34.0"
-tendermint = "0.34.0"
-tendermint-light-client-verifier = "0.34.0"
-ibc-types = { version = "0.11.0" }
-
-ibc-proto = { version = "0.40.0", default-features = false, features = [
-    "server",
-] }
-prost = "0.12.3"
-toml = "0.5"
-# We don't need this crate at all, but its upstream published a breaking change as
-# 0.7.1 (also prost-related), and depending on an exact version here will exclude
-# the bad update until it's yanked.
-ics23 = "0.11.0"
-
-pin-project-lite = "0.2.9"
-ark-ff = { version = "0.4" }
-async-stream = "0.2"
-bincode = "1.3.3"
-blake2b_simd = "0.5"
-bytes = "1"
-chrono = { version = "0.4", default-features = false, features = ["serde"] }
-csv = "1.1"
-directories = "4.0"
-tokio = { version = "1.22", features = ["full"] }
-tokio-stream = "0.1"
-tokio-util = { version = "0.7", features = ["compat"] }
-tower = { version = "0.4", features = ["full"] }
-tower-service = "0.3.2"
-tower-http = "0.4"
-tracing = "0.1"
-regex = "1.5"
-reqwest = { version = "0.11", features = ["json"] }
-prost-types = "0.12"
-pbjson-types = "0.6"
-tonic = "0.10"
-tonic-web = "0.10.0"
-tonic-reflection = "0.10.0"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
-url = "2"
-pin-project = "1"
-futures = "0.3"
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
-serde_with = { version = "1.11", features = ["hex"] }
-sha2 = "0.9"
-anyhow = "1"
-hex = "0.4"
-rand = "0.8"
-rand_chacha = "0.3.1"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-metrics = "0.22"
-metrics-exporter-prometheus = { version = "0.10.0", features = [
-    "http-listener",
-] }
-http = "0.2"
-ed25519-consensus = "2"
-
-async-trait = "0.1.52"
-tendermint-rpc = { version = "0.34.0", features = ["http-client"] }
-once_cell = "1.7.2"
-rocksdb = "0.21.0"
-tempfile = "3.3.0"
-base64 = "0.20"
-console-subscriber = "0.2"
-metrics-tracing-context = "0.11.0"
-metrics-util = "0.13"
-clap = { version = "3", features = ["derive", "env"] }
-atty = "0.2"
-fs_extra = "1.3.0"
-
-axum-server = { version = "0.4.7", features = ["tls-rustls"] }
-
-[dev-dependencies]
-penumbra-proof-params = { path = "../../crypto/proof-params", features = [
-    "bundled-proving-keys",
-    "download-proving-keys",
-] }
-
-[build-dependencies]
-anyhow = "1"
 
 [package.metadata.dist]
 dist = true
@@ -146,3 +19,116 @@ dist = true
 pre-release-replacements = [
     { file = "../../../docs/guide/src/penumbra_version.md", search = "^v.*", replace = "{{tag_name}}", exactly = 1 },
 ]
+
+[features]
+default = ["download-proving-keys"]
+std = ["ibc-types/std"]
+download-proving-keys = ["penumbra-proof-params/download-proving-keys"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[build-dependencies]
+anyhow = "1"
+
+[dependencies]
+penumbra-proto = {workspace = true, default-features = true}
+cnidarium = {workspace = true, features = ["migration", "rpc"], default-features = true}
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-shielded-pool = {workspace = true, features = [
+    "parallel",
+], default-features = true}
+penumbra-stake = {workspace = true, features = [
+    "parallel",
+], default-features = true}
+penumbra-sct = {workspace = true, default-features = true}
+penumbra-fee = {workspace = true, default-features = true}
+penumbra-dex = {workspace = true, features = ["parallel"], default-features = true}
+penumbra-governance = {workspace = true, features = [
+    "parallel",
+], default-features = true}
+penumbra-ibc = {workspace = true, features = ["rpc"], default-features = true}
+penumbra-compact-block = {workspace = true, default-features = true}
+penumbra-transaction = {workspace = true, default-features = true}
+penumbra-app = {workspace = true}
+penumbra-custody = {workspace = true}
+penumbra-tower-trace = { path = "../../util/tower-trace" }
+penumbra-tendermint-proxy = { path = "../../util/tendermint-proxy" }
+penumbra-auto-https = { path = "../../util/auto-https" }
+decaf377 = {workspace = true, features = ["parallel"], default-features = true}
+decaf377-rdsa = {workspace = true}
+tower-abci = "0.11"
+jmt = {workspace = true}
+tower-actor = "0.1.0"
+tendermint-config = {workspace = true}
+tendermint-proto = {workspace = true}
+tendermint = {workspace = true}
+tendermint-light-client-verifier = {workspace = true}
+ibc-types = {workspace = true, default-features = true}
+ibc-proto = {workspace = true, default-features = false, features = [
+    "server",
+]}
+prost = {workspace = true}
+toml = {workspace = true}
+ics23 = {workspace = true}
+pin-project-lite = {workspace = true}
+ark-ff = {workspace = true, default-features = true}
+async-stream = {workspace = true}
+bincode = {workspace = true}
+blake2b_simd = {workspace = true}
+bytes = {workspace = true}
+chrono = {workspace = true, default-features = false, features = ["serde"]}
+csv = "1.1"
+directories = {workspace = true}
+tokio = {workspace = true, features = ["full"]}
+tokio-stream = {workspace = true}
+tokio-util = {workspace = true, features = ["compat"]}
+tower = {workspace = true, features = ["full"]}
+tower-service = {workspace = true}
+tower-http = {workspace = true}
+tracing = {workspace = true}
+regex = {workspace = true}
+reqwest = { version = "0.11", features = ["json"] }
+prost-types = {workspace = true}
+pbjson-types = {workspace = true}
+tonic = {workspace = true}
+tonic-web = {workspace = true}
+tonic-reflection = {workspace = true}
+tracing-subscriber = {workspace = true, features = ["env-filter", "ansi"]}
+url = {workspace = true}
+pin-project = {workspace = true}
+futures = {workspace = true}
+serde_json = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_with = {workspace = true, features = ["hex"]}
+sha2 = {workspace = true}
+anyhow = {workspace = true}
+hex = {workspace = true}
+rand = {workspace = true}
+rand_chacha = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+metrics = {workspace = true}
+metrics-exporter-prometheus = { version = "0.10.0", features = [
+    "http-listener",
+] }
+http = {workspace = true}
+ed25519-consensus = {workspace = true}
+async-trait = {workspace = true}
+tendermint-rpc = {workspace = true, features = ["http-client"]}
+once_cell = {workspace = true}
+rocksdb = {workspace = true}
+tempfile = {workspace = true}
+base64 = {workspace = true}
+console-subscriber = {workspace = true}
+metrics-tracing-context = {workspace = true}
+metrics-util = "0.13"
+clap = {workspace = true, features = ["derive", "env"]}
+atty = {workspace = true}
+fs_extra = "1.3.0"
+axum-server = {workspace = true, features = ["tls-rustls"]}
+
+[dev-dependencies]
+penumbra-proof-params = {workspace = true, features = [
+    "bundled-proving-keys",
+    "download-proving-keys",
+], default-features = true}

--- a/crates/cnidarium-component/Cargo.toml
+++ b/crates/cnidarium-component/Cargo.toml
@@ -1,13 +1,11 @@
 [package]
 name = "cnidarium-component"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [dependencies]
-cnidarium = { path = "../cnidarium", default-features = false }
-async-trait = "0.1.52"
-anyhow = "1"
-tendermint = "0.34.0"
-hex = "0.4"
+cnidarium = {workspace = true, default-features = false}
+async-trait = {workspace = true}
+anyhow = {workspace = true}
+tendermint = {workspace = true}
+hex = {workspace = true}

--- a/crates/cnidarium/Cargo.toml
+++ b/crates/cnidarium/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "cnidarium"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 migration = []
@@ -11,38 +9,34 @@ default = ["metrics"]
 rpc = ["dep:tonic", "dep:prost", "dep:serde", "dep:pbjson", "dep:ibc-proto"]
 
 [dependencies]
-jmt = "0.9"
-tokio = { version = "1.21.1", features = ["full", "tracing"] }
-tokio-stream = { version = "0.1.11" }
-tempfile = "3.3.0"
-anyhow = "1"
-async-trait = "0.1.52"
-tracing = "0.1"
-rocksdb = "0.21.0"
-futures = "0.3"
-hex = "0.4"
-metrics = { version = "0.22", optional = true }
-parking_lot = "0.12"
-pin-project = "1.0.12"
+jmt = {workspace = true}
+tokio = {workspace = true, features = ["full", "tracing"]}
+tokio-stream = {workspace = true}
+tempfile = {workspace = true}
+anyhow = {workspace = true}
+async-trait = {workspace = true}
+tracing = {workspace = true}
+rocksdb = {workspace = true}
+futures = {workspace = true}
+hex = {workspace = true}
+metrics = {workspace = true, optional = true}
+parking_lot = {workspace = true}
+pin-project = {workspace = true}
 smallvec = { version = "1.10", features = ["union", "const_generics"] }
-ibc-types = { version = "0.11.0", default-features = false, features = ["std"] }
-once_cell = "1"
-
-# Tendermint/IBC crates
-ics23 = "0.11.0"
-tendermint = { version = "0.34.0", default-features = false }
+ibc-types = {workspace = true, default-features = false, features = ["std"]}
+once_cell = {workspace = true}
+ics23 = {workspace = true}
+tendermint = {workspace = true, default-features = false}
 borsh = "0.10.3"
-sha2 = "0.10.6"
-
-# Used for RPC.
-tonic = { version = "0.10", optional = true }
-prost = { version = "0.12.3", optional = true }
-serde = { version = "1", optional = true }
-pbjson = { version = "0.5", optional = true }
-ibc-proto = { version = "0.40.0", default-features = false, features = ["serde"], optional = true }
-regex = "1.10.2"
+sha2 = {workspace = true}
+tonic = {workspace = true, optional = true}
+prost = {workspace = true, optional = true}
+serde = {workspace = true, optional = true}
+pbjson = {workspace = true, optional = true}
+ibc-proto = {workspace = true, default-features = false, features = ["serde"], optional = true}
+regex = {workspace = true}
 
 [dev-dependencies]
-tempfile = "3.3.0"
-tracing-subscriber = "0.3"
-tokio = "1.21.1"
+tempfile = {workspace = true}
+tracing-subscriber = {workspace = true}
+tokio = {workspace = true}

--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -1,86 +1,80 @@
 [package]
 name = "penumbra-app"
-version = "0.65.0-alpha.1"
-authors = ["Penumbra Labs <team@penumbra.zone>"]
-edition = "2021"
-repository = "https://github.com/penumbra-zone/penumbra/"
-homepage = "https://penumbra.zone"
-license = "MIT OR Apache-2.0"
+version = {workspace = true}
+authors = {workspace = true}
+edition = {workspace = true}
+repository = {workspace = true}
+homepage = {workspace = true}
+license = {workspace = true}
 publish = false
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-# Workspace dependencies
-cnidarium = { path = "../../cnidarium" }
-cnidarium-component = { path = "../../cnidarium-component" }
-penumbra-proto = { path = "../../proto", features = ["cnidarium"] }
-penumbra-tct = { path = "../../crypto/tct" }
-penumbra-proof-params = { path = "../../crypto/proof-params" }
-penumbra-asset = { path = "../asset" }
-penumbra-keys = { path = "../keys" }
-penumbra-txhash = { path = "../txhash" }
-penumbra-num = { path = "../num" }
-penumbra-shielded-pool = { path = "../component/shielded-pool", features = [
-    "component",
-] }
-penumbra-stake = { path = "../component/stake" }
-penumbra-governance = { path = "../component/governance" }
-penumbra-sct = { path = "../component/sct" }
-penumbra-fee = { path = "../component/fee" }
-penumbra-funding = { path = "../component/funding" }
-penumbra-community-pool = { path = "../component/community-pool" }
-penumbra-dex = { path = "../component/dex" }
-penumbra-ibc = { path = "../component/ibc", features = ["component"] }
-penumbra-distributions = { path = "../component/distributions" }
-penumbra-compact-block = { path = "../component/compact-block" }
-penumbra-transaction = { path = "../transaction", features = ["parallel"] }
-
-# External dependencies
-decaf377 = { version = "0.5" }
-decaf377-rdsa = { version = "0.7" }
-jmt = "0.9"
-tokio = { version = "1.21.1", features = ["full", "tracing"] }
-async-trait = "0.1.52"
-tonic = "0.10"
-futures = "0.3"
-anyhow = "1"
-tracing = "0.1"
-ark-ff = { version = "0.4", default_features = false }
-blake2b_simd = "0.5"
-bincode = "1.3.3"
-serde = { version = "1", features = ["derive"] }
-serde_with = "2.2"
-metrics = "0.22"
-sha2 = "0.9"
-serde_json = "1"
-serde_unit_struct = "0.1"
-bech32 = "0.8"
-im = "15.1.0"
-regex = "1.5"
-once_cell = "1.8"
-bitvec = "1"
-hex = "0.4"
-base64 = "0.20"
-tempfile = "3.3.0"
-prost = "0.12.3"
-rand_chacha = "0.3"
-parking_lot = "0.12"
-
-tendermint = "0.34.0"
-tendermint-proto = "0.34.0"
-tendermint-light-client-verifier = "0.34.0"
-ibc-types = { version = "0.11.0", default-features = false }
-ibc-proto = { version = "0.40.0", default-features = false, features = [
-    "server",
-] }
-
-[dev-dependencies]
-ed25519-consensus = "2"
-rand_core = "0.6"
-rand_chacha = "0.3"
-tracing-subscriber = "0.3"
 
 [features]
 default = ["std"]
 std = ["ark-ff/std", "ibc-types/std"]
+
+[dependencies]
+cnidarium = {workspace = true, default-features = true}
+cnidarium-component = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, features = ["cnidarium"], default-features = true}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-txhash = {workspace = true, default-features = true}
+penumbra-num = {workspace = true, default-features = true}
+penumbra-shielded-pool = {workspace = true, features = [
+    "component",
+], default-features = true}
+penumbra-stake = {workspace = true, default-features = true}
+penumbra-governance = {workspace = true, default-features = true}
+penumbra-sct = {workspace = true, default-features = true}
+penumbra-fee = {workspace = true, default-features = true}
+penumbra-funding = {workspace = true, default-features = true}
+penumbra-community-pool = {workspace = true, default-features = true}
+penumbra-dex = {workspace = true, default-features = true}
+penumbra-ibc = {workspace = true, features = ["component"], default-features = true}
+penumbra-distributions = {workspace = true, default-features = true}
+penumbra-compact-block = {workspace = true, default-features = true}
+penumbra-transaction = {workspace = true, features = ["parallel"], default-features = true}
+decaf377 = {workspace = true, default-features = true}
+decaf377-rdsa = {workspace = true}
+jmt = {workspace = true}
+tokio = {workspace = true, features = ["full", "tracing"]}
+async-trait = {workspace = true}
+tonic = {workspace = true}
+futures = {workspace = true}
+anyhow = {workspace = true}
+tracing = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+blake2b_simd = {workspace = true}
+bincode = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_with = {workspace = true}
+metrics = {workspace = true}
+sha2 = {workspace = true}
+serde_json = {workspace = true}
+serde_unit_struct = {workspace = true}
+bech32 = {workspace = true}
+im = {workspace = true}
+regex = {workspace = true}
+once_cell = {workspace = true}
+bitvec = {workspace = true}
+hex = {workspace = true}
+base64 = {workspace = true}
+tempfile = {workspace = true}
+prost = {workspace = true}
+rand_chacha = {workspace = true}
+parking_lot = {workspace = true}
+tendermint = {workspace = true}
+tendermint-proto = {workspace = true}
+tendermint-light-client-verifier = {workspace = true}
+ibc-types = {workspace = true, default-features = false}
+ibc-proto = {workspace = true, default-features = false, features = [
+    "server",
+]}
+
+[dev-dependencies]
+ed25519-consensus = {workspace = true}
+rand_core = {workspace = true}
+rand_chacha = {workspace = true}
+tracing-subscriber = {workspace = true}

--- a/crates/core/asset/Cargo.toml
+++ b/crates/core/asset/Cargo.toml
@@ -1,56 +1,7 @@
 [package]
 name = "penumbra-asset"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-# Workspace deps
-decaf377-fmd = { path = "../../crypto/decaf377-fmd/" }
-penumbra-num = { path = "../num/" }
-penumbra-proto = { path = "../../proto/" }
-
-# Git deps
-decaf377 = { version = "0.5", features = ["r1cs"] }
-decaf377-rdsa = { version = "0.7" }
-poseidon377 = { version = "0.6", features = ["r1cs"] }
-
-# Crates.io deps
-base64 = "0.20"
-ark-ff = { version = "0.4", default_features = false }
-ark-std = { version = "0.4", default_features = false }
-ark-serialize = "0.4"
-regex = "1.5"
-sha2 = "0.10.1"
-bech32 = "0.8.1"
-anyhow = "1"
-thiserror = "1"
-bytes = "1"
-derivative = "2.2"
-hex = "0.4"
-# Not enabling js feature for getrandom, which is a transitive dep of rand_core,
-# because the docs recommend against doing it in libraries: https://docs.rs/getrandom/latest/getrandom/#webassembly-support
-# Downstream client projects can modify their Cargo.toml files to enable it.
-# getrandom = { version = "0.2", features = ["js"] }
-blake2b_simd = "0.5"
-serde = { version = "1", features = ["derive"] }
-serde_with = "3.5.1"
-once_cell = "1.8"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-ethnum = "1.3"
-# temporary -- only used for division
-ibig = "0.3"
-# only needed because ark-ff doesn't display correctly
-num-bigint = "0.4"
-tracing = "0.1"
-ark-r1cs-std = { version = "0.4", default-features = false }
-ark-relations = "0.4"
-
-[dev-dependencies]
-proptest = "1"
-serde_json = "1"
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 default = []
@@ -62,3 +13,39 @@ parallel = [
     "ark-r1cs-std/parallel",
     "decaf377/parallel",
 ]
+
+[dependencies]
+decaf377-fmd = {workspace = true}
+penumbra-num = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-rdsa = {workspace = true}
+poseidon377 = {workspace = true, features = ["r1cs"]}
+base64 = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-std = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+regex = {workspace = true}
+sha2 = {workspace = true}
+bech32 = {workspace = true}
+anyhow = {workspace = true}
+thiserror = {workspace = true}
+bytes = {workspace = true}
+derivative = {workspace = true}
+hex = {workspace = true}
+blake2b_simd = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_with = {workspace = true}
+once_cell = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+ethnum = {workspace = true}
+ibig = {workspace = true}
+num-bigint = {workspace = true}
+tracing = {workspace = true}
+ark-r1cs-std = {workspace = true, default-features = false}
+ark-relations = {workspace = true}
+
+[dev-dependencies]
+proptest = {workspace = true}
+serde_json = {workspace = true}

--- a/crates/core/component/community-pool/Cargo.toml
+++ b/crates/core/component/community-pool/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "penumbra-community-pool"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 component = [
@@ -16,34 +14,31 @@ default = ["component"]
 docsrs = []
 
 [dependencies]
-# Workspace dependencies
-cnidarium = { path = "../../../cnidarium", optional = true }
-cnidarium-component = { path = "../../../cnidarium-component", optional = true }
-penumbra-proto = { path = "../../../proto", default-features = false }
-penumbra-shielded-pool = { path = "../shielded-pool", default-features = false }
-penumbra-sct = { path = "../sct", default-features = false }
-penumbra-asset = { path = "../../../core/asset", default-features = false }
-penumbra-num = { path = "../../../core/num", default-features = false }
-penumbra-keys = { path = "../../../core/keys", default-features = false }
-penumbra-txhash = { path = "../../../core/txhash", default-features = false }
-
-# Crates.io deps
-ark-ff = { version = "0.4", default_features = false }
-async-trait = "0.1.52"
-hex = "0.4"
-anyhow = "1"
-tracing = "0.1"
-prost = "0.12.3"
-serde = { version = "1", features = ["derive"] }
-metrics = "0.22"
-pbjson-types = "0.6.0"
-tendermint = "0.34.0"
-tendermint-light-client-verifier = "0.34.0"
-sha2 = "0.10.6"
-once_cell = "1.17.1"
-base64 = "0.20"
-blake2b_simd = "0.5"
-futures = "0.3.28"
+cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = false}
+penumbra-txhash = {workspace = true, default-features = false}
+ark-ff = {workspace = true, default-features = false}
+async-trait = {workspace = true}
+hex = {workspace = true}
+anyhow = {workspace = true}
+tracing = {workspace = true}
+prost = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+metrics = {workspace = true}
+pbjson-types = {workspace = true}
+tendermint = {workspace = true}
+tendermint-light-client-verifier = {workspace = true}
+sha2 = {workspace = true}
+once_cell = {workspace = true}
+base64 = {workspace = true}
+blake2b_simd = {workspace = true}
+futures = {workspace = true}
 
 [dev-dependencies]
-tokio = { version = "1.3", features = ["full"] }
+tokio = {workspace = true, features = ["full"]}

--- a/crates/core/component/compact-block/Cargo.toml
+++ b/crates/core/component/compact-block/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "penumbra-compact-block"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 component = [
@@ -20,36 +18,33 @@ std = ["ark-ff/std"]
 docsrs = []
 
 [dependencies]
-# Workspace dependencies
-penumbra-proto = { path = "../../../proto", default-features = false }
-cnidarium = { path = "../../../cnidarium", optional = true }
-penumbra-tct = { path = "../../../crypto/tct" }
-penumbra-proof-params = { path = "../../../crypto/proof-params", default-features = false }
-cnidarium-component = { path = "../../../cnidarium-component", optional = true }
-penumbra-shielded-pool = { path = "../shielded-pool", default-features = false }
-penumbra-dex = { path = "../dex", default-features = false }
-penumbra-ibc = { path = "../ibc", default-features = false }
-penumbra-community-pool = { path = "../community-pool", default-features = false }
-penumbra-governance = { path = "../governance", default-features = false }
-penumbra-stake = { path = "../stake", default-features = false }
-penumbra-fee = { path = "../fee", default-features = false }
-penumbra-sct = { path = "../sct", default-features = false }
-
-# Crates.io dependencies
-ark-ff = { version = "0.4", default_features = false }
-decaf377-rdsa = { version = "0.7" }
-metrics = "0.22"
-serde = { version = "1", features = ["derive"] }
-tracing = "0.1"
-anyhow = "1"
-async-trait = "0.1.52"
-tendermint = "0.34.0"
-blake2b_simd = "0.5"
-bytes = "1"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-futures = "0.3.28"
-tonic = { version = "0.10", optional = true }
-tokio-stream = { version = "0.1", optional = true }
-tokio = { version = "1", optional = true }
-im = "15.1.0"
+penumbra-proto = {workspace = true, default-features = false}
+cnidarium = {workspace = true, optional = true, default-features = true}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true, default-features = false}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-dex = {workspace = true, default-features = false}
+penumbra-ibc = {workspace = true, default-features = false}
+penumbra-community-pool = {workspace = true, default-features = false}
+penumbra-governance = {workspace = true, default-features = false}
+penumbra-stake = {workspace = true, default-features = false}
+penumbra-fee = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+ark-ff = {workspace = true, default-features = false}
+decaf377-rdsa = {workspace = true}
+metrics = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+tracing = {workspace = true}
+anyhow = {workspace = true}
+async-trait = {workspace = true}
+tendermint = {workspace = true}
+blake2b_simd = {workspace = true}
+bytes = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+futures = {workspace = true}
+tonic = {workspace = true, optional = true}
+tokio-stream = {workspace = true, optional = true}
+tokio = {workspace = true, optional = true}
+im = {workspace = true}

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "penumbra-dex"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 component = [
@@ -29,65 +27,58 @@ parallel = [
 ]
 
 [dependencies]
-# Workspace dependencies
-penumbra-proto = { path = "../../../proto", default-features = false }
-cnidarium = { path = "../../../cnidarium", optional = true }
-cnidarium-component = { path = "../../../cnidarium-component", optional = true }
-penumbra-shielded-pool = { path = "../shielded-pool", default-features = false }
-penumbra-sct = { path = "../sct", default-features = false }
-penumbra-fee = { path = "../fee", default-features = false }
-penumbra-tct = { path = "../../../crypto/tct", default-features = false }
-penumbra-proof-params = { path = "../../../crypto/proof-params" }
-penumbra-asset = { path = "../../../core/asset", default-features = false }
-penumbra-num = { path = "../../../core/num", default-features = false }
-penumbra-keys = { path = "../../../core/keys", default-features = false }
-penumbra-txhash = { path = "../../../core/txhash", default-features = false }
-decaf377-ka = { path = "../../../crypto/decaf377-ka/" }
-decaf377-fmd = { path = "../../../crypto/decaf377-fmd/" }
-
-# Penumbra dependencies
-poseidon377 = { version = "0.6", features = ["r1cs"] }
-decaf377 = { version = "0.5", features = ["r1cs"] }
-decaf377-rdsa = { version = "0.7" }
-
-# Crates.io deps
-ark-r1cs-std = { version = "0.4", default-features = false }
-ark-relations = "0.4"
-ark-ff = { version = "0.4", default_features = false }
-ark-serialize = "0.4"
-ark-groth16 = { version = "0.4", default-features = false }
-ark-snark = "0.4"
-async-trait = "0.1.52"
-async-stream = "0.2"
-bincode = "1.3.3"
-hex = "0.4"
-thiserror = "1"
-anyhow = "1"
-tracing = "0.1"
-prost = "0.12.3"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1.0.96"
-metrics = "0.22"
-pbjson-types = "0.6.0"
-tendermint = "0.34.0"
-tendermint-light-client-verifier = "0.34.0"
-sha2 = "0.10.6"
-once_cell = "1.17.1"
-base64 = "0.20"
-blake2b_simd = "0.5"
-futures = "0.3.28"
-im = "15.1.0"
-parking_lot = "0.12.1"
-rand_core = "0.6.4"
-regex = "1.8.1"
-
-# Component dependencies
-tokio = { version = "1.3", features = ["full"], optional = true }
-tonic = { version = "0.10", optional = true }
+penumbra-proto = {workspace = true, default-features = false}
+cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-fee = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = false}
+penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = false}
+penumbra-txhash = {workspace = true, default-features = false}
+decaf377-ka = {workspace = true}
+decaf377-fmd = {workspace = true}
+poseidon377 = {workspace = true, features = ["r1cs"]}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-rdsa = {workspace = true}
+ark-r1cs-std = {workspace = true, default-features = false}
+ark-relations = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+ark-groth16 = {workspace = true, default-features = false}
+ark-snark = {workspace = true}
+async-trait = {workspace = true}
+async-stream = {workspace = true}
+bincode = {workspace = true}
+hex = {workspace = true}
+thiserror = {workspace = true}
+anyhow = {workspace = true}
+tracing = {workspace = true}
+prost = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+metrics = {workspace = true}
+pbjson-types = {workspace = true}
+tendermint = {workspace = true}
+tendermint-light-client-verifier = {workspace = true}
+sha2 = {workspace = true}
+once_cell = {workspace = true}
+base64 = {workspace = true}
+blake2b_simd = {workspace = true}
+futures = {workspace = true}
+im = {workspace = true}
+parking_lot = {workspace = true}
+rand_core = {workspace = true}
+regex = {workspace = true}
+tokio = {workspace = true, features = ["full"], optional = true}
+tonic = {workspace = true, optional = true}
 
 [dev-dependencies]
-proptest = "1"
-rand = "0.8.5"
-tracing-subscriber = "0.3.17"
-rand_chacha = "0.3"
+proptest = {workspace = true}
+rand = {workspace = true}
+tracing-subscriber = {workspace = true}
+rand_chacha = {workspace = true}
 itertools = "0.11"

--- a/crates/core/component/distributions/Cargo.toml
+++ b/crates/core/component/distributions/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "penumbra-distributions"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 component = [
@@ -16,21 +14,16 @@ default = ["component"]
 docsrs = []
 
 [dependencies]
-
-# Workspace dependencies
-cnidarium = { path = "../../../cnidarium", optional = true }
-cnidarium-component = { path = "../../../cnidarium-component", optional = true }
-penumbra-asset = { path = "../../../core/asset", default-features = false }
-penumbra-num = { path = "../../../core/num", default-features = false }
-penumbra-proto = { path = "../../../proto", default-features = false }
-penumbra-sct = { path = "../sct", default-features = false }
-
-# Crates.io deps
-async-trait = "0.1.52"
-anyhow = "1"
-tracing = "0.1"
-tendermint = "0.34.0"
-
-serde = { version = "1", features = ["derive"] }
+cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+async-trait = {workspace = true}
+anyhow = {workspace = true}
+tracing = {workspace = true}
+tendermint = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
 
 [dev-dependencies]

--- a/crates/core/component/fee/Cargo.toml
+++ b/crates/core/component/fee/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "penumbra-fee"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 component = [
@@ -17,29 +15,22 @@ std = ["ark-ff/std"]
 docsrs = []
 
 [dependencies]
-# Workspace dependencies
-cnidarium = { path = "../../../cnidarium", optional = true }
-cnidarium-component = { path = "../../../cnidarium-component", optional = true }
-penumbra-proto = { path = "../../../proto", default-features = false }
-penumbra-asset = { path = "../../../core/asset", default-features = false }
-penumbra-num = { path = "../../../core/num", default-features = false }
-
-# Penumbra dependencies
-decaf377-rdsa = { version = "0.7" }
-decaf377 = { version = "0.5" }
-
-# Crates.io dependencies
-ark-ff = { version = "0.4", default_features = false }
-metrics = "0.22"
-serde = { version = "1", features = ["derive"] }
-tracing = "0.1"
-anyhow = "1"
-async-trait = "0.1.52"
-tendermint = "0.34.0"
-blake2b_simd = "0.5"
-bytes = "1"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-
-# Component dependencies
-tonic = { version = "0.10", optional = true }
+cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+decaf377-rdsa = {workspace = true}
+decaf377 = {workspace = true, default-features = true}
+ark-ff = {workspace = true, default-features = false}
+metrics = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+tracing = {workspace = true}
+anyhow = {workspace = true}
+async-trait = {workspace = true}
+tendermint = {workspace = true}
+blake2b_simd = {workspace = true}
+bytes = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+tonic = {workspace = true, optional = true}

--- a/crates/core/component/funding/Cargo.toml
+++ b/crates/core/component/funding/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "penumbra-funding"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 component = [
@@ -21,25 +19,20 @@ default = ["component"]
 docsrs = []
 
 [dependencies]
-
-# Workspace dependencies
-cnidarium-component = { path = "../../../cnidarium-component", optional = true }
-penumbra-asset = { path = "../../asset" }
-penumbra-community-pool = { path = "../community-pool", default-features = false }
-penumbra-distributions = { path = "../distributions", default-features = false }
-penumbra-proto = { path = "../../../proto", default-features = false }
-penumbra-stake = { path = "../stake", default-features = false }
-penumbra-sct = { path = "../sct", default-features = false }
-penumbra-shielded-pool = { path = "../shielded-pool", default-features = false }
-cnidarium = { path = "../../../cnidarium", optional = true }
-
-# Crates.io deps
-async-trait = "0.1.52"
-anyhow = "1"
-tracing = "0.1"
-tendermint = "0.34.0"
-futures = { version = "0.3", optional = true }
-
-serde = { version = "1", features = ["derive"] }
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-community-pool = {workspace = true, default-features = false}
+penumbra-distributions = {workspace = true, default-features = false}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-stake = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+cnidarium = {workspace = true, optional = true, default-features = true}
+async-trait = {workspace = true}
+anyhow = {workspace = true}
+tracing = {workspace = true}
+tendermint = {workspace = true}
+futures = {workspace = true, optional = true}
+serde = {workspace = true, features = ["derive"]}
 
 [dev-dependencies]

--- a/crates/core/component/governance/Cargo.toml
+++ b/crates/core/component/governance/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "penumbra-governance"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 component = [
@@ -29,61 +27,53 @@ parallel = [
 docsrs = []
 
 [dependencies]
-# Workspace dependencies
-cnidarium = { path = "../../../cnidarium", optional = true }
-cnidarium-component = { path = "../../../cnidarium-component", optional = true }
-penumbra-proto = { path = "../../../proto", default-features = false }
-penumbra-tct = { path = "../../../crypto/tct" }
-penumbra-proof-params = { path = "../../../crypto/proof-params", default-features = false }
-penumbra-sct = { path = "../sct", default-features = false }
-penumbra-shielded-pool = { path = "../shielded-pool", default-features = false }
-penumbra-stake = { path = "../stake", default-features = false }
-penumbra-community-pool = { path = "../community-pool", default-features = false }
-penumbra-fee = { path = "../fee", default-features = false }
-penumbra-funding = { path = "../funding", default-features = false }
-penumbra-ibc = { path = "../ibc", default-features = false }
-penumbra-distributions = { path = "../distributions", default-features = false }
-penumbra-asset = { path = "../../../core/asset", default-features = false }
-penumbra-keys = { path = "../../../core/keys", default-features = false }
-penumbra-txhash = { path = "../../../core/txhash", default-features = false }
-penumbra-num = { path = "../../../core/num", default-features = false }
-
-# Penumbra dependencies
-decaf377-rdsa = { version = "0.7" }
-decaf377 = { version = "0.5", features = ["r1cs"] }
-
-# Crates.io dependencies
-base64 = "0.21"
-ark-r1cs-std = { version = "0.4", default-features = false }
-ark-relations = "0.4"
-ark-ff = { version = "0.4", default_features = false }
-ark-serialize = "0.4"
-ark-groth16 = { version = "0.4", default-features = false }
-ark-snark = "0.4"
-async-stream = "0.2"
-metrics = "0.22"
-serde = { version = "1", features = ["derive"] }
-tracing = "0.1"
-anyhow = "1"
-async-trait = "0.1.52"
-tendermint = "0.34.0"
-blake2b_simd = "0.5"
-bytes = "1"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-im = "15.1"
-regex = "1.5"
-futures = "0.3"
-pbjson-types = "0.6"
-once_cell = "1.8"
-rand_chacha = "0.3"
-ibc-types = { version = "0.11.0", default-features = false }
-
-# Component dependencies
-tokio = { version = "1.21.1", features = ["full", "tracing"], optional = true }
-tonic = { version = "0.10", optional = true }
-
+cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-stake = {workspace = true, default-features = false}
+penumbra-community-pool = {workspace = true, default-features = false}
+penumbra-fee = {workspace = true, default-features = false}
+penumbra-funding = {workspace = true, default-features = false}
+penumbra-ibc = {workspace = true, default-features = false}
+penumbra-distributions = {workspace = true, default-features = false}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = false}
+penumbra-txhash = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+decaf377-rdsa = {workspace = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+base64 = {workspace = true}
+ark-r1cs-std = {workspace = true, default-features = false}
+ark-relations = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+ark-groth16 = {workspace = true, default-features = false}
+ark-snark = {workspace = true}
+async-stream = {workspace = true}
+metrics = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+tracing = {workspace = true}
+anyhow = {workspace = true}
+async-trait = {workspace = true}
+tendermint = {workspace = true}
+blake2b_simd = {workspace = true}
+bytes = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+im = {workspace = true}
+regex = {workspace = true}
+futures = {workspace = true}
+pbjson-types = {workspace = true}
+once_cell = {workspace = true}
+rand_chacha = {workspace = true}
+ibc-types = {workspace = true, default-features = false}
+tokio = {workspace = true, features = ["full", "tracing"], optional = true}
+tonic = {workspace = true, optional = true}
 
 [dev-dependencies]
-proptest = "1"
-proptest-derive = "0.3"
+proptest = {workspace = true}
+proptest-derive = {workspace = true}

--- a/crates/core/component/ibc/Cargo.toml
+++ b/crates/core/component/ibc/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "penumbra-ibc"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 component = [
@@ -17,39 +15,34 @@ docsrs = []
 rpc = ["dep:tonic", "ibc-proto/client", "ibc-proto/server"]
 
 [dependencies]
-# Workspace dependencies
-cnidarium = { path = "../../../cnidarium", optional = true }
-penumbra-asset = { path = "../../../core/asset", default-features = false }
-penumbra-num = { path = "../../../core/num", default-features = false }
-penumbra-proto = { path = "../../../proto", default-features = false }
-penumbra-sct = { path = "../sct", default-features = false }
-penumbra-txhash = { path = "../../../core/txhash", default-features = false }
-
-# Penumbra dependencies
-ibc-types = { version = "0.11.0", default-features = false }
-ibc-proto = { version = "0.40.0", default-features = false }
-
-# Crates.io deps
-ics23 = "0.11.0"
-num-traits = { version = "0.2.15", default-features = false }
-ark-ff = { version = "0.4", default_features = false }
-async-trait = "0.1.52"
-hex = "0.4"
-anyhow = "1"
-tracing = "0.1"
-prost = "0.12.3"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-metrics = "0.22"
-pbjson-types = "0.6.0"
-tendermint = "0.34.0"
-tendermint-light-client-verifier = "0.34.0"
-sha2 = "0.10.6"
-once_cell = "1.17.1"
-base64 = "0.20"
-blake2b_simd = "0.5"
-tonic = { version = "0.10", optional = true }
-tower = "0.4"
+cnidarium = {workspace = true, optional = true, default-features = true}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-txhash = {workspace = true, default-features = false}
+ibc-types = {workspace = true, default-features = false}
+ibc-proto = {workspace = true, default-features = false}
+ics23 = {workspace = true}
+num-traits = {workspace = true, default-features = false}
+ark-ff = {workspace = true, default-features = false}
+async-trait = {workspace = true}
+hex = {workspace = true}
+anyhow = {workspace = true}
+tracing = {workspace = true}
+prost = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+metrics = {workspace = true}
+pbjson-types = {workspace = true}
+tendermint = {workspace = true}
+tendermint-light-client-verifier = {workspace = true}
+sha2 = {workspace = true}
+once_cell = {workspace = true}
+base64 = {workspace = true}
+blake2b_simd = {workspace = true}
+tonic = {workspace = true, optional = true}
+tower = {workspace = true}
 
 [dev-dependencies]
-tokio = { version = "1.3", features = ["full"] }
+tokio = {workspace = true, features = ["full"]}

--- a/crates/core/component/ibc/src/component/client.rs
+++ b/crates/core/component/ibc/src/component/client.rs
@@ -363,6 +363,7 @@ impl<T: StateRead + ?Sized> StateReadExt for T {}
 
 #[cfg(test)]
 mod tests {
+    use base64::prelude::*;
     use std::sync::Arc;
 
     use super::*;
@@ -529,15 +530,17 @@ mod tests {
         // base64 encoded MsgCreateClient that was used to create the currently in-use Stargaze
         // light client on the cosmos hub:
         // https://cosmos.bigdipper.live/transactions/13C1ECC54F088473E2925AD497DDCC092101ADE420BC64BADE67D34A75769CE9
-        let msg_create_client_stargaze_raw =
-            base64::decode(include_str!("./test/create_client.msg").replace('\n', "")).unwrap();
+        let msg_create_client_stargaze_raw = BASE64_STANDARD
+            .decode(include_str!("./test/create_client.msg").replace('\n', ""))
+            .unwrap();
         let msg_create_stargaze_client =
             MsgCreateClient::decode(msg_create_client_stargaze_raw.as_slice()).unwrap();
 
         // base64 encoded MsgUpdateClient that was used to issue the first update to the in-use stargaze light client on the cosmos hub:
         // https://cosmos.bigdipper.live/transactions/24F1E19F218CAF5CA41D6E0B653E85EB965843B1F3615A6CD7BCF336E6B0E707
-        let msg_update_client_stargaze_raw =
-            base64::decode(include_str!("./test/update_client_1.msg").replace('\n', "")).unwrap();
+        let msg_update_client_stargaze_raw = BASE64_STANDARD
+            .decode(include_str!("./test/update_client_1.msg").replace('\n', ""))
+            .unwrap();
         let mut msg_update_stargaze_client =
             MsgUpdateClient::decode(msg_update_client_stargaze_raw.as_slice()).unwrap();
 
@@ -568,8 +571,9 @@ mod tests {
 
         // We've had one client update, yes. What about second client update?
         // https://cosmos.bigdipper.live/transactions/ED217D360F51E622859F7B783FEF98BDE3544AA32BBD13C6C77D8D0D57A19FFD
-        let msg_update_second =
-            base64::decode(include_str!("./test/update_client_2.msg").replace('\n', "")).unwrap();
+        let msg_update_second = BASE64_STANDARD
+            .decode(include_str!("./test/update_client_2.msg").replace('\n', ""))
+            .unwrap();
 
         let mut second_update = MsgUpdateClient::decode(msg_update_second.as_slice()).unwrap();
         second_update.client_id = ClientId::from_str("07-tendermint-0").unwrap();

--- a/crates/core/component/sct/Cargo.toml
+++ b/crates/core/component/sct/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "penumbra-sct"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 component = [
@@ -18,37 +16,30 @@ std = ["ark-ff/std"]
 docsrs = []
 
 [dependencies]
-# Workspace dependencies
-cnidarium = { path = "../../../cnidarium", optional = true }
-cnidarium-component = { path = "../../../cnidarium-component", optional = true }
-penumbra-proto = { path = "../../../proto", default-features = false }
-penumbra-tct = { path = "../../../crypto/tct" }
-penumbra-keys = { path = "../../../core/keys", default-features = false }
-
-# Penumbra dependencies
-decaf377 = { version = "0.5", features = ["r1cs"] }
-poseidon377 = { version = "0.6", features = ["r1cs"] }
-decaf377-rdsa = { version = "0.7" }
-
-# Crates.io dependencies
-ark-r1cs-std = { version = "0.4", default-features = false }
-ark-relations = "0.4"
-ark-ff = { version = "0.4", default_features = false }
-ark-serialize = "0.4"
-metrics = "0.22"
-serde = { version = "1", features = ["derive"] }
-tracing = "0.1"
-anyhow = "1"
-async-trait = "0.1.52"
-tendermint = "0.34.0"
-blake2b_simd = "0.5"
-bytes = "1"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-bincode = "1.3.3"
-once_cell = "1.8"
-hex = "0.4"
-im = "15.1"
-
-# Component dependencies
-tonic = { version = "0.10", optional = true }
+cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-keys = {workspace = true, default-features = false}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+poseidon377 = {workspace = true, features = ["r1cs"]}
+decaf377-rdsa = {workspace = true}
+ark-r1cs-std = {workspace = true, default-features = false}
+ark-relations = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+metrics = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+tracing = {workspace = true}
+anyhow = {workspace = true}
+async-trait = {workspace = true}
+tendermint = {workspace = true}
+blake2b_simd = {workspace = true}
+bytes = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+bincode = {workspace = true}
+once_cell = {workspace = true}
+hex = {workspace = true}
+im = {workspace = true}
+tonic = {workspace = true, optional = true}

--- a/crates/core/component/shielded-pool/Cargo.toml
+++ b/crates/core/component/shielded-pool/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "penumbra-shielded-pool"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 component = [
@@ -30,55 +28,48 @@ parallel = [
 docsrs = []
 
 [dependencies]
-# Workspace dependencies
-penumbra-proto = { path = "../../../proto", default-features = false }
-cnidarium = { path = "../../../cnidarium", optional = true }
-penumbra-tct = { path = "../../../crypto/tct" }
-penumbra-proof-params = { path = "../../../crypto/proof-params", default-features = false }
-penumbra-sct = { path = "../sct", default-features = false }
-cnidarium-component = { path = "../../../cnidarium-component", optional = true }
-penumbra-ibc = { path = "../ibc", default-features = false }
-penumbra-asset = { path = "../../../core/asset", default-features = false }
-penumbra-num = { path = "../../../core/num", default-features = false }
-penumbra-keys = { path = "../../../core/keys", default-features = false }
-penumbra-txhash = { path = "../../../core/txhash", default-features = false }
-decaf377-ka = { path = "../../../crypto/decaf377-ka/" }
-decaf377-fmd = { path = "../../../crypto/decaf377-fmd/" }
-
-# Penumbra dependencies
-ibc-types = { version = "0.11.0", default-features = false }
-decaf377-rdsa = { version = "0.7" }
-decaf377 = { version = "0.5", features = ["r1cs"] }
-poseidon377 = { version = "0.6", features = ["r1cs"] }
-
-# Crates.io dependencies
-base64 = "0.20"
-thiserror = "1"
-chacha20poly1305 = "0.9.0"
-ark-r1cs-std = { version = "0.4", default-features = false }
-ark-relations = "0.4"
-ark-ff = { version = "0.4", default_features = false }
-ark-serialize = "0.4"
-ark-groth16 = { version = "0.4", default-features = false }
-ark-snark = "0.4"
-metrics = "0.22"
-prost = "0.12.3"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tracing = "0.1"
-anyhow = "1"
-async-trait = "0.1.52"
-tendermint = "0.34.0"
-blake2b_simd = "0.5"
-bytes = "1"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-im = "15.1"
-once_cell = "1.8"
-hex = "0.4"
-
-# Component dependencies
-tonic = { version = "0.10", optional = true }
+penumbra-proto = {workspace = true, default-features = false}
+cnidarium = {workspace = true, optional = true, default-features = true}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+penumbra-ibc = {workspace = true, default-features = false}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = false}
+penumbra-txhash = {workspace = true, default-features = false}
+decaf377-ka = {workspace = true}
+decaf377-fmd = {workspace = true}
+ibc-types = {workspace = true, default-features = false}
+decaf377-rdsa = {workspace = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+poseidon377 = {workspace = true, features = ["r1cs"]}
+base64 = {workspace = true}
+thiserror = {workspace = true}
+chacha20poly1305 = {workspace = true}
+ark-r1cs-std = {workspace = true, default-features = false}
+ark-relations = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+ark-groth16 = {workspace = true, default-features = false}
+ark-snark = {workspace = true}
+metrics = {workspace = true}
+prost = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+tracing = {workspace = true}
+anyhow = {workspace = true}
+async-trait = {workspace = true}
+tendermint = {workspace = true}
+blake2b_simd = {workspace = true}
+bytes = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+im = {workspace = true}
+once_cell = {workspace = true}
+hex = {workspace = true}
+tonic = {workspace = true, optional = true}
 
 [dev-dependencies]
-proptest = "1"
+proptest = {workspace = true}

--- a/crates/core/component/shielded-pool/src/convert.rs
+++ b/crates/core/component/shielded-pool/src/convert.rs
@@ -6,6 +6,7 @@ use ark_groth16::{
 use ark_relations::r1cs;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_snark::SNARK;
+use base64::prelude::*;
 use decaf377::{Bls12_377, FieldExt, Fq, Fr};
 use penumbra_asset::{
     asset::{self, AssetIdVar},
@@ -210,7 +211,7 @@ impl ConvertProof {
         Ok(Self(proof_bytes))
     }
 
-    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?base64::encode(&self.0), vk = ?vk.debug_id()))]
+    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?BASE64_STANDARD.encode(&self.0), vk = ?vk.debug_id()))]
     pub fn verify(
         &self,
         vk: &PreparedVerifyingKey<Bls12_377>,

--- a/crates/core/component/shielded-pool/src/nullifier_derivation.rs
+++ b/crates/core/component/shielded-pool/src/nullifier_derivation.rs
@@ -1,3 +1,4 @@
+use base64::prelude::*;
 use std::str::FromStr;
 
 use anyhow::Result;
@@ -155,7 +156,7 @@ impl NullifierDerivationProof {
     }
 
     /// Called to verify the proof using the provided public inputs.
-    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?base64::encode(&self.0), vk = ?vk.debug_id()))]
+    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?BASE64_STANDARD.encode(&self.0), vk = ?vk.debug_id()))]
     pub fn verify(
         &self,
         vk: &PreparedVerifyingKey<Bls12_377>,

--- a/crates/core/component/shielded-pool/src/output/proof.rs
+++ b/crates/core/component/shielded-pool/src/output/proof.rs
@@ -1,3 +1,4 @@
+use base64::prelude::*;
 use std::str::FromStr;
 
 use anyhow::Result;
@@ -203,7 +204,7 @@ impl OutputProof {
     /// * note commitment of the new note,
     // For debugging proof verification failures:
     // to check that the proof data and verification keys are consistent.
-    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?base64::encode(self.clone().encode_to_vec()), vk = ?vk.debug_id()))]
+    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?BASE64_STANDARD.encode(self.clone().encode_to_vec()), vk = ?vk.debug_id()))]
     pub fn verify(
         &self,
         vk: &PreparedVerifyingKey<Bls12_377>,

--- a/crates/core/component/shielded-pool/src/spend/proof.rs
+++ b/crates/core/component/shielded-pool/src/spend/proof.rs
@@ -1,3 +1,4 @@
+use base64::prelude::*;
 use std::str::FromStr;
 
 use anyhow::Result;
@@ -295,7 +296,7 @@ impl SpendProof {
     /// Called to verify the proof using the provided public inputs.
     // For debugging proof verification failures,
     // to check that the proof data and verification keys are consistent.
-    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?base64::encode(self.clone().encode_to_vec()), vk = ?vk.debug_id()))]
+    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?BASE64_STANDARD.encode(self.clone().encode_to_vec()), vk = ?vk.debug_id()))]
     pub fn verify(
         &self,
         vk: &PreparedVerifyingKey<Bls12_377>,

--- a/crates/core/component/stake/Cargo.toml
+++ b/crates/core/component/stake/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "penumbra-stake"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 component = [
@@ -36,57 +34,52 @@ parallel = [
 ]
 
 [dependencies]
-# Workspace dependencies
-cnidarium = { path = "../../../cnidarium", default-features = false, optional = true }
-cnidarium-component = { path = "../../../cnidarium-component", default-features = false, optional = true }
-penumbra-asset = { path = "../../../core/asset", default-features = false }
-penumbra-community-pool = { path = "../community-pool", default-features = false }
-penumbra-distributions = { path = "../distributions", default-features = false }
-penumbra-keys = { path = "../../../core/keys", default-features = false }
-penumbra-txhash = { path = "../../../core/txhash", default-features = false }
-penumbra-num = { path = "../../../core/num", default-features = false }
-penumbra-proof-params = { path = "../../../crypto/proof-params" }
-penumbra-proto = { path = "../../../proto" }
-penumbra-sct = { path = "../sct", default-features = false }
-penumbra-shielded-pool = { path = "../shielded-pool", default-features = false }
-penumbra-tct = { path = "../../../crypto/tct" }
-
-# Penumbra dependencies
-decaf377 = { version = "0.5", features = ["r1cs"] }
-decaf377-rdsa = { version = "0.7" }
-ark-r1cs-std = { version = "0.4", default-features = false }
-ark-relations = "0.4"
-ark-ff = { version = "0.4", default_features = false }
-ark-serialize = "0.4"
-ark-groth16 = { version = "0.4", default-features = false }
-ark-snark = "0.4"
-tendermint = { version = "0.34.0" }
-anyhow = "1"
-tracing = "0.1"
-serde = { version = "1", features = ["derive"] }
-serde_with = "2.2"
-sha2 = "0.9"
-serde_unit_struct = "0.1"
-bech32 = "0.8"
-regex = "1.5"
-once_cell = "1.8"
-bitvec = "1"
-hex = "0.4"
-base64 = "0.20"
-rand_core = "0.6"
-rand_chacha = "0.3"
-
-# Used by component implementation
-async-trait = { version = "0.1.52", optional = true }
-tokio = { version = "1.21.1", features = ["full", "tracing"], optional = true }
-tonic = { version = "0.10", optional = true }
-im = { version = "15.1.0", optional = true }
-futures = { version = "0.3", optional = true }
-metrics = { version = "0.22", optional = true }
-async-stream = { version = "0.3.5", optional = true }
+cnidarium = {workspace = true, default-features = false, optional = true}
+cnidarium-component = {workspace = true, default-features = false, optional = true}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-community-pool = {workspace = true, default-features = false}
+penumbra-distributions = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = false}
+penumbra-txhash = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, default-features = true}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-rdsa = {workspace = true}
+ark-r1cs-std = {workspace = true, default-features = false}
+ark-relations = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+ark-groth16 = {workspace = true, default-features = false}
+ark-snark = {workspace = true}
+tendermint = {workspace = true, default-features = true}
+anyhow = {workspace = true}
+tracing = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_with = {workspace = true}
+sha2 = {workspace = true}
+serde_unit_struct = {workspace = true}
+bech32 = {workspace = true}
+regex = {workspace = true}
+once_cell = {workspace = true}
+bitvec = {workspace = true}
+hex = {workspace = true}
+base64 = {workspace = true}
+rand_core = {workspace = true}
+rand_chacha = {workspace = true}
+async-trait = {workspace = true, optional = true}
+tokio = {workspace = true, features = ["full", "tracing"], optional = true}
+tonic = {workspace = true, optional = true}
+im = {workspace = true, optional = true}
+futures = {workspace = true, optional = true}
+metrics = {workspace = true, optional = true}
+async-stream = {workspace = true, optional = true}
 
 [dev-dependencies]
-ed25519-consensus = "2"
-rand_chacha = "0.3"
-tracing-subscriber = "0.3"
-proptest = "1"
+ed25519-consensus = {workspace = true}
+rand_chacha = {workspace = true}
+tracing-subscriber = {workspace = true}
+proptest = {workspace = true}

--- a/crates/core/component/stake/src/undelegate_claim/proof.rs
+++ b/crates/core/component/stake/src/undelegate_claim/proof.rs
@@ -1,6 +1,7 @@
 use decaf377::Bls12_377;
 
 use ark_groth16::{PreparedVerifyingKey, ProvingKey};
+use base64::prelude::*;
 use penumbra_proto::{core::component::stake::v1 as pb, DomainType};
 
 use decaf377::{Fq, Fr};
@@ -65,7 +66,7 @@ impl UndelegateClaimProof {
     }
 
     /// Called to verify the proof using the provided public inputs.
-    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?base64::encode(self.clone().encode_to_vec()), vk = ?vk.debug_id()))]
+    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?BASE64_STANDARD.encode(self.clone().encode_to_vec()), vk = ?vk.debug_id()))]
     pub fn verify(
         &self,
         vk: &PreparedVerifyingKey<Bls12_377>,

--- a/crates/core/keys/Cargo.toml
+++ b/crates/core/keys/Cargo.toml
@@ -1,65 +1,52 @@
 [package]
 name = "penumbra-keys"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-# Workspace deps
-decaf377-ka = { path = "../../crypto/decaf377-ka/" }
-decaf377-fmd = { path = "../../crypto/decaf377-fmd/" }
-penumbra-proto = { path = "../../proto/" }
-penumbra-tct = { path = "../../crypto/tct/", features = ["r1cs"] }
-penumbra-asset = { path = "../../core/asset" }
-
-# Git deps
-decaf377 = {version = "0.5", features = ["r1cs"] }
-decaf377-rdsa = { version = "0.7" }
-poseidon377 = { version = "0.6", features = ["r1cs"] }
-f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
-
-# Crates.io deps
-base64 = "0.20"
-bip32 = "0.5"
-ark-ff = { version = "0.4", default_features = false }
-ark-std = { version = "0.4", default_features = false }
-ark-serialize = "0.4"
-regex = "1.5"
-sha2 = "0.10.1"
-bech32 = "0.8.1"
-aes = "0.8.1"
-anyhow = "1"
-thiserror = "1"
-bytes = "1"
-derivative = "2.2"
-hex = "0.4"
-hmac = "0.12.0"
-# Not enabling js feature for getrandom, which is a transitive dep of rand_core,
-# because the docs recommend against doing it in libraries: https://docs.rs/getrandom/latest/getrandom/#webassembly-support
-# Downstream client projects can modify their Cargo.toml files to enable it.
-# getrandom = { version = "0.2", features = ["js"] }
-blake2b_simd = "0.5"
-serde = { version = "1", features = ["derive"] }
-once_cell = "1.8"
-pbkdf2 = "0.12.0"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-chacha20poly1305 = "0.9.0"
-ethnum = "1.3"
-# temporary -- only used for division
-ibig = "0.3"
-# only needed because ark-ff doesn't display correctly
-num-bigint = "0.4"
-tracing = "0.1"
-ark-r1cs-std = {version = "0.4", default-features = false }
-ark-relations = "0.4"
-
-[dev-dependencies]
-proptest = "1"
-serde_json = "1"
-num-traits = "0.2"
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 default = []
 parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "poseidon377/parallel", "decaf377-rdsa/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]
+
+[dependencies]
+decaf377-ka = {workspace = true}
+decaf377-fmd = {workspace = true}
+penumbra-proto = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true, features = ["r1cs"], default-features = true}
+penumbra-asset = {workspace = true, default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-rdsa = {workspace = true}
+poseidon377 = {workspace = true, features = ["r1cs"]}
+f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
+base64 = {workspace = true}
+bip32 = "0.5"
+ark-ff = {workspace = true, default-features = false}
+ark-std = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+regex = {workspace = true}
+sha2 = {workspace = true}
+bech32 = {workspace = true}
+aes = "0.8.1"
+anyhow = {workspace = true}
+thiserror = {workspace = true}
+bytes = {workspace = true}
+derivative = {workspace = true}
+hex = {workspace = true}
+hmac = "0.12.0"
+blake2b_simd = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+once_cell = {workspace = true}
+pbkdf2 = "0.12.0"
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+chacha20poly1305 = {workspace = true}
+ethnum = {workspace = true}
+ibig = {workspace = true}
+num-bigint = {workspace = true}
+tracing = {workspace = true}
+ark-r1cs-std = {workspace = true, default-features = false}
+ark-relations = {workspace = true}
+
+[dev-dependencies]
+proptest = {workspace = true}
+serde_json = {workspace = true}
+num-traits = {workspace = true}

--- a/crates/core/num/Cargo.toml
+++ b/crates/core/num/Cargo.toml
@@ -1,56 +1,43 @@
 [package]
 name = "penumbra-num"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-# Workspace deps
-decaf377-fmd = { path = "../../crypto/decaf377-fmd/" }
-penumbra-proto = { path = "../../proto/" }
-
-# Git deps
-decaf377 = {version = "0.5", features = ["r1cs"] }
-decaf377-rdsa = { version = "0.7" }
-
-# Crates.io deps
-base64 = "0.20"
-ark-ff = { version = "0.4", default_features = false }
-ark-std = { version = "0.4", default_features = false }
-ark-serialize = "0.4"
-regex = "1.5"
-sha2 = "0.10.1"
-bech32 = "0.8.1"
-anyhow = "1"
-thiserror = "1"
-bytes = "1"
-derivative = "2.2"
-hex = "0.4"
-# Not enabling js feature for getrandom, which is a transitive dep of rand_core,
-# because the docs recommend against doing it in libraries: https://docs.rs/getrandom/latest/getrandom/#webassembly-support
-# Downstream client projects can modify their Cargo.toml files to enable it.
-# getrandom = { version = "0.2", features = ["js"] }
-blake2b_simd = "0.5"
-serde = { version = "1", features = ["derive"] }
-once_cell = "1.8"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-ethnum = "1.3"
-# temporary -- only used for division
-ibig = "0.3"
-# only needed because ark-ff doesn't display correctly
-num-bigint = "0.4"
-tracing = "0.1"
-ark-groth16 = {version = "0.4", default-features = false}
-ark-snark = "0.4"
-ark-r1cs-std = {version = "0.4", default-features = false }
-ark-relations = "0.4"
-
-[dev-dependencies]
-proptest = "1"
-serde_json = "1"
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 default = []
 parallel = ["ark-ff/parallel", "decaf377-rdsa/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]
+
+[dependencies]
+decaf377-fmd = {workspace = true}
+penumbra-proto = {workspace = true, default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-rdsa = {workspace = true}
+base64 = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-std = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+regex = {workspace = true}
+sha2 = {workspace = true}
+bech32 = {workspace = true}
+anyhow = {workspace = true}
+thiserror = {workspace = true}
+bytes = {workspace = true}
+derivative = {workspace = true}
+hex = {workspace = true}
+blake2b_simd = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+once_cell = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+ethnum = {workspace = true}
+ibig = {workspace = true}
+num-bigint = {workspace = true}
+tracing = {workspace = true}
+ark-groth16 = {workspace = true, default-features = false}
+ark-snark = {workspace = true}
+ark-r1cs-std = {workspace = true, default-features = false}
+ark-relations = {workspace = true}
+
+[dev-dependencies]
+proptest = {workspace = true}
+serde_json = {workspace = true}

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -1,64 +1,7 @@
 [package]
 name = "penumbra-transaction"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-[dependencies]
-# Workspace deps
-penumbra-proto = { path = "../../proto/" }
-decaf377-ka = { path = "../../crypto/decaf377-ka/" }
-decaf377-fmd = { path = "../../crypto/decaf377-fmd/" }
-penumbra-tct = { path = "../../crypto/tct" }
-penumbra-proof-params = { path = "../../crypto/proof-params/" }
-penumbra-governance = { path = "../component/governance/", default-features = false }
-penumbra-shielded-pool = { path = "../component/shielded-pool/", default-features = false }
-penumbra-sct = { path = "../component/sct/", default-features = false }
-penumbra-stake = { path = "../component/stake", default-features = false }
-penumbra-ibc = { path = "../component/ibc/", default-features = false }
-penumbra-community-pool = { path = "../component/community-pool/", default-features = false }
-penumbra-dex = { path = "../component/dex/", default-features = false }
-penumbra-fee = { path = "../component/fee/", default-features = false }
-penumbra-num = { path = "../num", default-features = false }
-penumbra-asset = { path = "../asset", default-features = false }
-penumbra-keys = { path = "../keys", default-features = false }
-penumbra-txhash = { path = "../txhash", default-features = false }
-
-# Git deps
-ibc-types = { version = "0.11.0", default-features = false }
-
-# Crates.io deps
-ibc-proto = { version = "0.40.0", default-features = false }
-decaf377 = "0.5"
-decaf377-rdsa = { version = "0.7" }
-poseidon377 = { version = "0.6", features = ["r1cs"] }
-base64 = "0.21"
-ark-ff = { version = "0.4", default_features = false }
-ark-serialize = "0.4"
-regex = "1.5"
-sha2 = "0.9"
-bech32 = "0.8.1"
-anyhow = "1"
-thiserror = "1"
-bytes = "1"
-derivative = "2.2"
-hex = "0.4"
-blake2b_simd = "0.5"
-serde = { version = "1", features = ["derive"] }
-once_cell = "1.8"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-chacha20poly1305 = "0.9.0"
-pbjson-types = "0.6"
-# only needed because ark-ff doesn't display correctly
-num-bigint = "0.4"
-serde_json = "1"
-tracing = "0.1"
-tokio = { version = "1.21.1", features = ["full"], optional = true }
-
-[dev-dependencies]
-proptest = "1"
-proptest-derive = "0.3"
-serde_json = "1"
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 default = ["std", "parallel"]
@@ -71,3 +14,54 @@ parallel = [
     "penumbra-stake/parallel",
 ]
 download-proving-keys = ["penumbra-proof-params/download-proving-keys"]
+
+[dependencies]
+penumbra-proto = {workspace = true, default-features = true}
+decaf377-ka = {workspace = true}
+decaf377-fmd = {workspace = true}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-governance = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-stake = {workspace = true, default-features = false}
+penumbra-ibc = {workspace = true, default-features = false}
+penumbra-community-pool = {workspace = true, default-features = false}
+penumbra-dex = {workspace = true, default-features = false}
+penumbra-fee = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = false}
+penumbra-txhash = {workspace = true, default-features = false}
+ibc-types = {workspace = true, default-features = false}
+ibc-proto = {workspace = true, default-features = false}
+decaf377 = {workspace = true}
+decaf377-rdsa = {workspace = true}
+poseidon377 = {workspace = true, features = ["r1cs"]}
+base64 = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+regex = {workspace = true}
+sha2 = {workspace = true}
+bech32 = {workspace = true}
+anyhow = {workspace = true}
+thiserror = {workspace = true}
+bytes = {workspace = true}
+derivative = {workspace = true}
+hex = {workspace = true}
+blake2b_simd = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+once_cell = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+chacha20poly1305 = {workspace = true}
+pbjson-types = {workspace = true}
+num-bigint = {workspace = true}
+serde_json = {workspace = true}
+tracing = {workspace = true}
+tokio = {workspace = true, features = ["full"], optional = true}
+
+[dev-dependencies]
+proptest = {workspace = true}
+proptest-derive = {workspace = true}
+serde_json = {workspace = true}

--- a/crates/core/txhash/Cargo.toml
+++ b/crates/core/txhash/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "penumbra-txhash"
-version = "0.65.0-alpha.1"
-edition = "2021"
+version = {workspace = true}
+edition = {workspace = true}
 
 [dependencies]
-# Workspace dependencies
-penumbra-proto = { path = "../../proto", default-features = false }
-penumbra-tct = { path = "../../crypto/tct" }
-anyhow = "1"
-hex = "0.4"
-blake2b_simd = "0.5"
-serde = "1"
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = true}
+anyhow = {workspace = true}
+hex = {workspace = true}
+blake2b_simd = {workspace = true}
+serde = {workspace = true}

--- a/crates/crypto/decaf377-fmd/Cargo.toml
+++ b/crates/crypto/decaf377-fmd/Cargo.toml
@@ -1,27 +1,26 @@
 [package]
 name = "decaf377-fmd"
-version = "0.65.0-alpha.1"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-decaf377 = "0.5"
-ark-ff = { version = "0.4", default_features = false }
-ark-serialize = "0.4"
-thiserror = "1"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-bitvec = "1"
-blake2b_simd = "0.5"
-
-[dev-dependencies]
-proptest = "1"
-criterion = { version = "0.3", features = ["html_reports"] }
+version = {workspace = true}
+edition = {workspace = true}
 
 [[bench]]
 name = "fmd"
 harness = false
 
+
 [features]
 default = ["std"]
 std = ["ark-ff/std"]
+
+[dependencies]
+decaf377 = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+thiserror = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+bitvec = {workspace = true}
+blake2b_simd = {workspace = true}
+
+[dev-dependencies]
+proptest = {workspace = true}
+criterion = {workspace = true, features = ["html_reports"]}

--- a/crates/crypto/decaf377-frost/Cargo.toml
+++ b/crates/crypto/decaf377-frost/Cargo.toml
@@ -1,17 +1,15 @@
 [package]
 name = "decaf377-frost"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [dependencies]
-anyhow = "1"
-ark-ff = { version = "0.4", default_features = false }
-blake2b_simd = "0.5"
-decaf377 = "0.5"
-decaf377-rdsa = "0.7"
+anyhow = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+blake2b_simd = {workspace = true}
+decaf377 = {workspace = true}
+decaf377-rdsa = {workspace = true}
 frost-core = "0.7"
 frost-rerandomized = "0.7"
-rand_core = { version = "0.6.4", features = ["getrandom"] }
-penumbra-proto = { path = "../../proto/" }
+rand_core = {workspace = true, features = ["getrandom"]}
+penumbra-proto = {workspace = true, default-features = true}

--- a/crates/crypto/decaf377-ka/Cargo.toml
+++ b/crates/crypto/decaf377-ka/Cargo.toml
@@ -1,22 +1,20 @@
 [package]
 name = "decaf377-ka"
-version = "0.65.0-alpha.1"
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-ark-ff = { version = "0.4", default_features = false }
-decaf377 = "0.5"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-thiserror = "1"
-hex = "0.4"
-zeroize = "1.4"
-zeroize_derive = "1.3"
-
-[dev-dependencies]
-proptest = "1"
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 default = ["std"]
 std = ["ark-ff/std"]
+
+[dependencies]
+ark-ff = {workspace = true, default-features = false}
+decaf377 = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+thiserror = {workspace = true}
+hex = {workspace = true}
+zeroize = "1.4"
+zeroize_derive = "1.3"
+
+[dev-dependencies]
+proptest = {workspace = true}

--- a/crates/crypto/eddy/Cargo.toml
+++ b/crates/crypto/eddy/Cargo.toml
@@ -1,26 +1,24 @@
 [package]
 name = "penumbra-eddy"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-parking_lot = "0.12"
-decaf377 = "0.5"
-anyhow = "1"
-futures = "0.3"
-merlin = "3"
-rand_core = "0.6"
-rand = "0.8.5"
-proptest = "1"
-ark-ff = { version = "0.4", default_features = false }
-ark-std = {version = "0.4", default-features = false}
-thiserror = "1"
-
-[dev-dependencies]
-tokio = { version = "1.21.1", features = ["full"]}
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 default = ["std"]
 std = ["ark-ff/std", "ark-std/std"]
+
+[dependencies]
+parking_lot = {workspace = true}
+decaf377 = {workspace = true}
+anyhow = {workspace = true}
+futures = {workspace = true}
+merlin = "3"
+rand_core = {workspace = true}
+rand = {workspace = true}
+proptest = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-std = {workspace = true, default-features = false}
+thiserror = {workspace = true}
+
+[dev-dependencies]
+tokio = {workspace = true, features = ["full"]}

--- a/crates/crypto/proof-params/Cargo.toml
+++ b/crates/crypto/proof-params/Cargo.toml
@@ -1,34 +1,7 @@
 [package]
 name = "penumbra-proof-params"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-# Git deps
-decaf377 = { version = "0.5", features = ["r1cs"] }
-
-# Crates.io deps
-anyhow = "1"
-ark-ec = "0.4.2"
-ark-ff = { version = "0.4", default-features = false }
-ark-std = { version = "0.4", default-features = false }
-ark-serialize = "0.4"
-serde = { version = "1", features = ["derive"] }
-once_cell = "1.8"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-# only needed because ark-ff doesn't display correctly
-num-bigint = "0.4"
-tracing = "0.1"
-ark-groth16 = { version = "0.4", default-features = false }
-ark-snark = "0.4"
-ark-r1cs-std = { version = "0.4", default-features = false }
-ark-relations = "0.4"
-sha2 = "0.10.1"
-bech32 = "0.8.1"
-lazy_static = "1.4.0"
+version = {workspace = true}
+edition = {workspace = true}
 
 [build-dependencies]
 regex = { version = "1", optional = true }
@@ -58,3 +31,24 @@ parallel = [
     "ark-std/parallel",
     "ark-r1cs-std/parallel",
 ]
+
+[dependencies]
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+anyhow = {workspace = true}
+ark-ec = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-std = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+once_cell = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+num-bigint = {workspace = true}
+tracing = {workspace = true}
+ark-groth16 = {workspace = true, default-features = false}
+ark-snark = {workspace = true}
+ark-r1cs-std = {workspace = true, default-features = false}
+ark-relations = {workspace = true}
+sha2 = {workspace = true}
+bech32 = {workspace = true}
+lazy_static = "1.4.0"

--- a/crates/crypto/proof-setup/Cargo.toml
+++ b/crates/crypto/proof-setup/Cargo.toml
@@ -1,43 +1,12 @@
 [package]
 name = "penumbra-proof-setup"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-[dependencies]
-anyhow = "1.0"
-ark-ec = { version = "0.4.2", default_features = false }
-ark-ff = { version = "0.4.2", default_features = false }
-ark-groth16 = { version = "0.4.0", default_features = false }
-ark-poly = { version = "0.4.2", default_features = false }
-ark-relations = "0.4"
-ark-serialize = "0.4.2"
-blake2b_simd = "0.5"
-rand_core = { version = "0.6", features = ["getrandom"] }
-decaf377 = { version = "0.5", default_features = false }
-penumbra-dex = { path = "../../core/component/dex/" }
-penumbra-community-pool = { path = "../../core/component/community-pool/", features = [
-    "component",
-] }
-penumbra-governance = { path = "../../core/component/governance/" }
-penumbra-proof-params = { path = "../proof-params" }
-penumbra-proto = { path = "../../proto" }
-penumbra-shielded-pool = { path = "../../core/component/shielded-pool/" }
-penumbra-stake = { path = "../../core/component/stake/", features = [
-    "component",
-] }
-rayon = { version = "1.8.0", optional = true }
-
-[dev-dependencies]
-ark-r1cs-std = "0.4.0"
-ark-snark = "0.4.0"
-criterion = { version = "0.4", features = ["html_reports"] }
-penumbra-dex = { path = "../../core/component/dex/" }
-penumbra-proof-params = { path = "../proof-params" }
-rand_chacha = "0.3.1"
+version = {workspace = true}
+edition = {workspace = true}
 
 [[bench]]
 name = "all"
 harness = false
+
 
 [features]
 default = []
@@ -49,3 +18,35 @@ parallel = [
     "rayon",
     "penumbra-shielded-pool/parallel",
 ]
+
+[dependencies]
+anyhow = {workspace = true}
+ark-ec = {workspace = true, default-features = false}
+ark-ff = {workspace = true, default-features = false}
+ark-groth16 = {workspace = true, default-features = false}
+ark-poly = { version = "0.4.2", default_features = false }
+ark-relations = {workspace = true}
+ark-serialize = {workspace = true}
+blake2b_simd = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+decaf377 = {workspace = true, default-features = false}
+penumbra-dex = {workspace = true, default-features = true}
+penumbra-community-pool = {workspace = true, features = [
+    "component",
+], default-features = true}
+penumbra-governance = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, default-features = true}
+penumbra-shielded-pool = {workspace = true, default-features = true}
+penumbra-stake = {workspace = true, features = [
+    "component",
+], default-features = true}
+rayon = { version = "1.8.0", optional = true }
+
+[dev-dependencies]
+ark-r1cs-std = {workspace = true}
+ark-snark = {workspace = true}
+criterion = {workspace = true, features = ["html_reports"]}
+penumbra-dex = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true, default-features = true}
+rand_chacha = {workspace = true}

--- a/crates/crypto/tct/Cargo.toml
+++ b/crates/crypto/tct/Cargo.toml
@@ -1,37 +1,7 @@
 [package]
 name = "penumbra-tct"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-penumbra-proto = { path = "../../proto/" }
-
-derivative = "2"
-once_cell = "1"
-blake2b_simd = "1"
-hex = "0.4"
-hash_hasher = "2"
-thiserror = "1"
-serde = { version = "1.0", features = ["derive", "rc"] }
-parking_lot = "0.12"
-ark-ff = { version = "0.4", default_features = false }
-ark-serialize = "0.4"
-poseidon377 = { version = "0.6", features = ["r1cs"] }
-decaf377 = { version = "0.5" }
-tracing = { version = "0.1" }
-async-trait = { version = "0.1" }
-futures = "0.3"
-ark-ed-on-bls12-377 = "0.4"
-rand = "0.8"
-im = { version = "^15.1.0", features = ["serde"] } # IMPORTANT: an OrdMap correctness bug was fixed in 15.1.0, as well as a performance improvement to `union`
-ark-relations = {version = "0.4", optional=true }
-ark-r1cs-std = {version = "0.4", optional=true, default-features = false }
-
-# Dependencies for random testing
-proptest = { version = "1", optional = true }
-proptest-derive = { version = "0.3", optional = true }
+version = {workspace = true}
+edition = {workspace = true}
 
 [features]
 internal = []
@@ -39,8 +9,33 @@ arbitrary = ["proptest", "proptest-derive"]
 r1cs = ["ark-r1cs-std", "ark-relations", "decaf377/r1cs", "poseidon377/r1cs"]
 parallel = ["ark-r1cs-std/parallel", "ark-ff/parallel", "decaf377/parallel", "poseidon377/parallel"]
 
+[dependencies]
+penumbra-proto = {workspace = true, default-features = true}
+derivative = {workspace = true}
+once_cell = {workspace = true}
+blake2b_simd = {workspace = true}
+hex = {workspace = true}
+hash_hasher = "2"
+thiserror = {workspace = true}
+serde = {workspace = true, features = ["derive", "rc"]}
+parking_lot = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+poseidon377 = {workspace = true, features = ["r1cs"]}
+decaf377 = {workspace = true, default-features = true}
+tracing = {workspace = true}
+async-trait = {workspace = true}
+futures = {workspace = true}
+ark-ed-on-bls12-377 = "0.4"
+rand = {workspace = true}
+im = {workspace = true, features = ["serde"]}
+ark-relations = {workspace = true, optional = true}
+ark-r1cs-std = {workspace = true, optional = true, default-features = false}
+proptest = {workspace = true, optional = true}
+proptest-derive = {workspace = true, optional = true}
+
 [dev-dependencies]
 static_assertions = "1"
-proptest = "1"
-proptest-derive = "0.3"
-serde_json = "1"
+proptest = {workspace = true}
+proptest-derive = {workspace = true}
+serde_json = {workspace = true}

--- a/crates/custody/Cargo.toml
+++ b/crates/custody/Cargo.toml
@@ -1,39 +1,35 @@
 [package]
 name = "penumbra-custody"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [dependencies]
-# Workspace dependencies
-ark-ff = "0.4"
-ark-serialize = "0.4"
-blake2b_simd = "0.5"
-chacha20poly1305 = "0.9"
-decaf377 = "0.5"
-decaf377-rdsa = "0.7"
+ark-ff = {workspace = true}
+ark-serialize = {workspace = true}
+blake2b_simd = {workspace = true}
+chacha20poly1305 = {workspace = true}
+decaf377 = {workspace = true}
+decaf377-rdsa = {workspace = true}
 decaf377-frost = { path = "../crypto/decaf377-frost" }
-decaf377-ka = { path = "../crypto/decaf377-ka" }
-penumbra-keys = { path = "../core/keys" }
-penumbra-txhash = { path = "../core/txhash" }
-penumbra-proto = { path = "../proto", features = ["rpc"] }
-penumbra-transaction = { path = "../core/transaction" }
-
-tokio = { version = "1.21.1", features = ["full"] }
-anyhow = "1"
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
-serde_with = { version = "2.2", features = ["hex"] }
-tracing = "0.1"
-tonic = "0.10"
-bytes = { version = "1", features = ["serde"] }
-prost = "0.12.3"
-futures = "0.3"
-hex = "0.4"
-rand_core = "0.6"
-ed25519-consensus = "2.1"
-base64 = "0.20"
+decaf377-ka = {workspace = true}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-txhash = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+penumbra-transaction = {workspace = true, default-features = true}
+tokio = {workspace = true, features = ["full"]}
+anyhow = {workspace = true}
+serde_json = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_with = {workspace = true, features = ["hex"]}
+tracing = {workspace = true}
+tonic = {workspace = true}
+bytes = {workspace = true, features = ["serde"]}
+prost = {workspace = true}
+futures = {workspace = true}
+hex = {workspace = true}
+rand_core = {workspace = true}
+ed25519-consensus = {workspace = true}
+base64 = {workspace = true}
 
 [dev-dependencies]
-toml = "0.5"
+toml = {workspace = true}

--- a/crates/custody/src/policy.rs
+++ b/crates/custody/src/policy.rs
@@ -95,6 +95,8 @@ mod address_as_string {
 /// copy-paste pre-authorization keys from Go programs into the Rust config.
 // TODO: remove this after <https://github.com/penumbra-zone/ed25519-consensus/issues/7>
 mod ed25519_vec_base64 {
+    use base64::prelude::*;
+
     pub fn serialize<S: serde::Serializer>(
         keys: &[ed25519_consensus::VerificationKey],
         serializer: S,
@@ -102,7 +104,7 @@ mod ed25519_vec_base64 {
         use serde::Serialize;
         let mut base64_keys = Vec::with_capacity(keys.len());
         for key in keys {
-            base64_keys.push(base64::encode(key.as_bytes()));
+            base64_keys.push(BASE64_STANDARD.encode(key.as_bytes()));
         }
         base64_keys.serialize(serializer)
     }
@@ -116,7 +118,9 @@ mod ed25519_vec_base64 {
         let base64_keys: Vec<String> = Vec::deserialize(deserializer)?;
         let mut vks = Vec::with_capacity(base64_keys.len());
         for base64_key in base64_keys {
-            let bytes = base64::decode(base64_key).map_err(serde::de::Error::custom)?;
+            let bytes = BASE64_STANDARD
+                .decode(base64_key)
+                .map_err(serde::de::Error::custom)?;
             let vk = ed25519_consensus::VerificationKey::try_from(bytes.as_slice())
                 .map_err(serde::de::Error::custom)?;
             vks.push(vk);

--- a/crates/misc/measure/Cargo.toml
+++ b/crates/misc/measure/Cargo.toml
@@ -1,29 +1,27 @@
 [package]
 name = "penumbra-measure"
-version = "0.65.0-alpha.1"
-edition = "2021"
+version = {workspace = true}
+edition = {workspace = true}
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-penumbra-proto = { path = "../../proto", features = ["rpc"] }
-penumbra-app = { path = "../../core/app" }
-penumbra-compact-block = { path = "../../core/component/compact-block", default-features = false }
-
-tokio = { version = "1.21.1", features = ["full"] }
-tonic = "0.10"
-anyhow = "1"
-clap = { version = "3", features = ["derive", "env"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-url = "2.2"
-indicatif = "0.16"
-serde_json = "1"
-bytesize = "1.2"
+[package.metadata.dist]
+dist = false
 
 [[bin]]
 name = "measure"
 path = "src/main.rs"
 
-[package.metadata.dist]
-dist = false
+
+[dependencies]
+penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+penumbra-app = {workspace = true}
+penumbra-compact-block = {workspace = true, default-features = false}
+tokio = {workspace = true, features = ["full"]}
+tonic = {workspace = true}
+anyhow = {workspace = true}
+clap = {workspace = true, features = ["derive", "env"]}
+tracing = {workspace = true}
+tracing-subscriber = {workspace = true, features = ["env-filter"]}
+url = {workspace = true}
+indicatif = {workspace = true}
+serde_json = {workspace = true}
+bytesize = "1.2"

--- a/crates/misc/tct-visualize/Cargo.toml
+++ b/crates/misc/tct-visualize/Cargo.toml
@@ -1,38 +1,10 @@
 [package]
 name = "penumbra-tct-visualize"
-version = "0.65.0-alpha.1"
-edition = "2021"
+version = {workspace = true}
+edition = {workspace = true}
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-# We are visualizing the TCT, so we need to import it
-penumbra-tct = { path = "../../crypto/tct", features = ["arbitrary"] }
-decaf377 = "0.5"
-
-# Dependencies for live-view server
-tokio = { version = "1", features = ["full"] }
-tokio-util = { version = "0.7", features = ["full"] }
-tonic = { version = "0.10" }
-prost = { version = "0.12" }
-tokio-stream = { version = "0.1" }
-axum = { version = "0.5", features = ["headers", "query"] }
-axum-server = { version = "0.4", features = ["tls-rustls"] }
-serde_json = { version = "1", features = ["preserve_order"] }
-include-flate = { version = "0.1", features = ["stable"] }
-bytes = { version = "1.2" }
-parking_lot = "0.12"
-rand = "0.8"
-serde = "1.0"
-futures = "0.3"
-serde_urlencoded = "0.7"
-clap = { version = "3.2", features = ["derive"] }
-tower-http = { version = "0.3", features = ["trace"] }
-anyhow = "1.0"
-rand_distr = "0.4"
-tracing-subscriber = "0.3.15"
-hex = "0.4"
-rand_chacha = "0.3"
+[package.metadata.dist]
+dist = false
 
 [[bin]]
 name = "tct-visualize"
@@ -40,5 +12,29 @@ name = "tct-visualize"
 [[bin]]
 name = "tct-live-edit"
 
-[package.metadata.dist]
-dist = false
+
+[dependencies]
+penumbra-tct = {workspace = true, features = ["arbitrary"], default-features = true}
+decaf377 = {workspace = true}
+tokio = {workspace = true, features = ["full"]}
+tokio-util = {workspace = true, features = ["full"]}
+tonic = {workspace = true}
+prost = {workspace = true}
+tokio-stream = {workspace = true}
+axum = {workspace = true, features = ["headers", "query"]}
+axum-server = {workspace = true, features = ["tls-rustls"]}
+serde_json = {workspace = true, features = ["preserve_order"]}
+include-flate = { version = "0.1", features = ["stable"] }
+bytes = {workspace = true}
+parking_lot = {workspace = true}
+rand = {workspace = true}
+serde = {workspace = true}
+futures = {workspace = true}
+serde_urlencoded = "0.7"
+clap = {workspace = true, features = ["derive"]}
+tower-http = {workspace = true, features = ["trace"]}
+anyhow = {workspace = true}
+rand_distr = "0.4"
+tracing-subscriber = {workspace = true}
+hex = {workspace = true}
+rand_chacha = {workspace = true}

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,40 +1,7 @@
 [package]
 name = "penumbra-proto"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-decaf377-fmd = { path = "../crypto/decaf377-fmd" }
-decaf377-rdsa = { version = "0.7" }
-bytes = { version = "1", features = ["serde"] }
-prost = "0.12.3"
-tonic = { version = "0.10", optional = true }
-tower = { version = "0.4", features = ["full"], optional = true }
-http-body = { version = "0.4.5", optional = true }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-hex = "0.4"
-anyhow = "1.0"
-subtle-encoding = "0.5"
-bech32 = "0.8"
-cnidarium = { path = "../cnidarium", optional = true }
-ibc-types = { version = "0.11.0", features = ["std"] }
-pin-project = "1"
-async-trait = "0.1.52"
-tracing = "0.1"
-futures = "0.3"
-pbjson = "0.6"
-pbjson-types = "0.6"
-
-ibc-proto = { version = "0.40.0", default-features = false, features = [
-    "std",
-    "serde",
-] }
-
-ics23 = "0.11.0"
-tendermint = "0.34.0"
+version = {workspace = true}
+edition = {workspace = true}
 
 [build-dependencies]
 anyhow = "1"
@@ -43,3 +10,32 @@ anyhow = "1"
 rpc = ["dep:tonic", "ibc-proto/client"]
 box-grpc = ["dep:http-body", "dep:tonic", "dep:tower"]
 cnidarium = ["dep:cnidarium"]
+
+[dependencies]
+decaf377-fmd = {workspace = true}
+decaf377-rdsa = {workspace = true}
+bytes = {workspace = true, features = ["serde"]}
+prost = {workspace = true}
+tonic = {workspace = true, optional = true}
+tower = {workspace = true, features = ["full"], optional = true}
+http-body = {workspace = true, optional = true}
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+hex = {workspace = true}
+anyhow = {workspace = true}
+subtle-encoding = "0.5"
+bech32 = {workspace = true}
+cnidarium = {workspace = true, optional = true, default-features = true}
+ibc-types = {workspace = true, features = ["std"], default-features = true}
+pin-project = {workspace = true}
+async-trait = {workspace = true}
+tracing = {workspace = true}
+futures = {workspace = true}
+pbjson = {workspace = true}
+pbjson-types = {workspace = true}
+ibc-proto = {workspace = true, default-features = false, features = [
+    "std",
+    "serde",
+]}
+ics23 = {workspace = true}
+tendermint = {workspace = true}

--- a/crates/test/tct-property-test/Cargo.toml
+++ b/crates/test/tct-property-test/Cargo.toml
@@ -1,15 +1,12 @@
 [package]
 name = "penumbra-tct-property-test"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [dev-dependencies]
-penumbra-tct = { path = "../../crypto/tct", features = ["arbitrary"] }
-
-anyhow = "1"
-proptest = "1"
-proptest-derive = "0.3"
-tokio = { version = "1.21.1", features = ["full"] }
-futures = "0.3"
+penumbra-tct = {workspace = true, features = ["arbitrary"], default-features = true}
+anyhow = {workspace = true}
+proptest = {workspace = true}
+proptest-derive = {workspace = true}
+tokio = {workspace = true, features = ["full"]}
+futures = {workspace = true}

--- a/crates/util/auto-https/Cargo.toml
+++ b/crates/util/auto-https/Cargo.toml
@@ -1,20 +1,18 @@
 [package]
 name = "penumbra-auto-https"
-version = "0.65.0-alpha.1"
-authors = ["Penumbra Labs <team@penumbra.zone>"]
-edition = "2021"
+version = {workspace = true}
+authors = {workspace = true}
+edition = {workspace = true}
 description = "Automatic HTTPS management for Penumbra"
-repository = "https://github.com/penumbra-zone/penumbra/"
-homepage = "https://penumbra.zone"
-license = "MIT OR Apache-2.0"
+repository = {workspace = true}
+homepage = {workspace = true}
+license = {workspace = true}
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-anyhow = "1"
-futures = "0.3"
+anyhow = {workspace = true}
+futures = {workspace = true}
 rustls = "0.20.9"
-axum-server = { version = "0.4.7", features = [] }
+axum-server = {workspace = true, features = []}
 rustls-acme = { version = "0.6.0", features = ["axum"] }
-tracing = "0.1"
+tracing = {workspace = true}

--- a/crates/util/tendermint-proxy/Cargo.toml
+++ b/crates/util/tendermint-proxy/Cargo.toml
@@ -1,36 +1,31 @@
 [package]
 name = "penumbra-tendermint-proxy"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [dependencies]
-# Penumbra dependencies
-penumbra-proto = { path = "../../proto", features = ["rpc"] }
-penumbra-transaction = { path = "../../core/transaction" }
-
-# External dependencies
-anyhow = "1"
-chrono = { version = "0.4", default-features = false, features = ["serde"] }
-futures = "0.3"
-hex = "0.4"
-http = "0.2"
-metrics = "0.22"
-pbjson-types = "0.6"
-pin-project = "1"
-pin-project-lite = "0.2.9"
-sha2 = "0.9"
-tendermint = "0.34.0"
-tendermint-config = "0.34.0"
-tendermint-proto = "0.34.0"
-tendermint-light-client-verifier = "0.34.0"
-tendermint-rpc = { version = "0.34.0", features = ["http-client"] }
-tokio = { version = "1.22", features = ["full"] }
-tokio-stream = "0.1"
-tokio-util = "0.7"
-tonic = "0.10"
-tower = { version = "0.4", features = ["full"] }
-tower-service = "0.3.2"
-tracing = "0.1"
-url = "2"
+penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+penumbra-transaction = {workspace = true, default-features = true}
+anyhow = {workspace = true}
+chrono = {workspace = true, default-features = false, features = ["serde"]}
+futures = {workspace = true}
+hex = {workspace = true}
+http = {workspace = true}
+metrics = {workspace = true}
+pbjson-types = {workspace = true}
+pin-project = {workspace = true}
+pin-project-lite = {workspace = true}
+sha2 = {workspace = true}
+tendermint = {workspace = true}
+tendermint-config = {workspace = true}
+tendermint-proto = {workspace = true}
+tendermint-light-client-verifier = {workspace = true}
+tendermint-rpc = {workspace = true, features = ["http-client"]}
+tokio = {workspace = true, features = ["full"]}
+tokio-stream = {workspace = true}
+tokio-util = {workspace = true}
+tonic = {workspace = true}
+tower = {workspace = true, features = ["full"]}
+tower-service = {workspace = true}
+tracing = {workspace = true}
+url = {workspace = true}

--- a/crates/util/tower-trace/Cargo.toml
+++ b/crates/util/tower-trace/Cargo.toml
@@ -1,27 +1,21 @@
 [package]
-# A vendored copy of the unpublished `tracing-tower` crate.
 name = "penumbra-tower-trace"
-version = "0.65.0-alpha.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+version = {workspace = true}
+edition = {workspace = true}
 
 [dependencies]
-# Penumbra dependencies
-
-# External dependencies
-futures = "0.3"
-hex = "0.4"
-http = "0.2"
-pin-project = "1"
-pin-project-lite = "0.2.9"
-sha2 = "0.9"
-tendermint = "0.34.0"
-tendermint-proto = "0.34.0"
-tokio = { version = "1.22", features = ["full"] }
-tokio-stream = "0.1"
-tokio-util = "0.7"
-tonic = "0.10"
-tower = { version = "0.4", features = ["full"] }
-tower-service = "0.3.2"
-tracing = "0.1"
+futures = {workspace = true}
+hex = {workspace = true}
+http = {workspace = true}
+pin-project = {workspace = true}
+pin-project-lite = {workspace = true}
+sha2 = {workspace = true}
+tendermint = {workspace = true}
+tendermint-proto = {workspace = true}
+tokio = {workspace = true, features = ["full"]}
+tokio-stream = {workspace = true}
+tokio-util = {workspace = true}
+tonic = {workspace = true}
+tower = {workspace = true, features = ["full"]}
+tower-service = {workspace = true}
+tracing = {workspace = true}

--- a/crates/view/Cargo.toml
+++ b/crates/view/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
 name = "penumbra-view"
-version = "0.65.0-alpha.1"
-authors = ["Penumbra Labs <team@penumbra.zone>"]
-edition = "2021"
+version = {workspace = true}
+authors = {workspace = true}
+edition = {workspace = true}
 description = "The view RPC library for the Penumbra Zone"
-repository = "https://github.com/penumbra-zone/penumbra/"
-homepage = "https://penumbra.zone"
-license = "MIT OR Apache-2.0"
+repository = {workspace = true}
+homepage = {workspace = true}
+license = {workspace = true}
 publish = false
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 default = ["std"]
@@ -19,58 +17,54 @@ sct-divergence-check = []
 std = ["ark-std/std"]
 
 [dependencies]
-# Workspace dependencies
-penumbra-proto = { path = "../proto", features = ["rpc"] }
-penumbra-tct = { path = "../crypto/tct" }
-penumbra-num = { path = "../core/num" }
-penumbra-keys = { path = "../core/keys" }
-penumbra-asset = { path = "../core/asset" }
-penumbra-shielded-pool = { path = "../core/component/shielded-pool", default-features = false }
-penumbra-governance = { path = "../core/component/governance", default-features = false }
-penumbra-stake = { path = "../core/component/stake", default-features = false }
-penumbra-ibc = { path = "../core/component/ibc", default-features = false }
-penumbra-distributions = { path = "../core/component/distributions", default-features = false }
-penumbra-community-pool = { path = "../core/component/community-pool", default-features = false }
-penumbra-dex = { path = "../core/component/dex", default-features = false }
-penumbra-sct = { path = "../core/component/sct", default-features = false }
-penumbra-fee = { path = "../core/component/fee", default-features = false }
-penumbra-funding = { path = "../core/component/funding", default-features = false }
-penumbra-compact-block = { path = "../core/component/compact-block", default-features = false }
-penumbra-app = { path = "../core/app" }
-penumbra-transaction = { path = "../core/transaction" }
-
-ibc-types = { version = "0.11.0", default-features = false }
-
-ark-std = { version = "0.4", default-features = false }
-decaf377 = { version = "0.5", features = ["r1cs"] }
-tokio = { version = "1.22", features = ["full"] }
-tokio-stream = { version = "0.1.8", features = ["sync"] }
-anyhow = "1"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
-tracing = "0.1"
-tracing-subscriber = "0.2"
-tonic = "0.10"
-url = "2"
-bytes = { version = "1", features = ["serde"] }
-prost = "0.12.3"
-futures = "0.3"
-hex = "0.4"
-metrics = "0.22"
-async-stream = "0.2"
-parking_lot = "0.12"
-camino = "1"
-async-trait = "0.1"
-tendermint = "0.34.0"
-sha2 = "0.10.1"
-ed25519-consensus = "2.1"
-r2d2 = "0.8"
-# Depending on our fork of r2d2-sqlite, which updates the rusqlite dependency to 0.29
-r2d2_sqlite = { version = "0.22", git = "https://github.com/penumbra-zone/r2d2-sqlite.git", features = [
+penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-num = {workspace = true, default-features = true}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-governance = {workspace = true, default-features = false}
+penumbra-stake = {workspace = true, default-features = false}
+penumbra-ibc = {workspace = true, default-features = false}
+penumbra-distributions = {workspace = true, default-features = false}
+penumbra-community-pool = {workspace = true, default-features = false}
+penumbra-dex = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-fee = {workspace = true, default-features = false}
+penumbra-funding = {workspace = true, default-features = false}
+penumbra-compact-block = {workspace = true, default-features = false}
+penumbra-app = {workspace = true}
+penumbra-transaction = {workspace = true, default-features = true}
+ibc-types = {workspace = true, default-features = false}
+ark-std = {workspace = true, default-features = false}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+tokio = {workspace = true, features = ["full"]}
+tokio-stream = {workspace = true, features = ["sync"]}
+anyhow = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+serde_json = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+tracing = {workspace = true}
+tracing-subscriber = {workspace = true}
+tonic = {workspace = true}
+url = {workspace = true}
+bytes = {workspace = true, features = ["serde"]}
+prost = {workspace = true}
+futures = {workspace = true}
+hex = {workspace = true}
+metrics = {workspace = true}
+async-stream = {workspace = true}
+parking_lot = {workspace = true}
+camino = {workspace = true}
+async-trait = {workspace = true}
+tendermint = {workspace = true}
+sha2 = {workspace = true}
+ed25519-consensus = {workspace = true}
+r2d2 = {workspace = true}
+r2d2_sqlite = {workspace = true, features = [
     "bundled",
-] }
+]}
 genawaiter = "0.99"
 digest = "0.9"
-once_cell = "1"
+once_cell = {workspace = true}

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -1,54 +1,49 @@
 [package]
 name = "penumbra-wallet"
-version = "0.65.0-alpha.1"
-authors = ["Penumbra Labs <team@penumbra.zone>"]
-edition = "2021"
+version = {workspace = true}
+authors = {workspace = true}
+edition = {workspace = true}
 description = "The wallet software for the Penumbra Zone"
-repository = "https://github.com/penumbra-zone/penumbra/"
-homepage = "https://penumbra.zone"
-license = "MIT OR Apache-2.0"
+repository = {workspace = true}
+homepage = {workspace = true}
+license = {workspace = true}
 publish = false
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-# Workspace dependencies
-penumbra-proto = { path = "../proto" }
-penumbra-tct = { path = "../crypto/tct" }
-penumbra-num = { path = "../core/num" }
-penumbra-asset = { path = "../core/asset" }
-penumbra-keys = { path = "../core/keys" }
-penumbra-dex = { path = "../core/component/dex" }
-penumbra-transaction = { path = "../core/transaction" }
-penumbra-app = { path = "../core/app" }
-penumbra-stake = { path = "../core/component/stake" }
-penumbra-governance = { path = "../core/component/governance" }
-penumbra-fee = { path = "../core/component/fee" }
-penumbra-view = { path = "../view" }
-penumbra-custody = { path = "../custody" }
-
-# External dependencies
-bytes = "1"
-bincode = "1.3.3"
-ark-std = { version = "0.4", default_features = false }
-decaf377 = { version = "0.5" }
-tokio = { version = "1.21.1", features = ["full"] }
-tower = { version = "0.4", features = ["full"] }
-tonic = "0.10"
-tracing = "0.1"
-pin-project = "1"
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
-anyhow = "1"
-hex = "0.4"
-rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8"
-
-[dev-dependencies]
-proptest = "1"
-proptest-derive = "0.3"
-once_cell = "1"
 
 [features]
 default = []
 parallel = ["penumbra-transaction/parallel"]
+
+[dependencies]
+penumbra-proto = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-num = {workspace = true, default-features = true}
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-dex = {workspace = true, default-features = true}
+penumbra-transaction = {workspace = true, default-features = true}
+penumbra-app = {workspace = true}
+penumbra-stake = {workspace = true, default-features = true}
+penumbra-governance = {workspace = true, default-features = true}
+penumbra-fee = {workspace = true, default-features = true}
+penumbra-view = {workspace = true}
+penumbra-custody = {workspace = true}
+bytes = {workspace = true}
+bincode = {workspace = true}
+ark-std = {workspace = true, default-features = false}
+decaf377 = {workspace = true, default-features = true}
+tokio = {workspace = true, features = ["full"]}
+tower = {workspace = true, features = ["full"]}
+tonic = {workspace = true}
+tracing = {workspace = true}
+pin-project = {workspace = true}
+serde_json = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+anyhow = {workspace = true}
+hex = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+rand = {workspace = true}
+
+[dev-dependencies]
+proptest = {workspace = true}
+proptest-derive = {workspace = true}
+once_cell = {workspace = true}

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,11 +1,8 @@
 [package]
 name = "penumbra-wasm"
-version = "0.65.0-alpha.1"
-authors = [
-    "Valentine <valentine@zpoken.io>",
-    "Gabe R. <gabe@penumbralabs.xyz"
-]
-edition = "2021"
+version = {workspace = true}
+authors = {workspace = true}
+edition = {workspace = true}
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -15,45 +12,36 @@ default = ["console_error_panic_hook"]
 mock-database = []
 
 [dependencies]
-penumbra-asset         = { path = "../core/asset" }
-penumbra-compact-block = { path = "../core/component/compact-block", default-features = false }
-penumbra-dex           = { path = "../core/component/dex", default-features = false }
-penumbra-fee           = { path = "../core/component/fee", default-features = false }
-penumbra-governance    = { path = "../core/component/governance", default-features = false }
-penumbra-ibc           = { path = "../core/component/ibc", default-features = false }
-penumbra-keys          = { path = "../core/keys" }
-penumbra-num           = { path = "../core/num" }
-penumbra-proof-params  = { path = "../crypto/proof-params", default-features = false }
-penumbra-proto         = { path = "../proto", default-features = false }
-penumbra-sct           = { path = "../core/component/sct", default-features = false }
-penumbra-shielded-pool = { path = "../core/component/shielded-pool", default-features = false }
-penumbra-stake         = { path = "../core/component/stake", default-features = false }
-penumbra-tct           = { path = "../crypto/tct" }
-penumbra-transaction   = { path = "../core/transaction", default-features = false }
-
-anyhow                   = "1.0.75"
-ark-ff                   = { version = "0.4.2", features = ["std"] }
-base64                   = "0.21.2"
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-compact-block = {workspace = true, default-features = false}
+penumbra-dex = {workspace = true, default-features = false}
+penumbra-fee = {workspace = true, default-features = false}
+penumbra-governance = {workspace = true, default-features = false}
+penumbra-ibc = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-num = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true, default-features = false}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-stake = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-transaction = {workspace = true, default-features = false}
+anyhow = {workspace = true}
+ark-ff = {workspace = true, features = ["std"], default-features = true}
+base64 = {workspace = true}
 console_error_panic_hook = { version = "0.1.7", optional = true }
-decaf377                 = { version = "0.5", features = ["r1cs"] }
-hex                      = "0.4.3"
-indexed_db_futures       = "0.3.0"
-rand_core                = { version = "0.6.4", features = ["getrandom"] }
-serde                    = { version = "1.0.186", features = ["derive"] }
-serde-wasm-bindgen       = "0.5.0"
-thiserror                = "1.0"
-wasm-bindgen             = "0.2.87"
-wasm-bindgen-futures     = "0.4.37"
-web-sys                  = { version = "0.3.64", features = ["console"] }
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+hex = {workspace = true}
+indexed_db_futures = "0.3.0"
+rand_core = {workspace = true, features = ["getrandom"]}
+serde = {workspace = true, features = ["derive"]}
+serde-wasm-bindgen = "0.5.0"
+thiserror = {workspace = true}
+wasm-bindgen = "0.2.87"
+wasm-bindgen-futures = "0.4.37"
+web-sys = { version = "0.3.64", features = ["console"] }
 
 [dev-dependencies]
-wasm-bindgen-test        = "0.3.37"
-serde_json               = "1.0.107"
-
-# Profiles are ignored for crates within a workspace.
-# In order to customize the profile for wasm, we must
-# either break the crate out of the workspace, or set
-# the profile options at the workspace level, affecting
-# all crates.
-# [profile.release]
-# lto = true
+wasm-bindgen-test = "0.3.37"
+serde_json = {workspace = true}

--- a/tools/parameter-setup/Cargo.toml
+++ b/tools/parameter-setup/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "penumbra-parameter-setup"
-version = "0.1.0"
-edition = "2021"
+version = {workspace = true}
+edition = {workspace = true}
 publish = false
 
 [dependencies]
-penumbra-proof-params = { path = "../../crates/crypto/proof-params" }
-penumbra-proof-setup = { path = "../../crates/crypto/proof-setup", features = [
+penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-proof-setup = {workspace = true, features = [
     "parallel",
-] }
-penumbra-dex = { path = "../../crates/core/component/dex/" }
-penumbra-community-pool = { path = "../../crates/core/component/community-pool/", features = [
+]}
+penumbra-dex = {workspace = true, default-features = true}
+penumbra-community-pool = {workspace = true, features = [
     "component",
-] }
-penumbra-governance = { path = "../../crates/core/component/governance/" }
-penumbra-shielded-pool = { path = "../../crates/core/component/shielded-pool/", features = [
+], default-features = true}
+penumbra-governance = {workspace = true, default-features = true}
+penumbra-shielded-pool = {workspace = true, features = [
     "parallel",
-] }
-penumbra-stake = { path = "../../crates/core/component/stake/", features = [
+], default-features = true}
+penumbra-stake = {workspace = true, features = [
     "component",
-] }
-ark-groth16 = "0.4"
-ark-serialize = "0.4"
-decaf377 = { version = "0.5", features = ["r1cs"] }
-rand_core = "0.6.4"
+], default-features = true}
+ark-groth16 = {workspace = true}
+ark-serialize = {workspace = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+rand_core = {workspace = true}

--- a/tools/summonerd/Cargo.toml
+++ b/tools/summonerd/Cargo.toml
@@ -1,55 +1,50 @@
 [package]
 name = "summonerd"
-version = "0.65.0-alpha.1"
-authors = ["Penumbra Labs <team@penumbra.zone>"]
-edition = "2021"
+version = {workspace = true}
+authors = {workspace = true}
+edition = {workspace = true}
 description = "Coordination node for summoning ceremony"
-repository = "https://github.com/penumbra-zone/penumbra/"
-homepage = "https://penumbra.zone"
-license = "MIT OR Apache-2.0"
+repository = {workspace = true}
+homepage = {workspace = true}
+license = {workspace = true}
 publish = false
-# Pin a MSRV. Anything more recent than this value is OK.
-# If a lower version is used for build, the build will fail.
 rust-version = "1.65"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-anyhow = "1"
-ark-groth16 = "0.4"
-ark-serialize = "0.4"
-async-trait = "0.1.52"
-atty = "0.2"
+anyhow = {workspace = true}
+ark-groth16 = {workspace = true}
+ark-serialize = {workspace = true}
+async-trait = {workspace = true}
+atty = {workspace = true}
 askama = "0.11"
-axum = "0.6"
-bytes = "1"
-camino = "1"
-clap = { version = "3", features = ["derive", "env", "color"] }
-chrono = "0.4"
-console-subscriber = "0.2"
-decaf377 = "0.5"
-futures = "0.3.28"
-hex = "0.4"
-http-body = "0.4.5"
-metrics-tracing-context = "0.11.0"
-penumbra-asset = { path = "../../crates/core/asset/" }
-penumbra-keys = { path = "../../crates/core/keys/" }
-penumbra-num = { path = "../../crates/core/num/" }
-penumbra-proof-params = { path = "../../crates/crypto/proof-params" }
-penumbra-proof-setup = { path = "../../crates/crypto/proof-setup/", features = ["parallel"] }
-penumbra-proto = { path = "../../crates/proto/" }
-penumbra-view = { path = "../../crates/view/" }
-rand = "0.8"
-rand_core = "0.6.4"
-tokio = { version = "1.22", features = ["full"] }
-tokio-stream = "0.1"
-tonic = "0.10"
-tower = "0.4"
-tracing = "0.1"
-tracing-subscriber = "0.3"
-url = "2"
-r2d2 = "0.8"
-# Depending on our fork of r2d2-sqlite, which updates the rusqlite dependency to 0.29
-r2d2_sqlite = { version = "0.22", git = "https://github.com/penumbra-zone/r2d2-sqlite.git", features = [
+axum = {workspace = true}
+bytes = {workspace = true}
+camino = {workspace = true}
+clap = {workspace = true, features = ["derive", "env", "color"]}
+chrono = {workspace = true}
+console-subscriber = {workspace = true}
+decaf377 = {workspace = true}
+futures = {workspace = true}
+hex = {workspace = true}
+http-body = {workspace = true}
+metrics-tracing-context = {workspace = true}
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-num = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-proof-setup = {workspace = true, features = ["parallel"]}
+penumbra-proto = {workspace = true, default-features = true}
+penumbra-view = {workspace = true}
+rand = {workspace = true}
+rand_core = {workspace = true}
+tokio = {workspace = true, features = ["full"]}
+tokio-stream = {workspace = true}
+tonic = {workspace = true}
+tower = {workspace = true}
+tracing = {workspace = true}
+tracing-subscriber = {workspace = true}
+url = {workspace = true}
+r2d2 = {workspace = true}
+r2d2_sqlite = {workspace = true, features = [
     "bundled",
-] }
+]}


### PR DESCRIPTION
Whenever a crate is used more than once, this switches to a workspace dependency.

This makes upgrading versions much easier.