### PR TITLE
staking: make multi-tombstoning a no-op and a state machine fix

### DIFF
--- a/crates/core/component/stake/src/component/epoch_handler.rs
+++ b/crates/core/component/stake/src/component/epoch_handler.rs
@@ -20,7 +20,7 @@ use tracing::{instrument, Instrument};
 use crate::{
     component::{
         stake::{ConsensusUpdateWrite, InternalStakingData, RateDataWrite},
-        validator_handler::{ValidatorDataRead, ValidatorManager, ValidatorStore},
+        validator_handler::{ValidatorDataRead, ValidatorManager, ValidatorDataWrite},
         SlashingData, FP_SCALING_FACTOR,
     },
     validator, CurrentConsensusKeys, DelegationToken, FundingStreams, IdentityKey, Penalty,

--- a/crates/core/component/stake/src/component/epoch_handler.rs
+++ b/crates/core/component/stake/src/component/epoch_handler.rs
@@ -20,7 +20,7 @@ use tracing::{instrument, Instrument};
 use crate::{
     component::{
         stake::{ConsensusUpdateWrite, InternalStakingData, RateDataWrite},
-        validator_handler::{ValidatorDataRead, ValidatorManager, ValidatorDataWrite},
+        validator_handler::{ValidatorDataRead, ValidatorDataWrite, ValidatorManager},
         SlashingData, FP_SCALING_FACTOR,
     },
     validator, CurrentConsensusKeys, DelegationToken, FundingStreams, IdentityKey, Penalty,

--- a/crates/core/component/stake/src/component/epoch_handler.rs
+++ b/crates/core/component/stake/src/component/epoch_handler.rs
@@ -152,7 +152,7 @@ pub trait EpochHandler: StateWriteExt + ConsensusIndexRead {
             // First, apply any penalty recorded in the epoch we are ending.
             let penalty = self
                 .get_penalty_in_epoch(&validator.identity_key, epoch_to_end.index)
-                .await?
+                .await
                 .unwrap_or(Penalty::from_percent(0));
             let prev_validator_rate_with_penalty = prev_validator_rate.slash(penalty);
 

--- a/crates/core/component/stake/src/component/stake.rs
+++ b/crates/core/component/stake/src/component/stake.rs
@@ -432,7 +432,11 @@ pub trait RateDataWrite: StateWrite {
         identity_key: &IdentityKey,
         slashing_penalty: Penalty,
     ) {
-        let current_epoch_index = self.get_current_epoch().await.expect("epoch has been set").index;
+        let current_epoch_index = self
+            .get_current_epoch()
+            .await
+            .expect("epoch has been set")
+            .index;
 
         let current_penalty = self
             .get_penalty_in_epoch(identity_key, current_epoch_index)

--- a/crates/core/component/stake/src/component/stake.rs
+++ b/crates/core/component/stake/src/component/stake.rs
@@ -324,13 +324,10 @@ impl<T: StateWrite + ?Sized> StateWriteExt for T {}
 
 #[async_trait]
 pub trait SlashingData: StateRead {
-    async fn get_penalty_in_epoch(
-        &self,
-        id: &IdentityKey,
-        epoch_index: u64,
-    ) -> Result<Option<Penalty>> {
+    async fn get_penalty_in_epoch(&self, id: &IdentityKey, epoch_index: u64) -> Option<Penalty> {
         self.get(&state_key::penalty_in_epoch(id, epoch_index))
             .await
+            .expect("serialization error cannot happen")
     }
 
     async fn get_penalty_for_range(&self, id: &IdentityKey, start: u64, end: u64) -> Vec<Penalty> {
@@ -434,12 +431,12 @@ pub trait RateDataWrite: StateWrite {
         &mut self,
         identity_key: &IdentityKey,
         slashing_penalty: Penalty,
-    ) -> Result<()> {
-        let current_epoch_index = self.get_current_epoch().await?.index;
+    ) {
+        let current_epoch_index = self.get_current_epoch().await.expect("epoch has been set").index;
 
         let current_penalty = self
             .get_penalty_in_epoch(identity_key, current_epoch_index)
-            .await?
+            .await
             .unwrap_or(Penalty::from_percent(0));
 
         let new_penalty = current_penalty.compound(slashing_penalty);
@@ -448,8 +445,6 @@ pub trait RateDataWrite: StateWrite {
             state_key::penalty_in_epoch(identity_key, current_epoch_index),
             new_penalty,
         );
-
-        Ok(())
     }
 
     async fn set_delegation_changes(&mut self, height: block::Height, changes: DelegationChanges) {

--- a/crates/core/component/stake/src/component/validator_handler.rs
+++ b/crates/core/component/stake/src/component/validator_handler.rs
@@ -3,4 +3,4 @@ pub(crate) use validator_manager::ValidatorManager;
 
 pub mod validator_store;
 pub use validator_store::ValidatorDataRead;
-pub use validator_store::ValidatorStore;
+pub use validator_store::ValidatorDataWrite;

--- a/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
@@ -146,7 +146,33 @@ pub trait ValidatorManager: StateWrite {
 
                 tracing::debug!(validator_identity = %identity_key, voting_power = ?power, "validator has become active");
             }
+            (Active, Jailed) => {
+                // An active validator has committed misbehavior (e.g. failing to sign a block),
+                // we must punish it by applying a penalty to its delegation pool and start the
+                // unbonding process. We also record that the validator was jailed, so delegations
+                // to it are not processed.
+                let penalty = self.get_stake_params().await?.slashing_penalty_downtime;
 
+                // Record the slashing penalty on this validator.
+                self.record_slashing_penalty(identity_key, Penalty::from_bps_squared(penalty))
+                    .await?;
+
+                // The validator's delegation pool begins unbonding.  Jailed
+                // validators are not unbonded immediately, because they need to
+                // be held accountable for byzantine behavior for the entire
+                // unbonding period.
+                self.set_validator_bonding_state(
+                    identity_key,
+                    Unbonding {
+                        unbonds_at_epoch: self
+                            .compute_unbonding_epoch_for_validator(identity_key)
+                            .await?,
+                    },
+                );
+
+                // Finally, set the validator to be jailed.
+                self.put(validator_state_path, Jailed);
+            }
             (Active, new_state @ (Inactive | Disabled)) => {
                 // When an active validator becomes inactive, or is disabled by its operator,
                 // we need to start the unbonding process for its delegation pool. We keep it
@@ -190,33 +216,7 @@ pub trait ValidatorManager: StateWrite {
                 tracing::debug!(validator_identity = %identity_key, validator_state = ?old_state, "validator has been disabled");
                 self.put(validator_state_path, Disabled);
             }
-            (Active, Jailed) => {
-                // An active validator has committed misbehavior (e.g. failing to sign a block),
-                // we must punish it by applying a penalty to its delegation pool and start the
-                // unbonding process. We also record that the validator was jailed, so delegations
-                // to it are not processed.
-                let penalty = self.get_stake_params().await?.slashing_penalty_downtime;
 
-                // Record the slashing penalty on this validator.
-                self.record_slashing_penalty(identity_key, Penalty::from_bps_squared(penalty))
-                    .await?;
-
-                // The validator's delegation pool begins unbonding.  Jailed
-                // validators are not unbonded immediately, because they need to
-                // be held accountable for byzantine behavior for the entire
-                // unbonding period.
-                self.set_validator_bonding_state(
-                    identity_key,
-                    Unbonding {
-                        unbonds_at_epoch: self
-                            .compute_unbonding_epoch_for_validator(identity_key)
-                            .await?,
-                    },
-                );
-
-                // Finally, set the validator to be jailed.
-                self.put(validator_state_path, Jailed);
-            }
             (Active, Defined) => {
                 // The validator was part of the active set, but its delegation pool fell below
                 // the minimum threshold. We remove it from the active set and the consensus set.

--- a/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use crate::{
     component::{
         metrics, stake::ConsensusIndexRead, stake::ConsensusIndexWrite, stake::RateDataWrite,
-        validator_handler::ValidatorStore,
+        validator_handler::ValidatorDataWrite,
     },
     rate::{BaseRateData, RateData},
     validator::{State, Validator},

--- a/crates/core/component/stake/src/component/validator_handler/validator_store.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_store.rs
@@ -211,7 +211,7 @@ pub trait ValidatorDataRead: StateRead {
 impl<T: StateRead + ?Sized> ValidatorDataRead for T {}
 
 #[async_trait]
-pub trait ValidatorStore: StateWrite {
+pub trait ValidatorDataWrite: StateWrite {
     fn set_validator_uptime(&mut self, identity_key: &IdentityKey, uptime: Uptime) {
         self.put(state_key::uptime_by_validator(identity_key), uptime);
     }
@@ -265,4 +265,4 @@ pub trait ValidatorStore: StateWrite {
     }
 }
 
-impl<T: StateWrite + ?Sized> ValidatorStore for T {}
+impl<T: StateWrite + ?Sized> ValidatorDataWrite for T {}


### PR DESCRIPTION
This PR implement fixes that were surfaced during a validator state-machine
review:

- Double tombstoning: Previously, we disallowed the state transition
`Tombstoned -> Tombstoned` implicitly assuming that a validator
node can only commit byzantine behavior once.  This is, of course,
not a reasonable assumption. A malicious validator can equivocate
as many times as they want. Therefore, we need to be able to support
`T-> T` transitions

- Missing transitions: We did not implement the `Defined <-> Disabled`
transition. This is a bug in #2921.
