### PR TITLE
Make effect hash optional

### DIFF
--- a/crates/core/app/src/action_handler/actions/submit.rs
+++ b/crates/core/app/src/action_handler/actions/submit.rs
@@ -4,27 +4,14 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use ark_ff::PrimeField;
 use async_trait::async_trait;
-use cnidarium::{StateDelta, StateRead, StateWrite};
 use decaf377::Fq;
 use decaf377_rdsa::{VerificationKey, VerificationKeyBytes};
 use ibc_types::core::client::ClientId;
 use once_cell::sync::Lazy;
+
+use cnidarium::{StateDelta, StateRead, StateWrite};
 use penumbra_asset::STAKING_TOKEN_DENOM;
 use penumbra_community_pool::component::StateReadExt as _;
-use penumbra_ibc::component::ClientStateReadExt;
-use penumbra_keys::keys::{FullViewingKey, NullifierKey};
-use penumbra_proto::{DomainType, StateWriteProto as _};
-use penumbra_sct::component::clock::EpochRead;
-use penumbra_sct::component::tree::SctRead;
-use penumbra_shielded_pool::component::SupplyWrite;
-
-use penumbra_transaction::plan::TransactionPlan;
-use penumbra_transaction::Transaction;
-use penumbra_transaction::{AuthorizationData, WitnessData};
-
-use crate::action_handler::ActionHandler;
-use crate::community_pool_ext::CommunityPoolStateWriteExt;
-use crate::params::AppParameters;
 use penumbra_governance::{
     component::{StateReadExt as _, StateWriteExt as _},
     event,
@@ -32,6 +19,19 @@ use penumbra_governance::{
     proposal_state::State as ProposalState,
     ProposalNft, ProposalSubmit, VotingReceiptToken,
 };
+use penumbra_ibc::component::ClientStateReadExt;
+use penumbra_keys::keys::{FullViewingKey, NullifierKey};
+use penumbra_proto::{DomainType, StateWriteProto as _};
+use penumbra_sct::component::clock::EpochRead;
+use penumbra_sct::component::tree::SctRead;
+use penumbra_shielded_pool::component::SupplyWrite;
+use penumbra_transaction::plan::TransactionPlan;
+use penumbra_transaction::Transaction;
+use penumbra_transaction::{AuthorizationData, WitnessData};
+
+use crate::action_handler::ActionHandler;
+use crate::community_pool_ext::CommunityPoolStateWriteExt;
+use crate::params::AppParameters;
 
 // IMPORTANT: these length limits are enforced by consensus! Changing them will change which
 // transactions are accepted by the network, and so they *cannot* be changed without a network
@@ -364,7 +364,7 @@ async fn build_community_pool_transaction(
             state_commitment_proofs: Default::default(),
         },
         &AuthorizationData {
-            effect_hash,
+            effect_hash: Some(effect_hash),
             spend_auths: Default::default(),
             delegator_vote_auths: Default::default(),
         },

--- a/crates/core/transaction/src/auth_data.rs
+++ b/crates/core/transaction/src/auth_data.rs
@@ -1,4 +1,5 @@
 use decaf377_rdsa::{Signature, SpendAuth};
+
 use penumbra_proto::{core::transaction::v1 as pb, DomainType};
 use penumbra_txhash::EffectHash;
 
@@ -7,7 +8,7 @@ use penumbra_txhash::EffectHash;
 #[derive(Clone, Debug)]
 pub struct AuthorizationData {
     /// The computed authorization hash for the approved transaction.
-    pub effect_hash: EffectHash,
+    pub effect_hash: Option<EffectHash>,
     /// The required spend authorization signatures, returned in the same order as the Spend actions
     /// in the original request.
     pub spend_auths: Vec<Signature<SpendAuth>>,
@@ -23,7 +24,7 @@ impl DomainType for AuthorizationData {
 impl From<AuthorizationData> for pb::AuthorizationData {
     fn from(msg: AuthorizationData) -> Self {
         Self {
-            effect_hash: Some(msg.effect_hash.into()),
+            effect_hash: msg.effect_hash.map(Into::into),
             spend_auths: msg.spend_auths.into_iter().map(Into::into).collect(),
             delegator_vote_auths: msg
                 .delegator_vote_auths
@@ -38,10 +39,7 @@ impl TryFrom<pb::AuthorizationData> for AuthorizationData {
     type Error = anyhow::Error;
     fn try_from(value: pb::AuthorizationData) -> Result<Self, Self::Error> {
         Ok(Self {
-            effect_hash: value
-                .effect_hash
-                .ok_or_else(|| anyhow::anyhow!("missing effect_hash"))?
-                .try_into()?,
+            effect_hash: value.effect_hash.map(TryInto::try_into).transpose()?,
             spend_auths: value
                 .spend_auths
                 .into_iter()

--- a/crates/core/transaction/src/plan/auth.rs
+++ b/crates/core/transaction/src/plan/auth.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
-use penumbra_keys::keys::SpendKey;
 use rand::{CryptoRng, RngCore};
+
+use penumbra_keys::keys::SpendKey;
 
 use crate::{plan::TransactionPlan, AuthorizationData};
 
@@ -30,7 +31,7 @@ impl TransactionPlan {
             delegator_vote_auths.push(auth_sig);
         }
         Ok(AuthorizationData {
-            effect_hash,
+            effect_hash: Some(effect_hash),
             spend_auths,
             delegator_vote_auths,
         })

--- a/crates/custody/src/threshold.rs
+++ b/crates/custody/src/threshold.rs
@@ -1,13 +1,11 @@
 use anyhow::{anyhow, Result};
-use penumbra_keys::{keys::AddressIndex, Address, FullViewingKey};
-use penumbra_proto::{
-    custody::v1::{self as pb},
-    DomainType,
-};
-use penumbra_transaction::{plan::TransactionPlan, AuthorizationData};
 use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
 use tonic::{async_trait, Request, Response, Status};
+
+use penumbra_keys::{keys::AddressIndex, Address, FullViewingKey};
+use penumbra_proto::{custody::v1 as pb, DomainType};
+use penumbra_transaction::{plan::TransactionPlan, AuthorizationData};
 
 use crate::AuthorizeRequest;
 
@@ -579,7 +577,12 @@ mod test {
                 pre_authorizations: Vec::new(),
             })
             .await?;
-        assert_eq!(plan.effect_hash(&fvk)?, authorization_data.effect_hash);
+        assert_eq!(
+            plan.effect_hash(&fvk)?,
+            authorization_data
+                .effect_hash
+                .expect("effect hash not present")
+        );
         // The transaction plan only has spends
         for (randomizer, sig) in plan
             .spend_plans()
@@ -587,9 +590,13 @@ mod test {
             .map(|x| x.randomizer)
             .zip(authorization_data.spend_auths)
         {
-            fvk.spend_verification_key()
-                .randomize(&randomizer)
-                .verify(authorization_data.effect_hash.as_bytes(), &sig)?;
+            fvk.spend_verification_key().randomize(&randomizer).verify(
+                authorization_data
+                    .effect_hash
+                    .expect("effect hash not present")
+                    .as_bytes(),
+                &sig,
+            )?;
         }
         Ok(())
     }

--- a/crates/custody/src/threshold/sign.rs
+++ b/crates/custody/src/threshold/sign.rs
@@ -4,13 +4,14 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use decaf377_frost as frost;
 use ed25519_consensus::{Signature, SigningKey, VerificationKey};
+use rand_core::CryptoRngCore;
+
+use decaf377_frost as frost;
 use frost::round1::SigningCommitments;
 use penumbra_proto::{penumbra::custody::threshold::v1 as pb, DomainType, Message};
 use penumbra_transaction::{plan::TransactionPlan, AuthorizationData};
 use penumbra_txhash::EffectHash;
-use rand_core::CryptoRngCore;
 
 use super::config::Config;
 
@@ -404,7 +405,7 @@ pub fn coordinator_round3(
         .collect::<Result<Vec<_>, _>>()?;
     let delegator_vote_auths = spend_auths.split_off(state.plan.spend_plans().count());
     Ok(AuthorizationData {
-        effect_hash: state.effect_hash,
+        effect_hash: Some(state.effect_hash),
         spend_auths,
         delegator_vote_auths,
     })


### PR DESCRIPTION
Allows web's `WitnessAndBuildRequest` to not pass `authorizationData` as a field. Needed for cases like `swapClaim` where no auth is required to building.