### PR TITLE
staking: namespace state keys and remove dups

### DIFF
--- a/crates/core/component/stake/src/component/epoch_handler.rs
+++ b/crates/core/component/stake/src/component/epoch_handler.rs
@@ -423,7 +423,7 @@ pub trait EpochHandler: StateWriteExt + ConsensusIndexRead {
     #[instrument(skip(self))]
     async fn build_tendermint_validator_updates(&mut self) -> Result<()> {
         let current_consensus_keys: CurrentConsensusKeys = self
-            .get(state_key::current_consensus_keys())
+            .get(state_key::consensus_update::consensus_keys())
             .await?
             .expect("current consensus keys must be present");
         let current_consensus_keys = current_consensus_keys
@@ -512,7 +512,7 @@ pub trait EpochHandler: StateWriteExt + ConsensusIndexRead {
         };
         tracing::debug!(?updated_consensus_keys);
         self.put(
-            state_key::current_consensus_keys().to_owned(),
+            state_key::consensus_update::consensus_keys().to_owned(),
             updated_consensus_keys,
         );
 

--- a/crates/core/component/stake/src/component/stake.rs
+++ b/crates/core/component/stake/src/component/stake.rs
@@ -229,7 +229,7 @@ pub trait StateReadExt: StateRead {
 
     /// Returns the funding queue from object storage (end-epoch).
     fn get_funding_queue(&self) -> Option<Vec<(IdentityKey, FundingStreams, Amount)>> {
-        self.object_get(state_key::validators::rewards::object_storage_key())
+        self.object_get(state_key::validators::rewards::staking())
     }
 
     async fn get_delegation_changes(&self, height: block::Height) -> Result<DelegationChanges> {
@@ -284,7 +284,7 @@ pub trait StateWriteExt: StateWrite {
         staking_reward_queue: Vec<(IdentityKey, FundingStreams, Amount)>,
     ) {
         self.object_put(
-            state_key::validators::rewards::object_storage_key(),
+            state_key::validators::rewards::staking(),
             staking_reward_queue,
         )
     }

--- a/crates/core/component/stake/src/component/stake.rs
+++ b/crates/core/component/stake/src/component/stake.rs
@@ -250,10 +250,10 @@ pub trait StateWriteExt: StateWrite {
     /// Writes the provided stake parameters to the JMT.
     fn put_stake_params(&mut self, params: StakeParameters) {
         // Note that the stake params have been updated:
-        self.object_put(state_key::parameters::key(), ());
+        self.object_put(state_key::parameters::updated_flag(), ());
 
         // Change the stake parameters:
-        self.put(state_key::parameters::updated_flag().into(), params)
+        self.put(state_key::parameters::key().into(), params)
     }
 
     /// Delegation changes accumulated over the course of this block, to be

--- a/crates/core/component/stake/src/component/stake.rs
+++ b/crates/core/component/stake/src/component/stake.rs
@@ -213,7 +213,7 @@ pub trait StateReadExt: StateRead {
     /// persisted at the end of the block for processing at the end of the next
     /// epoch.
     fn get_delegation_changes_tally(&self) -> DelegationChanges {
-        self.object_get(state_key::internal::delegation_changes())
+        self.object_get(state_key::chain::delegation_changes::key())
             .unwrap_or_default()
     }
 
@@ -234,7 +234,9 @@ pub trait StateReadExt: StateRead {
 
     async fn get_delegation_changes(&self, height: block::Height) -> Result<DelegationChanges> {
         Ok(self
-            .get(&state_key::delegation_changes_by_height(height.value()))
+            .get(&state_key::chain::delegation_changes::by_height(
+                height.value(),
+            ))
             .await?
             .ok_or_else(|| anyhow!("missing delegation changes for block {}", height))?)
     }
@@ -259,7 +261,7 @@ pub trait StateWriteExt: StateWrite {
     /// epoch.
     fn put_delegation_changes(&mut self, delegation_changes: DelegationChanges) {
         self.object_put(
-            state_key::internal::delegation_changes(),
+            state_key::chain::delegation_changes::key(),
             delegation_changes,
         )
     }
@@ -453,7 +455,7 @@ pub trait RateDataWrite: StateWrite {
 
     async fn set_delegation_changes(&mut self, height: block::Height, changes: DelegationChanges) {
         self.put(
-            state_key::delegation_changes_by_height(height.value()),
+            state_key::chain::delegation_changes::by_height(height.value()),
             changes,
         );
     }

--- a/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
@@ -94,7 +94,7 @@ pub trait ValidatorManager: StateWrite {
         new_state: validator::State,
     ) -> Result<()> {
         use validator::State::*;
-        let validator_state_path = state_key::state_by_validator(identity_key);
+        let validator_state_path = state_key::validators::state::by_id(identity_key);
 
         // Validator state transitions are usually triggered by an epoch transition. The exception
         // to this rule is when a validator exits the active set. In this case, we want to end the
@@ -637,7 +637,7 @@ pub trait ValidatorManager: StateWrite {
     /// Returns an error if the validator is not found in the JMT.
     async fn process_evidence(&mut self, evidence: &Misbehavior) -> Result<()> {
         let validator = self
-            .get_validator_by_tendermint_address(&evidence.validator.address)
+            .get_validator_by_cometbft_address(&evidence.validator.address)
             .await?
             .ok_or_else(|| {
                 anyhow::anyhow!(

--- a/crates/core/component/stake/src/state_key.rs
+++ b/crates/core/component/stake/src/state_key.rs
@@ -1,5 +1,3 @@
-use std::string::String;
-
 pub mod parameters {
     pub fn key() -> &'static str {
         "staking/parameters"
@@ -95,6 +93,16 @@ pub mod chain {
             "staking/chain/base_rate/previous"
         }
     }
+
+    pub mod delegation_changes {
+        pub fn key() -> &'static str {
+            "staking/delegation_changes"
+        }
+
+        pub fn by_height(height: u64) -> String {
+            format!("staking/delegation_changes/{height}")
+        }
+    }
 }
 
 pub mod penalty {
@@ -114,10 +122,6 @@ pub mod penalty {
     }
 }
 
-pub fn delegation_changes_by_height(height: u64) -> String {
-    format!("staking/delegation_changes/{height}")
-}
-
 pub mod consensus_update {
     pub fn consensus_keys() -> &'static str {
         "staking/cometbft_data/consensus_keys"
@@ -125,9 +129,6 @@ pub mod consensus_update {
 }
 
 pub(super) mod internal {
-    pub fn delegation_changes() -> &'static str {
-        "staking/delegation_changes"
-    }
 
     pub fn tendermint_validator_updates() -> &'static str {
         "staking/tendermint_validator_updates"

--- a/crates/core/component/stake/src/state_key.rs
+++ b/crates/core/component/stake/src/state_key.rs
@@ -79,8 +79,8 @@ pub mod validators {
     /// Tracks the funding rewards of the previously active validator set
     /// in object storage. Consumed by the funding component.
     pub mod rewards {
-        pub fn object_storage_key() -> &'static str {
-            "staking/validators/rewards"
+        pub fn staking() -> &'static str {
+            "staking/validators/staking_rewards"
         }
     }
 }

--- a/crates/core/component/stake/src/state_key.rs
+++ b/crates/core/component/stake/src/state_key.rs
@@ -1,37 +1,37 @@
 use std::string::String;
-use tendermint::PublicKey;
 
-use crate::IdentityKey;
+pub mod parameters {
+    pub fn key() -> &'static str {
+        "staking/parameters"
+    }
 
-pub fn stake_params() -> &'static str {
-    "staking/params"
+    pub fn updated_flag() -> &'static str {
+        "staking/parameters/updated"
+    }
 }
 
-pub fn stake_params_updated() -> &'static str {
-    "staking/stake_params_updated"
-}
-
-pub fn current_base_rate() -> &'static str {
-    "staking/base_rate/current"
-}
-
-pub fn previous_base_rate() -> &'static str {
-    "staking/base_rate/previous"
-}
-
-// TODO(erwan): refactor the state key so that each module
-// represents a coherent set of keys, so that the module path
-// aligns roughly with the actual schema of the data.
-// Tracked by #3615.
 pub mod validators {
-    pub mod index {
-        pub mod consensus_set {
-            pub fn prefix() -> &'static str {
-                "staking/validators/index/consensus_set/"
-            }
-            pub fn by_id(id: &crate::IdentityKey) -> String {
-                format!("{}{id}", prefix())
-            }
+    pub mod consensus_set_index {
+        pub fn prefix() -> &'static str {
+            "staking/validators/consensus_set_index/"
+        }
+        pub fn by_id(id: &crate::IdentityKey) -> String {
+            format!("{}{id}", prefix())
+        }
+    }
+
+    pub mod lookup_by {
+        use tendermint::PublicKey;
+
+        pub fn consensus_key(pk: &PublicKey) -> String {
+            format!("staking/validators/lookup_by/consensus_key/{}", pk.to_hex())
+        }
+
+        pub fn cometbft_address(address: &[u8; 20]) -> String {
+            format!(
+                "staking/validators/lookup_by/cometbft_address/{}",
+                hex::encode(address)
+            )
         }
     }
 
@@ -44,8 +44,40 @@ pub mod validators {
         }
     }
 
-    /// Tracks the rewards of the previously active validator set
-    /// in object storage.
+    pub mod state {
+        pub fn by_id(id: &crate::IdentityKey) -> String {
+            format!("staking/validators/data/{id}/state")
+        }
+    }
+
+    pub mod rate {
+        pub fn current_by_id(id: &crate::IdentityKey) -> String {
+            format!("staking/validators/data/{id}/rate/current")
+        }
+        pub fn next_by_id(id: &crate::IdentityKey) -> String {
+            format!("staking/validators/data/{id}/rate/next")
+        }
+    }
+
+    pub mod power {
+        pub fn by_id(id: &crate::IdentityKey) -> String {
+            format!("staking/validators/data/{id}/power")
+        }
+    }
+    pub mod bonding_state {
+        pub fn by_id(id: &crate::IdentityKey) -> String {
+            format!("staking/validators/data/{id}/bonding_state")
+        }
+    }
+
+    pub mod uptime {
+        pub fn by_id(id: &crate::IdentityKey) -> String {
+            format!("staking/validators/data/{id}/uptime")
+        }
+    }
+
+    /// Tracks the funding rewards of the previously active validator set
+    /// in object storage. Consumed by the funding component.
     pub mod rewards {
         pub fn object_storage_key() -> &'static str {
             "staking/validators/rewards"
@@ -53,62 +85,40 @@ pub mod validators {
     }
 }
 
-pub fn penalty_in_epoch(id: &IdentityKey, epoch: u64) -> String {
-    // Load-bearing format string: we need to pad with 0s to ensure that
-    // the lex order agrees with the numeric order on epochs.
-    // 10 decimal digits covers 2^32 epochs.
-    format!("staking/penalty_in_epoch/{id}/{epoch:010}")
+pub mod chain {
+    pub mod base_rate {
+        pub fn current() -> &'static str {
+            "staking/chain/base_rate/current"
+        }
+
+        pub fn previous() -> &'static str {
+            "staking/chain/base_rate/previous"
+        }
+    }
 }
 
-pub fn penalty_in_epoch_prefix(id: &IdentityKey) -> String {
-    format!("staking/penalty_in_epoch/{id}/")
-}
+pub mod penalty {
+    use crate::IdentityKey;
 
-pub fn state_by_validator(id: &IdentityKey) -> String {
-    format!("staking/validator_state/{id}")
-}
-
-pub fn current_rate_by_validator(id: &IdentityKey) -> String {
-    format!("staking/validator_rate/current/{id}")
-}
-
-pub fn next_rate_by_validator(id: &IdentityKey) -> String {
-    format!("staking/validator_rate/next/{id}")
-}
-
-pub fn power_by_validator(id: &IdentityKey) -> String {
-    format!("staking/validator_power/{id}")
-}
-
-pub fn bonding_state_by_validator(id: &IdentityKey) -> String {
-    format!("staking/validator_bonding_state/{id}")
-}
-
-pub fn uptime_by_validator(id: &IdentityKey) -> String {
-    format!("staking/validator_uptime/{id}")
-}
-
-pub fn slashed_validators(height: u64) -> String {
-    format!("staking/slashed_validators/{height}")
-}
-
-pub fn validator_id_by_consensus_key(pk: &PublicKey) -> String {
-    format!("staking/validator_id_by_consensus_key/{}", pk.to_hex())
-}
-
-pub fn consensus_key_by_tendermint_address(address: &[u8; 20]) -> String {
-    format!(
-        "staking/consensus_key_by_tendermint_address/{}",
-        hex::encode(address)
-    )
+    pub fn prefix(id: &IdentityKey) -> String {
+        format!("staking/penalty/{id}/")
+    }
+    pub fn for_id_in_epoch(id: &crate::IdentityKey, epoch_index: u64) -> String {
+        // Load-bearing format string: we need to pad with 0s to ensure that
+        // the lex order agrees with the numeric order on epochs.
+        // 10 decimal digits covers 2^32 epochs.
+        format!("{}{epoch_index:010}", prefix(id))
+    }
 }
 
 pub fn delegation_changes_by_height(height: u64) -> String {
     format!("staking/delegation_changes/{height}")
 }
 
-pub fn current_consensus_keys() -> &'static str {
-    "staking/current_consensus_keys"
+pub mod consensus_update {
+    pub fn consensus_keys() -> &'static str {
+        "staking/cometbft_data/consensus_keys"
+    }
 }
 
 pub(super) mod internal {
@@ -125,6 +135,9 @@ pub(super) mod internal {
 mod tests {
     use decaf377_rdsa as rdsa;
     use std::collections::BTreeSet;
+    use tests::penalty;
+
+    use crate::IdentityKey;
 
     use super::*;
     use rand_core::OsRng;
@@ -135,7 +148,7 @@ mod tests {
         let ik = IdentityKey((&sk).into());
 
         assert_eq!(
-            penalty_in_epoch(&ik, 791),
+            penalty::for_id_in_epoch(&ik, 791),
             //                                     0123456789
             format!("staking/penalty_in_epoch/{ik}/0000000791"),
         );
@@ -146,11 +159,11 @@ mod tests {
         let sk = rdsa::SigningKey::new(OsRng);
         let ik = IdentityKey((&sk).into());
 
-        let k791 = penalty_in_epoch(&ik, 791);
-        let k792 = penalty_in_epoch(&ik, 792);
-        let k793 = penalty_in_epoch(&ik, 793);
-        let k79 = penalty_in_epoch(&ik, 79);
-        let k7 = penalty_in_epoch(&ik, 7);
+        let k791 = penalty::for_id_in_epoch(&ik, 791);
+        let k792 = penalty::for_id_in_epoch(&ik, 792);
+        let k793 = penalty::for_id_in_epoch(&ik, 793);
+        let k79 = penalty::for_id_in_epoch(&ik, 79);
+        let k7 = penalty::for_id_in_epoch(&ik, 7);
 
         let keys = vec![k791.clone(), k792.clone(), k793.clone(), k79, k7]
             .into_iter()

--- a/crates/core/component/stake/src/state_key.rs
+++ b/crates/core/component/stake/src/state_key.rs
@@ -46,33 +46,33 @@ pub mod validators {
 
     pub mod state {
         pub fn by_id(id: &crate::IdentityKey) -> String {
-            format!("staking/validators/data/{id}/state")
+            format!("staking/validators/data/state/{id}")
         }
     }
 
     pub mod rate {
         pub fn current_by_id(id: &crate::IdentityKey) -> String {
-            format!("staking/validators/data/{id}/rate/current")
+            format!("staking/validators/data/rate/current/{id}")
         }
         pub fn next_by_id(id: &crate::IdentityKey) -> String {
-            format!("staking/validators/data/{id}/rate/next")
+            format!("staking/validators/data/rate/next/{id}")
         }
     }
 
     pub mod power {
         pub fn by_id(id: &crate::IdentityKey) -> String {
-            format!("staking/validators/data/{id}/power")
+            format!("staking/validators/data/power/{id}")
         }
     }
     pub mod bonding_state {
         pub fn by_id(id: &crate::IdentityKey) -> String {
-            format!("staking/validators/data/{id}/bonding_state")
+            format!("staking/validators/data/bonding_state/{id}")
         }
     }
 
     pub mod uptime {
         pub fn by_id(id: &crate::IdentityKey) -> String {
-            format!("staking/validators/data/{id}/uptime")
+            format!("staking/validators/data/uptime/{id}")
         }
     }
 
@@ -101,6 +101,9 @@ pub mod penalty {
     use crate::IdentityKey;
 
     pub fn prefix(id: &IdentityKey) -> String {
+        // Note: We typically put the key at the end of the path to increase
+        // locality. Here we don't because we want to build a prefix iterator
+        // to accumulate validator penalty across epochs.
         format!("staking/penalty/{id}/")
     }
     pub fn for_id_in_epoch(id: &crate::IdentityKey, epoch_index: u64) -> String {
@@ -149,8 +152,8 @@ mod tests {
 
         assert_eq!(
             penalty::for_id_in_epoch(&ik, 791),
-            //                                     0123456789
-            format!("staking/penalty_in_epoch/{ik}/0000000791"),
+            //                            0123456789
+            format!("staking/penalty/{ik}/0000000791")
         );
     }
 


### PR DESCRIPTION
This is the final chunk of work for #3615.

This PR:
- remove duplicates in the staking state keys
- picks a namespacing format that leaves room for future optimization
- organize state keys into a module hierarchy

Overall, there aren't dramatic changes, but a series of modest attempts at future-proofing our state key format.