### PR TITLE
ci: fix docs build nightly version

### DIFF
--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -17,8 +17,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        # The script for rustdoc build requires nightly toolchain.
+        uses: dtolnay/rust-toolchain@master
+        with:
+          # TODO 2024-02-06: this is pinned due to tkaitchuck/aHash#200, see GH3750.
+          toolchain: nightly-2024-02-01
+
       - name: Load Rust caching
         uses: astriaorg/buildjet-rust-cache@v2.5.1
       - name: Load get-version action to grab version component of deployment path

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
         # The script for rustdoc build requires nightly toolchain.
         uses: dtolnay/rust-toolchain@master
         with:
-          # TODO 24-02-06: this is pinned due to tkaitchuck/aHash#200.
+          # TODO 2024-02-06: this is pinned due to tkaitchuck/aHash#200, see GH3750.
           toolchain: nightly-2024-02-01
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1


### PR DESCRIPTION
Refs #3750. Follow-up to #3749, which updated the per-PR CI workflow, but not the deploy-on-merge-to-main workflow.