### PR TITLE
ci: fix yaml typo in testnet manifest

### DIFF
--- a/deployments/helmfile.d/penumbra-testnet.yaml
+++ b/deployments/helmfile.d/penumbra-testnet.yaml
@@ -71,7 +71,7 @@ releases:
       # It's not strictly necessary to wait for node deploys, but doing so allows us to exercise
       # the public HTTPS RPC endpoint for joining, which is nice.
       - penumbra-testnet-nodes
-   values:
+    values:
       - penumbra_bootstrap_node_cometbft_rpc_url: "https://rpc.testnet.penumbra.zone"
       - ingressRoute:
           enabled: false


### PR DESCRIPTION
Follow-up to #3699, which introduced a YAML typo I overlooked. Will need to be backported to release branch for 65 if we want to use the automated deploy pipeline.