### PR TITLE
refactor(pd): 🏋️ hoist `Consensus` and `Mempool` into `penumba-app`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4763,6 +4763,8 @@ dependencies = [
  "tendermint-proto",
  "tokio",
  "tonic",
+ "tower",
+ "tower-actor",
  "tracing",
  "tracing-subscriber 0.3.18",
 ]

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -60,7 +60,6 @@ decaf377 = {workspace = true, features = ["parallel"], default-features = true}
 decaf377-rdsa = {workspace = true}
 tower-abci = "0.11"
 jmt = {workspace = true}
-tower-actor = "0.1.0"
 tendermint-config = {workspace = true}
 tendermint-proto = {workspace = true}
 tendermint = {workspace = true}
@@ -85,6 +84,7 @@ tokio = {workspace = true, features = ["full"]}
 tokio-stream = {workspace = true}
 tokio-util = {workspace = true, features = ["compat"]}
 tower = {workspace = true, features = ["full"]}
+tower-actor = "0.1.0"
 tower-service = {workspace = true}
 tower-http = {workspace = true}
 tracing = {workspace = true}

--- a/crates/bin/pd/src/lib.rs
+++ b/crates/bin/pd/src/lib.rs
@@ -6,7 +6,6 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod info;
-mod mempool;
 mod metrics;
 mod snapshot;
 
@@ -17,6 +16,5 @@ pub mod testnet;
 
 pub use crate::metrics::register_metrics;
 pub use info::Info;
-pub use mempool::Mempool;
 pub use penumbra_app::app::App;
 pub use snapshot::Snapshot;

--- a/crates/bin/pd/src/lib.rs
+++ b/crates/bin/pd/src/lib.rs
@@ -5,7 +5,6 @@
 // Requires nightly.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-mod consensus;
 mod info;
 mod mempool;
 mod metrics;
@@ -17,7 +16,6 @@ pub mod migrate;
 pub mod testnet;
 
 pub use crate::metrics::register_metrics;
-pub use consensus::Consensus;
 pub use info::Info;
 pub use mempool::Mempool;
 pub use penumbra_app::app::App;

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -152,7 +152,12 @@ async fn main() -> anyhow::Result<()> {
                 }))
                 .service(tower_actor::Actor::new(10, |queue: _| {
                     let storage = storage.clone();
-                    async move { pd::Mempool::new(storage.clone(), queue).await?.run().await }
+                    async move {
+                        penumbra_app::mempool::Mempool::new(storage.clone(), queue)
+                            .await?
+                            .run()
+                            .await
+                    }
                 }));
             let info = pd::Info::new(storage.clone());
             let tm_proxy = TendermintProxy::new(cometbft_addr);

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -140,7 +140,7 @@ async fn main() -> anyhow::Result<()> {
                 .service(tower_actor::Actor::new(10, |queue: _| {
                     let storage = storage.clone();
                     async move {
-                        pd::Consensus::new(storage.clone(), queue)
+                        penumbra_app::consensus::Consensus::new(storage.clone(), queue)
                             .await?
                             .run()
                             .await

--- a/crates/bin/pd/src/metrics.rs
+++ b/crates/bin/pd/src/metrics.rs
@@ -11,6 +11,7 @@
 //! This trick is probably good to avoid in general, because it could be
 //! confusing, but in this limited case, it seems like a clean option.
 
+#[allow(unused_imports)] // It is okay if this reëxport isn't used, see above.
 pub use metrics::*;
 
 /// Registers all metrics used by this crate.
@@ -20,12 +21,4 @@ pub use metrics::*;
 pub fn register_metrics() {
     // This will register metrics for all components.
     penumbra_app::register_metrics();
-
-    describe_counter!(
-        MEMPOOL_CHECKTX_TOTAL,
-        Unit::Count,
-        "The total number of checktx requests made to the mempool"
-    );
 }
-
-pub const MEMPOOL_CHECKTX_TOTAL: &str = "penumbra_pd_mempool_checktx_total";

--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -73,6 +73,8 @@ ibc-types = {workspace = true, default-features = false}
 ibc-proto = {workspace = true, default-features = false, features = [
     "server",
 ]}
+tower-actor = "0.1.0"
+tower = {workspace = true, features = ["full"]}
 
 [dev-dependencies]
 ed25519-consensus = {workspace = true}

--- a/crates/core/app/src/consensus.rs
+++ b/crates/core/app/src/consensus.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 use tower_actor::Message;
 use tracing::Instrument;
 
-use crate::App;
+use crate::app::App;
 
 pub struct Consensus {
     queue: mpsc::Receiver<Message<Request, Response, tower::BoxError>>,

--- a/crates/core/app/src/lib.rs
+++ b/crates/core/app/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod app;
+pub mod consensus;
 pub mod metrics;
 pub mod params;
 pub mod rpc;

--- a/crates/core/app/src/lib.rs
+++ b/crates/core/app/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod app;
 pub mod consensus;
+pub mod mempool;
 pub mod metrics;
 pub mod params;
 pub mod rpc;

--- a/crates/core/app/src/mempool.rs
+++ b/crates/core/app/src/mempool.rs
@@ -10,7 +10,7 @@ use tokio::sync::{mpsc, watch};
 use tower_actor::Message;
 use tracing::Instrument;
 
-use crate::{metrics, App};
+use crate::{app::App, metrics};
 
 /// When using ABCI, we can't control block proposal directly, so we could
 /// potentially end up creating blocks with mutually incompatible transactions.

--- a/crates/core/app/src/metrics.rs
+++ b/crates/core/app/src/metrics.rs
@@ -22,4 +22,12 @@ pub fn register_metrics() {
     penumbra_governance::register_metrics();
     penumbra_ibc::component::register_metrics();
     penumbra_shielded_pool::component::register_metrics();
+
+    describe_counter!(
+        MEMPOOL_CHECKTX_TOTAL,
+        Unit::Count,
+        "The total number of checktx requests made to the mempool"
+    );
 }
+
+pub const MEMPOOL_CHECKTX_TOTAL: &str = "penumbra_pd_mempool_checktx_total";


### PR DESCRIPTION
see #3588, #3787. we'll need these in the `penumbra-app` crate to instantiate a test node. this is plain code motion.