### PR TITLE
feat(pcli): smart colorization for pcli output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,6 +1449,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "colored_json"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4450,6 +4460,7 @@ dependencies = [
  "bytes",
  "camino",
  "clap",
+ "colored",
  "colored_json",
  "comfy-table",
  "decaf377 0.5.0",

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -97,6 +97,7 @@ toml = {workspace = true, features = ["preserve_order"]}
 once_cell = {workspace = true}
 ndarray = "0.15.6"
 dialoguer = "0.10.4"
+colored = "2.1.0"
 
 [dev-dependencies]
 assert_cmd = {workspace = true}

--- a/crates/bin/pcli/src/command/query/validator.rs
+++ b/crates/bin/pcli/src/command/query/validator.rs
@@ -1,6 +1,7 @@
 use std::{fs::File, io::Write};
 
 use anyhow::{Context, Result};
+use colored::Colorize;
 use comfy_table::{presets, Table};
 use futures::TryStreamExt;
 use penumbra_num::Amount;
@@ -121,7 +122,7 @@ impl ValidatorCmd {
                         v.status.bonding_state.to_string(),
                         // TODO: consider rewriting this with term colors
                         // at some point, when we get around to it
-                        format!("\x1b[1;31m{}\x1b[0m", v.validator.identity_key),
+                        v.validator.identity_key.to_string().red().to_string(),
                     ]);
                     table.add_row(vec![
                         "".into(),
@@ -129,7 +130,7 @@ impl ValidatorCmd {
                         "".into(),
                         "".into(),
                         "".into(),
-                        format!("  \x1b[1;92m{}\x1b[0m", v.validator.name),
+                        v.validator.name.to_string().bright_green().to_string(),
                     ]);
                     if *detailed {
                         table.add_row(vec![


### PR DESCRIPTION
Using the `colored` crate for readable ANSI color schemes. We also get free tty detection, so this command is now readable:

  pcli query validator list | less

That's a command I run a lot, particularly since we've had a sharp increase in validator interest, coinciding with phase 1 of the summoning ceremony (~2023-12).

In 1676879ee365d72d35883be391ef9d10aa5c5e31 we ensured that pcli only colorizes log output where appropriate, but the validator query list wasn't using logging interfaces.