### PR TITLE
staking: use validator exchange rate to compute rewards

### DIFF
--- a/crates/core/component/stake/src/component/epoch_handler.rs
+++ b/crates/core/component/stake/src/component/epoch_handler.rs
@@ -156,6 +156,11 @@ pub trait EpochHandler: StateWriteExt + ConsensusIndexRead {
                 .unwrap_or(Penalty::from_percent(0));
             let prev_validator_rate_with_penalty = prev_validator_rate.slash(penalty);
 
+            self.set_prev_validator_rate(
+                &validator.identity_key,
+                prev_validator_rate_with_penalty.clone(),
+            );
+
             // Then compute the next validator rate, accounting for funding streams and validator state.
             let next_validator_rate = prev_validator_rate_with_penalty.next_epoch(
                 &next_base_rate,

--- a/crates/core/component/stake/src/component/validator_handler/validator_store.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_store.rs
@@ -86,6 +86,12 @@ pub trait ValidatorDataRead: StateRead {
             .boxed()
     }
 
+    async fn get_prev_validator_rate(&self, identity_key: &IdentityKey) -> Option<RateData> {
+        self.get(&state_key::validators::rate::previous_by_id(identity_key))
+            .await
+            .expect("no deserialization error expected")
+    }
+
     fn get_validator_power(
         &self,
         validator: &IdentityKey,
@@ -268,6 +274,13 @@ pub trait ValidatorDataWrite: StateWrite {
             state_key::validators::rate::current_by_id(identity_key),
             rate_data,
         );
+    }
+
+    #[instrument(skip(self))]
+    /// Persist the previous validator rate data, inclusive of accumulated penalties.
+    fn set_prev_validator_rate(&mut self, identity_key: &IdentityKey, rate_data: RateData) {
+        let path = state_key::validators::rate::previous_by_id(identity_key);
+        self.put(path, rate_data)
     }
 }
 

--- a/crates/core/component/stake/src/state_key.rs
+++ b/crates/core/component/stake/src/state_key.rs
@@ -52,8 +52,9 @@ pub mod validators {
         pub fn current_by_id(id: &crate::IdentityKey) -> String {
             format!("staking/validators/data/rate/current/{id}")
         }
-        pub fn next_by_id(id: &crate::IdentityKey) -> String {
-            format!("staking/validators/data/rate/next/{id}")
+
+        pub fn previous_by_id(id: &crate::IdentityKey) -> String {
+            format!("staking/validators/data/rate/previous/{id}")
         }
     }
 


### PR DESCRIPTION
Submitted for independent review and testing, should fix #3802. 

Testing that this change work is a little bit tricky, here are the steps that I have taken just now:

1. I setup a devnet with short block time (300ms), and short epoch durations (50 blocks).
2. The default validator has 100% of the total active stake and a 100% commission rate.
3. On the `v0.66.0` tag, this experimental setups leads to a chain halt on epoch 2 (~ 25 seconds after start).

