### PR TITLE
staking: lower `StakeParameters::min_threshold_stake` to 1penumbra

### DIFF
--- a/crates/core/component/stake/src/params.rs
+++ b/crates/core/component/stake/src/params.rs
@@ -78,8 +78,8 @@ impl Default for StakeParameters {
             slashing_penalty_downtime: 1_0000,
             // 3bps -> 11% return over 365 epochs
             base_reward_rate: 3_0000,
-            // 100 penumbra
-            min_validator_stake: 100_000_000u128.into(),
+            // 1 penumbra
+            min_validator_stake: 1_000_000u128.into(),
         }
     }
 }


### PR DESCRIPTION
Lowering the limit since the faucet only gives out so many tokens, and we have received feedback that this made it time-consuming to experiment with the application if one wants to setup a validator as well.