### PR TITLE
Add cometbft-addr to docker-compose.yml

### DIFF
--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     command: >-
       /bin/pd start --home /pd/testnet_data/node0/pd
       --grpc-bind 0.0.0.0:8080 --abci-bind 0.0.0.0:26658
+      --cometbft-addr http://cometbft-node0:26657
     restart: on-failure
     volumes:
       - penumbra-pd-node0:/pd


### PR DESCRIPTION
pd-node have to know correct address JSON-RPC of cometbft node to work correctly gRPC request to 8080 will fail if pd can't send request to cometbft node RPC port