### PR TITLE
tests: ✨ provide app state in genesis request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5219,7 +5219,6 @@ version = "0.67.0"
 dependencies = [
  "anyhow",
  "bytes",
- "penumbra-genesis",
  "serde_json",
  "tap",
  "tendermint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5219,6 +5219,8 @@ version = "0.67.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "penumbra-genesis",
+ "serde_json",
  "tap",
  "tendermint",
  "tower",

--- a/crates/core/app/tests/common/mod.rs
+++ b/crates/core/app/tests/common/mod.rs
@@ -60,3 +60,22 @@ impl TempStorageExt for TempStorage {
         self.apply_genesis(Default::default()).await
     }
 }
+
+/// Penumbra-specific extensions to the mock consensus builder.
+pub trait BuilderExt: Sized {
+    type Error;
+    fn with_penumbra_auto_app_state(self, app_state: AppState) -> Result<Self, Self::Error>;
+}
+
+impl BuilderExt for penumbra_mock_consensus::builder::Builder {
+    type Error = anyhow::Error;
+    fn with_penumbra_auto_app_state(self, app_state: AppState) -> Result<Self, Self::Error> {
+        // what to do here?
+        // - read out list of abci/comet validators from the builder,
+        // - define a penumbra validator for each one
+        // - inject that into the penumbra app state
+        // - serialize to json and then call `with_app_state_bytes`
+        let app_state = serde_json::to_vec(&app_state)?;
+        Ok(self.app_state(app_state))
+    }
+}

--- a/crates/core/app/tests/mock_consensus.rs
+++ b/crates/core/app/tests/mock_consensus.rs
@@ -7,24 +7,27 @@ mod common;
 
 use cnidarium::TempStorage;
 use penumbra_app::server::consensus::Consensus;
+use penumbra_genesis::AppState;
 
 #[tokio::test]
-async fn mock_consensus_can_send_a_failing_init_chain_request() -> anyhow::Result<()> {
+async fn mock_consensus_can_send_an_init_chain_request() -> anyhow::Result<()> {
     // Install a test logger, and acquire some temporary storage.
     let guard = common::set_tracing_subscriber();
     let storage = TempStorage::new().await?;
 
     // Instantiate the consensus service, and start the test node.
-    use penumbra_mock_consensus::TestNode;
-    let consensus = Consensus::new(storage.as_ref().clone());
-    let engine = TestNode::builder()
-        .single_validator()
-        .app_state(() /*genesis::AppState::default()*/)
-        .init_chain(consensus)
-        .await;
+    let engine = {
+        use penumbra_mock_consensus::TestNode;
+        let app_state = AppState::default();
+        let consensus = Consensus::new(storage.as_ref().clone());
+        TestNode::builder()
+            .single_validator()
+            .app_state(app_state)
+            .init_chain(consensus)
+            .await?
+    };
 
-    // NB: we don't expect this to succeed... yet.
-    assert!(engine.is_err(), "init_chain does not return an Ok(()) yet");
+    tracing::info!(hash = %engine.last_app_hash_hex(), "finished init chain");
 
     // Free our temporary storage.
     drop(storage);

--- a/crates/core/app/tests/mock_consensus.rs
+++ b/crates/core/app/tests/mock_consensus.rs
@@ -6,6 +6,7 @@
 mod common;
 
 use cnidarium::TempStorage;
+use common::BuilderExt;
 use penumbra_app::server::consensus::Consensus;
 use penumbra_genesis::AppState;
 
@@ -22,7 +23,7 @@ async fn mock_consensus_can_send_an_init_chain_request() -> anyhow::Result<()> {
         let consensus = Consensus::new(storage.as_ref().clone());
         TestNode::builder()
             .single_validator()
-            .app_state(app_state)
+            .with_penumbra_auto_app_state(app_state)?
             .init_chain(consensus)
             .await?
     };

--- a/crates/test/mock-consensus/Cargo.toml
+++ b/crates/test/mock-consensus/Cargo.toml
@@ -10,7 +10,6 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 bytes = { workspace = true }
-penumbra-genesis = { workspace = true }
 serde_json = { workspace = true }
 tap = "1.0.1"
 tendermint = { workspace = true }

--- a/crates/test/mock-consensus/Cargo.toml
+++ b/crates/test/mock-consensus/Cargo.toml
@@ -10,7 +10,9 @@ license.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 bytes = { workspace = true }
+penumbra-genesis = { workspace = true }
+serde_json = { workspace = true }
+tap = "1.0.1"
 tendermint = { workspace = true }
 tower = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
-tap = "1.0.1"

--- a/crates/test/mock-consensus/src/builder.rs
+++ b/crates/test/mock-consensus/src/builder.rs
@@ -5,13 +5,12 @@
 /// Most importantly, defines [`Builder::init_chain()`].
 mod init_chain;
 
-use crate::TestNode;
-use penumbra_genesis::AppState;
+use {crate::TestNode, bytes::Bytes};
 
 /// A buider, used to prepare and instantiate a new [`TestNode`].
 #[derive(Default)]
 pub struct Builder {
-    app_state: Option<AppState>,
+    app_state: Option<Bytes>,
 }
 
 impl TestNode<()> {
@@ -30,13 +29,9 @@ impl Builder {
         self
     }
 
-    pub fn app_state(self, app_state: AppState) -> Self {
-        let app_state = Some(app_state);
+    /// Sets the `app_state_bytes` to send the ABCI application upon chain initialization.
+    pub fn app_state(self, app_state: impl Into<Bytes>) -> Self {
+        let app_state = Some(app_state.into());
         Self { app_state, ..self }
-    }
-
-    pub fn app_state_bytes(self, _: Vec<u8>) -> Self {
-        // this does not do anything yet
-        self
     }
 }

--- a/crates/test/mock-consensus/src/builder.rs
+++ b/crates/test/mock-consensus/src/builder.rs
@@ -6,14 +6,18 @@
 mod init_chain;
 
 use crate::TestNode;
+use penumbra_genesis::AppState;
 
 /// A buider, used to prepare and instantiate a new [`TestNode`].
-pub struct Builder;
+#[derive(Default)]
+pub struct Builder {
+    app_state: Option<AppState>,
+}
 
 impl TestNode<()> {
     /// Returns a new [`Builder`].
     pub fn builder() -> Builder {
-        Builder
+        Builder::default()
     }
 }
 
@@ -26,9 +30,9 @@ impl Builder {
         self
     }
 
-    pub fn app_state(self, _: ()) -> Self {
-        // this does not do anything yet
-        self
+    pub fn app_state(self, app_state: AppState) -> Self {
+        let app_state = Some(app_state);
+        Self { app_state, ..self }
     }
 
     pub fn app_state_bytes(self, _: Vec<u8>) -> Self {

--- a/crates/test/mock-consensus/src/builder/init_chain.rs
+++ b/crates/test/mock-consensus/src/builder/init_chain.rs
@@ -1,6 +1,7 @@
 use {
     super::*,
     anyhow::{anyhow, bail},
+    bytes::Bytes,
     std::time,
     tap::TapFallible,
     tendermint::{
@@ -63,10 +64,9 @@ impl Builder {
         })
     }
 
-    fn init_chain_request(app_state: AppState) -> Result<ConsensusRequest, anyhow::Error> {
+    fn init_chain_request(app_state_bytes: Bytes) -> Result<ConsensusRequest, anyhow::Error> {
         use tendermint::v0_37::abci::request::InitChain;
         let consensus_params = Self::consensus_params();
-        let app_state_bytes = serde_json::to_vec(&app_state)?.into();
         Ok(ConsensusRequest::InitChain(InitChain {
             time: tendermint::Time::now(),
             chain_id: "test".to_string(), // XXX const here?

--- a/crates/test/mock-consensus/src/lib.rs
+++ b/crates/test/mock-consensus/src/lib.rs
@@ -3,7 +3,7 @@
 //  see penumbra-zone/penumbra#3588.
 
 mod block;
-mod builder;
+pub mod builder;
 
 // TODO(kate): this is a temporary allowance while we set the test node up.
 #[allow(dead_code)]

--- a/crates/test/mock-consensus/src/lib.rs
+++ b/crates/test/mock-consensus/src/lib.rs
@@ -11,3 +11,17 @@ pub struct TestNode<C> {
     consensus: C,
     last_app_hash: Vec<u8>,
 }
+
+impl<C> TestNode<C> {
+    /// Returns the last app_hash value, as a slice of bytes.
+    pub fn last_app_hash(&self) -> &[u8] {
+        &self.last_app_hash
+    }
+
+    /// Returns the last app_hash value, as a hexadecimal string.
+    pub fn last_app_hash_hex(&self) -> String {
+        // Use upper-case hexadecimal integers, include leading zeroes.
+        // - https://doc.rust-lang.org/std/fmt/#formatting-traits
+        format!("{:02X?}", self.last_app_hash)
+    }
+}


### PR DESCRIPTION
this is a follow-on to #3807. this makes the
`mock_consensus_can_send_an_init_chain_request` test pass.

see #3588.

add an app state field to the builder, thread that through to the abci request. log this after the response is received.

```
; RUST_LOG="penumbra-app=debug,info" cargo test --package penumbra-app init_chain -- --nocapture

running 1 test
  2024-02-13T15:18:01.770473Z  INFO cnidarium::storage: snapshot dispatcher task has started
    at crates/cnidarium/src/storage.rs:208

  2024-02-13T15:18:01.880291Z  INFO penumbra_app::server::consensus: genesis state is a full configuration
    at crates/core/app/src/server/consensus.rs:143

  2024-02-13T15:18:01.883007Z  INFO penumbra_app::server::consensus: finished init_chain, consensus_params: Params { block: Size { max_bytes: 1, max_gas: 1, time_iota_ms: 1 }, evidence: Params { max_age_num_blocks: 1, max_age_duration: Duration(1s), max_bytes: 1 }, validator: ValidatorParams { pub_key_types: [] }, version: Some(VersionParams { app: 1 }), abci: AbciParams { vote_extensions_enable_height: None } }, validators: [], app_hash: RootHash("5fc87d8a020365f0bc2cff7b1e8fc5dc3d14f862a7c860dc231e6d44fa847277")
    at crates/core/app/src/server/consensus.rs:153

  2024-02-13T15:18:01.883067Z  INFO mock_consensus: finished init chain, hash: [5F, C8, 7D, 8A, 2, 3, 65, F0, BC, 2C, FF, 7B, 1E, 8F, C5, DC, 3D, 14, F8, 62, A7, C8, 60, DC, 23, 1E, 6D, 44, FA, 84, 72, 77]
    at crates/core/app/tests/mock_consensus.rs:30

test mock_consensus_can_send_an_init_chain_request ... ok
```