### PR TITLE
funding: make reward budget a soft limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5015,6 +5015,7 @@ dependencies = [
  "cnidarium",
  "cnidarium-component",
  "futures",
+ "metrics",
  "penumbra-asset",
  "penumbra-community-pool",
  "penumbra-distributions",

--- a/crates/core/app/src/metrics.rs
+++ b/crates/core/app/src/metrics.rs
@@ -17,6 +17,7 @@ pub use metrics::*;
 pub fn register_metrics() {
     cnidarium::register_metrics();
     penumbra_stake::component::register_metrics();
+    penumbra_funding::component::register_metrics();
     penumbra_dex::component::register_metrics();
     // TODO: this should be under component::
     penumbra_governance::register_metrics();

--- a/crates/core/component/funding/Cargo.toml
+++ b/crates/core/component/funding/Cargo.toml
@@ -13,6 +13,7 @@ component = [
     "penumbra-sct/component",
     "penumbra-shielded-pool/component",
     "penumbra-stake/component",
+    "metrics",
     "futures"
 ]
 default = ["component"]
@@ -33,6 +34,7 @@ anyhow = {workspace = true}
 tracing = {workspace = true}
 tendermint = {workspace = true}
 futures = {workspace = true, optional = true}
+metrics = {workspace = true, optional = true}
 serde = {workspace = true, features = ["derive"]}
 
 [dev-dependencies]

--- a/crates/core/component/funding/src/component.rs
+++ b/crates/core/component/funding/src/component.rs
@@ -102,14 +102,14 @@ impl Component for Funding {
                     .saturating_add(reward_amount_for_stream.value());
 
                 if total_staking_rewards_for_epoch > staking_issuance_budget.value() {
-                    tracing::error!(
+                    tracing::warn!(
                         %total_staking_rewards_for_epoch,
                         %staking_issuance_budget,
                         %reward_amount_for_stream,
                         "the sum of staking rewards for the epoch has exceeded the issuance budget"
                     );
 
-                    tracing::error!(%validator_identity,
+                    tracing::warn!(%validator_identity,
                         index,
                         funding_queue_len,
                         ending_epoch_base_rate = ?base_rate,

--- a/crates/core/component/funding/src/component.rs
+++ b/crates/core/component/funding/src/component.rs
@@ -1,5 +1,10 @@
+pub mod metrics;
 mod state_key;
 pub mod view;
+use ::metrics::{gauge, histogram};
+pub use metrics::register_metrics;
+
+/* Component implementation */
 use penumbra_asset::{Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_stake::component::validator_handler::ValidatorDataRead;
 pub use view::{StateReadExt, StateWriteExt};
@@ -58,12 +63,14 @@ impl Component for Funding {
         use penumbra_stake::StateReadExt as _;
 
         let state = Arc::get_mut(state).expect("state should be unique");
+        let funding_execution_start = std::time::Instant::now();
 
         // Here, we want to process the funding rewards for the epoch that just ended. To do this,
         // we pull the funding queue that the staking component has prepared for us, as well as the
         // base rate data for the epoch that just ended.
         let funding_queue = state.get_funding_queue().unwrap_or_default();
-        let funding_queue_len = funding_queue.len();
+        let fetching_funding_queue_duration = funding_execution_start.elapsed().as_millis() as f64;
+        histogram!(metrics::FETCH_FUNDING_QUEUE_LATENCY,).record(fetching_funding_queue_duration);
 
         let Some(base_rate) = state.get_previous_base_rate() else {
             tracing::error!("the ending epoch's base rate has not beed found in object storage, computing rewards is not possible");
@@ -75,17 +82,14 @@ impl Component for Funding {
         let staking_issuance_budget = state
             .get_staking_token_issuance_for_epoch()
             .expect("staking token issuance MUST be set");
+
         let mut total_staking_rewards_for_epoch = 0u128;
 
-        for (index, (validator_identity, funding_streams, delegation_token_supply)) in
-            funding_queue.into_iter().enumerate()
-        {
+        for (validator_identity, funding_streams, delegation_token_supply) in funding_queue {
             let Some(validator_rate) = state.get_prev_validator_rate(&validator_identity).await
             else {
                 tracing::error!(
                     %validator_identity,
-                    index,
-                    funding_queue_len,
                     ending_epoch_base_rate = ?base_rate,
                     "the ending epoch's rate data for the validator has not been found in storage, computing rewards is not possible"
                 );
@@ -100,22 +104,6 @@ impl Component for Funding {
 
                 total_staking_rewards_for_epoch = total_staking_rewards_for_epoch
                     .saturating_add(reward_amount_for_stream.value());
-
-                if total_staking_rewards_for_epoch > staking_issuance_budget.value() {
-                    tracing::warn!(
-                        %total_staking_rewards_for_epoch,
-                        %staking_issuance_budget,
-                        %reward_amount_for_stream,
-                        "the sum of staking rewards for the epoch has exceeded the issuance budget"
-                    );
-
-                    tracing::warn!(%validator_identity,
-                        index,
-                        funding_queue_len,
-                        ending_epoch_base_rate = ?base_rate,
-                        funding_stream = ?stream,
-                        delegation_token_supply = ?delegation_token_supply, "debugging information for the funding stream that caused the error");
-                }
 
                 match stream.recipient() {
                     // If the recipient is an address, mint a note to that address
@@ -145,6 +133,26 @@ impl Component for Funding {
                 }
             }
         }
+
+        // We compute and log the difference between the total rewards distributed and the
+        // staking token issuance budget for the epoch. This is useful to monitor the
+        // correctness of the funding rewards computation.
+        let rewards_difference = (total_staking_rewards_for_epoch as i128
+            - staking_issuance_budget.value() as i128) as f64;
+
+        gauge!(metrics::VALIDATOR_FUNDING_VS_BUDGET_DIFFERENCE).set(rewards_difference);
+
+        if total_staking_rewards_for_epoch > staking_issuance_budget.value() {
+            tracing::warn!(
+                total_staking_rewards_for_epoch = total_staking_rewards_for_epoch,
+                staking_issuance_budget = staking_issuance_budget.value(),
+                "total staking rewards for the epoch exceeded the staking token issuance budget target"
+            );
+        }
+
+        histogram!(metrics::TOTAL_FUNDING_STREAMS_PROCESSING_TIME,)
+            .record(funding_execution_start.elapsed().as_millis() as f64);
+
         Ok(())
     }
 }

--- a/crates/core/component/funding/src/component.rs
+++ b/crates/core/component/funding/src/component.rs
@@ -115,7 +115,6 @@ impl Component for Funding {
                         ending_epoch_base_rate = ?base_rate,
                         funding_stream = ?stream,
                         delegation_token_supply = ?delegation_token_supply, "debugging information for the funding stream that caused the error");
-                    panic!("staking rewards for epoch exceeds the staking issuance budget, halting chain")
                 }
 
                 match stream.recipient() {

--- a/crates/core/component/funding/src/component/metrics.rs
+++ b/crates/core/component/funding/src/component/metrics.rs
@@ -1,0 +1,49 @@
+//! Crate-specific metrics functionality.
+//!
+//! This module re-exports the contents of the `metrics` crate.  This is
+//! effectively a way to monkey-patch the functions in this module into the
+//! `metrics` crate, at least from the point of view of the other code in this
+//! crate.
+//!
+//! Code in this crate that wants to use metrics should `use crate::metrics;`,
+//! so that this module shadows the `metrics` crate.
+//!
+//! This trick is probably good to avoid in general, because it could be
+//! confusing, but in this limited case, it seems like a clean option.
+
+pub use metrics::*;
+
+/// Registers all metrics used by this crate.
+pub fn register_metrics() {
+    describe_gauge!(
+        TOTAL_VALIDATOR_REWARDS,
+        Unit::Count,
+        "The total amount of rewards distributed to validators during the epoch"
+    );
+
+    describe_gauge!(
+        VALIDATOR_FUNDING_VS_BUDGET_DIFFERENCE,
+        Unit::Count,
+        "The delta between the total amount of rewards distributed to validators and the rewards budget for the epoch"
+    );
+
+    describe_histogram!(
+        TOTAL_FUNDING_STREAMS_PROCESSING_TIME,
+        Unit::Milliseconds,
+        "The amount of time spent processing funding rewards for the epoch"
+    );
+
+    describe_histogram!(
+        FETCH_FUNDING_QUEUE_LATENCY,
+        Unit::Milliseconds,
+        "The amount of time spent fetching the funding queue from storage"
+    );
+}
+
+pub const TOTAL_VALIDATOR_REWARDS: &str = "penumbra_funding_total_validator_rewards_staking_token";
+pub const VALIDATOR_FUNDING_VS_BUDGET_DIFFERENCE: &str =
+    "penumbra_funding_validator_vs_budget_difference_staking_token";
+pub const FETCH_FUNDING_QUEUE_LATENCY: &str =
+    "penumbra_funding_fetch_funding_queue_latency_milliseconds";
+pub const TOTAL_FUNDING_STREAMS_PROCESSING_TIME: &str =
+    "penumbra_funding_streams_total_processing_time_milliseconds";


### PR DESCRIPTION
Close #3815, this PR:

- removes the `panic!` branch if the total validator rewards are greater than the epoch budget
- adds metrics to make the funding component observable via prometheus