### PR TITLE
staking(undelegate_claim): fix unbonding check condition

### DIFF
--- a/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
@@ -96,6 +96,10 @@ pub trait ValidatorManager: StateWrite {
         use validator::State::*;
         let validator_state_path = state_key::validators::state::by_id(identity_key);
 
+        // We use the current epoch index to compute the unbonding epoch for the validator,
+        // when necessary.
+        let current_epoch = self.get_current_epoch().await?;
+
         // Validator state transitions are usually triggered by an epoch transition. The exception
         // to this rule is when a validator exits the active set. In this case, we want to end the
         // current epoch early in order to hold that validator transitions happen at epoch boundaries.
@@ -153,7 +157,7 @@ pub trait ValidatorManager: StateWrite {
                     identity_key,
                     Unbonding {
                         unbonds_at_epoch: self
-                            .compute_unbonding_epoch_for_validator(identity_key)
+                            .compute_unbonding_epoch(identity_key, current_epoch.index)
                             .await?,
                     },
                 );
@@ -204,7 +208,7 @@ pub trait ValidatorManager: StateWrite {
                     identity_key,
                     Unbonding {
                         unbonds_at_epoch: self
-                            .compute_unbonding_epoch_for_validator(identity_key)
+                            .compute_unbonding_epoch(identity_key, current_epoch.index)
                             .await?,
                     },
                 );
@@ -222,7 +226,7 @@ pub trait ValidatorManager: StateWrite {
                     identity_key,
                     Unbonding {
                         unbonds_at_epoch: self
-                            .compute_unbonding_epoch_for_validator(identity_key)
+                            .compute_unbonding_epoch(identity_key, current_epoch.index)
                             .await?,
                     },
                 );

--- a/deployments/scripts/smoke-test.sh
+++ b/deployments/scripts/smoke-test.sh
@@ -47,7 +47,8 @@ cargo build --quiet --release --bin pd
 
 echo "Generating testnet config..."
 EPOCH_DURATION="${EPOCH_DURATION:-100}"
-cargo run --quiet --release --bin pd -- testnet generate --epoch-duration "$EPOCH_DURATION" --timeout-commit 500ms
+UNBONDING_EPOCHS="${UNBONDING_EPOCHS:-1}"
+cargo run --quiet --release --bin pd -- testnet generate --unbonding-epochs "$UNBONDING_EPOCHS" --epoch-duration "$EPOCH_DURATION" --timeout-commit 500ms
 
 echo "Starting CometBFT..."
 cometbft start --log_level=error --home "${HOME}/.penumbra/testnet_data/node0/cometbft" > "${SMOKE_LOG_DIR}/comet.log" &

--- a/deployments/scripts/smoke-test.sh
+++ b/deployments/scripts/smoke-test.sh
@@ -46,7 +46,7 @@ echo "Building latest version of pd from source..."
 cargo build --quiet --release --bin pd
 
 echo "Generating testnet config..."
-EPOCH_DURATION="${EPOCH_DURATION:-100}"
+EPOCH_DURATION="${EPOCH_DURATION:-50}"
 UNBONDING_EPOCHS="${UNBONDING_EPOCHS:-1}"
 cargo run --quiet --release --bin pd -- testnet generate --unbonding-epochs "$UNBONDING_EPOCHS" --epoch-duration "$EPOCH_DURATION" --timeout-commit 500ms
 


### PR DESCRIPTION
This PR:
- fixes a bug with the unbonding epoch validation rule (claims are allowed _after_ the target epoch has been reached)
- simplifies the unbonding delay calculation logic