### PR TITLE
ci: add indexing node for dex-explorer

### DIFF
--- a/deployments/helmfile.d/penumbra-preview.yaml
+++ b/deployments/helmfile.d/penumbra-preview.yaml
@@ -85,3 +85,26 @@ releases:
       - part_of: penumbra-preview
       - nodes:
         - moniker: cuiloa
+
+  - name: penumbra-preview-dex-explorer-node
+    chart: ../charts/penumbra-node
+    needs:
+      - penumbra-preview
+      # It's not strictly necessary to wait for node deploys, but doing so allows us to exercise
+      # the public HTTPS RPC endpoint for joining, which is nice.
+      - penumbra-preview-nodes
+    values:
+      - penumbra_bootstrap_node_cometbft_rpc_url: "https://rpc.testnet-preview.penumbra.zone"
+      - ingressRoute:
+          enabled: false
+      - image:
+          tag: main
+      - persistence:
+          enabled: true
+          size: 20G
+      - cometbft:
+          config:
+            indexer: psql
+      - part_of: penumbra-preview
+      - nodes:
+        - moniker: dex-explorer

--- a/deployments/helmfile.d/penumbra-testnet.yaml
+++ b/deployments/helmfile.d/penumbra-testnet.yaml
@@ -86,3 +86,24 @@ releases:
       - part_of: penumbra-testnet
       - nodes:
         - moniker: cuiloa
+
+  - name: penumbra-testnet-dex-explorer-node
+    chart: ../charts/penumbra-node
+    needs:
+      - penumbra-testnet
+      - penumbra-testnet-nodes
+    values:
+      - penumbra_bootstrap_node_cometbft_rpc_url: "https://rpc.testnet.penumbra.zone"
+      - ingressRoute:
+          enabled: false
+      - image:
+          tag: latest
+      - persistence:
+          enabled: true
+          size: 300G
+      - cometbft:
+          config:
+            indexer: psql
+      - part_of: penumbra-testnet
+      - nodes:
+        - moniker: dex-explorer


### PR DESCRIPTION
We're starting work on a new webapp that will provide a visual frontend for the DEX. That work is currently housed in [0]. Similar to cuiloa [1], we must enable CometBFT indexing to Postgres, so the application (yet to be written) can query those events. Strictly speaking, it's possible to reuse a db connection across multiple apps, particularly if we're careful about ensuring read-only access, but duplicating the node config per-app will simplify debugging in the near-term.

These changes have been manually applied for both environments. URLs may change in the future.

[0] https://github.com/penumbra-zone/dex-explorer
[1] https://github.com/penumbra-zone/cuiloa