### PR TITLE
dex: 🏒  `SwapClaimProof::verify` is fallible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4913,6 +4913,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
+ "tap",
  "tendermint",
  "tendermint-light-client-verifier",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ serde_json = {version = "1.0.96"}
 serde_unit_struct = {version = "0.1"}
 serde_with = {version = "3.5.1"}
 sha2 = {version = "0.10"}
+tap = "1.0.1"
 tempfile = {version = "3.3.0"}
 tendermint = {default-features = false, version = "0.34.0"}
 tendermint-config = {version = "0.34.0"}

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -75,6 +75,7 @@ rand_core = {workspace = true}
 regex = {workspace = true}
 tokio = {workspace = true, features = ["full"], optional = true}
 tonic = {workspace = true, optional = true}
+tap = {workspace = true}
 
 [dev-dependencies]
 proptest = {workspace = true}

--- a/crates/core/component/dex/src/swap_claim/proof.rs
+++ b/crates/core/component/dex/src/swap_claim/proof.rs
@@ -384,26 +384,34 @@ impl SwapClaimProof {
             Proof::deserialize_compressed_unchecked(&self.0[..]).map_err(|e| anyhow::anyhow!(e))?;
 
         let mut public_inputs = Vec::new();
+
+        let SwapClaimProofPublic {
+            anchor,
+            nullifier,
+            claim_fee,
+            output_data,
+            note_commitment_1,
+            note_commitment_2,
+        } = public;
+
         public_inputs.extend(
-            Fq::from(public.anchor.0)
+            Fq::from(anchor.0)
                 .to_field_elements()
                 .expect("Fq types are Bls12-377 field members"),
         );
         public_inputs.extend(
-            public
-                .nullifier
+            nullifier
                 .0
                 .to_field_elements()
                 .expect("nullifier is a Bls12-377 field member"),
         );
         public_inputs.extend(
-            Fq::from(public.claim_fee.0.amount)
+            Fq::from(claim_fee.0.amount)
                 .to_field_elements()
                 .expect("Fq types are Bls12-377 field members"),
         );
         public_inputs.extend(
-            public
-                .claim_fee
+            claim_fee
                 .0
                 .asset_id
                 .0
@@ -411,21 +419,18 @@ impl SwapClaimProof {
                 .expect("asset_id is a Bls12-377 field member"),
         );
         public_inputs.extend(
-            public
-                .output_data
+            output_data
                 .to_field_elements()
                 .expect("output_data is a Bls12-377 field member"),
         );
         public_inputs.extend(
-            public
-                .note_commitment_1
+            note_commitment_1
                 .0
                 .to_field_elements()
                 .expect("note_commitment_1 is a Bls12-377 field member"),
         );
         public_inputs.extend(
-            public
-                .note_commitment_2
+            note_commitment_2
                 .0
                 .to_field_elements()
                 .expect("note_commitment_2 is a Bls12-377 field member"),

--- a/crates/core/component/dex/src/swap_claim/proof.rs
+++ b/crates/core/component/dex/src/swap_claim/proof.rs
@@ -14,7 +14,7 @@ use penumbra_tct as tct;
 use penumbra_tct::r1cs::StateCommitmentVar;
 
 use penumbra_asset::{
-    asset::{self},
+    asset::{self, Id},
     Value, ValueVar,
 };
 use penumbra_keys::keys::{Bip44Path, NullifierKey, NullifierKeyVar, SeedPhrase, SpendKey};
@@ -24,6 +24,7 @@ use penumbra_shielded_pool::{
     note::{self, NoteVar},
     Rseed,
 };
+use tct::{Root, StateCommitment};
 
 use crate::{
     batch_swap_output_data::BatchSwapOutputDataVar,
@@ -410,35 +411,35 @@ impl SwapClaimProof {
         let mut public_inputs = Vec::new();
 
         let SwapClaimProofPublic {
-            anchor,
-            nullifier,
-            claim_fee,
+            anchor: Root(anchor),
+            nullifier: Nullifier(nullifier),
+            claim_fee:
+                Fee(Value {
+                    amount,
+                    asset_id: Id(asset_id),
+                }),
             output_data,
-            note_commitment_1,
-            note_commitment_2,
+            note_commitment_1: StateCommitment(note_commitment_1),
+            note_commitment_2: StateCommitment(note_commitment_2),
         } = public;
 
         public_inputs.extend(
-            Fq::from(anchor.0)
+            Fq::from(anchor)
                 .to_field_elements()
                 .ok_or(VerificationError::Anchor)?,
         );
         public_inputs.extend(
             nullifier
-                .0
                 .to_field_elements()
                 .ok_or(VerificationError::Nullifier)?,
         );
         public_inputs.extend(
-            Fq::from(claim_fee.0.amount)
+            Fq::from(amount)
                 .to_field_elements()
                 .ok_or(VerificationError::ClaimFeeAmount)?,
         );
         public_inputs.extend(
-            claim_fee
-                .0
-                .asset_id
-                .0
+            asset_id
                 .to_field_elements()
                 .ok_or(VerificationError::ClaimFeeAssetId)?,
         );
@@ -449,13 +450,11 @@ impl SwapClaimProof {
         );
         public_inputs.extend(
             note_commitment_1
-                .0
                 .to_field_elements()
                 .ok_or(VerificationError::NoteCommitment1)?,
         );
         public_inputs.extend(
             note_commitment_2
-                .0
                 .to_field_elements()
                 .ok_or(VerificationError::NoteCommitment2)?,
         );

--- a/crates/core/component/dex/src/swap_claim/proof.rs
+++ b/crates/core/component/dex/src/swap_claim/proof.rs
@@ -24,6 +24,7 @@ use penumbra_shielded_pool::{
     note::{self, NoteVar},
     Rseed,
 };
+use tap::Tap;
 use tct::{Root, StateCommitment};
 
 use crate::{
@@ -461,16 +462,15 @@ impl SwapClaimProof {
 
         tracing::trace!(?public_inputs);
         let start = std::time::Instant::now();
-        let proof_result = Groth16::<Bls12_377, LibsnarkReduction>::verify_with_processed_vk(
+        Groth16::<Bls12_377, LibsnarkReduction>::verify_with_processed_vk(
             vk,
             public_inputs.as_slice(),
             &proof,
         )
-        .map_err(VerificationError::SynthesisError)?;
-        tracing::debug!(?proof_result, elapsed = ?start.elapsed());
-        proof_result
-            .then_some(())
-            .ok_or(VerificationError::InvalidProof)
+        .map_err(VerificationError::SynthesisError)?
+        .tap(|proof_result| tracing::debug!(?proof_result, elapsed = ?start.elapsed()))
+        .then_some(())
+        .ok_or(VerificationError::InvalidProof)
     }
 }
 

--- a/crates/test/mock-consensus/Cargo.toml
+++ b/crates/test/mock-consensus/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 anyhow = { workspace = true }
 bytes = { workspace = true }
 serde_json = { workspace = true }
-tap = "1.0.1"
+tap = { workspace = true }
 tendermint = { workspace = true }
 tower = { workspace = true, features = ["full"] }
 tracing = { workspace = true }


### PR DESCRIPTION
see https://github.com/penumbra-zone/penumbra/issues/3777 for more information. this replaces the `Result::expect` statements with error variants that are propagated to the caller.

:heart_decoration: some gardening is done along the way to make this code a little more visually consistent. refactoring changes are intentionally kept in separate commits, to facilitate ease of review.