### PR TITLE
governance: 🎾 `DelegatorVoteProof::verify` is fallible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5072,6 +5072,7 @@ dependencies = [
  "regex",
  "serde",
  "tendermint",
+ "thiserror",
  "tokio",
  "tonic",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5071,6 +5071,7 @@ dependencies = [
  "rand_core 0.6.4",
  "regex",
  "serde",
+ "tap",
  "tendermint",
  "thiserror",
  "tokio",

--- a/crates/core/component/governance/Cargo.toml
+++ b/crates/core/component/governance/Cargo.toml
@@ -69,6 +69,7 @@ rand_chacha = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}
 regex = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
+tap = {workspace = true}
 tendermint = {workspace = true}
 thiserror = {workspace = true}
 tokio = {workspace = true, features = ["full", "tracing"], optional = true}

--- a/crates/core/component/governance/Cargo.toml
+++ b/crates/core/component/governance/Cargo.toml
@@ -70,6 +70,7 @@ rand_core = {workspace = true, features = ["getrandom"]}
 regex = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
 tendermint = {workspace = true}
+thiserror = {workspace = true}
 tokio = {workspace = true, features = ["full", "tracing"], optional = true}
 tonic = {workspace = true, optional = true}
 tracing = {workspace = true}

--- a/crates/core/component/governance/src/delegator_vote/proof.rs
+++ b/crates/core/component/governance/src/delegator_vote/proof.rs
@@ -296,6 +296,28 @@ impl DummyWitness for DelegatorVoteCircuit {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationError {
+    #[error("error deserializing compressed proof: {0:?}")]
+    ProofDeserialize(ark_serialize::SerializationError),
+    #[error("Fq types are Bls12-377 field members")]
+    Anchor,
+    #[error("balance commitment is a Bls12-377 field member")]
+    BalanceCommitment,
+    #[error("nullifier is a Bls12-377 field member")]
+    Nullifier,
+    #[error("could not decompress element points: {0:?}")]
+    DecompressRk(decaf377::EncodingError),
+    #[error("randomized spend key is a Bls12-377 field member")]
+    Rk,
+    #[error("start position is a Bls12-377 field member")]
+    StartPosition,
+    #[error("error verifying proof: {0:?}")]
+    SynthesisError(ark_relations::r1cs::SynthesisError),
+    #[error("delegator vote proof did not verify")]
+    InvalidProof,
+}
+
 #[derive(Clone, Debug, Copy)]
 pub struct DelegatorVoteProof([u8; GROTH16_PROOF_LENGTH_BYTES]);
 

--- a/crates/core/component/governance/src/delegator_vote/proof.rs
+++ b/crates/core/component/governance/src/delegator_vote/proof.rs
@@ -342,7 +342,14 @@ impl DelegatorVoteProof {
     /// Called to verify the proof using the provided public inputs.
     // For debugging proof verification failures,
     // to check that the proof data and verification keys are consistent.
-    #[tracing::instrument(level="debug", skip(self, vk), fields(self = ?general_purpose::STANDARD.encode(self.clone().encode_to_vec()), vk = ?vk.debug_id()))]
+    #[tracing::instrument(
+        level="debug",
+        skip(self, vk),
+        fields(
+            self = ?general_purpose::STANDARD.encode(self.clone().encode_to_vec()),
+            vk = ?vk.debug_id()
+        )
+    )]
     pub fn verify(
         &self,
         vk: &PreparedVerifyingKey<Bls12_377>,

--- a/crates/core/component/governance/src/delegator_vote/proof.rs
+++ b/crates/core/component/governance/src/delegator_vote/proof.rs
@@ -377,15 +377,18 @@ impl DelegatorVoteProof {
         }
 
         use VerificationError::*;
+        let public_inputs = [
+            to_field_elements!(Fq::from(anchor), Anchor),
+            to_field_elements!(balance_commitment, BalanceCommitment),
+            to_field_elements!(nullifier, Nullifier),
+            to_field_elements!(element_rk, Rk),
+            to_field_elements!(start_position, StartPosition),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .tap(|public_inputs| tracing::trace!(?public_inputs));
 
-        let mut public_inputs = Vec::new();
-        public_inputs.extend(to_field_elements!(Fq::from(anchor), Anchor));
-        public_inputs.extend(to_field_elements!(balance_commitment, BalanceCommitment));
-        public_inputs.extend(to_field_elements!(nullifier, Nullifier));
-        public_inputs.extend(to_field_elements!(element_rk, Rk));
-        public_inputs.extend(to_field_elements!(start_position, StartPosition));
-
-        tracing::trace!(?public_inputs);
         let start = std::time::Instant::now();
         Groth16::<Bls12_377, LibsnarkReduction>::verify_with_processed_vk(
             vk,

--- a/crates/core/component/governance/src/delegator_vote/proof.rs
+++ b/crates/core/component/governance/src/delegator_vote/proof.rs
@@ -1,36 +1,37 @@
-use base64::{engine::general_purpose, Engine as _};
-use penumbra_asset::balance::Commitment;
-use std::str::FromStr;
-use tct::Root;
-
 use anyhow::Result;
-use ark_groth16::r1cs_to_qap::LibsnarkReduction;
-use ark_r1cs_std::{prelude::*, uint8::UInt8};
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use decaf377::r1cs::ElementVar;
-use decaf377::FieldExt;
-use decaf377::{r1cs::FqVar, Bls12_377, Fq, Fr};
-
 use ark_ff::ToConstraintField;
-use ark_groth16::{Groth16, PreparedVerifyingKey, Proof, ProvingKey};
-use ark_r1cs_std::prelude::AllocVar;
+use ark_groth16::{
+    r1cs_to_qap::LibsnarkReduction, Groth16, PreparedVerifyingKey, Proof, ProvingKey,
+};
+use ark_r1cs_std::{prelude::*, uint8::UInt8};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_snark::SNARK;
+use base64::{engine::general_purpose, Engine as _};
+use decaf377::{
+    r1cs::{ElementVar, FqVar},
+    Bls12_377, FieldExt, Fq, Fr,
+};
 use decaf377_rdsa::{SpendAuth, VerificationKey};
-use penumbra_proto::{core::component::governance::v1 as pb, DomainType};
-use penumbra_tct as tct;
-use penumbra_tct::r1cs::StateCommitmentVar;
-use tap::Tap;
-use tct::r1cs::PositionVar;
-
-use penumbra_asset::{balance, balance::commitment::BalanceCommitmentVar, Value};
+use penumbra_asset::{
+    balance::{self, commitment::BalanceCommitmentVar, Commitment},
+    Value,
+};
 use penumbra_keys::keys::{
     AuthorizationKeyVar, Bip44Path, IncomingViewingKeyVar, NullifierKey, NullifierKeyVar,
     RandomizedVerificationKey, SeedPhrase, SpendAuthRandomizerVar, SpendKey,
 };
 use penumbra_proof_params::{DummyWitness, VerifyingKeyExt, GROTH16_PROOF_LENGTH_BYTES};
+use penumbra_proto::{core::component::governance::v1 as pb, DomainType};
 use penumbra_sct::{Nullifier, NullifierVar};
 use penumbra_shielded_pool::{note, Note, Rseed};
+use penumbra_tct::{
+    self as tct,
+    r1cs::{PositionVar, StateCommitmentVar},
+    Root,
+};
+use std::str::FromStr;
+use tap::Tap;
 
 /// The public input for a [`DelegatorVoteProof`].
 #[derive(Clone, Debug)]

--- a/crates/core/component/governance/src/delegator_vote/proof.rs
+++ b/crates/core/component/governance/src/delegator_vote/proof.rs
@@ -365,6 +365,9 @@ impl DelegatorVoteProof {
     ) -> Result<(), VerificationError> {
         let proof = Proof::deserialize_compressed_unchecked(&self.0[..])
             .map_err(VerificationError::ProofDeserialize)?;
+        let element_rk = decaf377::Encoding(rk.to_bytes())
+            .vartime_decompress()
+            .map_err(VerificationError::DecompressRk)?;
 
         /// Shorthand helper, convert expressions into field elements.
         macro_rules! to_field_elements {
@@ -379,9 +382,6 @@ impl DelegatorVoteProof {
         public_inputs.extend(to_field_elements!(Fq::from(anchor), Anchor));
         public_inputs.extend(to_field_elements!(balance_commitment, BalanceCommitment));
         public_inputs.extend(to_field_elements!(nullifier, Nullifier));
-        let element_rk = decaf377::Encoding(rk.to_bytes())
-            .vartime_decompress()
-            .map_err(VerificationError::DecompressRk)?;
         public_inputs.extend(to_field_elements!(element_rk, Rk));
         public_inputs.extend(to_field_elements!(start_position, StartPosition));
 

--- a/crates/core/component/governance/src/delegator_vote/proof.rs
+++ b/crates/core/component/governance/src/delegator_vote/proof.rs
@@ -366,35 +366,24 @@ impl DelegatorVoteProof {
         let proof = Proof::deserialize_compressed_unchecked(&self.0[..])
             .map_err(VerificationError::ProofDeserialize)?;
 
+        /// Shorthand helper, convert expressions into field elements.
+        macro_rules! to_field_elements {
+            ($fe:expr, $err:expr) => {
+                $fe.to_field_elements().ok_or($err)?
+            };
+        }
+
+        use VerificationError::*;
+
         let mut public_inputs = Vec::new();
-        public_inputs.extend(
-            Fq::from(anchor)
-                .to_field_elements()
-                .ok_or(VerificationError::Anchor)?,
-        );
-        public_inputs.extend(
-            balance_commitment
-                .to_field_elements()
-                .ok_or(VerificationError::BalanceCommitment)?,
-        );
-        public_inputs.extend(
-            nullifier
-                .to_field_elements()
-                .ok_or(VerificationError::Nullifier)?,
-        );
+        public_inputs.extend(to_field_elements!(Fq::from(anchor), Anchor));
+        public_inputs.extend(to_field_elements!(balance_commitment, BalanceCommitment));
+        public_inputs.extend(to_field_elements!(nullifier, Nullifier));
         let element_rk = decaf377::Encoding(rk.to_bytes())
             .vartime_decompress()
             .map_err(VerificationError::DecompressRk)?;
-        public_inputs.extend(
-            element_rk
-                .to_field_elements()
-                .ok_or(VerificationError::Rk)?,
-        );
-        public_inputs.extend(
-            start_position
-                .to_field_elements()
-                .ok_or(VerificationError::StartPosition)?,
-        );
+        public_inputs.extend(to_field_elements!(element_rk, Rk));
+        public_inputs.extend(to_field_elements!(start_position, StartPosition));
 
         tracing::trace!(?public_inputs);
         let start = std::time::Instant::now();


### PR DESCRIPTION
see https://github.com/penumbra-zone/penumbra/issues/3777.

this changes `DelegatorVoteProof::verify` so that it is fallible. errors will be propagated to the caller, rather than inducing a panic.

* #3777
* #3829

as with #3829, i've applied some tlc to the code as i've addressed the core issue at hand (_panics_). noop code transformations are applied in distinct commits, to facilitate ease of review.