### PR TITLE
shielded-pool: 🏊 `SpendProof::verify` is fallible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5404,6 +5404,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
+ "tap",
  "tendermint",
  "thiserror",
  "tonic",

--- a/crates/core/component/shielded-pool/Cargo.toml
+++ b/crates/core/component/shielded-pool/Cargo.toml
@@ -66,6 +66,7 @@ rand = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}
 serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}
+tap = {workspace = true}
 tendermint = {workspace = true}
 thiserror = {workspace = true}
 tonic = {workspace = true, optional = true}

--- a/crates/core/component/shielded-pool/src/spend/proof.rs
+++ b/crates/core/component/shielded-pool/src/spend/proof.rs
@@ -31,6 +31,7 @@ use penumbra_keys::keys::{
 };
 use penumbra_proof_params::{DummyWitness, VerifyingKeyExt, GROTH16_PROOF_LENGTH_BYTES};
 use penumbra_sct::{Nullifier, NullifierVar};
+use tap::Tap;
 
 /// The public input for a [`SpendProof`].
 #[derive(Clone, Debug)]
@@ -354,16 +355,15 @@ impl SpendProof {
 
         tracing::trace!(?public_inputs);
         let start = std::time::Instant::now();
-        let proof_result = Groth16::<Bls12_377, LibsnarkReduction>::verify_with_processed_vk(
+        Groth16::<Bls12_377, LibsnarkReduction>::verify_with_processed_vk(
             vk,
             public_inputs.as_slice(),
             &proof,
         )
-        .map_err(VerificationError::SynthesisError)?;
-        tracing::debug!(?proof_result, elapsed = ?start.elapsed());
-        proof_result
-            .then_some(())
-            .ok_or(VerificationError::InvalidProof)
+        .map_err(VerificationError::SynthesisError)?
+        .tap(|proof_result| tracing::debug!(?proof_result, elapsed = ?start.elapsed()))
+        .then_some(())
+        .ok_or(VerificationError::InvalidProof)
     }
 }
 

--- a/crates/core/component/shielded-pool/src/spend/proof.rs
+++ b/crates/core/component/shielded-pool/src/spend/proof.rs
@@ -326,6 +326,9 @@ impl SpendProof {
     ) -> Result<(), VerificationError> {
         let proof = Proof::deserialize_compressed_unchecked(&self.0[..])
             .map_err(VerificationError::ProofDeserialize)?;
+        let element_rk = decaf377::Encoding(public.rk.to_bytes())
+            .vartime_decompress()
+            .map_err(VerificationError::DecompressRk)?;
 
         let mut public_inputs = Vec::new();
         public_inputs.extend([Fq::from(public.anchor.0)]);
@@ -343,9 +346,6 @@ impl SpendProof {
                 .to_field_elements()
                 .ok_or(VerificationError::Nullifier)?,
         );
-        let element_rk = decaf377::Encoding(public.rk.to_bytes())
-            .vartime_decompress()
-            .map_err(VerificationError::DecompressRk)?;
         public_inputs.extend(
             element_rk
                 .to_field_elements()


### PR DESCRIPTION
see https://github.com/penumbra-zone/penumbra/issues/3777.

this changes `DelegatorVoteProof::verify` so that it is fallible. errors will be propagated to the caller, rather than inducing a panic.

* #3777
* #3829
* #3833

as with #3829 and #3833, i've applied some tlc to the code as i've addressed the core issue at hand (_panics_). noop code transformations are applied in distinct commits, to facilitate ease of review.