### PR TITLE
dependencies: 🧹 sort `Cargo.toml` dependencies

### DIFF
--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -53,41 +53,45 @@ name = "convert"
 harness = false
 
 [dependencies]
-penumbra-num = {workspace = true, default-features = true}
-penumbra-asset = {workspace = true, default-features = true}
-penumbra-keys = {workspace = true, default-features = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
 ark-ec = {workspace = true}
 ark-ff = {workspace = true, default-features = false}
-ark-std = {workspace = true, default-features = false}
-ark-serialize = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-once_cell = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
-rand = {workspace = true}
-num-bigint = {workspace = true}
-tracing = {workspace = true}
 ark-groth16 = {workspace = true, default-features = false}
-ark-snark = {workspace = true}
 ark-r1cs-std = {workspace = true, default-features = false}
 ark-relations = {workspace = true}
-sha2 = {workspace = true}
+ark-serialize = {workspace = true}
+ark-snark = {workspace = true}
+ark-std = {workspace = true, default-features = false}
 bech32 = {workspace = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+num-bigint = {workspace = true}
+once_cell = {workspace = true}
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-num = {workspace = true, default-features = true}
+rand = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+serde = {workspace = true, features = ["derive"]}
+sha2 = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
-penumbra-tct = {workspace = true, features = ["r1cs"], default-features = true}
 criterion = {workspace = true, features = ["html_reports"]}
-penumbra-dex = {workspace = true, default-features = true}
-penumbra-community-pool = {workspace = true, default-features = true}
-penumbra-stake = {workspace = true, default-features = true}
-penumbra-shielded-pool = {workspace = true, default-features = true}
-penumbra-governance = {workspace = true, default-features = true}
-penumbra-fee = {workspace = true, default-features = true}
-penumbra-sct = {workspace = true, default-features = true}
 decaf377-fmd = {workspace = true}
 decaf377-ka = {workspace = true}
 decaf377-rdsa = {workspace = true}
-penumbra-proof-params = {workspace = true, features = [
+penumbra-community-pool = {workspace = true, default-features = true}
+penumbra-dex = {workspace = true, default-features = true}
+penumbra-fee = {workspace = true, default-features = true}
+penumbra-governance = {workspace = true, default-features = true}
+penumbra-sct = {workspace = true, default-features = true}
+penumbra-shielded-pool = {workspace = true, default-features = true}
+penumbra-stake = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true, features = ["r1cs"], default-features = true}
+
+[dev-dependencies.penumbra-proof-params]
+workspace = true
+default-features = true
+features = [
     "bundled-proving-keys",
     "download-proving-keys",
-], default-features = true}
+]

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -30,82 +30,86 @@ parallel = [
 ]
 
 [dependencies]
-penumbra-proto = {workspace = true, features = ["rpc", "box-grpc"], default-features = true}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-num = {workspace = true, default-features = false}
-penumbra-asset = {workspace = true, default-features = false}
-penumbra-keys = {workspace = true, default-features = false}
-penumbra-shielded-pool = {workspace = true, default-features = false}
-penumbra-governance = {workspace = true, default-features = false}
-penumbra-stake = {workspace = true, default-features = false}
-penumbra-sct = {workspace = true, default-features = false}
-penumbra-fee = {workspace = true, default-features = false}
-penumbra-dex = {workspace = true, default-features = false}
-penumbra-community-pool = {workspace = true, default-features = false}
-penumbra-ibc = {workspace = true, default-features = false}
-penumbra-compact-block = {workspace = true, default-features = false}
-penumbra-transaction = {workspace = true, default-features = true}
-penumbra-proof-setup = {workspace = true}
-penumbra-app = {workspace = true}
-penumbra-wallet = { path = "../../wallet" }
-penumbra-custody = {workspace = true}
-penumbra-view = {workspace = true}
-decaf377 = {workspace = true, default-features = true}
-decaf377-rdsa = {workspace = true}
-tendermint = {workspace = true, features = ["rust-crypto"], default-features = true}
-jmt = {workspace = true}
-ibc-types = {workspace = true, features = ["std", "with_serde"], default-features = true}
-ibc-proto = {workspace = true, default-features = true}
+anyhow = {workspace = true}
 ark-ff = {workspace = true, default-features = false}
-atty = {workspace = true}
-ed25519-consensus = {workspace = true}
-futures = {workspace = true}
 async-stream = {workspace = true}
+atty = {workspace = true}
+base64 = {workspace = true}
 bincode = {workspace = true}
 blake2b_simd = {workspace = true}
-base64 = {workspace = true}
-simple-base64 = "0.23"
 bytes = {workspace = true}
+camino = {workspace = true}
+clap = {workspace = true, features = ["derive", "env"]}
+colored = "2.1.0"
+colored_json = "2.1"
 comfy-table = "5"
+decaf377 = {workspace = true, default-features = true}
+decaf377-rdsa = {workspace = true}
+dialoguer = "0.10.4"
 directories = {workspace = true}
-tokio = {workspace = true, features = ["full"]}
-tokio-stream = {workspace = true}
-tokio-util = {workspace = true}
-tower = {workspace = true, features = ["full"]}
-tracing = {workspace = true}
-tonic = {workspace = true, features = ["tls-webpki-roots", "tls"]}
-tracing-subscriber = {workspace = true, features = ["env-filter", "ansi"]}
-pin-project = {workspace = true}
-serde_json = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-regex = {workspace = true}
-serde_with = {workspace = true, features = ["hex"]}
-sha2 = {workspace = true}
-anyhow = {workspace = true}
+ed25519-consensus = {workspace = true}
+futures = {workspace = true}
 hex = {workspace = true}
+http-body = {workspace = true}
+ibc-proto = {workspace = true, default-features = true}
+ibc-types = {workspace = true, features = ["std", "with_serde"], default-features = true}
+indicatif = {workspace = true}
+jmt = {workspace = true}
+ndarray = "0.15.6"
+once_cell = {workspace = true}
+penumbra-app = {workspace = true}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-community-pool = {workspace = true, default-features = false}
+penumbra-compact-block = {workspace = true, default-features = false}
+penumbra-custody = {workspace = true}
+penumbra-dex = {workspace = true, default-features = false}
+penumbra-fee = {workspace = true, default-features = false}
+penumbra-governance = {workspace = true, default-features = false}
+penumbra-ibc = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-proof-setup = {workspace = true}
+penumbra-proto = {workspace = true, features = ["rpc", "box-grpc"], default-features = true}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-stake = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-transaction = {workspace = true, default-features = true}
+penumbra-view = {workspace = true}
+penumbra-wallet = { path = "../../wallet" }
+pin-project = {workspace = true}
 rand = {workspace = true}
 rand_chacha = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}
+regex = {workspace = true}
 rpassword = "7"
-indicatif = {workspace = true}
-http-body = {workspace = true}
-clap = {workspace = true, features = ["derive", "env"]}
-camino = {workspace = true}
-url = {workspace = true, features = ["serde"]}
-colored_json = "2.1"
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+serde_with = {workspace = true, features = ["hex"]}
+sha2 = {workspace = true}
+simple-base64 = "0.23"
+tendermint = {workspace = true, features = ["rust-crypto"], default-features = true}
+tokio = {workspace = true, features = ["full"]}
+tokio-stream = {workspace = true}
+tokio-util = {workspace = true}
 toml = {workspace = true, features = ["preserve_order"]}
-once_cell = {workspace = true}
-ndarray = "0.15.6"
-dialoguer = "0.10.4"
-colored = "2.1.0"
+tonic = {workspace = true, features = ["tls-webpki-roots", "tls"]}
+tower = {workspace = true, features = ["full"]}
+tracing = {workspace = true}
+tracing-subscriber = {workspace = true, features = ["env-filter", "ansi"]}
+url = {workspace = true, features = ["serde"]}
 
 [dev-dependencies]
 assert_cmd = {workspace = true}
-predicates = "2.1"
-tempfile = {workspace = true}
-regex = {workspace = true}
 penumbra-governance = {workspace = true, default-features = false}
-penumbra-proof-params = {workspace = true, features = [
+predicates = "2.1"
+regex = {workspace = true}
+tempfile = {workspace = true}
+
+[dev-dependencies.penumbra-proof-params]
+default-features = true
+workspace = true
+features = [
     "bundled-proving-keys",
     "download-proving-keys",
-], default-features = true}
+]

--- a/crates/bin/pclientd/Cargo.toml
+++ b/crates/bin/pclientd/Cargo.toml
@@ -12,55 +12,55 @@ parallel = ["penumbra-transaction/parallel"]
 download-proving-keys = ["penumbra-proof-params/download-proving-keys"]
 
 [dependencies]
+anyhow = {workspace = true}
+async-stream = {workspace = true}
+async-trait = {workspace = true}
+atty = {workspace = true}
+bytes = {workspace = true, features = ["serde"]}
+camino = {workspace = true}
+clap = {workspace = true, features = ["derive", "env"]}
+directories = {workspace = true}
+ed25519-consensus = {workspace = true}
+futures = {workspace = true}
+hex = {workspace = true}
+http = {workspace = true}
+http-body = {workspace = true}
+metrics = {workspace = true}
+parking_lot = {workspace = true}
+penumbra-app = {workspace = true}
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-custody = {workspace = true}
+penumbra-keys = {workspace = true, default-features = true}
 penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
 penumbra-tct = {workspace = true, default-features = true}
-penumbra-asset = {workspace = true, default-features = true}
-penumbra-keys = {workspace = true, default-features = true}
 penumbra-transaction = {workspace = true, default-features = true}
-penumbra-app = {workspace = true}
-penumbra-custody = {workspace = true}
 penumbra-view = {workspace = true}
+prost = {workspace = true}
+rand = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+serde_with = {workspace = true, features = ["hex"]}
+sha2 = {workspace = true}
+tendermint = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
 tokio-stream = {workspace = true, features = ["sync"]}
-anyhow = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
-rand = {workspace = true}
-serde_json = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-serde_with = {workspace = true, features = ["hex"]}
+toml = {workspace = true}
+tonic = {workspace = true}
+tonic-reflection = {workspace = true}
+tonic-web = {workspace = true}
+tower = {workspace = true}
 tracing = {workspace = true}
 tracing-subscriber = {workspace = true, features = ["env-filter"]}
 url = {workspace = true, features = ["serde"]}
-http = {workspace = true}
-http-body = {workspace = true}
-tower = {workspace = true}
-tonic = {workspace = true}
-tonic-web = {workspace = true}
-tonic-reflection = {workspace = true}
-bytes = {workspace = true, features = ["serde"]}
-prost = {workspace = true}
-futures = {workspace = true}
-hex = {workspace = true}
-metrics = {workspace = true}
-async-stream = {workspace = true}
-parking_lot = {workspace = true}
-clap = {workspace = true, features = ["derive", "env"]}
-camino = {workspace = true}
-async-trait = {workspace = true}
-tendermint = {workspace = true}
-sha2 = {workspace = true}
-toml = {workspace = true}
-ed25519-consensus = {workspace = true}
-atty = {workspace = true}
-directories = {workspace = true}
 
 [dev-dependencies]
-tempfile = {workspace = true}
 assert_cmd = {workspace = true}
 base64 = {workspace = true}
-ibc-types = {workspace = true, default-features = true}
 ibc-proto = {workspace = true, default-features = false, features = ["server"]}
+ibc-types = {workspace = true, default-features = true}
 penumbra-proof-params = {workspace = true, features = [
     "bundled-proving-keys",
     "download-proving-keys",
 ], default-features = true}
+tempfile = {workspace = true}

--- a/crates/cnidarium-component/Cargo.toml
+++ b/crates/cnidarium-component/Cargo.toml
@@ -4,8 +4,8 @@ version = {workspace = true}
 edition = {workspace = true}
 
 [dependencies]
-cnidarium = {workspace = true, default-features = false}
-async-trait = {workspace = true}
 anyhow = {workspace = true}
-tendermint = {workspace = true}
+async-trait = {workspace = true}
+cnidarium = {workspace = true, default-features = false}
 hex = {workspace = true}
+tendermint = {workspace = true}

--- a/crates/cnidarium/Cargo.toml
+++ b/crates/cnidarium/Cargo.toml
@@ -9,32 +9,32 @@ default = ["metrics"]
 rpc = ["dep:tonic", "dep:prost", "dep:serde", "dep:pbjson", "dep:ibc-proto"]
 
 [dependencies]
-jmt = {workspace = true}
-tokio = {workspace = true, features = ["full", "tracing"]}
-tokio-stream = {workspace = true}
-tempfile = {workspace = true}
 anyhow = {workspace = true}
 async-trait = {workspace = true}
-tracing = {workspace = true}
-rocksdb = {workspace = true}
+borsh = "0.10.3"
 futures = {workspace = true}
 hex = {workspace = true}
-metrics = {workspace = true, optional = true}
-parking_lot = {workspace = true}
-pin-project = {workspace = true}
-smallvec = { version = "1.10", features = ["union", "const_generics"] }
-ibc-types = {workspace = true, default-features = false, features = ["std"]}
-once_cell = {workspace = true}
-ics23 = {workspace = true}
-tendermint = {workspace = true, default-features = false}
-borsh = "0.10.3"
-sha2 = {workspace = true}
-tonic = {workspace = true, optional = true}
-prost = {workspace = true, optional = true}
-serde = {workspace = true, optional = true}
-pbjson = {workspace = true, optional = true}
 ibc-proto = {workspace = true, default-features = false, features = ["serde"], optional = true}
+ibc-types = {workspace = true, default-features = false, features = ["std"]}
+ics23 = {workspace = true}
+jmt = {workspace = true}
+metrics = {workspace = true, optional = true}
+once_cell = {workspace = true}
+parking_lot = {workspace = true}
+pbjson = {workspace = true, optional = true}
+pin-project = {workspace = true}
+prost = {workspace = true, optional = true}
 regex = {workspace = true}
+rocksdb = {workspace = true}
+serde = {workspace = true, optional = true}
+sha2 = {workspace = true}
+smallvec = { version = "1.10", features = ["union", "const_generics"] }
+tempfile = {workspace = true}
+tendermint = {workspace = true, default-features = false}
+tokio = {workspace = true, features = ["full", "tracing"]}
+tokio-stream = {workspace = true}
+tonic = {workspace = true, optional = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 tempfile = {workspace = true}

--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -13,73 +13,69 @@ default = ["std"]
 std = ["ark-ff/std", "ibc-types/std"]
 
 [dependencies]
+anyhow = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+async-trait = {workspace = true}
+base64 = {workspace = true}
+bech32 = {workspace = true}
+bincode = {workspace = true}
+bitvec = {workspace = true}
+blake2b_simd = {workspace = true}
 cnidarium = {workspace = true, default-features = true}
 cnidarium-component = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, features = ["cnidarium"], default-features = true}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-proof-params = {workspace = true, default-features = true}
-penumbra-asset = {workspace = true, default-features = true}
-penumbra-keys = {workspace = true, default-features = true}
-penumbra-txhash = {workspace = true, default-features = true}
-penumbra-num = {workspace = true, default-features = true}
-penumbra-shielded-pool = {workspace = true, features = [
-    "component",
-], default-features = true}
-penumbra-stake = {workspace = true, default-features = true}
-penumbra-governance = {workspace = true, default-features = true}
-penumbra-sct = {workspace = true, default-features = true}
-penumbra-fee = {workspace = true, default-features = true}
-penumbra-funding = {workspace = true, default-features = true}
-penumbra-community-pool = {workspace = true, default-features = true}
-penumbra-dex = {workspace = true, default-features = true}
-penumbra-ibc = {workspace = true, features = ["component"], default-features = true}
-penumbra-distributions = {workspace = true, default-features = true}
-penumbra-compact-block = {workspace = true, default-features = true}
-penumbra-transaction = {workspace = true, features = ["parallel"], default-features = true}
-penumbra-genesis = {workspace = true}
 decaf377 = {workspace = true, default-features = true}
 decaf377-rdsa = {workspace = true}
-jmt = {workspace = true}
-tokio = {workspace = true, features = ["full", "tracing"]}
-tokio-util = {workspace = true}
-async-trait = {workspace = true}
-tonic = {workspace = true}
 futures = {workspace = true}
-anyhow = {workspace = true}
-tracing = {workspace = true}
-ark-ff = {workspace = true, default-features = false}
-blake2b_simd = {workspace = true}
-bincode = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-serde_with = {workspace = true}
-metrics = {workspace = true}
-sha2 = {workspace = true}
-serde_json = {workspace = true}
-serde_unit_struct = {workspace = true}
-bech32 = {workspace = true}
-im = {workspace = true}
-regex = {workspace = true}
-once_cell = {workspace = true}
-bitvec = {workspace = true}
 hex = {workspace = true}
-base64 = {workspace = true}
-tempfile = {workspace = true}
+ibc-proto = {workspace = true, default-features = false, features = ["server"]}
+ibc-types = {workspace = true, default-features = false}
+ics23 = {workspace = true}
+im = {workspace = true}
+jmt = {workspace = true}
+metrics = {workspace = true}
+once_cell = {workspace = true}
+parking_lot = {workspace = true}
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-community-pool = {workspace = true, default-features = true}
+penumbra-compact-block = {workspace = true, default-features = true}
+penumbra-dex = {workspace = true, default-features = true}
+penumbra-distributions = {workspace = true, default-features = true}
+penumbra-fee = {workspace = true, default-features = true}
+penumbra-funding = {workspace = true, default-features = true}
+penumbra-genesis = {workspace = true}
+penumbra-governance = {workspace = true, default-features = true}
+penumbra-ibc = {workspace = true, features = ["component"], default-features = true}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-num = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, features = ["cnidarium"], default-features = true}
+penumbra-sct = {workspace = true, default-features = true}
+penumbra-shielded-pool = {workspace = true, features = ["component"], default-features = true}
+penumbra-stake = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-tower-trace = { path = "../../util/tower-trace" }
+penumbra-transaction = {workspace = true, features = ["parallel"], default-features = true}
+penumbra-txhash = {workspace = true, default-features = true}
 prost = {workspace = true}
 rand_chacha = {workspace = true}
-parking_lot = {workspace = true}
+regex = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+serde_unit_struct = {workspace = true}
+serde_with = {workspace = true}
+sha2 = {workspace = true}
+tempfile = {workspace = true}
 tendermint = {workspace = true}
-tendermint-proto = {workspace = true}
 tendermint-light-client-verifier = {workspace = true}
-ibc-types = {workspace = true, default-features = false}
-ibc-proto = {workspace = true, default-features = false, features = [
-    "server",
-]}
+tendermint-proto = {workspace = true}
+tokio = {workspace = true, features = ["full", "tracing"]}
+tokio-util = {workspace = true}
+tonic = {workspace = true}
 tower = {workspace = true, features = ["full"]}
 tower-abci = "0.11"
 tower-actor = "0.1.0"
 tower-service = {workspace = true}
-penumbra-tower-trace = { path = "../../util/tower-trace" }
-ics23 = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 ed25519-consensus = {workspace = true}

--- a/crates/core/asset/Cargo.toml
+++ b/crates/core/asset/Cargo.toml
@@ -15,36 +15,36 @@ parallel = [
 ]
 
 [dependencies]
-decaf377-fmd = {workspace = true}
-penumbra-num = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, default-features = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
-decaf377-rdsa = {workspace = true}
-poseidon377 = {workspace = true, features = ["r1cs"]}
-base64 = {workspace = true}
-ark-ff = {workspace = true, default-features = false}
-ark-std = {workspace = true, default-features = false}
-ark-serialize = {workspace = true}
-regex = {workspace = true}
-sha2 = {workspace = true}
-bech32 = {workspace = true}
 anyhow = {workspace = true}
-thiserror = {workspace = true}
-bytes = {workspace = true}
-derivative = {workspace = true}
-hex = {workspace = true}
-blake2b_simd = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-serde_with = {workspace = true}
-once_cell = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
-rand = {workspace = true}
-ethnum = {workspace = true}
-ibig = {workspace = true}
-num-bigint = {workspace = true}
-tracing = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
 ark-r1cs-std = {workspace = true, default-features = false}
 ark-relations = {workspace = true}
+ark-serialize = {workspace = true}
+ark-std = {workspace = true, default-features = false}
+base64 = {workspace = true}
+bech32 = {workspace = true}
+blake2b_simd = {workspace = true}
+bytes = {workspace = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-fmd = {workspace = true}
+decaf377-rdsa = {workspace = true}
+derivative = {workspace = true}
+ethnum = {workspace = true}
+hex = {workspace = true}
+ibig = {workspace = true}
+num-bigint = {workspace = true}
+once_cell = {workspace = true}
+penumbra-num = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, default-features = true}
+poseidon377 = {workspace = true, features = ["r1cs"]}
+rand = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+regex = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_with = {workspace = true}
+sha2 = {workspace = true}
+thiserror = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 proptest = {workspace = true}

--- a/crates/core/component/community-pool/Cargo.toml
+++ b/crates/core/component/community-pool/Cargo.toml
@@ -14,31 +14,31 @@ default = ["component"]
 docsrs = []
 
 [dependencies]
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
-penumbra-proto = {workspace = true, default-features = false}
-penumbra-shielded-pool = {workspace = true, default-features = false}
-penumbra-sct = {workspace = true, default-features = false}
-penumbra-asset = {workspace = true, default-features = false}
-penumbra-num = {workspace = true, default-features = false}
-penumbra-keys = {workspace = true, default-features = false}
-penumbra-txhash = {workspace = true, default-features = false}
+anyhow = {workspace = true}
 ark-ff = {workspace = true, default-features = false}
 async-trait = {workspace = true}
-hex = {workspace = true}
-anyhow = {workspace = true}
-tracing = {workspace = true}
-prost = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-metrics = {workspace = true}
-pbjson-types = {workspace = true}
-tendermint = {workspace = true}
-tendermint-light-client-verifier = {workspace = true}
-sha2 = {workspace = true}
-once_cell = {workspace = true}
 base64 = {workspace = true}
 blake2b_simd = {workspace = true}
+cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
 futures = {workspace = true}
+hex = {workspace = true}
+metrics = {workspace = true}
+once_cell = {workspace = true}
+pbjson-types = {workspace = true}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-txhash = {workspace = true, default-features = false}
+prost = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+sha2 = {workspace = true}
+tendermint = {workspace = true}
+tendermint-light-client-verifier = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 tokio = {workspace = true, features = ["full"]}

--- a/crates/core/component/compact-block/Cargo.toml
+++ b/crates/core/component/compact-block/Cargo.toml
@@ -19,33 +19,33 @@ std = ["ark-ff/std"]
 docsrs = []
 
 [dependencies]
-penumbra-proto = {workspace = true, default-features = false}
-cnidarium = {workspace = true, optional = true, default-features = true}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-proof-params = {workspace = true, default-features = false}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
-penumbra-shielded-pool = {workspace = true, default-features = false}
-penumbra-dex = {workspace = true, default-features = false}
-penumbra-ibc = {workspace = true, default-features = false}
-penumbra-community-pool = {workspace = true, default-features = false}
-penumbra-governance = {workspace = true, default-features = false}
-penumbra-stake = {workspace = true, default-features = false}
-penumbra-fee = {workspace = true, default-features = false}
-penumbra-sct = {workspace = true, default-features = false}
-ark-ff = {workspace = true, default-features = false}
-decaf377-rdsa = {workspace = true}
-metrics = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-tracing = {workspace = true}
 anyhow = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
 async-trait = {workspace = true}
-tendermint = {workspace = true}
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
-rand = {workspace = true}
+cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+decaf377-rdsa = {workspace = true}
 futures = {workspace = true}
-tonic = {workspace = true, optional = true}
-tokio-stream = {workspace = true, optional = true}
-tokio = {workspace = true, optional = true}
 im = {workspace = true}
+metrics = {workspace = true}
+penumbra-community-pool = {workspace = true, default-features = false}
+penumbra-dex = {workspace = true, default-features = false}
+penumbra-fee = {workspace = true, default-features = false}
+penumbra-governance = {workspace = true, default-features = false}
+penumbra-ibc = {workspace = true, default-features = false}
+penumbra-proof-params = {workspace = true, default-features = false}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-stake = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = true}
+rand = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+serde = {workspace = true, features = ["derive"]}
+tendermint = {workspace = true}
+tokio = {workspace = true, optional = true}
+tokio-stream = {workspace = true, optional = true}
+tonic = {workspace = true, optional = true}
+tracing = {workspace = true}

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -27,55 +27,55 @@ parallel = [
 ]
 
 [dependencies]
-penumbra-proto = {workspace = true, default-features = false}
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
-penumbra-shielded-pool = {workspace = true, default-features = false}
-penumbra-sct = {workspace = true, default-features = false}
-penumbra-fee = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = false}
-penumbra-proof-params = {workspace = true, default-features = true}
-penumbra-asset = {workspace = true, default-features = false}
-penumbra-num = {workspace = true, default-features = false}
-penumbra-keys = {workspace = true, default-features = false}
-penumbra-txhash = {workspace = true, default-features = false}
-decaf377-ka = {workspace = true}
-decaf377-fmd = {workspace = true}
-poseidon377 = {workspace = true, features = ["r1cs"]}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
-decaf377-rdsa = {workspace = true}
+anyhow = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-groth16 = {workspace = true, default-features = false}
 ark-r1cs-std = {workspace = true, default-features = false}
 ark-relations = {workspace = true}
-ark-ff = {workspace = true, default-features = false}
 ark-serialize = {workspace = true}
-ark-groth16 = {workspace = true, default-features = false}
 ark-snark = {workspace = true}
-async-trait = {workspace = true}
 async-stream = {workspace = true}
-bincode = {workspace = true}
-hex = {workspace = true}
-thiserror = {workspace = true}
-anyhow = {workspace = true}
-tracing = {workspace = true}
-prost = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-serde_json = {workspace = true}
-metrics = {workspace = true}
-pbjson-types = {workspace = true}
-tendermint = {workspace = true}
-tendermint-light-client-verifier = {workspace = true}
-sha2 = {workspace = true}
-once_cell = {workspace = true}
+async-trait = {workspace = true}
 base64 = {workspace = true}
+bincode = {workspace = true}
 blake2b_simd = {workspace = true}
+cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-fmd = {workspace = true}
+decaf377-ka = {workspace = true}
+decaf377-rdsa = {workspace = true}
 futures = {workspace = true}
+hex = {workspace = true}
 im = {workspace = true}
+metrics = {workspace = true}
+once_cell = {workspace = true}
 parking_lot = {workspace = true}
+pbjson-types = {workspace = true}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-fee = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = false}
+penumbra-txhash = {workspace = true, default-features = false}
+poseidon377 = {workspace = true, features = ["r1cs"]}
+prost = {workspace = true}
 rand_core = {workspace = true}
 regex = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+sha2 = {workspace = true}
+tap = {workspace = true}
+tendermint = {workspace = true}
+tendermint-light-client-verifier = {workspace = true}
+thiserror = {workspace = true}
 tokio = {workspace = true, features = ["full"], optional = true}
 tonic = {workspace = true, optional = true}
-tap = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 proptest = {workspace = true}

--- a/crates/core/component/distributions/Cargo.toml
+++ b/crates/core/component/distributions/Cargo.toml
@@ -14,16 +14,16 @@ default = ["component"]
 docsrs = []
 
 [dependencies]
+anyhow = {workspace = true}
+async-trait = {workspace = true}
 cnidarium = {workspace = true, optional = true, default-features = true}
 cnidarium-component = {workspace = true, optional = true, default-features = true}
 penumbra-asset = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}
 penumbra-proto = {workspace = true, default-features = false}
 penumbra-sct = {workspace = true, default-features = false}
-async-trait = {workspace = true}
-anyhow = {workspace = true}
-tracing = {workspace = true}
-tendermint = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
+tendermint = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]

--- a/crates/core/component/fee/Cargo.toml
+++ b/crates/core/component/fee/Cargo.toml
@@ -15,22 +15,22 @@ std = ["ark-ff/std"]
 docsrs = []
 
 [dependencies]
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
-penumbra-proto = {workspace = true, default-features = false}
-penumbra-asset = {workspace = true, default-features = false}
-penumbra-num = {workspace = true, default-features = false}
-decaf377-rdsa = {workspace = true}
-decaf377 = {workspace = true, default-features = true}
-ark-ff = {workspace = true, default-features = false}
-metrics = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-tracing = {workspace = true}
 anyhow = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
 async-trait = {workspace = true}
-tendermint = {workspace = true}
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
+cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+decaf377 = {workspace = true, default-features = true}
+decaf377-rdsa = {workspace = true}
+metrics = {workspace = true}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-proto = {workspace = true, default-features = false}
 rand = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+serde = {workspace = true, features = ["derive"]}
+tendermint = {workspace = true}
 tonic = {workspace = true, optional = true}
+tracing = {workspace = true}

--- a/crates/core/component/funding/Cargo.toml
+++ b/crates/core/component/funding/Cargo.toml
@@ -20,21 +20,21 @@ default = ["component"]
 docsrs = []
 
 [dependencies]
+anyhow = {workspace = true}
+async-trait = {workspace = true}
+cnidarium = {workspace = true, optional = true, default-features = true}
 cnidarium-component = {workspace = true, optional = true, default-features = true}
+futures = {workspace = true, optional = true}
+metrics = {workspace = true, optional = true}
 penumbra-asset = {workspace = true, default-features = true}
 penumbra-community-pool = {workspace = true, default-features = false}
 penumbra-distributions = {workspace = true, default-features = false}
 penumbra-proto = {workspace = true, default-features = false}
-penumbra-stake = {workspace = true, default-features = false}
 penumbra-sct = {workspace = true, default-features = false}
 penumbra-shielded-pool = {workspace = true, default-features = false}
-cnidarium = {workspace = true, optional = true, default-features = true}
-async-trait = {workspace = true}
-anyhow = {workspace = true}
-tracing = {workspace = true}
-tendermint = {workspace = true}
-futures = {workspace = true, optional = true}
-metrics = {workspace = true, optional = true}
+penumbra-stake = {workspace = true, default-features = false}
 serde = {workspace = true, features = ["derive"]}
+tendermint = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]

--- a/crates/core/component/governance/Cargo.toml
+++ b/crates/core/component/governance/Cargo.toml
@@ -27,52 +27,52 @@ parallel = [
 docsrs = []
 
 [dependencies]
+anyhow = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-groth16 = {workspace = true, default-features = false}
+ark-r1cs-std = {workspace = true, default-features = false}
+ark-relations = {workspace = true}
+ark-serialize = {workspace = true}
+ark-snark = {workspace = true}
+async-stream = {workspace = true}
+async-trait = {workspace = true}
+base64 = {workspace = true}
+blake2b_simd = {workspace = true}
+bytes = {workspace = true}
 cnidarium = {workspace = true, optional = true, default-features = true}
 cnidarium-component = {workspace = true, optional = true, default-features = true}
-penumbra-proto = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-proof-params = {workspace = true, default-features = false}
-penumbra-sct = {workspace = true, default-features = false}
-penumbra-shielded-pool = {workspace = true, default-features = false}
-penumbra-stake = {workspace = true, default-features = false}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-rdsa = {workspace = true}
+futures = {workspace = true}
+ibc-types = {workspace = true, default-features = false}
+im = {workspace = true}
+metrics = {workspace = true}
+once_cell = {workspace = true}
+pbjson-types = {workspace = true}
+penumbra-asset = {workspace = true, default-features = false}
 penumbra-community-pool = {workspace = true, default-features = false}
+penumbra-distributions = {workspace = true, default-features = false}
 penumbra-fee = {workspace = true, default-features = false}
 penumbra-funding = {workspace = true, default-features = false}
 penumbra-ibc = {workspace = true, default-features = false}
-penumbra-distributions = {workspace = true, default-features = false}
-penumbra-asset = {workspace = true, default-features = false}
 penumbra-keys = {workspace = true, default-features = false}
-penumbra-txhash = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}
-decaf377-rdsa = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
-base64 = {workspace = true}
-ark-r1cs-std = {workspace = true, default-features = false}
-ark-relations = {workspace = true}
-ark-ff = {workspace = true, default-features = false}
-ark-serialize = {workspace = true}
-ark-groth16 = {workspace = true, default-features = false}
-ark-snark = {workspace = true}
-async-stream = {workspace = true}
-metrics = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-tracing = {workspace = true}
-anyhow = {workspace = true}
-async-trait = {workspace = true}
-tendermint = {workspace = true}
-blake2b_simd = {workspace = true}
-bytes = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
+penumbra-proof-params = {workspace = true, default-features = false}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-stake = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-txhash = {workspace = true, default-features = false}
 rand = {workspace = true}
-im = {workspace = true}
-regex = {workspace = true}
-futures = {workspace = true}
-pbjson-types = {workspace = true}
-once_cell = {workspace = true}
 rand_chacha = {workspace = true}
-ibc-types = {workspace = true, default-features = false}
+rand_core = {workspace = true, features = ["getrandom"]}
+regex = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+tendermint = {workspace = true}
 tokio = {workspace = true, features = ["full", "tracing"], optional = true}
 tonic = {workspace = true, optional = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 proptest = {workspace = true}

--- a/crates/core/component/ibc/Cargo.toml
+++ b/crates/core/component/ibc/Cargo.toml
@@ -15,34 +15,34 @@ docsrs = []
 rpc = ["dep:tonic", "ibc-proto/client", "ibc-proto/server"]
 
 [dependencies]
+anyhow = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+async-trait = {workspace = true}
+base64 = {workspace = true}
+blake2b_simd = {workspace = true}
 cnidarium = {workspace = true, optional = true, default-features = true}
+hex = {workspace = true}
+ibc-proto = {workspace = true, default-features = false}
+ibc-types = {workspace = true, default-features = false}
+ics23 = {workspace = true}
+metrics = {workspace = true}
+num-traits = {workspace = true, default-features = false}
+once_cell = {workspace = true}
+pbjson-types = {workspace = true}
 penumbra-asset = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}
 penumbra-proto = {workspace = true, default-features = false}
 penumbra-sct = {workspace = true, default-features = false}
 penumbra-txhash = {workspace = true, default-features = false}
-ibc-types = {workspace = true, default-features = false}
-ibc-proto = {workspace = true, default-features = false}
-ics23 = {workspace = true}
-num-traits = {workspace = true, default-features = false}
-ark-ff = {workspace = true, default-features = false}
-async-trait = {workspace = true}
-hex = {workspace = true}
-anyhow = {workspace = true}
-tracing = {workspace = true}
 prost = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}
-metrics = {workspace = true}
-pbjson-types = {workspace = true}
+sha2 = {workspace = true}
 tendermint = {workspace = true}
 tendermint-light-client-verifier = {workspace = true}
-sha2 = {workspace = true}
-once_cell = {workspace = true}
-base64 = {workspace = true}
-blake2b_simd = {workspace = true}
 tonic = {workspace = true, optional = true}
 tower = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 tokio = {workspace = true, features = ["full"]}

--- a/crates/core/component/sct/Cargo.toml
+++ b/crates/core/component/sct/Cargo.toml
@@ -16,30 +16,30 @@ std = ["ark-ff/std"]
 docsrs = []
 
 [dependencies]
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
-penumbra-proto = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-keys = {workspace = true, default-features = false}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
-poseidon377 = {workspace = true, features = ["r1cs"]}
-decaf377-rdsa = {workspace = true}
+anyhow = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
 ark-r1cs-std = {workspace = true, default-features = false}
 ark-relations = {workspace = true}
-ark-ff = {workspace = true, default-features = false}
 ark-serialize = {workspace = true}
-metrics = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-tracing = {workspace = true}
-anyhow = {workspace = true}
 async-trait = {workspace = true}
-tendermint = {workspace = true}
+bincode = {workspace = true}
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
-rand = {workspace = true}
-bincode = {workspace = true}
-once_cell = {workspace = true}
+cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-rdsa = {workspace = true}
 hex = {workspace = true}
 im = {workspace = true}
+metrics = {workspace = true}
+once_cell = {workspace = true}
+penumbra-keys = {workspace = true, default-features = false}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = true}
+poseidon377 = {workspace = true, features = ["r1cs"]}
+rand = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+serde = {workspace = true, features = ["derive"]}
+tendermint = {workspace = true}
 tonic = {workspace = true, optional = true}
+tracing = {workspace = true}

--- a/crates/core/component/shielded-pool/Cargo.toml
+++ b/crates/core/component/shielded-pool/Cargo.toml
@@ -28,48 +28,48 @@ parallel = [
 docsrs = []
 
 [dependencies]
-penumbra-proto = {workspace = true, default-features = false}
-cnidarium = {workspace = true, optional = true, default-features = true}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-proof-params = {workspace = true, default-features = false}
-penumbra-sct = {workspace = true, default-features = false}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
-penumbra-ibc = {workspace = true, default-features = false}
-penumbra-asset = {workspace = true, default-features = false}
-penumbra-num = {workspace = true, default-features = false}
-penumbra-keys = {workspace = true, default-features = false}
-penumbra-txhash = {workspace = true, default-features = false}
-decaf377-ka = {workspace = true}
-decaf377-fmd = {workspace = true}
-ibc-types = {workspace = true, default-features = false}
-decaf377-rdsa = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
-poseidon377 = {workspace = true, features = ["r1cs"]}
-base64 = {workspace = true}
-thiserror = {workspace = true}
-chacha20poly1305 = {workspace = true}
+anyhow = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-groth16 = {workspace = true, default-features = false}
 ark-r1cs-std = {workspace = true, default-features = false}
 ark-relations = {workspace = true}
-ark-ff = {workspace = true, default-features = false}
 ark-serialize = {workspace = true}
-ark-groth16 = {workspace = true, default-features = false}
 ark-snark = {workspace = true}
-metrics = {workspace = true}
-prost = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-serde_json = {workspace = true}
-tracing = {workspace = true}
-anyhow = {workspace = true}
 async-trait = {workspace = true}
-tendermint = {workspace = true}
+base64 = {workspace = true}
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
-rand = {workspace = true}
-im = {workspace = true}
-once_cell = {workspace = true}
+chacha20poly1305 = {workspace = true}
+cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium-component = {workspace = true, optional = true, default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-fmd = {workspace = true}
+decaf377-ka = {workspace = true}
+decaf377-rdsa = {workspace = true}
 hex = {workspace = true}
+ibc-types = {workspace = true, default-features = false}
+im = {workspace = true}
+metrics = {workspace = true}
+once_cell = {workspace = true}
+penumbra-asset = {workspace = true, default-features = false}
+penumbra-ibc = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-proof-params = {workspace = true, default-features = false}
+penumbra-proto = {workspace = true, default-features = false}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-txhash = {workspace = true, default-features = false}
+poseidon377 = {workspace = true, features = ["r1cs"]}
+prost = {workspace = true}
+rand = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+tendermint = {workspace = true}
+thiserror = {workspace = true}
 tonic = {workspace = true, optional = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 proptest = {workspace = true}

--- a/crates/core/component/stake/Cargo.toml
+++ b/crates/core/component/stake/Cargo.toml
@@ -34,52 +34,52 @@ parallel = [
 ]
 
 [dependencies]
+anyhow = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-groth16 = {workspace = true, default-features = false}
+ark-r1cs-std = {workspace = true, default-features = false}
+ark-relations = {workspace = true}
+ark-serialize = {workspace = true}
+ark-snark = {workspace = true}
+async-stream = {workspace = true, optional = true}
+async-trait = {workspace = true, optional = true}
+base64 = {workspace = true}
+bech32 = {workspace = true}
+bitvec = {workspace = true}
 cnidarium = {workspace = true, default-features = false, optional = true}
 cnidarium-component = {workspace = true, default-features = false, optional = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-rdsa = {workspace = true}
+futures = {workspace = true, optional = true}
+hex = {workspace = true}
+im = {workspace = true, optional = true}
+metrics = {workspace = true, optional = true}
+once_cell = {workspace = true}
 penumbra-asset = {workspace = true, default-features = false}
 penumbra-community-pool = {workspace = true, default-features = false}
 penumbra-distributions = {workspace = true, default-features = false}
 penumbra-keys = {workspace = true, default-features = false}
-penumbra-txhash = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}
 penumbra-proof-params = {workspace = true, default-features = true}
 penumbra-proto = {workspace = true, default-features = true}
 penumbra-sct = {workspace = true, default-features = false}
 penumbra-shielded-pool = {workspace = true, default-features = false}
 penumbra-tct = {workspace = true, default-features = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
-decaf377-rdsa = {workspace = true}
-ark-r1cs-std = {workspace = true, default-features = false}
-ark-relations = {workspace = true}
-ark-ff = {workspace = true, default-features = false}
-ark-serialize = {workspace = true}
-ark-groth16 = {workspace = true, default-features = false}
-ark-snark = {workspace = true}
-tendermint = {workspace = true, default-features = true}
-anyhow = {workspace = true}
-tracing = {workspace = true}
+penumbra-txhash = {workspace = true, default-features = false}
+rand_chacha = {workspace = true}
+rand_core = {workspace = true}
+regex = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
+serde_unit_struct = {workspace = true}
 serde_with = {workspace = true}
 sha2 = {workspace = true}
-serde_unit_struct = {workspace = true}
-bech32 = {workspace = true}
-regex = {workspace = true}
-once_cell = {workspace = true}
-bitvec = {workspace = true}
-hex = {workspace = true}
-base64 = {workspace = true}
-rand_core = {workspace = true}
-rand_chacha = {workspace = true}
-async-trait = {workspace = true, optional = true}
+tendermint = {workspace = true, default-features = true}
 tokio = {workspace = true, features = ["full", "tracing"], optional = true}
 tonic = {workspace = true, optional = true}
-im = {workspace = true, optional = true}
-futures = {workspace = true, optional = true}
-metrics = {workspace = true, optional = true}
-async-stream = {workspace = true, optional = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 ed25519-consensus = {workspace = true}
+proptest = {workspace = true}
 rand_chacha = {workspace = true}
 tracing-subscriber = {workspace = true}
-proptest = {workspace = true}

--- a/crates/core/keys/Cargo.toml
+++ b/crates/core/keys/Cargo.toml
@@ -8,43 +8,43 @@ default = []
 parallel = ["penumbra-tct/parallel", "ark-ff/parallel", "poseidon377/parallel", "decaf377-rdsa/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]
 
 [dependencies]
-decaf377-ka = {workspace = true}
-decaf377-fmd = {workspace = true}
-penumbra-proto = {workspace = true, default-features = true}
-penumbra-tct = {workspace = true, features = ["r1cs"], default-features = true}
-penumbra-asset = {workspace = true, default-features = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
-decaf377-rdsa = {workspace = true}
-poseidon377 = {workspace = true, features = ["r1cs"]}
-f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
-base64 = {workspace = true}
-bip32 = "0.5"
-ark-ff = {workspace = true, default-features = false}
-ark-std = {workspace = true, default-features = false}
-ark-serialize = {workspace = true}
-regex = {workspace = true}
-sha2 = {workspace = true}
-bech32 = {workspace = true}
 aes = "0.8.1"
 anyhow = {workspace = true}
-thiserror = {workspace = true}
-bytes = {workspace = true}
-derivative = {workspace = true}
-hex = {workspace = true}
-hmac = "0.12.0"
-blake2b_simd = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-once_cell = {workspace = true}
-pbkdf2 = "0.12.0"
-rand_core = {workspace = true, features = ["getrandom"]}
-rand = {workspace = true}
-chacha20poly1305 = {workspace = true}
-ethnum = {workspace = true}
-ibig = {workspace = true}
-num-bigint = {workspace = true}
-tracing = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
 ark-r1cs-std = {workspace = true, default-features = false}
 ark-relations = {workspace = true}
+ark-serialize = {workspace = true}
+ark-std = {workspace = true, default-features = false}
+base64 = {workspace = true}
+bech32 = {workspace = true}
+bip32 = "0.5"
+blake2b_simd = {workspace = true}
+bytes = {workspace = true}
+chacha20poly1305 = {workspace = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-fmd = {workspace = true}
+decaf377-ka = {workspace = true}
+decaf377-rdsa = {workspace = true}
+derivative = {workspace = true}
+ethnum = {workspace = true}
+f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
+hex = {workspace = true}
+hmac = "0.12.0"
+ibig = {workspace = true}
+num-bigint = {workspace = true}
+once_cell = {workspace = true}
+pbkdf2 = "0.12.0"
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true, features = ["r1cs"], default-features = true}
+poseidon377 = {workspace = true, features = ["r1cs"]}
+rand = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+regex = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+sha2 = {workspace = true}
+thiserror = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 proptest = {workspace = true}

--- a/crates/core/num/Cargo.toml
+++ b/crates/core/num/Cargo.toml
@@ -8,35 +8,35 @@ default = []
 parallel = ["ark-ff/parallel", "decaf377-rdsa/parallel", "ark-groth16/parallel", "ark-std/parallel", "ark-r1cs-std/parallel", "decaf377/parallel"]
 
 [dependencies]
-decaf377-fmd = {workspace = true}
-penumbra-proto = {workspace = true, default-features = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
-decaf377-rdsa = {workspace = true}
-base64 = {workspace = true}
-ark-ff = {workspace = true, default-features = false}
-ark-std = {workspace = true, default-features = false}
-ark-serialize = {workspace = true}
-regex = {workspace = true}
-sha2 = {workspace = true}
-bech32 = {workspace = true}
 anyhow = {workspace = true}
-thiserror = {workspace = true}
-bytes = {workspace = true}
-derivative = {workspace = true}
-hex = {workspace = true}
-blake2b_simd = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-once_cell = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
-rand = {workspace = true}
-ethnum = {workspace = true}
-ibig = {workspace = true}
-num-bigint = {workspace = true}
-tracing = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
 ark-groth16 = {workspace = true, default-features = false}
-ark-snark = {workspace = true}
 ark-r1cs-std = {workspace = true, default-features = false}
 ark-relations = {workspace = true}
+ark-serialize = {workspace = true}
+ark-snark = {workspace = true}
+ark-std = {workspace = true, default-features = false}
+base64 = {workspace = true}
+bech32 = {workspace = true}
+blake2b_simd = {workspace = true}
+bytes = {workspace = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377-fmd = {workspace = true}
+decaf377-rdsa = {workspace = true}
+derivative = {workspace = true}
+ethnum = {workspace = true}
+hex = {workspace = true}
+ibig = {workspace = true}
+num-bigint = {workspace = true}
+once_cell = {workspace = true}
+penumbra-proto = {workspace = true, default-features = true}
+rand = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+regex = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+sha2 = {workspace = true}
+thiserror = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 proptest = {workspace = true}

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -16,50 +16,50 @@ parallel = [
 download-proving-keys = ["penumbra-proof-params/download-proving-keys"]
 
 [dependencies]
-penumbra-proto = {workspace = true, default-features = true}
-decaf377-ka = {workspace = true}
+anyhow = {workspace = true}
+ark-ff = {workspace = true, default-features = false}
+ark-serialize = {workspace = true}
+base64 = {workspace = true}
+bech32 = {workspace = true}
+blake2b_simd = {workspace = true}
+bytes = {workspace = true}
+chacha20poly1305 = {workspace = true}
+decaf377 = {workspace = true}
 decaf377-fmd = {workspace = true}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-proof-params = {workspace = true, default-features = true}
-penumbra-governance = {workspace = true, default-features = false}
-penumbra-shielded-pool = {workspace = true, default-features = false}
-penumbra-sct = {workspace = true, default-features = false}
-penumbra-stake = {workspace = true, default-features = false}
-penumbra-ibc = {workspace = true, default-features = false}
+decaf377-ka = {workspace = true}
+decaf377-rdsa = {workspace = true}
+derivative = {workspace = true}
+hex = {workspace = true}
+ibc-proto = {workspace = true, default-features = false}
+ibc-types = {workspace = true, default-features = false}
+num-bigint = {workspace = true}
+once_cell = {workspace = true}
+pbjson-types = {workspace = true}
+penumbra-asset = {workspace = true, default-features = false}
 penumbra-community-pool = {workspace = true, default-features = false}
 penumbra-dex = {workspace = true, default-features = false}
 penumbra-fee = {workspace = true, default-features = false}
-penumbra-num = {workspace = true, default-features = false}
-penumbra-asset = {workspace = true, default-features = false}
+penumbra-governance = {workspace = true, default-features = false}
+penumbra-ibc = {workspace = true, default-features = false}
 penumbra-keys = {workspace = true, default-features = false}
+penumbra-num = {workspace = true, default-features = false}
+penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, default-features = true}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-stake = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = true}
 penumbra-txhash = {workspace = true, default-features = false}
-ibc-types = {workspace = true, default-features = false}
-ibc-proto = {workspace = true, default-features = false}
-decaf377 = {workspace = true}
-decaf377-rdsa = {workspace = true}
 poseidon377 = {workspace = true, features = ["r1cs"]}
-base64 = {workspace = true}
-ark-ff = {workspace = true, default-features = false}
-ark-serialize = {workspace = true}
-regex = {workspace = true}
-sha2 = {workspace = true}
-bech32 = {workspace = true}
-anyhow = {workspace = true}
-thiserror = {workspace = true}
-bytes = {workspace = true}
-derivative = {workspace = true}
-hex = {workspace = true}
-blake2b_simd = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-once_cell = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
 rand = {workspace = true}
-chacha20poly1305 = {workspace = true}
-pbjson-types = {workspace = true}
-num-bigint = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+regex = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}
-tracing = {workspace = true}
+sha2 = {workspace = true}
+thiserror = {workspace = true}
 tokio = {workspace = true, features = ["full"], optional = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 proptest = {workspace = true}

--- a/crates/core/txhash/Cargo.toml
+++ b/crates/core/txhash/Cargo.toml
@@ -4,9 +4,9 @@ version = {workspace = true}
 edition = {workspace = true}
 
 [dependencies]
+anyhow = {workspace = true}
+blake2b_simd = {workspace = true}
+hex = {workspace = true}
 penumbra-proto = {workspace = true, default-features = false}
 penumbra-tct = {workspace = true, default-features = true}
-anyhow = {workspace = true}
-hex = {workspace = true}
-blake2b_simd = {workspace = true}
 serde = {workspace = true}

--- a/crates/crypto/decaf377-fmd/Cargo.toml
+++ b/crates/crypto/decaf377-fmd/Cargo.toml
@@ -13,14 +13,14 @@ default = ["std"]
 std = ["ark-ff/std"]
 
 [dependencies]
-decaf377 = {workspace = true}
 ark-ff = {workspace = true, default-features = false}
 ark-serialize = {workspace = true}
-thiserror = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
 bitvec = {workspace = true}
 blake2b_simd = {workspace = true}
+decaf377 = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+thiserror = {workspace = true}
 
 [dev-dependencies]
-proptest = {workspace = true}
 criterion = {workspace = true, features = ["html_reports"]}
+proptest = {workspace = true}

--- a/crates/crypto/decaf377-ka/Cargo.toml
+++ b/crates/crypto/decaf377-ka/Cargo.toml
@@ -10,9 +10,9 @@ std = ["ark-ff/std"]
 [dependencies]
 ark-ff = {workspace = true, default-features = false}
 decaf377 = {workspace = true}
+hex = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}
 thiserror = {workspace = true}
-hex = {workspace = true}
 zeroize = "1.4"
 zeroize_derive = "1.3"
 

--- a/crates/crypto/eddy/Cargo.toml
+++ b/crates/crypto/eddy/Cargo.toml
@@ -8,16 +8,16 @@ default = ["std"]
 std = ["ark-ff/std", "ark-std/std"]
 
 [dependencies]
-parking_lot = {workspace = true}
-decaf377 = {workspace = true}
 anyhow = {workspace = true}
-futures = {workspace = true}
-merlin = "3"
-rand_core = {workspace = true}
-rand = {workspace = true}
-proptest = {workspace = true}
 ark-ff = {workspace = true, default-features = false}
 ark-std = {workspace = true, default-features = false}
+decaf377 = {workspace = true}
+futures = {workspace = true}
+merlin = "3"
+parking_lot = {workspace = true}
+proptest = {workspace = true}
+rand = {workspace = true}
+rand_core = {workspace = true}
 thiserror = {workspace = true}
 
 [dev-dependencies]

--- a/crates/crypto/proof-params/Cargo.toml
+++ b/crates/crypto/proof-params/Cargo.toml
@@ -33,22 +33,22 @@ parallel = [
 ]
 
 [dependencies]
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
 anyhow = {workspace = true}
 ark-ec = {workspace = true}
 ark-ff = {workspace = true, default-features = false}
-ark-std = {workspace = true, default-features = false}
-ark-serialize = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-once_cell = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
-rand = {workspace = true}
-num-bigint = {workspace = true}
-tracing = {workspace = true}
 ark-groth16 = {workspace = true, default-features = false}
-ark-snark = {workspace = true}
 ark-r1cs-std = {workspace = true, default-features = false}
 ark-relations = {workspace = true}
-sha2 = {workspace = true}
+ark-serialize = {workspace = true}
+ark-snark = {workspace = true}
+ark-std = {workspace = true, default-features = false}
 bech32 = {workspace = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
 lazy_static = "1.4.0"
+num-bigint = {workspace = true}
+once_cell = {workspace = true}
+rand = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+serde = {workspace = true, features = ["derive"]}
+sha2 = {workspace = true}
+tracing = {workspace = true}

--- a/crates/crypto/proof-setup/Cargo.toml
+++ b/crates/crypto/proof-setup/Cargo.toml
@@ -28,19 +28,15 @@ ark-poly = { version = "0.4.2", default_features = false }
 ark-relations = {workspace = true}
 ark-serialize = {workspace = true}
 blake2b_simd = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
 decaf377 = {workspace = true, default-features = false}
+penumbra-community-pool = {workspace = true, features = ["component"], default-features = true}
 penumbra-dex = {workspace = true, default-features = true}
-penumbra-community-pool = {workspace = true, features = [
-    "component",
-], default-features = true}
 penumbra-governance = {workspace = true, default-features = true}
 penumbra-proof-params = {workspace = true, default-features = true}
 penumbra-proto = {workspace = true, default-features = true}
 penumbra-shielded-pool = {workspace = true, default-features = true}
-penumbra-stake = {workspace = true, features = [
-    "component",
-], default-features = true}
+penumbra-stake = {workspace = true, features = ["component"], default-features = true}
+rand_core = {workspace = true, features = ["getrandom"]}
 rayon = { version = "1.8.0", optional = true }
 
 [dev-dependencies]

--- a/crates/crypto/tct/Cargo.toml
+++ b/crates/crypto/tct/Cargo.toml
@@ -10,29 +10,29 @@ r1cs = ["ark-r1cs-std", "ark-relations", "decaf377/r1cs", "poseidon377/r1cs"]
 parallel = ["ark-r1cs-std/parallel", "ark-ff/parallel", "decaf377/parallel", "poseidon377/parallel"]
 
 [dependencies]
-penumbra-proto = {workspace = true, default-features = true}
-derivative = {workspace = true}
-once_cell = {workspace = true}
-blake2b_simd = {workspace = true}
-hex = {workspace = true}
-hash_hasher = "2"
-thiserror = {workspace = true}
-serde = {workspace = true, features = ["derive", "rc"]}
-parking_lot = {workspace = true}
-ark-ff = {workspace = true, default-features = false}
-ark-serialize = {workspace = true}
-poseidon377 = {workspace = true, features = ["r1cs"]}
-decaf377 = {workspace = true, default-features = true}
-tracing = {workspace = true}
-async-trait = {workspace = true}
-futures = {workspace = true}
 ark-ed-on-bls12-377 = "0.4"
-rand = {workspace = true}
-im = {workspace = true, features = ["serde"]}
-ark-relations = {workspace = true, optional = true}
+ark-ff = {workspace = true, default-features = false}
 ark-r1cs-std = {workspace = true, optional = true, default-features = false}
+ark-relations = {workspace = true, optional = true}
+ark-serialize = {workspace = true}
+async-trait = {workspace = true}
+blake2b_simd = {workspace = true}
+decaf377 = {workspace = true, default-features = true}
+derivative = {workspace = true}
+futures = {workspace = true}
+hash_hasher = "2"
+hex = {workspace = true}
+im = {workspace = true, features = ["serde"]}
+once_cell = {workspace = true}
+parking_lot = {workspace = true}
+penumbra-proto = {workspace = true, default-features = true}
+poseidon377 = {workspace = true, features = ["r1cs"]}
 proptest = {workspace = true, optional = true}
 proptest-derive = {workspace = true, optional = true}
+rand = {workspace = true}
+serde = {workspace = true, features = ["derive", "rc"]}
+thiserror = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 static_assertions = "1"

--- a/crates/custody/Cargo.toml
+++ b/crates/custody/Cargo.toml
@@ -4,32 +4,32 @@ version = {workspace = true}
 edition = {workspace = true}
 
 [dependencies]
+anyhow = {workspace = true}
 ark-ff = {workspace = true}
 ark-serialize = {workspace = true}
+base64 = {workspace = true}
 blake2b_simd = {workspace = true}
+bytes = {workspace = true, features = ["serde"]}
 chacha20poly1305 = {workspace = true}
 decaf377 = {workspace = true}
-decaf377-rdsa = {workspace = true}
 decaf377-frost = { path = "../crypto/decaf377-frost" }
 decaf377-ka = {workspace = true}
-penumbra-keys = {workspace = true, default-features = true}
-penumbra-txhash = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
-penumbra-transaction = {workspace = true, default-features = true}
-tokio = {workspace = true, features = ["full"]}
-anyhow = {workspace = true}
-serde_json = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
-serde_with = {workspace = true, features = ["hex"]}
-tracing = {workspace = true}
-tonic = {workspace = true}
-bytes = {workspace = true, features = ["serde"]}
-prost = {workspace = true}
+decaf377-rdsa = {workspace = true}
+ed25519-consensus = {workspace = true}
 futures = {workspace = true}
 hex = {workspace = true}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+penumbra-transaction = {workspace = true, default-features = true}
+penumbra-txhash = {workspace = true, default-features = true}
+prost = {workspace = true}
 rand_core = {workspace = true}
-ed25519-consensus = {workspace = true}
-base64 = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+serde_with = {workspace = true, features = ["hex"]}
+tokio = {workspace = true, features = ["full"]}
+tonic = {workspace = true}
+tracing = {workspace = true}
 
 [dev-dependencies]
 toml = {workspace = true}

--- a/crates/misc/measure/Cargo.toml
+++ b/crates/misc/measure/Cargo.toml
@@ -10,18 +10,17 @@ dist = false
 name = "measure"
 path = "src/main.rs"
 
-
 [dependencies]
-penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+anyhow = {workspace = true}
+bytesize = "1.2"
+clap = {workspace = true, features = ["derive", "env"]}
+indicatif = {workspace = true}
 penumbra-app = {workspace = true}
 penumbra-compact-block = {workspace = true, default-features = false}
+penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+serde_json = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
 tonic = {workspace = true}
-anyhow = {workspace = true}
-clap = {workspace = true, features = ["derive", "env"]}
 tracing = {workspace = true}
 tracing-subscriber = {workspace = true, features = ["env-filter"]}
 url = {workspace = true}
-indicatif = {workspace = true}
-serde_json = {workspace = true}
-bytesize = "1.2"

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -12,30 +12,34 @@ box-grpc = ["dep:http-body", "dep:tonic", "dep:tower"]
 cnidarium = ["dep:cnidarium"]
 
 [dependencies]
+anyhow = {workspace = true}
+async-trait = {workspace = true}
+bech32 = {workspace = true}
+bytes = {workspace = true, features = ["serde"]}
+cnidarium = {workspace = true, optional = true, default-features = true}
 decaf377-fmd = {workspace = true}
 decaf377-rdsa = {workspace = true}
-bytes = {workspace = true, features = ["serde"]}
-prost = {workspace = true}
-tonic = {workspace = true, optional = true}
-tower = {workspace = true, features = ["full"], optional = true}
-http-body = {workspace = true, optional = true}
-serde = {workspace = true, features = ["derive"]}
-serde_json = {workspace = true}
-hex = {workspace = true}
-anyhow = {workspace = true}
-subtle-encoding = "0.5"
-bech32 = {workspace = true}
-cnidarium = {workspace = true, optional = true, default-features = true}
-ibc-types = {workspace = true, features = ["std"], default-features = true}
-pin-project = {workspace = true}
-async-trait = {workspace = true}
-tracing = {workspace = true}
 futures = {workspace = true}
+hex = {workspace = true}
+http-body = {workspace = true, optional = true}
+ibc-types = {workspace = true, features = ["std"], default-features = true}
+ics23 = {workspace = true}
 pbjson = {workspace = true}
 pbjson-types = {workspace = true}
-ibc-proto = {workspace = true, default-features = false, features = [
+pin-project = {workspace = true}
+prost = {workspace = true}
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+subtle-encoding = "0.5"
+tendermint = {workspace = true}
+tonic = {workspace = true, optional = true}
+tower = {workspace = true, features = ["full"], optional = true}
+tracing = {workspace = true}
+
+[dependencies.ibc-proto]
+workspace = true
+default-features = false
+features = [
     "std",
     "serde",
-]}
-ics23 = {workspace = true}
-tendermint = {workspace = true}
+]

--- a/crates/test/tct-property-test/Cargo.toml
+++ b/crates/test/tct-property-test/Cargo.toml
@@ -4,9 +4,9 @@ version = {workspace = true}
 edition = {workspace = true}
 
 [dev-dependencies]
-penumbra-tct = {workspace = true, features = ["arbitrary"], default-features = true}
 anyhow = {workspace = true}
+futures = {workspace = true}
+penumbra-tct = {workspace = true, features = ["arbitrary"], default-features = true}
 proptest = {workspace = true}
 proptest-derive = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
-futures = {workspace = true}

--- a/crates/util/tendermint-proxy/Cargo.toml
+++ b/crates/util/tendermint-proxy/Cargo.toml
@@ -4,8 +4,6 @@ version = {workspace = true}
 edition = {workspace = true}
 
 [dependencies]
-penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
-penumbra-transaction = {workspace = true, default-features = true}
 anyhow = {workspace = true}
 chrono = {workspace = true, default-features = false, features = ["serde"]}
 futures = {workspace = true}
@@ -13,13 +11,15 @@ hex = {workspace = true}
 http = {workspace = true}
 metrics = {workspace = true}
 pbjson-types = {workspace = true}
+penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+penumbra-transaction = {workspace = true, default-features = true}
 pin-project = {workspace = true}
 pin-project-lite = {workspace = true}
 sha2 = {workspace = true}
 tendermint = {workspace = true}
 tendermint-config = {workspace = true}
-tendermint-proto = {workspace = true}
 tendermint-light-client-verifier = {workspace = true}
+tendermint-proto = {workspace = true}
 tendermint-rpc = {workspace = true, features = ["http-client"]}
 tokio = {workspace = true, features = ["full"]}
 tokio-stream = {workspace = true}

--- a/crates/view/Cargo.toml
+++ b/crates/view/Cargo.toml
@@ -17,54 +17,52 @@ sct-divergence-check = []
 std = ["ark-std/std"]
 
 [dependencies]
-penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-num = {workspace = true, default-features = true}
-penumbra-keys = {workspace = true, default-features = true}
+anyhow = {workspace = true}
+ark-std = {workspace = true, default-features = false}
+async-stream = {workspace = true}
+async-trait = {workspace = true}
+bytes = {workspace = true, features = ["serde"]}
+camino = {workspace = true}
+decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+digest = "0.9"
+ed25519-consensus = {workspace = true}
+futures = {workspace = true}
+genawaiter = "0.99"
+hex = {workspace = true}
+ibc-types = {workspace = true, default-features = false}
+metrics = {workspace = true}
+once_cell = {workspace = true}
+parking_lot = {workspace = true}
+penumbra-app = {workspace = true}
 penumbra-asset = {workspace = true, default-features = true}
-penumbra-shielded-pool = {workspace = true, default-features = false}
-penumbra-governance = {workspace = true, default-features = false}
-penumbra-stake = {workspace = true, default-features = false}
-penumbra-ibc = {workspace = true, default-features = false}
-penumbra-distributions = {workspace = true, default-features = false}
 penumbra-community-pool = {workspace = true, default-features = false}
+penumbra-compact-block = {workspace = true, default-features = false}
 penumbra-dex = {workspace = true, default-features = false}
-penumbra-sct = {workspace = true, default-features = false}
+penumbra-distributions = {workspace = true, default-features = false}
 penumbra-fee = {workspace = true, default-features = false}
 penumbra-funding = {workspace = true, default-features = false}
-penumbra-compact-block = {workspace = true, default-features = false}
-penumbra-app = {workspace = true}
+penumbra-governance = {workspace = true, default-features = false}
+penumbra-ibc = {workspace = true, default-features = false}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-num = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+penumbra-sct = {workspace = true, default-features = false}
+penumbra-shielded-pool = {workspace = true, default-features = false}
+penumbra-stake = {workspace = true, default-features = false}
+penumbra-tct = {workspace = true, default-features = true}
 penumbra-transaction = {workspace = true, default-features = true}
-ibc-types = {workspace = true, default-features = false}
-ark-std = {workspace = true, default-features = false}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+prost = {workspace = true}
+r2d2 = {workspace = true}
+r2d2_sqlite = {workspace = true, features = ["bundled"]}
+rand = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+sha2 = {workspace = true}
+tendermint = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
 tokio-stream = {workspace = true, features = ["sync"]}
-anyhow = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
-rand = {workspace = true}
-serde_json = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
+tonic = {workspace = true}
 tracing = {workspace = true}
 tracing-subscriber = {workspace = true}
-tonic = {workspace = true}
 url = {workspace = true}
-bytes = {workspace = true, features = ["serde"]}
-prost = {workspace = true}
-futures = {workspace = true}
-hex = {workspace = true}
-metrics = {workspace = true}
-async-stream = {workspace = true}
-parking_lot = {workspace = true}
-camino = {workspace = true}
-async-trait = {workspace = true}
-tendermint = {workspace = true}
-sha2 = {workspace = true}
-ed25519-consensus = {workspace = true}
-r2d2 = {workspace = true}
-r2d2_sqlite = {workspace = true, features = [
-    "bundled",
-]}
-genawaiter = "0.99"
-digest = "0.9"
-once_cell = {workspace = true}

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -14,36 +14,36 @@ default = []
 parallel = ["penumbra-transaction/parallel"]
 
 [dependencies]
-penumbra-proto = {workspace = true, default-features = true}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-num = {workspace = true, default-features = true}
-penumbra-asset = {workspace = true, default-features = true}
-penumbra-keys = {workspace = true, default-features = true}
-penumbra-dex = {workspace = true, default-features = true}
-penumbra-transaction = {workspace = true, default-features = true}
-penumbra-app = {workspace = true}
-penumbra-stake = {workspace = true, default-features = true}
-penumbra-governance = {workspace = true, default-features = true}
-penumbra-fee = {workspace = true, default-features = true}
-penumbra-view = {workspace = true}
-penumbra-custody = {workspace = true}
-bytes = {workspace = true}
-bincode = {workspace = true}
-ark-std = {workspace = true, default-features = false}
-decaf377 = {workspace = true, default-features = true}
-tokio = {workspace = true, features = ["full"]}
-tower = {workspace = true, features = ["full"]}
-tonic = {workspace = true}
-tracing = {workspace = true}
-pin-project = {workspace = true}
-serde_json = {workspace = true}
-serde = {workspace = true, features = ["derive"]}
 anyhow = {workspace = true}
+ark-std = {workspace = true, default-features = false}
+bincode = {workspace = true}
+bytes = {workspace = true}
+decaf377 = {workspace = true, default-features = true}
 hex = {workspace = true}
-rand_core = {workspace = true, features = ["getrandom"]}
+penumbra-app = {workspace = true}
+penumbra-asset = {workspace = true, default-features = true}
+penumbra-custody = {workspace = true}
+penumbra-dex = {workspace = true, default-features = true}
+penumbra-fee = {workspace = true, default-features = true}
+penumbra-governance = {workspace = true, default-features = true}
+penumbra-keys = {workspace = true, default-features = true}
+penumbra-num = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true, default-features = true}
+penumbra-stake = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true, default-features = true}
+penumbra-transaction = {workspace = true, default-features = true}
+penumbra-view = {workspace = true}
+pin-project = {workspace = true}
 rand = {workspace = true}
+rand_core = {workspace = true, features = ["getrandom"]}
+serde = {workspace = true, features = ["derive"]}
+serde_json = {workspace = true}
+tokio = {workspace = true, features = ["full"]}
+tonic = {workspace = true}
+tower = {workspace = true, features = ["full"]}
+tracing = {workspace = true}
 
 [dev-dependencies]
+once_cell = {workspace = true}
 proptest = {workspace = true}
 proptest-derive = {workspace = true}
-once_cell = {workspace = true}

--- a/tools/proto-compiler/Cargo.toml
+++ b/tools/proto-compiler/Cargo.toml
@@ -6,14 +6,13 @@ publish = false
 
 [dependencies]
 anyhow = "1"
-prost = "0.12.3"
-prost-types = "0.12"
-prost-build = "0.12.3"
-tonic-build = { version = "0.10.0", features = ["cleanup-markdown"] }
-pbjson = "0.6"
-pbjson-types = "0.6"
-pbjson-build = "0.6"
-tempfile = "3"
-
 ibc-proto = { version = "0.40.0" }
 ics23 = "0.11.0"
+pbjson = "0.6"
+pbjson-build = "0.6"
+pbjson-types = "0.6"
+prost = "0.12.3"
+prost-build = "0.12.3"
+prost-types = "0.12"
+tempfile = "3"
+tonic-build = { version = "0.10.0", features = ["cleanup-markdown"] }

--- a/tools/summonerd/Cargo.toml
+++ b/tools/summonerd/Cargo.toml
@@ -14,14 +14,14 @@ rust-version = "1.65"
 anyhow = {workspace = true}
 ark-groth16 = {workspace = true}
 ark-serialize = {workspace = true}
+askama = "0.11"
 async-trait = {workspace = true}
 atty = {workspace = true}
-askama = "0.11"
 axum = {workspace = true}
 bytes = {workspace = true}
 camino = {workspace = true}
-clap = {workspace = true, features = ["derive", "env", "color"]}
 chrono = {workspace = true}
+clap = {workspace = true, features = ["derive", "env", "color"]}
 console-subscriber = {workspace = true}
 decaf377 = {workspace = true}
 futures = {workspace = true}
@@ -35,6 +35,8 @@ penumbra-proof-params = {workspace = true, default-features = true}
 penumbra-proof-setup = {workspace = true, features = ["parallel"]}
 penumbra-proto = {workspace = true, default-features = true}
 penumbra-view = {workspace = true}
+r2d2 = {workspace = true}
+r2d2_sqlite = {workspace = true, features = ["bundled"]}
 rand = {workspace = true}
 rand_core = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
@@ -44,7 +46,3 @@ tower = {workspace = true}
 tracing = {workspace = true}
 tracing-subscriber = {workspace = true}
 url = {workspace = true}
-r2d2 = {workspace = true}
-r2d2_sqlite = {workspace = true, features = [
-    "bundled",
-]}


### PR DESCRIPTION
cargo dependencies, sorted alphabetically. thanks to the magic of vim macros. :sparkling_heart:

sorted dependencies helps reduce the likelihood of merge conflicts when dependencies are added to a crate. long-term quality-of-life benefit :slightly_smiling_face: