### PR TITLE
docs: stipulate support for precompiled binaries

### DIFF
--- a/docs/guide/src/pcli/install.md
+++ b/docs/guide/src/pcli/install.md
@@ -8,7 +8,7 @@ Make sure choose the correct platform for your machine. After downloading the `.
 extract it, and copy its contents to your `$PATH`. For example:
 
 ```
-curl -O -L https://github.com/penumbra-zone/penumbra/releases/download/{{ #include ../penumbra_version.md }}/pcli-x86_64-unknown-linux-gnu.tar.xz
+curl -sSfL -O https://github.com/penumbra-zone/penumbra/releases/download/{{ #include ../penumbra_version.md }}/pcli-x86_64-unknown-linux-gnu.tar.xz
 unxz pcli-x86_64-unknown-linux-gnu.tar.xz
 tar -xf pcli-x86_64-unknown-linux-gnu.tar
 sudo mv pcli-x86_64-unknown-linux-gnu/pcli /usr/local/bin/
@@ -17,8 +17,30 @@ sudo mv pcli-x86_64-unknown-linux-gnu/pcli /usr/local/bin/
 pcli --version
 ```
 
-Only macOS and Linux are supported. If you need to use Windows,
-consider using [WSL]. If you prefer to build from source,
-see the [compilation guide](../dev/build.md).
+If you see an error message containing `GLIBC`, then your system is not compatible
+with the precompiled binaries. See details below.
+
+## Platform support
+
+Only modern versions of Linux and macOS are supported, such as:
+
+  * Ubuntu 22.04
+  * Debian 12
+  * Fedora 39
+  * macOS 14
+
+When checking the locally installed binary via `pcli --version`, you may see an error message similar to:
+
+```
+pcli: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by pcli)
+pcli: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by pcli)
+pcli: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by pcli)
+pcli: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by pcli)
+pcli: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by pcli)
+```
+
+If you see that message, you must either switch to a supported platform, or else
+[build the software from source](../dev/build.md). If you need to use Windows,
+consider using [WSL].
 
 [WSL]: https://learn.microsoft.com/en-us/windows/wsl/install

--- a/docs/guide/src/pd/install.md
+++ b/docs/guide/src/pd/install.md
@@ -8,7 +8,7 @@ Make sure to choose the correct platform for your machine. After downloading the
 extract it, and copy its contents to your `$PATH`. For example:
 
 ```
-curl -O -L https://github.com/penumbra-zone/penumbra/releases/download/{{ #include ../penumbra_version.md }}/pd-x86_64-unknown-linux-gnu.tar.xz
+curl -sSfL -O https://github.com/penumbra-zone/penumbra/releases/download/{{ #include ../penumbra_version.md }}/pd-x86_64-unknown-linux-gnu.tar.xz
 unxz pd-x86_64-unknown-linux-gnu.tar.xz
 tar -xf pd-x86_64-unknown-linux-gnu.tar
 sudo mv pd-x86_64-unknown-linux-gnu/pd /usr/local/bin/


### PR DESCRIPTION
This is a common question in the Discord, from folks trying to install the precompiled binaries on an LTS OS like Ubuntu 20.04. We only build one set of binaries per architecture, and we don't want to start building per-OS, so let's just be clear about what we know works.