### PR TITLE
mock-consensus: 💹 generated blocks' height increases

### DIFF
--- a/crates/core/app/tests/mock_consensus.rs
+++ b/crates/core/app/tests/mock_consensus.rs
@@ -5,12 +5,17 @@
 
 mod common;
 
-use cnidarium::TempStorage;
-use common::BuilderExt;
-use penumbra_app::server::consensus::Consensus;
-use penumbra_genesis::AppState;
-use tendermint::evidence::List;
+use {
+    self::common::BuilderExt,
+    cnidarium::TempStorage,
+    penumbra_app::server::consensus::Consensus,
+    penumbra_genesis::AppState,
+    penumbra_sct::component::clock::EpochRead,
+    tendermint::evidence::List,
+    tracing::{error_span, Instrument},
+};
 
+/// Exercises that a test node can be instantiated using the consensus service.
 #[tokio::test]
 async fn mock_consensus_can_send_an_init_chain_request() -> anyhow::Result<()> {
     // Install a test logger, and acquire some temporary storage.
@@ -38,8 +43,10 @@ async fn mock_consensus_can_send_an_init_chain_request() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Exercises that a series of empty blocks, with no validator set present, can be successfully
+/// executed by the consensus service.
 #[tokio::test]
-async fn mock_consensus_can_send_a_single_empty_block() -> anyhow::Result<()> {
+async fn mock_consensus_can_send_a_sequence_of_empty_blocks() -> anyhow::Result<()> {
     // Install a test logger, and acquire some temporary storage.
     let guard = common::set_tracing_subscriber();
     let storage = TempStorage::new().await?;
@@ -56,12 +63,30 @@ async fn mock_consensus_can_send_a_single_empty_block() -> anyhow::Result<()> {
             .await?
     };
 
-    engine
-        .block()
-        .with_data(vec![])
-        .with_evidence(List::new(Vec::new()))
-        .execute()
-        .await?;
+    // Check that we begin at height 0, before any blocks have been generated.
+    assert_eq!(
+        storage.latest_snapshot().get_block_height().await?,
+        0,
+        "height should begin at 0"
+    );
+
+    for expected in 1..=8 {
+        // Generate an empty block.
+        engine
+            .block()
+            .with_data(vec![])
+            .with_evidence(List::new(Vec::new()))
+            .execute()
+            .instrument(error_span!("executing block", %expected))
+            .await?;
+
+        // Check that the latest snapshot has the expected block height.
+        let height = storage.latest_snapshot().get_block_height().await?;
+        assert_eq!(
+            height, expected,
+            "height should continue to incrementally grow"
+        );
+    }
 
     // Free our temporary storage.
     drop(storage);

--- a/crates/test/mock-consensus/src/builder/init_chain.rs
+++ b/crates/test/mock-consensus/src/builder/init_chain.rs
@@ -60,6 +60,7 @@ impl Builder {
 
         Ok(TestNode {
             consensus,
+            height: block::Height::from(0_u8),
             last_app_hash: app_hash.as_bytes().to_owned(),
         })
     }

--- a/crates/test/mock-consensus/src/lib.rs
+++ b/crates/test/mock-consensus/src/lib.rs
@@ -21,6 +21,7 @@ mod block;
 pub struct TestNode<C> {
     consensus: C,
     last_app_hash: Vec<u8>,
+    height: tendermint::block::Height,
 }
 
 impl<C> TestNode<C> {


### PR DESCRIPTION
this makes changes to the mock consensus engine so that the generated `Block`s have monotonically increasing height.

see also:
* #3588
* #3788

an example, running the
`mock_consensus_can_send_a_sequence_of_empty_blocks` test:

```
; RUST_LOG="penumbra_mock_consensus=info" cargo test --package penumbra-app sequence_of_empty_blocks -- --nocapture
   Compiling penumbra-mock-consensus v0.67.1
   Compiling penumbra-app v0.67.1
    Finished test [unoptimized + debuginfo] target(s) in 9.10s
     Running unittests src/lib.rs (target/debug/deps/penumbra_app-1e86f1775ec8d9a7)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s

     Running tests/mock_consensus.rs (target/debug/deps/mock_consensus-caa27518a071c6af)

running 1 test
  2024-02-16T21:18:58.850646Z  INFO penumbra_mock_consensus::block: sending block
    at crates/test/mock-consensus/src/block.rs:97
    in penumbra_mock_consensus::block::execute with height: 1, time: 1708118338

  2024-02-16T21:18:58.860604Z  INFO penumbra_mock_consensus::block: finished sending block
    at crates/test/mock-consensus/src/block.rs:105
    in penumbra_mock_consensus::block::execute with height: 1, time: 1708118338

  2024-02-16T21:18:58.860725Z  INFO penumbra_mock_consensus::block: sending block
    at crates/test/mock-consensus/src/block.rs:97
    in penumbra_mock_consensus::block::execute with height: 2, time: 1708118338

  2024-02-16T21:18:58.869760Z  INFO penumbra_mock_consensus::block: finished sending block
    at crates/test/mock-consensus/src/block.rs:105
    in penumbra_mock_consensus::block::execute with height: 2, time: 1708118338

  2024-02-16T21:18:58.869883Z  INFO penumbra_mock_consensus::block: sending block
    at crates/test/mock-consensus/src/block.rs:97
    in penumbra_mock_consensus::block::execute with height: 3, time: 1708118338

  2024-02-16T21:18:58.879037Z  INFO penumbra_mock_consensus::block: finished sending block
    at crates/test/mock-consensus/src/block.rs:105
    in penumbra_mock_consensus::block::execute with height: 3, time: 1708118338

  2024-02-16T21:18:58.879143Z  INFO penumbra_mock_consensus::block: sending block
    at crates/test/mock-consensus/src/block.rs:97
    in penumbra_mock_consensus::block::execute with height: 4, time: 1708118338

  2024-02-16T21:18:58.888524Z  INFO penumbra_mock_consensus::block: finished sending block
    at crates/test/mock-consensus/src/block.rs:105
    in penumbra_mock_consensus::block::execute with height: 4, time: 1708118338

  2024-02-16T21:18:58.888659Z  INFO penumbra_mock_consensus::block: sending block
    at crates/test/mock-consensus/src/block.rs:97
    in penumbra_mock_consensus::block::execute with height: 5, time: 1708118338

  2024-02-16T21:18:58.898337Z  INFO penumbra_mock_consensus::block: finished sending block
    at crates/test/mock-consensus/src/block.rs:105
    in penumbra_mock_consensus::block::execute with height: 5, time: 1708118338

  2024-02-16T21:18:58.898486Z  INFO penumbra_mock_consensus::block: sending block
    at crates/test/mock-consensus/src/block.rs:97
    in penumbra_mock_consensus::block::execute with height: 6, time: 1708118338

  2024-02-16T21:18:58.908190Z  INFO penumbra_mock_consensus::block: finished sending block
    at crates/test/mock-consensus/src/block.rs:105
    in penumbra_mock_consensus::block::execute with height: 6, time: 1708118338

  2024-02-16T21:18:58.908325Z  INFO penumbra_mock_consensus::block: sending block
    at crates/test/mock-consensus/src/block.rs:97
    in penumbra_mock_consensus::block::execute with height: 7, time: 1708118338

  2024-02-16T21:18:58.917988Z  INFO penumbra_mock_consensus::block: finished sending block
    at crates/test/mock-consensus/src/block.rs:105
    in penumbra_mock_consensus::block::execute with height: 7, time: 1708118338

  2024-02-16T21:18:58.918116Z  INFO penumbra_mock_consensus::block: sending block
    at crates/test/mock-consensus/src/block.rs:97
    in penumbra_mock_consensus::block::execute with height: 8, time: 1708118338

  2024-02-16T21:18:58.927903Z  INFO penumbra_mock_consensus::block: finished sending block
    at crates/test/mock-consensus/src/block.rs:105
    in penumbra_mock_consensus::block::execute with height: 8, time: 1708118338

test mock_consensus_can_send_a_sequence_of_empty_blocks ... ok
```