### PR TITLE
mock-consensus: 💇 use `evidence::List::default`

### DIFF
--- a/crates/core/app/tests/mock_consensus.rs
+++ b/crates/core/app/tests/mock_consensus.rs
@@ -11,7 +11,6 @@ use {
     penumbra_app::server::consensus::Consensus,
     penumbra_genesis::AppState,
     penumbra_sct::component::clock::EpochRead,
-    tendermint::evidence::List,
     tracing::{error_span, Instrument},
 };
 
@@ -75,7 +74,6 @@ async fn mock_consensus_can_send_a_sequence_of_empty_blocks() -> anyhow::Result<
         engine
             .block()
             .with_data(vec![])
-            .with_evidence(List::new(Vec::new()))
             .execute()
             .instrument(error_span!("executing block", %expected))
             .await?;

--- a/crates/test/mock-consensus/src/block.rs
+++ b/crates/test/mock-consensus/src/block.rs
@@ -28,7 +28,7 @@ pub struct Builder<'e, C> {
     data: Option<Vec<Vec<u8>>>,
 
     /// Evidence of malfeasance.
-    evidence: Option<evidence::List>,
+    evidence: evidence::List,
 }
 
 impl<C> TestNode<C> {
@@ -55,10 +55,7 @@ impl<'e, C> Builder<'e, C> {
 
     /// Sets the evidence [`List`][evidence::List] for this block.
     pub fn with_evidence(self, evidence: evidence::List) -> Self {
-        Self {
-            evidence: Some(evidence),
-            ..self
-        }
+        Self { evidence, ..self }
     }
 
     // TODO(kate): add more `with_` setters for fields in the header.
@@ -116,7 +113,7 @@ where
         tracing::trace!("building block");
         let Self {
             data: Some(data),
-            evidence: Some(evidence),
+            evidence,
             test_node,
         } = self
         else {


### PR DESCRIPTION
`tendermint::evidence::List` implements `std::default::Default`. so, let's use that instead of mandating that an empty evidence list be provided each time that we build a new block.

https://github.com/penumbra-zone/penumbra/pull/3840#discussion_r1493025098

Reference: https://github.com/penumbra-zone/penumbra/issues/3588
Reference: https://github.com/penumbra-zone/penumbra/issues/3792
Reference: https://github.com/penumbra-zone/penumbra/pull/3840