### PR TITLE
mock-consensus: 🙂 simplify test node startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4653,6 +4653,7 @@ dependencies = [
  "serde_unit_struct",
  "serde_with",
  "sha2 0.10.8",
+ "tap",
  "tempfile",
  "tendermint",
  "tendermint-light-client-verifier",

--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -83,6 +83,7 @@ penumbra-mock-consensus = {workspace = true}
 penumbra-mock-client = {workspace = true}
 rand_core = {workspace = true}
 rand_chacha = {workspace = true}
+tap = {workspace = true}
 tracing-subscriber = {workspace = true}
 
 # Enable the feature flags to get proving keys when running tests.

--- a/crates/core/app/src/server/consensus.rs
+++ b/crates/core/app/src/server/consensus.rs
@@ -57,7 +57,7 @@ impl Consensus {
         })
     }
 
-    pub async fn run(mut self) -> Result<(), tower::BoxError> {
+    async fn run(mut self) -> Result<(), tower::BoxError> {
         while let Some(Message {
             req,
             rsp_sender,

--- a/crates/core/app/src/server/consensus.rs
+++ b/crates/core/app/src/server/consensus.rs
@@ -18,6 +18,8 @@ pub struct Consensus {
     app: App,
 }
 
+pub type ConsensusService = tower_actor::Actor<Request, Response, BoxError>;
+
 fn trace_events(events: &[Event]) {
     for event in events {
         let span = tracing::info_span!("event", kind = ?event.kind);
@@ -32,7 +34,7 @@ fn trace_events(events: &[Event]) {
 impl Consensus {
     const QUEUE_SIZE: usize = 10;
 
-    pub fn new(storage: Storage) -> tower_actor::Actor<Request, Response, BoxError> {
+    pub fn new(storage: Storage) -> ConsensusService {
         tower_actor::Actor::new(Self::QUEUE_SIZE, |queue: _| {
             let storage = storage.clone();
             async move {


### PR DESCRIPTION
this is a bit of polish for the mock consensus tests. `Consensus` provides its `tower::Service` implementation via `tower-actor`, which makes naming a `TestNode<_>` slightly verbose. this introduces a `ConsensusService` type alias, and outlines our test node startup into a shared function in `common`.

in the future we'll probably extend this `start_test_node` to allow for callers to override particular settings on the test node builder. for now, that is elided. our primary goal is to provide an ergonomic "_start a test node backed by temporary storage_" button to reduce test boilerplate.

* #3588
* #3788