### PR TITLE
transaction: 🚪 reëxport `TransactionPlan`

### DIFF
--- a/crates/bin/pcli/src/command/tx/proposal.rs
+++ b/crates/bin/pcli/src/command/tx/proposal.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use penumbra_app::params::AppParameters;
 use penumbra_governance::{proposal::ChangedAppParameters, Proposal, ProposalPayload};
 use penumbra_proto::DomainType;
-use penumbra_transaction::plan::TransactionPlan;
+use penumbra_transaction::TransactionPlan;
 
 use super::FeeTier;
 

--- a/crates/bin/pcli/src/network.rs
+++ b/crates/bin/pcli/src/network.rs
@@ -6,9 +6,7 @@ use penumbra_proto::{
     view::v1::broadcast_transaction_response::Status as BroadcastStatus,
     view::v1::GasPricesRequest, DomainType,
 };
-use penumbra_transaction::{
-    gas::GasCost, plan::TransactionPlan, txhash::TransactionId, Transaction,
-};
+use penumbra_transaction::{gas::GasCost, txhash::TransactionId, Transaction, TransactionPlan};
 use penumbra_view::ViewClient;
 use std::future::Future;
 use tonic::transport::{Channel, ClientTlsConfig};

--- a/crates/bin/pcli/src/terminal.rs
+++ b/crates/bin/pcli/src/terminal.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use penumbra_custody::threshold::Terminal;
-use penumbra_transaction::plan::TransactionPlan;
+use penumbra_transaction::TransactionPlan;
 use tokio::io::{self, AsyncBufReadExt};
 use tonic::async_trait;
 

--- a/crates/bin/pclientd/tests/network_integration.rs
+++ b/crates/bin/pclientd/tests/network_integration.rs
@@ -314,13 +314,12 @@ async fn swap_claim_flow() -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::anyhow!("TransactionPlannerResponse missing plan"))?;
 
     // Hold on to the swap plaintext to be able to claim.
-    let swap_plaintext =
-        TryInto::<penumbra_transaction::plan::TransactionPlan>::try_into(plan.clone())?
-            .swap_plans()
-            .next()
-            .expect("swap plan must be present")
-            .swap_plaintext
-            .clone();
+    let swap_plaintext = TryInto::<penumbra_transaction::TransactionPlan>::try_into(plan.clone())?
+        .swap_plans()
+        .next()
+        .expect("swap plan must be present")
+        .swap_plaintext
+        .clone();
 
     // 5.2. Get authorization data for the transaction from pclientd (signing).
     let auth_data = custody_client

--- a/crates/core/app/src/action_handler/actions/submit.rs
+++ b/crates/core/app/src/action_handler/actions/submit.rs
@@ -25,9 +25,7 @@ use penumbra_proto::{DomainType, StateWriteProto as _};
 use penumbra_sct::component::clock::EpochRead;
 use penumbra_sct::component::tree::SctRead;
 use penumbra_shielded_pool::component::SupplyWrite;
-use penumbra_transaction::plan::TransactionPlan;
-use penumbra_transaction::Transaction;
-use penumbra_transaction::{AuthorizationData, WitnessData};
+use penumbra_transaction::{AuthorizationData, Transaction, TransactionPlan, WitnessData};
 
 use crate::action_handler::ActionHandler;
 use crate::community_pool_ext::CommunityPoolStateWriteExt;

--- a/crates/core/transaction/src/lib.rs
+++ b/crates/core/transaction/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate defines data structures that provide modeling of shielded
 //! transactions through their entire lifecycle:
 //!
-//! * the [`TransactionPlan`](plan::TransactionPlan) type completely describes a
+//! * the [`TransactionPlan`](TransactionPlan) type completely describes a
 //! planned transaction before it is created;
 //!
 //! * the [`Transaction`] type represents the shielded transaction itself;
@@ -37,7 +37,7 @@ pub use detection_data::DetectionData;
 pub use error::Error;
 pub use is_action::IsAction;
 pub use parameters::TransactionParameters;
-pub use plan::ActionPlan;
+pub use plan::{ActionPlan, TransactionPlan};
 pub use transaction::{Transaction, TransactionBody};
 pub use view::{ActionView, MemoPlaintextView, MemoView, TransactionPerspective, TransactionView};
 pub use witness_data::WitnessData;

--- a/crates/core/transaction/src/plan/auth.rs
+++ b/crates/core/transaction/src/plan/auth.rs
@@ -3,7 +3,7 @@ use rand::{CryptoRng, RngCore};
 
 use penumbra_keys::keys::SpendKey;
 
-use crate::{plan::TransactionPlan, AuthorizationData};
+use crate::{AuthorizationData, TransactionPlan};
 
 impl TransactionPlan {
     /// Authorize this [`TransactionPlan`] with the provided [`SpendKey`].

--- a/crates/custody/src/policy.rs
+++ b/crates/custody/src/policy.rs
@@ -34,7 +34,7 @@ pub enum AuthPolicy {
     /// This policy should be combined with an `AllowList` to prevent sending
     /// funds outside of the relayer account.
     OnlyIbcRelay,
-    /// Require specific pre-authorizations for submitted [`TransactionPlan`](penumbra_transaction::plan::TransactionPlan)s.
+    /// Require specific pre-authorizations for submitted [`TransactionPlan`](penumbra_transaction::TransactionPlan)s.
     PreAuthorization(PreAuthorizationPolicy),
 }
 

--- a/crates/custody/src/pre_auth.rs
+++ b/crates/custody/src/pre_auth.rs
@@ -1,5 +1,5 @@
 use penumbra_proto::{custody::v1 as pb, DomainType};
-use penumbra_transaction::plan::TransactionPlan;
+use penumbra_transaction::TransactionPlan;
 use serde::{Deserialize, Serialize};
 
 /// A pre-authorization packet.  This allows a custodian to delegate (partial)

--- a/crates/custody/src/request.rs
+++ b/crates/custody/src/request.rs
@@ -1,5 +1,5 @@
 use penumbra_proto::{custody::v1 as pb, DomainType};
-use penumbra_transaction::plan::TransactionPlan;
+use penumbra_transaction::TransactionPlan;
 
 use crate::PreAuthorization;
 

--- a/crates/custody/src/soft_kms.rs
+++ b/crates/custody/src/soft_kms.rs
@@ -24,7 +24,7 @@ impl SoftKms {
         Self { config }
     }
 
-    /// Attempt to authorize the requested [`TransactionPlan`](penumbra_transaction::plan::TransactionPlan).
+    /// Attempt to authorize the requested [`TransactionPlan`](penumbra_transaction::TransactionPlan).
     #[tracing::instrument(skip(self, request), name = "softhsm_sign")]
     pub fn sign(&self, request: &AuthorizeRequest) -> anyhow::Result<AuthorizationData> {
         tracing::debug!(?request.plan);

--- a/crates/custody/src/threshold.rs
+++ b/crates/custody/src/threshold.rs
@@ -5,7 +5,7 @@ use tonic::{async_trait, Request, Response, Status};
 
 use penumbra_keys::{keys::AddressIndex, Address, FullViewingKey};
 use penumbra_proto::{custody::v1 as pb, DomainType};
-use penumbra_transaction::{plan::TransactionPlan, AuthorizationData};
+use penumbra_transaction::{AuthorizationData, TransactionPlan};
 
 use crate::AuthorizeRequest;
 

--- a/crates/custody/src/threshold/sign.rs
+++ b/crates/custody/src/threshold/sign.rs
@@ -10,7 +10,7 @@ use rand_core::CryptoRngCore;
 use decaf377_frost as frost;
 use frost::round1::SigningCommitments;
 use penumbra_proto::{penumbra::custody::threshold::v1 as pb, DomainType, Message};
-use penumbra_transaction::{plan::TransactionPlan, AuthorizationData};
+use penumbra_transaction::{AuthorizationData, TransactionPlan};
 use penumbra_txhash::EffectHash;
 
 use super::config::Config;

--- a/crates/view/src/client.rs
+++ b/crates/view/src/client.rs
@@ -21,9 +21,8 @@ use penumbra_proto::view::v1::{
 use penumbra_sct::Nullifier;
 use penumbra_shielded_pool::{fmd, note};
 use penumbra_stake::IdentityKey;
-use penumbra_transaction::AuthorizationData;
 use penumbra_transaction::{
-    plan::TransactionPlan, txhash::TransactionId, Transaction, WitnessData,
+    txhash::TransactionId, AuthorizationData, Transaction, TransactionPlan, WitnessData,
 };
 
 use crate::{SpendableNoteRecord, StatusStreamResponse, SwapRecord, TransactionInfo};

--- a/crates/view/src/service.rs
+++ b/crates/view/src/service.rs
@@ -55,7 +55,7 @@ use penumbra_proto::{
 use penumbra_stake::rate::RateData;
 use penumbra_tct::{Proof, StateCommitment};
 use penumbra_transaction::{
-    plan::TransactionPlan, AuthorizationData, Transaction, TransactionPerspective, WitnessData,
+    AuthorizationData, Transaction, TransactionPerspective, TransactionPlan, WitnessData,
 };
 
 use crate::{Planner, Storage, Worker};

--- a/crates/wallet/src/build.rs
+++ b/crates/wallet/src/build.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use penumbra_custody::{AuthorizeRequest, CustodyClient};
 use penumbra_keys::FullViewingKey;
-use penumbra_transaction::{plan::TransactionPlan, AuthorizationData, Transaction};
+use penumbra_transaction::{AuthorizationData, Transaction, TransactionPlan};
 use penumbra_view::ViewClient;
 
 pub async fn build_transaction<V, C>(

--- a/crates/wallet/src/plan.rs
+++ b/crates/wallet/src/plan.rs
@@ -15,7 +15,7 @@ use penumbra_num::Amount;
 use penumbra_proto::view::v1::NotesRequest;
 use penumbra_stake::rate::RateData;
 use penumbra_stake::validator;
-use penumbra_transaction::{memo::MemoPlaintext, plan::TransactionPlan, TransactionParameters};
+use penumbra_transaction::{memo::MemoPlaintext, TransactionParameters, TransactionPlan};
 pub use penumbra_view::Planner;
 use penumbra_view::{SpendableNoteRecord, ViewClient};
 


### PR DESCRIPTION
as the crate's documentation points out, `TransactionPlan` is one of the critical types provided by this library.

let's `pub use` it in `lib.rs`, alongside `Transaction`.