### PR TITLE
staking: add a `min_validator_stake` first delegation requirement

### DIFF
--- a/crates/core/component/stake/src/component/action_handler/delegate.rs
+++ b/crates/core/component/stake/src/component/action_handler/delegate.rs
@@ -131,7 +131,6 @@ impl ActionHandler for Delegate {
                 "first delegation to a `Defined` validator must be at least min_validator_stake"
             );
                 tracing::debug!(%validator, %unbonded_delegation, "first delegation to validator recorded");
-                state.set_validator_state(&validator, Inactive).await?;
             }
         }
 

--- a/crates/core/component/stake/src/component/action_handler/delegate.rs
+++ b/crates/core/component/stake/src/component/action_handler/delegate.rs
@@ -7,10 +7,7 @@ use cnidarium_component::ActionHandler;
 use penumbra_num::Amount;
 
 use crate::{
-    component::{
-        validator_handler::{ValidatorDataRead, ValidatorManager},
-        StateWriteExt as _,
-    },
+    component::{validator_handler::ValidatorDataRead, StateWriteExt as _},
     event,
     validator::State::*,
     Delegate, StateReadExt as _,

--- a/crates/core/component/stake/src/component/action_handler/delegate.rs
+++ b/crates/core/component/stake/src/component/action_handler/delegate.rs
@@ -124,9 +124,9 @@ impl ActionHandler for Delegate {
 
             if validator_pool_size == Amount::zero() {
                 ensure!(
-                unbonded_delegation >= min_stake,
-                "first delegation to a `Defined` validator must be at least min_validator_stake"
-            );
+                    unbonded_delegation >= min_stake,
+                    "first delegation to a `Defined` validator must be at least {min_stake}"
+                );
                 tracing::debug!(%validator, %unbonded_delegation, "first delegation to validator recorded");
             }
         }

--- a/crates/core/component/stake/src/component/action_handler/validator_definition.rs
+++ b/crates/core/component/stake/src/component/action_handler/validator_definition.rs
@@ -121,9 +121,12 @@ impl ActionHandler for validator::Definition {
             .is_some();
 
         if validator_exists {
-            state.update_validator(v.validator.clone()).await.context(
-                "should be able to update validator during validator definition execution",
-            )?;
+            state
+                .update_validator_definition(v.validator.clone())
+                .await
+                .context(
+                    "should be able to update validator during validator definition execution",
+                )?;
         } else {
             // This is a new validator definition. We prime the validator's
             // rate data with an initial exchange rate of 1:1.

--- a/crates/core/component/stake/src/component/stake.rs
+++ b/crates/core/component/stake/src/component/stake.rs
@@ -191,7 +191,8 @@ pub trait StateReadExt: StateRead {
     /// Gets the stake parameters from the JMT.
     async fn get_stake_params(&self) -> Result<StakeParameters> {
         self.get(state_key::parameters::key())
-            .await?
+            .await
+            .expect("no deserialization error should happen")
             .ok_or_else(|| anyhow!("Missing StakeParameters"))
     }
 

--- a/crates/core/component/stake/src/component/validator_handler/validator_store.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_store.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use crate::{
     rate::RateData,
     validator::{State, Validator},
+    DelegationToken,
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -112,6 +113,14 @@ pub trait ValidatorDataRead: StateRead {
         identity_key: &IdentityKey,
     ) -> DomainFuture<Uptime, Self::GetRawFut> {
         self.get(&state_key::validators::uptime::by_id(identity_key))
+    }
+
+    async fn get_validator_pool_size(&self, identity_key: &IdentityKey) -> Option<Amount> {
+        use penumbra_shielded_pool::component::SupplyRead;
+
+        self.token_supply(&DelegationToken::from(identity_key).id())
+            .await
+            .expect("no deserialization error expected")
     }
 
     // Tendermint validators are referenced to us by their Tendermint consensus key,


### PR DESCRIPTION
Close #3853 

This PR:
- removes the `Defined -> Inactive` transition from the delegate action execution
- ensure that the first delegation to a validator pool must be at least `min_validator_stake`
- add a `try_precursor_transition` method to the validator state machine to safely drive transitions in/out of the `Defined` state