### PR TITLE
ci: enable ratelimiting via traefik

### DIFF
--- a/deployments/charts/penumbra-node/values.yaml
+++ b/deployments/charts/penumbra-node/values.yaml
@@ -86,7 +86,8 @@ ingressRoute:
   secretName: ""
   # Traefik middleware CRDs, to be applied to pd's gRPC service.
   # These config objects must already exist in the API, i.e. create them out of band.
-  middlewares: []
+  middlewares:
+    - name: ratelimit-pd
 
 # Whether to place the application in "maintenance mode", effectively stopping pd and cometbft,
 # allowing an administrator to inspect and munge local state, e.g. to perform a chain upgrade.


### PR DESCRIPTION
As a temporary measure, we've added ratelimiting on the gRPC endpoint for pd, via Traefik middleware. We plan to add similar ratelimiting functionality to pd itself, so that solo node operators can benefit from limited DoS protection. For now, we add this so that a subsequent CI deploy (e.g. #3784) doesn't remove the protection that's currently live.