### PR TITLE
mock-consensus: 📵 raise default tracing log level in tests

### DIFF
--- a/crates/core/app/tests/common/mod.rs
+++ b/crates/core/app/tests/common/mod.rs
@@ -17,7 +17,7 @@ use std::ops::Deref;
 pub fn set_tracing_subscriber() -> tracing::subscriber::DefaultGuard {
     use tracing_subscriber::filter::EnvFilter;
 
-    let filter = "debug,penumbra_app=trace,penumbra_mock_consensus=trace";
+    let filter = "info,penumbra_app=trace,penumbra_mock_consensus=trace";
     let filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new(filter))
         .expect("should have a valid filter directive")


### PR DESCRIPTION
debug logs are rather noisy as a default log level. use info for the default level, callers can opt in to higher verbosity with `RUST_LOG`.

cherry-picked from #3866.