### PR TITLE
ci: try restoring testnet-preview deployments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 # Set virtual workspace's resolver to v1, to support the "rust-docs" script.
 resolver = "1"
 
-exclude = ["tools/proto-compiler"]
+exclude = ["tools/proto-compiler", "tools/parameter-setup"]
 
 # Also remember to add to deployments/scripts/rust-docs
 members = [
@@ -50,7 +50,6 @@ members = [
   "crates/misc/tct-visualize",
   "crates/bench",
   "tools/summonerd", "crates/core/component/funding", "crates/core/genesis",
-  "tools/parameter-setup"
 ]
 
 # Config for 'cargo dist'


### PR DESCRIPTION
From looking at the CI history, it seems like deployments have been failing since #3871; this seems like it might be the cause, so I'll try reverting it and seeing if that fixes the problem.