### PR TITLE
Add `PartialOrd`/`Ord` impl for `validator::{State, BondingState}`

### DIFF
--- a/crates/core/component/stake/src/validator/bonding.rs
+++ b/crates/core/component/stake/src/validator/bonding.rs
@@ -1,7 +1,7 @@
 use penumbra_proto::{penumbra::core::component::stake::v1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 #[serde(try_from = "pb::BondingState", into = "pb::BondingState")]
 pub enum State {
     /// The validator is in the active set.

--- a/crates/core/component/stake/src/validator/state.rs
+++ b/crates/core/component/stake/src/validator/state.rs
@@ -3,7 +3,7 @@ use penumbra_proto::{penumbra::core::component::stake::v1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
 /// The state of a validator in the validator state machine.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Serialize, Deserialize)]
 #[serde(try_from = "pb::ValidatorState", into = "pb::ValidatorState")]
 pub enum State {
     /// The validator definition has been published, but the validator stake is below the minimum


### PR DESCRIPTION
This permits them to be used as keys to `BTreeMap`s, which is useful on occasion (like in my present situation, developing an external integration).