### PR TITLE
app: 💸 a mock consensus spend is performed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5263,6 +5263,8 @@ dependencies = [
  "penumbra-sct",
  "penumbra-shielded-pool",
  "penumbra-tct",
+ "penumbra-transaction",
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/crates/core/app/tests/mock_consensus.rs
+++ b/crates/core/app/tests/mock_consensus.rs
@@ -8,15 +8,22 @@ mod common;
 use {
     anyhow::anyhow,
     cnidarium::TempStorage,
+    penumbra_fee::Fee,
     penumbra_keys::test_keys,
     penumbra_mock_client::MockClient,
+    penumbra_mock_consensus::TestNode,
     penumbra_proto::DomainType,
     penumbra_sct::component::clock::EpochRead,
-    penumbra_shielded_pool::SpendPlan,
-    penumbra_transaction::TransactionPlan,
+    penumbra_shielded_pool::{OutputPlan, SpendPlan},
+    penumbra_transaction::{
+        memo::MemoPlaintext,
+        plan::{CluePlan, DetectionDataPlan, MemoPlan},
+        ActionPlan, Transaction, TransactionParameters, TransactionPlan, WitnessData,
+    },
+    rand_core::OsRng,
     std::ops::Deref,
     tap::Tap,
-    tracing::{error_span, Instrument},
+    tracing::{error_span, info, Instrument},
 };
 
 /// Exercises that a test node can be instantiated using the consensus service.
@@ -80,13 +87,13 @@ async fn mock_consensus_can_send_a_spend_action() -> anyhow::Result<()> {
     let guard = common::set_tracing_subscriber();
     let storage = TempStorage::new().await?;
     let mut test_node = common::start_test_node(&storage).await?;
-    let mut rng = <rand_chacha::ChaChaRng as rand_core::SeedableRng>::seed_from_u64(0xBEEF);
 
     // Sync the mock client, using the test account's full viewing key, to the latest snapshot.
     let (viewing_key, spend_key) = (&test_keys::FULL_VIEWING_KEY, &test_keys::SPEND_KEY);
     let client = MockClient::new(viewing_key.deref().clone())
         .with_sync_to_storage(&storage)
-        .await?;
+        .await?
+        .tap(|c| info!(client.notes = %c.notes.len(), "mock client synced to test storage"));
 
     // Take one of the test account's notes...
     let (commitment, note) = client
@@ -94,40 +101,76 @@ async fn mock_consensus_can_send_a_spend_action() -> anyhow::Result<()> {
         .iter()
         .next()
         .ok_or_else(|| anyhow!("mock client had no note"))?
-        .tap(|(commitment, note)| {
-            tracing::info!(?commitment, ?note, "mock client note commitment")
-        });
+        .tap(|(commitment, note)| info!(?commitment, ?note, "mock client note commitment"));
+
+    let spend: ActionPlan = {
+        let proof = client
+            .sct
+            .witness(commitment.clone())
+            .ok_or_else(|| anyhow!("commitment is not witnessed"))?;
+        let note = note.clone();
+        let position = proof.position();
+        SpendPlan::new(&mut OsRng, note, position).into()
+    };
 
     // Build a transaction spending this note.
-    let tx = {
-        let position = client
-            .sct
-            .witness(*commitment)
-            .ok_or_else(|| anyhow!("commitment is not witnessed"))?
-            .position();
-        let spend = SpendPlan::new(&mut rng, note.clone(), position);
-        let plan = TransactionPlan {
-            actions: vec![spend.into()],
-            ..Default::default()
+    let tx: Transaction = {
+        let chain_id = TestNode::<()>::CHAIN_ID.to_string();
+        let transaction_parameters = TransactionParameters {
+            expiry_height: 0,
+            fee: Fee::default(),
+            chain_id,
         };
-        let witness = plan.witness_data(&client.sct)?;
-        let auth = plan.authorize(rand_core::OsRng, spend_key)?;
+        let detection_data = Some(DetectionDataPlan {
+            clue_plans: vec![CluePlan::new(&mut OsRng, *test_keys::ADDRESS_0, 0)],
+        });
+        let plan = TransactionPlan {
+            actions: vec![
+                spend,
+                OutputPlan::new(&mut OsRng, note.value(), *test_keys::ADDRESS_1).into(),
+            ],
+            transaction_parameters,
+            detection_data,
+            memo: Some(MemoPlan::new(
+                &mut OsRng,
+                MemoPlaintext::blank_memo(*test_keys::ADDRESS_1),
+            )?),
+        };
+        let witness = WitnessData {
+            anchor: client.sct.root(),
+            state_commitment_proofs: plan
+                .spend_plans()
+                .map(|spend| {
+                    (
+                        spend.note.commit(),
+                        client.sct.witness(spend.note.commit()).unwrap(),
+                    )
+                })
+                .collect(),
+        };
+        let auth = plan.authorize(OsRng, spend_key)?;
         plan.build_concurrent(viewing_key, &witness, &auth).await?
     };
 
     // Execute the transaction, and sync another mock client up to the latest snapshot.
     test_node
         .block()
-        .with_data(vec![tx.encode_to_vec()]) // TODO(kate): add a `with_tx` extension method
+        .with_data(vec![tx.encode_to_vec()])
         .execute()
         .await?;
 
     // Sync to the latest storage snapshot once more.
-    let client = MockClient::new(test_keys::FULL_VIEWING_KEY.clone())
+    let client_after_spend = MockClient::new(viewing_key.deref().clone())
         .with_sync_to_storage(&storage)
-        .await?;
+        .await?
+        .tap(|c| info!(client.notes = %c.notes.len(), "mock client synced to test storage"));
 
-    client.notes.get(&commitment).unwrap();
+    // Show that we performed the spend as expected.
+    assert_eq!(
+        client_after_spend.notes.len(),
+        client.notes.len() + 1,
+        "a new note should exist after performing the spend",
+    );
 
     // Free our temporary storage.
     drop(storage);

--- a/crates/core/app/tests/spend.rs
+++ b/crates/core/app/tests/spend.rs
@@ -35,7 +35,7 @@ async fn spend_happy_path() -> anyhow::Result<()> {
     let height = 1;
 
     // Precondition: This test uses the default genesis which has existing notes for the test keys.
-    let mut client = MockClient::new(test_keys::FULL_VIEWING_KEY.clone());
+    let mut client = MockClient::new(test_keys::SPEND_KEY.clone());
     let sk = test_keys::SPEND_KEY.clone();
     client.sync_to(0, state.deref()).await?;
     let note = client.notes.values().next().unwrap().clone();
@@ -112,7 +112,7 @@ async fn invalid_dummy_spend() {
     let height = 1;
 
     // Precondition: This test uses the default genesis which has existing notes for the test keys.
-    let mut client = MockClient::new(test_keys::FULL_VIEWING_KEY.clone());
+    let mut client = MockClient::new(test_keys::SPEND_KEY.clone());
     let sk = test_keys::SPEND_KEY.clone();
     client.sync_to(0, state.deref()).await.unwrap();
     let note = client.notes.values().next().unwrap().clone();
@@ -212,7 +212,7 @@ async fn spend_duplicate_nullifier_previous_transaction() {
     let height = 1;
 
     // Precondition: This test uses the default genesis which has existing notes for the test keys.
-    let mut client = MockClient::new(test_keys::FULL_VIEWING_KEY.clone());
+    let mut client = MockClient::new(test_keys::SPEND_KEY.clone());
     let sk = test_keys::SPEND_KEY.clone();
     client
         .sync_to(0, state.deref())
@@ -303,7 +303,7 @@ async fn spend_duplicate_nullifier_same_transaction() {
     let height = 1;
 
     // Precondition: This test uses the default genesis which has existing notes for the test keys.
-    let mut client = MockClient::new(test_keys::FULL_VIEWING_KEY.clone());
+    let mut client = MockClient::new(test_keys::SPEND_KEY.clone());
     let sk = test_keys::SPEND_KEY.clone();
     client
         .sync_to(0, state.deref())

--- a/crates/core/app/tests/swap_and_swap_claim.rs
+++ b/crates/core/app/tests/swap_and_swap_claim.rs
@@ -96,14 +96,14 @@ async fn swap_and_swap_claim() -> anyhow::Result<()> {
     // means we have to synchronize a client's view of the test chain's SCT
     // state.
     let epoch_duration = state.get_epoch_duration_parameter().await?;
-    let mut client = MockClient::new(test_keys::FULL_VIEWING_KEY.clone());
+    let mut client = MockClient::new(test_keys::SPEND_KEY.clone());
     // TODO: generalize StateRead/StateWrite impls from impl for &S to impl for Deref<Target=S>
     client.sync_to(1, state.deref()).await?;
 
     let output_data = state.output_data(height, trading_pair).await?.unwrap();
 
     let commitment = swap.body.payload.commitment;
-    let swap_auth_path = client.witness(commitment).unwrap();
+    let swap_auth_path = client.witness_commitment(commitment).unwrap();
     let detected_plaintext = client.swap_by_commitment(&commitment).unwrap();
     assert_eq!(plaintext, detected_plaintext);
 
@@ -207,7 +207,7 @@ async fn swap_claim_duplicate_nullifier_previous_transaction() {
 
     // 6. Create a SwapClaim action
     let epoch_duration = state.get_epoch_duration_parameter().await.unwrap();
-    let mut client = MockClient::new(test_keys::FULL_VIEWING_KEY.clone());
+    let mut client = MockClient::new(test_keys::SPEND_KEY.clone());
     client.sync_to(1, state.deref()).await.unwrap();
 
     let output_data = state
@@ -217,7 +217,7 @@ async fn swap_claim_duplicate_nullifier_previous_transaction() {
         .unwrap();
 
     let commitment = swap.body.payload.commitment;
-    let swap_auth_path = client.witness(commitment).unwrap();
+    let swap_auth_path = client.witness_commitment(commitment).unwrap();
     let detected_plaintext = client.swap_by_commitment(&commitment).unwrap();
     assert_eq!(plaintext, detected_plaintext);
 

--- a/crates/core/transaction/src/memo.rs
+++ b/crates/core/transaction/src/memo.rs
@@ -103,9 +103,9 @@ impl MemoPlaintext {
         self.into()
     }
 
-    pub fn blank_memo(address: Address) -> MemoPlaintext {
+    pub fn blank_memo(return_address: Address) -> MemoPlaintext {
         MemoPlaintext {
-            return_address: address,
+            return_address,
             text: String::new(),
         }
     }

--- a/crates/test/mock-client/Cargo.toml
+++ b/crates/test/mock-client/Cargo.toml
@@ -18,3 +18,6 @@ penumbra-shielded-pool = {workspace = true, features = [
     "component",
 ], default-features = true}
 penumbra-tct = {workspace = true, default-features = true}
+penumbra-transaction = {workspace = true, default-features = true}
+rand_core = {workspace = true}
+

--- a/crates/test/mock-client/src/lib.rs
+++ b/crates/test/mock-client/src/lib.rs
@@ -1,15 +1,19 @@
+use anyhow::Error;
 use cnidarium::StateRead;
 use penumbra_compact_block::{component::StateReadExt as _, CompactBlock, StatePayload};
 use penumbra_dex::swap::SwapPlaintext;
-use penumbra_keys::FullViewingKey;
+use penumbra_keys::{keys::SpendKey, FullViewingKey};
 use penumbra_sct::component::{clock::EpochRead, tree::SctRead};
 use penumbra_shielded_pool::{note, Note};
 use penumbra_tct as tct;
+use penumbra_transaction::{AuthorizationData, Transaction, TransactionPlan, WitnessData};
+use rand_core::OsRng;
 use std::collections::BTreeMap;
 
 /// A bare-bones mock client for use exercising the state machine.
 pub struct MockClient {
     latest_height: u64,
+    sk: SpendKey,
     pub fvk: FullViewingKey,
     pub notes: BTreeMap<note::StateCommitment, Note>,
     swaps: BTreeMap<tct::StateCommitment, SwapPlaintext>,
@@ -17,10 +21,11 @@ pub struct MockClient {
 }
 
 impl MockClient {
-    pub fn new(fvk: FullViewingKey) -> MockClient {
+    pub fn new(sk: SpendKey) -> MockClient {
         Self {
             latest_height: u64::MAX,
-            fvk,
+            fvk: sk.full_viewing_key().clone(),
+            sk,
             notes: Default::default(),
             sct: Default::default(),
             swaps: Default::default(),
@@ -32,11 +37,15 @@ impl MockClient {
         storage: impl AsRef<cnidarium::Storage>,
     ) -> anyhow::Result<Self> {
         let latest = storage.as_ref().latest_snapshot();
-        let height = latest.get_block_height().await?;
-        let state = cnidarium::StateDelta::new(latest);
-        self.sync_to(height, state).await?;
+        self.sync_to_latest(latest).await?;
 
         Ok(self)
+    }
+
+    pub async fn sync_to_latest<R: StateRead>(&mut self, state: R) -> anyhow::Result<()> {
+        let height = state.get_block_height().await?;
+        self.sync_to(height, state).await?;
+        Ok(())
     }
 
     pub async fn sync_to<R: StateRead>(
@@ -44,7 +53,8 @@ impl MockClient {
         target_height: u64,
         state: R,
     ) -> anyhow::Result<()> {
-        for height in 0..=target_height {
+        let start_height = self.latest_height.wrapping_add(1);
+        for height in start_height..=target_height {
             let compact_block = state
                 .compact_block(height)
                 .await?
@@ -149,7 +159,45 @@ impl MockClient {
         self.swaps.get(commitment).cloned()
     }
 
-    pub fn witness(&self, commitment: note::StateCommitment) -> Option<penumbra_tct::Proof> {
+    pub fn position(&self, commitment: note::StateCommitment) -> Option<penumbra_tct::Position> {
+        self.sct.witness(commitment).map(|proof| proof.position())
+    }
+
+    pub fn witness_commitment(
+        &self,
+        commitment: note::StateCommitment,
+    ) -> Option<penumbra_tct::Proof> {
         self.sct.witness(commitment)
+    }
+
+    pub fn witness_plan(&self, plan: &TransactionPlan) -> Result<WitnessData, Error> {
+        Ok(WitnessData {
+            anchor: self.sct.root(),
+            // TODO: this will only witness spends, not other proofs like swaps
+            state_commitment_proofs: plan
+                .spend_plans()
+                .map(|spend| {
+                    let nc = spend.note.commit();
+                    Ok((
+                        nc,
+                        self.sct.witness(nc).ok_or_else(|| {
+                            anyhow::anyhow!("note commitment {:?} unknown to client", nc)
+                        })?,
+                    ))
+                })
+                .collect::<Result<_, Error>>()?,
+        })
+    }
+
+    pub fn authorize_plan(&self, plan: &TransactionPlan) -> Result<AuthorizationData, Error> {
+        plan.authorize(OsRng, &self.sk)
+    }
+
+    pub async fn witness_auth_build(&self, plan: &TransactionPlan) -> Result<Transaction, Error> {
+        let witness_data = self.witness_plan(plan)?;
+        let auth_data = self.authorize_plan(plan)?;
+        plan.clone()
+            .build_concurrent(&self.fvk, &witness_data, &auth_data)
+            .await
     }
 }

--- a/crates/test/mock-consensus/src/builder/init_chain.rs
+++ b/crates/test/mock-consensus/src/builder/init_chain.rs
@@ -67,10 +67,11 @@ impl Builder {
 
     fn init_chain_request(app_state_bytes: Bytes) -> Result<ConsensusRequest, anyhow::Error> {
         use tendermint::v0_37::abci::request::InitChain;
+        let chain_id = TestNode::<()>::CHAIN_ID.to_string();
         let consensus_params = Self::consensus_params();
         Ok(ConsensusRequest::InitChain(InitChain {
             time: tendermint::Time::now(),
-            chain_id: "test".to_string(), // XXX const here?
+            chain_id,
             consensus_params,
             validators: vec![],
             app_state_bytes,

--- a/crates/test/mock-consensus/src/lib.rs
+++ b/crates/test/mock-consensus/src/lib.rs
@@ -25,6 +25,8 @@ pub struct TestNode<C> {
 }
 
 impl<C> TestNode<C> {
+    pub const CHAIN_ID: &'static str = "penumbra-test-chain";
+
     /// Returns the last app_hash value, as a slice of bytes.
     pub fn last_app_hash(&self) -> &[u8] {
         &self.last_app_hash


### PR DESCRIPTION
fixes #3788.

this branch builds upon the work in #3857 and #3866, filling out the remaining holes in the transaction plan. this now performs a spend, using the mock consensus engine.