### PR TITLE
app: 🤠 address warning

### DIFF
--- a/crates/core/app/tests/spend.rs
+++ b/crates/core/app/tests/spend.rs
@@ -96,7 +96,7 @@ async fn spend_happy_path() -> anyhow::Result<()> {
 #[tokio::test]
 #[cfg_attr(
     debug_assertions,
-    should_panic("assertion failed: cs.is_satisfied().unwrap()")
+    should_panic = "assertion failed: cs.is_satisfied().unwrap()"
 )]
 async fn invalid_dummy_spend() {
     let mut rng = rand_chacha::ChaChaRng::seed_from_u64(1312);


### PR DESCRIPTION
addresses this compiler warning:

```
warning: argument must be of the form: `expected = "error message"`
  --> crates/core/app/tests/spend.rs:97:1
   |
97 | #[cfg_attr(
   | ^
   |
   = note: errors in this attribute were erroneously allowed and will become a hard error in a future release
```