### PR TITLE
Add intra-transaction duplicate position-id check

### DIFF
--- a/crates/core/component/dex/src/component/action_handler/position/open.rs
+++ b/crates/core/component/dex/src/component/action_handler/position/open.rs
@@ -32,14 +32,13 @@ impl ActionHandler for PositionOpen {
         Ok(())
     }
 
-    async fn check_stateful<S: StateRead + 'static>(&self, state: Arc<S>) -> Result<()> {
-        // Validate that the position ID doesn't collide
-        state.check_position_id_unused(&self.position.id()).await?;
-
+    async fn check_stateful<S: StateRead + 'static>(&self, _state: Arc<S>) -> Result<()> {
         Ok(())
     }
 
     async fn execute<S: StateWrite>(&self, mut state: S) -> Result<()> {
+        // Validate that the position ID doesn't collide
+        state.check_position_id_unused(&self.position.id()).await?;
         state.put_position(self.position.clone()).await?;
         state.record_proto(event::position_open(self));
         Ok(())

--- a/crates/core/component/dex/src/component/action_handler/position/open.rs
+++ b/crates/core/component/dex/src/component/action_handler/position/open.rs
@@ -9,7 +9,7 @@ use penumbra_proto::StateWriteProto as _;
 use crate::{
     component::{PositionManager, PositionRead},
     event,
-    lp::action::PositionOpen,
+    lp::{action::PositionOpen, position},
 };
 
 #[async_trait]
@@ -26,6 +26,9 @@ impl ActionHandler for PositionOpen {
         //  + the trading function doesn't specify a cyclic pair,
         //  + the fee is <=50%.
         self.position.check_stateless()?;
+        if self.position.state != position::State::Opened {
+            anyhow::bail!("attempted to open a position with a state besides `Opened`");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Closes #3855.

Also adds an extra sanity check that opened positions are in the `Opened` state.