### PR TITLE
keys: 🍴 `SpendKeyBytes: From<[u8; SPENDKEY_LEN_BYTES]>`

### DIFF
--- a/crates/core/keys/src/keys/spend.rs
+++ b/crates/core/keys/src/keys/spend.rs
@@ -152,6 +152,12 @@ impl SpendKey {
     }
 }
 
+impl From<[u8; SPENDKEY_LEN_BYTES]> for SpendKeyBytes {
+    fn from(bytes: [u8; SPENDKEY_LEN_BYTES]) -> Self {
+        Self(bytes)
+    }
+}
+
 impl TryFrom<&[u8]> for SpendKeyBytes {
     type Error = anyhow::Error;
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {


### PR DESCRIPTION
this saves us a needless length check if we already have an array in-hand.

this would be useful for my work in #3902. (x-ref #3816)