### PR TITLE
stake: fix missing index and simplify state machine

### DIFF
--- a/crates/core/component/stake/src/component/epoch_handler.rs
+++ b/crates/core/component/stake/src/component/epoch_handler.rs
@@ -363,6 +363,7 @@ pub trait EpochHandler: StateWriteExt + ConsensusIndexRead {
         Ok(reward_queue_entry)
     }
 
+    /// Compute and return the chain base rate ("L1BOR").
     async fn process_chain_base_rate(&mut self) -> Result<BaseRateData> {
         // We are transitioning to the next epoch, so the "current" base rate in
         // the state is now the previous base rate.

--- a/crates/core/component/stake/src/component/stake.rs
+++ b/crates/core/component/stake/src/component/stake.rs
@@ -497,7 +497,9 @@ pub trait ConsensusIndexRead: StateRead {
             .boxed())
     }
 
-    /// Returns whether the given validator should be indexed in the consensus set.
+    /// Returns whether a validator should be indexed in the consensus set.
+    /// Here, "consensus set" refers to the set of active validators as well as
+    /// the "inactive" validators which could be promoted during a view change.
     #[instrument(level = "error", skip(self))]
     async fn belongs_in_index(&self, validator_id: &IdentityKey) -> bool {
         let Some(state) = self

--- a/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
@@ -235,10 +235,13 @@ pub trait ValidatorManager: StateWrite {
                 tracing::debug!(penalty, unbonds_at_epoch, "jailed validator");
             }
             (Defined | Disabled | Inactive | Active | Jailed, Tombstoned) => {
-                // We have processed evidence of byzantine behavior for this validator.
-                // It will be terminated, its delegation pool slashed and unbonded.
-                // The epoch-handler is responsible for removing it from the consensus
-                // set index.
+                // When we detect byzantine misbehavior from a validator, we:
+                // 1. Record the maximum slashing penalty for the corresponding pool
+                // 2. Immediately unbond its delegation pool
+                // 3. Forbid new delegations
+                //
+                // Later, during end-epoch processing, we remove the validator from the
+                // consensus set index.
                 let misbehavior_penalty =
                     self.get_stake_params().await?.slashing_penalty_misbehavior;
 


### PR DESCRIPTION
This PR:
- fix a bug that would cause unjailed validators to not be re-added to the consensus index
- simplify the validator state machine, and in particular:
    - move the state effect outside of the `match` implementation
    - unify valid, but no-op, branches (e.g. `Disabled <> Defined`)
    - improve and elaborate comments