### PR TITLE
refactor(workspace dependency): add feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ penumbra-keys                    = { default-features = false, path = "crates/co
 penumbra-mock-client             = { path = "crates/test/mock-client" }
 penumbra-mock-consensus          = { path = "crates/test/mock-consensus" }
 penumbra-num                     = { default-features = false, path = "crates/core/num" }
-penumbra-proof-params            = { default-features = false, path = "crates/crypto/proof-params" }
+penumbra-proof-params            = { default-features = false, path = "crates/crypto/proof-params", features = ["download-proving-keys"] }
 penumbra-proof-setup             = { path = "crates/crypto/proof-setup" }
 penumbra-proto                   = { default-features = false, path = "crates/proto" }
 penumbra-sct                     = { default-features = false, path = "crates/core/component/sct" }


### PR DESCRIPTION
missing feature resulted in failing to call [try_load](https://github.com/penumbra-zone/penumbra/blob/katie/cometstub/crates/crypto/proof-params/src/lib.rs#L55) before attempting to dereference the keys, causing some test failures.