### PR TITLE
dex: disable limit orders

### DIFF
--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -145,7 +145,10 @@ pub trait PositionManager: StateWrite + PositionRead {
         // reserves or the position state might have invalidated them.
         self.deindex_position_by_price(&position);
 
-        let position = self.handle_limit_order(&prev, position);
+        // currently, we are disabling limit orders due to the complexity involved in managing
+        // limit orders in the dex state machine (see
+        // https://github.com/penumbra-zone/penumbra/issues/3850#issuecomment-1977300433)
+        // let position = self.handle_limit_order(&prev, position);
 
         // Only index the position's liquidity if it is active.
         if position.state == position::State::Opened {

--- a/crates/core/component/dex/src/lp/position.rs
+++ b/crates/core/component/dex/src/lp/position.rs
@@ -32,8 +32,8 @@ pub struct Position {
     /// duplicate position [`Id`]s, so it can track position ownership with a
     /// sequence of stateful NFTs based on the [`Id`].
     pub nonce: [u8; 32],
-    /// Set to `true` if a position is a limit-order, meaning that it will be closed
-    /// after being filled against.
+    /// Set to `true` if a position is a limit-order, meaning that it will be closed after being
+    /// filled against. Note that this is not currently supported in the dex state machine.
     pub close_on_fill: bool,
 }
 


### PR DESCRIPTION
Per the discussion in #3850, this PR removes the handling of limit orders in the dex, which cuts scope and removes the specific issue found by Zellic.