### PR TITLE
pd: 📦 add a tracing event with cargo version

### DIFF
--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -66,6 +66,7 @@ async fn main() -> anyhow::Result<()> {
         registry.init();
     }
 
+    tracing::info!(?cmd, version = env!("CARGO_PKG_VERSION"), "running command");
     match cmd {
         RootCommand::Start {
             home,


### PR DESCRIPTION
this adds a small tracing event including the version of pd that is running, before proceeding to handle the CLI command.

this should help operators identify when they are running a stale version of pd.