### PR TITLE
ibc: show client expiry status in channel query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,6 +4462,7 @@ dependencies = [
  "simple-base64",
  "tempfile",
  "tendermint",
+ "time 0.3.34",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.10",

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -45,6 +45,7 @@ comfy-table = "5"
 decaf377 = {workspace = true, default-features = true}
 decaf377-rdsa = {workspace = true}
 dialoguer = "0.10.4"
+time = "0.3"
 directories = {workspace = true}
 ed25519-consensus = {workspace = true}
 futures = {workspace = true}


### PR DESCRIPTION
Improves `ibc q channel(s)` so that it will show the status as 'CLIENT EXPIRED' if the underlying client for a channel has expired.