### PR TITLE
docs: update deimos ibc channel for osmosis

### DIFF
--- a/docs/guide/book.toml
+++ b/docs/guide/book.toml
@@ -24,3 +24,6 @@ additional-js =["theme/js/mermaid.min.js", "theme/js/mermaid-init.js"]
 # [output.linkcheck]
 # follow-web-links = false
 # warning-policy = "ignore"
+#
+# The buf.build website doesn't support HTTP HEAD calls, returning 405.
+# exclude = ['buf\.build']

--- a/docs/guide/src/pcli/transaction.md
+++ b/docs/guide/src/pcli/transaction.md
@@ -181,44 +181,33 @@ has been configured between the Osmosis testnet and the *current* Penumbra testn
 
 Penumbra aims to implement full IBC support for cross-chain asset transfers. For now, however,
 we're only running a relayer between the Penumbra testnet and the [Osmosis testnet] chains.
-For Testnet 64 Titan, the channel information is:
+For Testnet 69 Deimos, the channel is `0`:
 
 <!--
 To update the information below, update the Hermes config, then run:
-`pcli q ibc channels | jq '.[0]'` and confirm that output matches what Hermes emitted
+`pcli q ibc channels` and confirm that output matches what Hermes emitted
 during setup.
 -->
 
 ```
-{
-  "state": 3,
-  "ordering": 1,
-  "counterparty": {
-    "port_id": "transfer",
-    "channel_id": "channel-5077"
-  },
-  "connection_hops": [
-    "connection-6"
-  ],
-  "version": "ics20-1",
-  "port_id": "transfer",
-  "channel_id": "channel-2"
-}
++------------+----------+--------------+-------------------------+-------+-----------------+---------------+
+| Channel ID | Port     | Counterparty | Counterparty Channel ID | State | Client ID       | Client Height |
++==========================================================================================================+
+| 0          | transfer | osmo-test-5  | channel-6105            | OPEN  | 07-tendermint-4 | 5-5937586     |
++------------+----------+--------------+-------------------------+-------+-----------------+---------------+
 ```
 
-The output above shows that the IBC channel id on Penumbra is 2, and on Osmosis it's 5077.
-There's one more piece of information we need to make an IBC withdrawal: the appropriate IBC
-timeout height, which is composed of two values: `<counterparty_chain_id_revision>-<counterparty_chain_block_height>`.
-For the Osmosis testnet, as of 2023Q4, the chain id is `osmo-test-5`, meaning the chain id revision is `5`.
-So a value like `5-5000000` (i.e. revision 5 at height 5 million) will work.
+You can see this yourself by running `pcli query ibc channels` and comparing the output you see
+with what's shown above. It's possible the output will include mention of other chains.
 
+The output above shows that the IBC channel id on Penumbra is 0, and on Osmosis it's 6105.
 To initiate an IBC withdrawal from Penumbra testnet to Osmosis testnet:
 
 ```bash
-pcli tx withdraw --to <OSMOSIS_ADDRESS> --channel <CHANNEL_ID> 5gm --timeout-height 5-5000000
+pcli tx withdraw --to <OSMOSIS_ADDRESS> --channel <CHANNEL_ID> 5gm
 ```
 
-Unfortunately the CLI tooling for Osmosis is cumbersome. For now, use `rly` as a user agent
+Unfortunately the CLI tooling for Osmosis is cumbersome. For now, use `hermes` as a user agent
 for the Osmosis testnet, as described in the [IBC dev docs](../dev/ibc.md).
 
 [Osmosis testnet]: https://docs.osmosis.zone/overview/endpoints#testnet-networks


### PR DESCRIPTION
We had a few chain halts on the `v0.68.x` release series. As of `v0.69.0`, "channel-0" is the correct value for relaying to Osmosis testnet. Added mention of the slick new `pcli query ibc channels` to the docs.

Also overhauled the dev docs for how to test IBC functionality interactively, since that knowledge has mostly been communicated via pairing session, but not yet fully written down. We no longer use `rly`, neither for running relayer instances nor for ad-hoc CLI transfers.  Instead, we can use `hermes` for both roles.

Linked out to wiki docs on the high-churn hermes relayer config steps, since we're updating those frequently. Therefore review should also include eyes on https://github.com/penumbra-zone/penumbra/wiki/Updating-Hermes