### PR TITLE
add compat addresses that use bech32 (non-m) for compatibility with noble IBC

### DIFF
--- a/crates/bin/pcli/src/command/view/address.rs
+++ b/crates/bin/pcli/src/command/view/address.rs
@@ -15,6 +15,9 @@ pub struct AddressCmd {
     /// Output in base64 format, instead of the default bech32.
     #[clap(long)]
     base64: bool,
+    /// Use compat (bech32, not bech32m) address encoding, for compatibility with some IBC chains.
+    #[clap(long)]
+    compat: bool,
 }
 
 impl AddressCmd {
@@ -39,6 +42,8 @@ impl AddressCmd {
                     "{}",
                     base64::engine::general_purpose::STANDARD.encode(address.to_vec()),
                 );
+            } else if self.compat {
+                println!("{}", address.compat_encoding());
             } else {
                 println!("{}", address);
             };

--- a/crates/core/keys/src/address.rs
+++ b/crates/core/keys/src/address.rs
@@ -331,6 +331,27 @@ mod tests {
     }
 
     #[test]
+    fn test_compat_encoding() {
+        let rng = OsRng;
+        let seed_phrase = SeedPhrase::generate(rng);
+        let sk = SpendKey::from_seed_phrase_bip44(seed_phrase, &Bip44Path::new(0));
+        let fvk = sk.full_viewing_key();
+        let ivk = fvk.incoming();
+        let (dest, _dtk_d) = ivk.payment_address(0u32.into());
+
+        let bech32_addr = dest.compat_encoding();
+
+        let addr = Address::from_str(&bech32_addr).expect("can decode valid address");
+
+        let proto_addr = dest.encode_to_vec();
+
+        let addr2 = Address::decode(proto_addr.as_ref()).expect("can decode valid address");
+
+        assert_eq!(addr, dest);
+        assert_eq!(addr2, dest);
+    }
+
+    #[test]
     fn test_bytes_roundtrip() {
         let rng = OsRng;
         let seed_phrase = SeedPhrase::generate(rng);

--- a/crates/proto/src/serializers/bech32str.rs
+++ b/crates/proto/src/serializers/bech32str.rs
@@ -139,6 +139,28 @@ pub mod address {
     }
 }
 
+pub mod compat_address {
+    use super::*;
+
+    /// The Bech32 prefix used for compat addresses (Bech32, not Bech32m, addresses).
+    pub const BECH32_PREFIX: &str = "penumbracompat1";
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_bech32(deserializer, BECH32_PREFIX, Variant::Bech32)
+    }
+
+    pub fn serialize<S, T>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: AsRef<[u8]>,
+    {
+        serialize_bech32(value, serializer, BECH32_PREFIX, Variant::Bech32)
+    }
+}
+
 pub mod asset_id {
     use super::*;
 


### PR DESCRIPTION
Bech32 (non-m) encoded addresses are the standard in the broader cosmos ecosystem. [Noble requires that withdrawal addresses be encoded as bech32](https://github.com/noble-assets/noble/blob/757b3111d15ef2ee8640639af60edef1b7712c6d/app/ante.go#L155), and attempting to transfer to a bech32m address (such as a penumbra address) results in a decoding error. This issue is acknowledged by the broader ecosystem. In the mean time, we can fix this on our end and enable testing with Noble or other similarly constrained cosmos chains by introducing a 'compat' address encoding `penumbracompat1`, that uses Bech32(non-m). 

This PR adds the compat encoding, adds a pcli flag to `view address` to allow you to see it, and changes the FromStr impl for address to detect and use the compat encoding.