### PR TITLE
view: 🌯 remove frivolous `Option::expect` call

### DIFF
--- a/crates/view/src/storage.rs
+++ b/crates/view/src/storage.rs
@@ -82,12 +82,7 @@ impl Storage {
     ) -> anyhow::Result<Self> {
         if let Some(path) = storage_path.as_ref() {
             if path.as_ref().exists() {
-                return Self::load(
-                    storage_path.expect(
-                        "storage path is not `None` because we already matched on it above",
-                    ),
-                )
-                .await;
+                return Self::load(path).await;
             }
         };
 


### PR DESCRIPTION
here, we are within an `if let Some(_)` clause that has already bound the contents of the storage path. so, let's just pass that to `Self::load` instead of unwrapping it again.