### PR TITLE
tests(pcli): 🔇 make large tracing event trace-level

### DIFF
--- a/crates/bin/pcli/tests/network_integration.rs
+++ b/crates/bin/pcli/tests/network_integration.rs
@@ -323,8 +323,7 @@ fn delegate_and_undelegate() {
             .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS));
         let undelegation_result = undelegate_cmd.assert().try_success();
 
-        tracing::debug!("undelegation done - output");
-        tracing::trace!(?undelegation_result);
+        tracing::debug!("undelegation done");
         // If the undelegation command succeeded, we can exit this loop.
         if undelegation_result.is_ok() {
             break;

--- a/crates/bin/pcli/tests/network_integration.rs
+++ b/crates/bin/pcli/tests/network_integration.rs
@@ -323,18 +323,14 @@ fn delegate_and_undelegate() {
             .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS));
         let undelegation_result = undelegate_cmd.assert().try_success();
 
-        tracing::debug!(?undelegation_result, "undelegation done - output");
+        tracing::debug!("undelegation done - output");
+        tracing::trace!(?undelegation_result);
         // If the undelegation command succeeded, we can exit this loop.
         if undelegation_result.is_ok() {
             break;
         } else {
             num_attempts += 1;
-            tracing::info!(
-                ?undelegation_result,
-                num_attempts,
-                max_attempts,
-                "undelegation failed"
-            );
+            tracing::info!(num_attempts, max_attempts, "undelegation failed");
             if num_attempts >= max_attempts {
                 panic!("Exceeded max attempts for fallible command");
             }


### PR DESCRIPTION
there are two issues at hand:
- we log `undelegation_result` twice
- `undelegation_result` can be many thousands of lines long

this means that the `delegate_and_undelegate` pcli network integration test thrashes the test output somewhat severely, and test logs aren't fully viewable in e.g. tmux, when running this locally.

https://github.com/penumbra-zone/penumbra/actions/runs/8210700115/job/22458602964#step:11:18

as of `main` at the time of writing, this CI job logs an event that is...

```
; xclip -o -selection clipboard | wc --bytes
243775
```

243Kb is disruptively long. (_let alone 486Kb!_)

so, let's make this field an opt-in field to display. we only log it once, and do so at the trace level.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label.
