### PR TITLE
mock-consensus: 🍐 clarify builder kind in error

### DIFF
--- a/crates/test/mock-consensus/src/block.rs
+++ b/crates/test/mock-consensus/src/block.rs
@@ -117,7 +117,7 @@ where
             test_node,
         } = self
         else {
-            bail!("builder was not fully initialized")
+            bail!("block builder was not fully initialized")
         };
 
         let height = {


### PR DESCRIPTION
there is a test node builder and a block builder. let's clarify which builder we mean in our error message. cherry-picked out of #4001.