### PR TITLE
mock-consensus: 👷 block data is implicitly empty, can be appended

### DIFF
--- a/crates/test/mock-consensus/src/block.rs
+++ b/crates/test/mock-consensus/src/block.rs
@@ -49,6 +49,12 @@ impl<'e, C> Builder<'e, C> {
         Self { data, ..self }
     }
 
+    /// Appends the given tx to this block's data.
+    pub fn add_tx(mut self, tx: Vec<u8>) -> Self {
+        self.data.push(tx);
+        self
+    }
+
     /// Sets the evidence [`List`][evidence::List] for this block.
     pub fn with_evidence(self, evidence: evidence::List) -> Self {
         Self { evidence, ..self }

--- a/crates/test/mock-consensus/src/block.rs
+++ b/crates/test/mock-consensus/src/block.rs
@@ -4,7 +4,6 @@
 
 use {
     crate::TestNode,
-    anyhow::bail,
     tap::Tap,
     tendermint::{
         account,
@@ -25,7 +24,7 @@ pub struct Builder<'e, C> {
     test_node: &'e mut TestNode<C>,
 
     /// Transaction data.
-    data: Option<Vec<Vec<u8>>>,
+    data: Vec<Vec<u8>>,
 
     /// Evidence of malfeasance.
     evidence: evidence::List,
@@ -47,10 +46,7 @@ impl<C> TestNode<C> {
 impl<'e, C> Builder<'e, C> {
     /// Sets the data for this block.
     pub fn with_data(self, data: Vec<Vec<u8>>) -> Self {
-        Self {
-            data: Some(data),
-            ..self
-        }
+        Self { data, ..self }
     }
 
     /// Sets the evidence [`List`][evidence::List] for this block.
@@ -112,13 +108,10 @@ where
     fn finish(self) -> Result<(&'e mut TestNode<C>, Block), anyhow::Error> {
         tracing::trace!("building block");
         let Self {
-            data: Some(data),
+            data,
             evidence,
             test_node,
-        } = self
-        else {
-            bail!("builder was not fully initialized")
-        };
+        } = self;
 
         let height = {
             let height = test_node.height.increment();

--- a/crates/test/mock-consensus/src/lib.rs
+++ b/crates/test/mock-consensus/src/lib.rs
@@ -69,7 +69,6 @@ where
 
         for i in 0..blocks {
             self.block()
-                .with_data(vec![])
                 .execute()
                 .tap(|_| trace!(%i, "executing empty block"))
                 .await


### PR DESCRIPTION
fixes #3936. based upon #4002. see #3588.

this changes the type of the block builder's `data`, allowing it to be implicitly kept empty. this is useful when e.g. fast forwarding a number of blocks _(see #4002)_. this spares us the need to call `with_data(vec![])`, and additionally means that the block builder is never in an uninitialized state _(making #4003 needless)._

* #3936
* #4002
* #3588