### PR TITLE
refactor(staking): 😊 tracing telemetry for delegation changes

### DIFF
--- a/crates/core/component/stake/src/component/stake.rs
+++ b/crates/core/component/stake/src/component/stake.rs
@@ -461,11 +461,19 @@ pub trait RateDataWrite: StateWrite {
         );
     }
 
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(
+            %height,
+            delegations = ?changes.delegations,
+            undelegations = ?changes.undelegations,
+        )
+    )]
     async fn set_delegation_changes(&mut self, height: block::Height, changes: DelegationChanges) {
-        self.put(
-            state_key::chain::delegation_changes::by_height(height.value()),
-            changes,
-        );
+        let key = state_key::chain::delegation_changes::by_height(height.value());
+        tracing::trace!(%key, "setting delegation changes");
+        self.put(key, changes);
     }
 }
 

--- a/crates/core/component/stake/src/component/stake.rs
+++ b/crates/core/component/stake/src/component/stake.rs
@@ -140,15 +140,12 @@ impl Component for Staking {
     ) {
         let state = Arc::get_mut(state).expect("state should be unique");
         // Write the delegation changes for this block.
-        state
-            .set_delegation_changes(
-                end_block
-                    .height
-                    .try_into()
-                    .expect("should be able to convert i64 into block height"),
-                state.get_delegation_changes_tally().clone(),
-            )
-            .await;
+        let height = end_block
+            .height
+            .try_into()
+            .expect("should be able to convert i64 into block height");
+        let changes = state.get_delegation_changes_tally().clone();
+        state.set_delegation_changes(height, changes).await;
     }
 
     #[instrument(name = "staking", skip(state))]

--- a/crates/core/component/stake/src/component/stake.rs
+++ b/crates/core/component/stake/src/component/stake.rs
@@ -133,18 +133,19 @@ impl Component for Staking {
             .expect("should be able to track uptime");
     }
 
+    /// Writes the delegation changes for this block.
     #[instrument(name = "staking", skip(state, end_block))]
     async fn end_block<S: StateWrite + 'static>(
         state: &mut Arc<S>,
         end_block: &abci::request::EndBlock,
     ) {
         let state = Arc::get_mut(state).expect("state should be unique");
-        // Write the delegation changes for this block.
         let height = end_block
             .height
             .try_into()
             .expect("should be able to convert i64 into block height");
         let changes = state.get_delegation_changes_tally();
+
         state.set_delegation_changes(height, changes).await;
     }
 

--- a/crates/core/component/stake/src/component/stake.rs
+++ b/crates/core/component/stake/src/component/stake.rs
@@ -144,7 +144,7 @@ impl Component for Staking {
             .height
             .try_into()
             .expect("should be able to convert i64 into block height");
-        let changes = state.get_delegation_changes_tally().clone();
+        let changes = state.get_delegation_changes_tally();
         state.set_delegation_changes(height, changes).await;
     }
 


### PR DESCRIPTION
this makes some small logging additions to the staking component. delegation changes will be logged at the trace level.