### PR TITLE
ci: bump cometbft v0.37.2 -> v0.37.5

### DIFF
--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -172,9 +172,9 @@ impl App {
         //   the target, presuming that some transactions might be yanked.
         // For more details, see the specification:
         // - Adapting existing applications to use ABCI+:
-        //  https://github.com/cometbft/cometbft/blob/v0.37.2/spec/abci/abci%2B%2B_comet_expected_behavior.md#adapting-existing-applications-that-use-abci
+        //  https://github.com/cometbft/cometbft/blob/v0.37.5/spec/abci/abci%2B%2B_comet_expected_behavior.md#adapting-existing-applications-that-use-abci
         // - Application requirements:
-        // https://github.com/cometbft/cometbft/blob/v0.37.2/spec/abci/abci%2B%2B_app_requirements
+        // https://github.com/cometbft/cometbft/blob/v0.37.5/spec/abci/abci%2B%2B_app_requirements
         for tx in proposal.txs {
             let tx_len_bytes = tx.len() as u64;
             proposal_size_bytes = proposal_size_bytes.saturating_add(tx_len_bytes);

--- a/deployments/charts/penumbra-network/values.yaml
+++ b/deployments/charts/penumbra-network/values.yaml
@@ -92,7 +92,7 @@ cometbft:
     repository: cometbft/cometbft
     pullPolicy: IfNotPresent
     # https://github.com/cometbft/cometbft#supported-versions
-    tag: "v0.37.2"
+    tag: "v0.37.5"
   containerArgs:
     - start
     - --proxy_app=tcp://127.0.0.1:26658

--- a/deployments/charts/penumbra-node/values.yaml
+++ b/deployments/charts/penumbra-node/values.yaml
@@ -38,7 +38,7 @@ cometbft:
     repository: cometbft/cometbft
     pullPolicy: IfNotPresent
     # https://github.com/cometbft/cometbft#supported-versions
-    tag: "v0.37.2"
+    tag: "v0.37.5"
   # Override sections of the CometBFT config. Applies to all nodes.
   config:
     p2p:

--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -55,7 +55,7 @@ services:
 
   # The CometBFT node
   cometbft-node0:
-    image: "docker.io/cometbft/cometbft:v0.37.2"
+    image: "docker.io/cometbft/cometbft:v0.37.5"
     ports:
       - "26656:26656"
       - "26657:26657"

--- a/deployments/scripts/install-cometbft
+++ b/deployments/scripts/install-cometbft
@@ -5,7 +5,7 @@ set -euo pipefail
 
 
 # Sane defaults
-COMETBFT_VERSION="${COMETBFT_VERSION:-0.37.2}"
+COMETBFT_VERSION="${COMETBFT_VERSION:-0.37.5}"
 
 # Download and extract
 cometbft_download_url="https://github.com/cometbft/cometbft/releases/download/v${COMETBFT_VERSION}/cometbft_${COMETBFT_VERSION}_linux_amd64.tar.gz"


### PR DESCRIPTION
Increments the minor version of CometBFT used in deployments. This commit changes the CometBFT version everywhere, except in the guide docs. After we confirm on preview that the version bump works fine, then we can update the docs, and mention in subsequent release notes.

Refs #4021.