### PR TITLE
feat(num): ✨ `Amount` is `From<u8>` and `From<u16>`

### DIFF
--- a/crates/core/num/src/amount.rs
+++ b/crates/core/num/src/amount.rs
@@ -340,6 +340,22 @@ impl From<u32> for Amount {
     }
 }
 
+impl From<u16> for Amount {
+    fn from(amount: u16) -> Amount {
+        Amount {
+            inner: amount as u128,
+        }
+    }
+}
+
+impl From<u8> for Amount {
+    fn from(amount: u8) -> Amount {
+        Amount {
+            inner: amount as u128,
+        }
+    }
+}
+
 impl From<Amount> for f64 {
     fn from(amount: Amount) -> f64 {
         amount.inner as f64


### PR DESCRIPTION
this expands on the existing `u32` and `u64` implementations, which themselves delegate down to `u128`.

https://doc.rust-lang.org/stable/std/primitive.u128.html#impl-From%3Cu16%3E-for-u128 https://doc.rust-lang.org/stable/std/primitive.u128.html#impl-From%3Cu8%3E-for-u128