### PR TITLE
fix(mock-consensus): 🍰 fix two height bugs in mock consensus tests

### DIFF
--- a/crates/test/mock-consensus/src/abci.rs
+++ b/crates/test/mock-consensus/src/abci.rs
@@ -2,7 +2,7 @@
 
 use {
     super::TestNode,
-    anyhow::anyhow,
+    anyhow::{anyhow, Context},
     bytes::Bytes,
     tap::{Tap, TapFallible},
     tendermint::{
@@ -110,7 +110,13 @@ where
     /// Sends a [`ConsensusRequest::EndBlock`] request to the ABCI application.
     #[instrument(level = "debug", skip_all)]
     pub async fn end_block(&mut self) -> Result<response::EndBlock, anyhow::Error> {
-        let request = ConsensusRequest::EndBlock(request::EndBlock { height: 1 });
+        let height = self
+            .height
+            .value()
+            .try_into()
+            .context("converting height into `i64`")?;
+        let request = ConsensusRequest::EndBlock(request::EndBlock { height });
+
         let service = self.service().await?;
         match service
             .call(request)

--- a/crates/test/mock-consensus/src/lib.rs
+++ b/crates/test/mock-consensus/src/lib.rs
@@ -56,21 +56,19 @@ where
     /// Fast forwards a number of blocks.
     #[tracing::instrument(
         skip(self),
-        fields(
-            height = %self.height,
-            fast_forward.blocks = %blocks,
-        )
+        fields(fast_forward.blocks = %blocks)
     )]
     pub async fn fast_forward(&mut self, blocks: usize) -> anyhow::Result<()> {
         use {
             tap::Tap,
-            tracing::{info, trace},
+            tracing::{info, trace, trace_span, Instrument},
         };
 
         for i in 0..blocks {
             self.block()
                 .execute()
                 .tap(|_| trace!(%i, "executing empty block"))
+                .instrument(trace_span!("executing empty block", %i))
                 .await
                 .tap(|_| trace!(%i, "finished executing empty block"))?;
         }


### PR DESCRIPTION
fixes #4005.

#### 4002dff48be3400302c47ae85c88e5fdaf14655a feat(mock-consensus): ➰ record height in inner span

this tweaks the fast-forward facilities (#3933, #4002) so that we record
the height as a span field per-loop iteration, not as a field in the
encompassing `#[instrument]` span.

see #4005 for an example of the misleading `height: 0` logs this would
generate.

#### c5118f16241d560957468eba9678aab3923e7400 feat(mock-consensus): 🍰 EndBlock abci request height increases

this patches the mock consensus `TestNode::end_block` method so that the
height of these requests does not stay at 1.

this is needed for staking tests, see #3995.

* #3588
* #4001
* #3995
* #3840
