### PR TITLE
fix(pd): rename unbonding epochs -> delay

### DIFF
--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -144,9 +144,9 @@ pub enum TestnetCommand {
         /// Number of blocks per epoch.
         #[clap(long)]
         epoch_duration: Option<u64>,
-        /// Number of epochs before unbonding stake is released.
+        /// Number of blocks that must elapse before unbonding stake is released.
         #[clap(long)]
-        unbonding_epochs: Option<u64>,
+        unbonding_delay: Option<u64>,
         /// Maximum number of validators in the consensus set.
         #[clap(long)]
         active_validator_limit: Option<u64>,

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -306,7 +306,7 @@ async fn main() -> anyhow::Result<()> {
                     peer_address_template,
                     timeout_commit,
                     epoch_duration,
-                    unbonding_epochs,
+                    unbonding_delay,
                     active_validator_limit,
                     allocations_input_file,
                     validators_input_file,
@@ -368,7 +368,7 @@ async fn main() -> anyhow::Result<()> {
                 timeout_commit,
                 active_validator_limit,
                 epoch_duration,
-                unbonding_epochs,
+                unbonding_delay,
                 proposal_voting_blocks,
             )?;
             tracing::info!(

--- a/crates/bin/pd/src/testnet/generate.rs
+++ b/crates/bin/pd/src/testnet/generate.rs
@@ -67,7 +67,7 @@ impl TestnetConfig {
         tendermint_timeout_commit: Option<tendermint::Timeout>,
         active_validator_limit: Option<u64>,
         epoch_duration: Option<u64>,
-        unbonding_epochs: Option<u64>,
+        unbonding_delay: Option<u64>,
         proposal_voting_blocks: Option<u64>,
     ) -> anyhow::Result<TestnetConfig> {
         let external_addresses = external_addresses.unwrap_or_default();
@@ -96,7 +96,7 @@ impl TestnetConfig {
             validators.to_vec(),
             active_validator_limit,
             epoch_duration,
-            unbonding_epochs,
+            unbonding_delay,
             proposal_voting_blocks,
         )?;
         let genesis = Self::make_genesis(app_state)?;
@@ -343,7 +343,7 @@ pub fn testnet_generate(
     active_validator_limit: Option<u64>,
     tendermint_timeout_commit: Option<tendermint::Timeout>,
     epoch_duration: Option<u64>,
-    unbonding_epochs: Option<u64>,
+    unbonding_delay: Option<u64>,
     peer_address_template: Option<String>,
     external_addresses: Vec<TendermintAddress>,
     validators_input_file: Option<PathBuf>,
@@ -361,7 +361,7 @@ pub fn testnet_generate(
         tendermint_timeout_commit,
         active_validator_limit,
         epoch_duration,
-        unbonding_epochs,
+        unbonding_delay,
         proposal_voting_blocks,
     )?;
     tracing::info!(

--- a/deployments/scripts/smoke-test.sh
+++ b/deployments/scripts/smoke-test.sh
@@ -47,8 +47,8 @@ cargo build --quiet --release --bin pd
 
 echo "Generating testnet config..."
 EPOCH_DURATION="${EPOCH_DURATION:-50}"
-UNBONDING_EPOCHS="${UNBONDING_EPOCHS:-1}"
-cargo run --quiet --release --bin pd -- testnet generate --unbonding-epochs "$UNBONDING_EPOCHS" --epoch-duration "$EPOCH_DURATION" --timeout-commit 500ms
+UNBONDING_DELAY="${UNBONDING_DELAY:-50}"
+cargo run --quiet --release --bin pd -- testnet generate --unbonding-delay "$UNBONDING_DELAY" --epoch-duration "$EPOCH_DURATION" --timeout-commit 500ms
 
 echo "Starting CometBFT..."
 cometbft start --log_level=error --home "${HOME}/.penumbra/testnet_data/node0/cometbft" > "${SMOKE_LOG_DIR}/comet.log" &


### PR DESCRIPTION
Follow-up to changes made in [0], where we settled on "unbonded delay" rather than "unbonding epochs" to describe how many blocks must elapse until undelegated stake becomes claimable. The `pd` CLI options are only used by developers, so I'm not worried about breaking operator scripts in the wild.

[0] https://github.com/penumbra-zone/penumbra/pull/3923