### PR TITLE
ci: add dedicated indexer node for gov dashboard

### DIFF
--- a/deployments/helmfile.d/penumbra-testnet.yaml
+++ b/deployments/helmfile.d/penumbra-testnet.yaml
@@ -110,3 +110,24 @@ releases:
       - postgres:
           certificateSecretName: penumbra-testnet-wildcard
           credentialsSecretName: postgres-creds
+
+  - name: penumbra-testnet-gov-dash-node
+    chart: ../charts/penumbra-node
+    values:
+      - penumbra_bootstrap_node_cometbft_rpc_url: "https://rpc.testnet.penumbra.zone"
+      - ingressRoute:
+          enabled: false
+      - image:
+          tag: latest
+      - persistence:
+          enabled: true
+          size: 300G
+      - cometbft:
+          config:
+            indexer: psql
+      - part_of: penumbra-testnet
+      - nodes:
+        - moniker: gov-dash
+      - postgres:
+          certificateSecretName: penumbra-testnet-wildcard
+          credentialsSecretName: postgres-creds-gov-dash


### PR DESCRIPTION
Temporary testnet fullnode to unblock prototyping on the gov dashboard project. We'll circle back and clean this up in a few weeks, so that the fullnode config backing the webapp lives alongside the webapp deployment, wherever it's hosted.

Follow-up to 829dc64a3939f54ac0630023b8240251cdc5d78e.