### PR TITLE
pcli: show action / proof count before building

### DIFF
--- a/crates/bin/pcli/src/network.rs
+++ b/crates/bin/pcli/src/network.rs
@@ -45,7 +45,11 @@ impl App {
         &mut self,
         plan: TransactionPlan,
     ) -> impl Future<Output = anyhow::Result<Transaction>> + '_ {
-        println!("building transaction...");
+        println!(
+            "building transaction [{} actions, {} proofs]...",
+            plan.actions.len(),
+            plan.num_proofs(),
+        );
         let start = std::time::Instant::now();
         let tx = penumbra_wallet::build_transaction(
             &self.config.full_viewing_key,

--- a/crates/core/transaction/src/plan.rs
+++ b/crates/core/transaction/src/plan.rs
@@ -331,6 +331,22 @@ impl TransactionPlan {
         self.spend_plans().count()
     }
 
+    /// Convenience method to get the number of proofs in this transaction.
+    pub fn num_proofs(&self) -> usize {
+        self.actions
+            .iter()
+            .map(|action| match action {
+                ActionPlan::Spend(_) => 1,
+                ActionPlan::Output(_) => 1,
+                ActionPlan::Swap(_) => 1,
+                ActionPlan::SwapClaim(_) => 1,
+                ActionPlan::UndelegateClaim(_) => 1,
+                ActionPlan::DelegatorVote(_) => 1,
+                _ => 0,
+            })
+            .sum()
+    }
+
     /// Method to populate the detection data for this transaction plan.
     pub fn populate_detection_data<R: CryptoRng + Rng>(
         &mut self,


### PR DESCRIPTION
This helps slightly in case there are many many actions, currently the user only finds out how many there were _after_ doing all the proving.