### PR TITLE
staking: change `compute_unbonding_height` api

### DIFF
--- a/crates/core/component/stake/src/component/action_handler/undelegate_claim.rs
+++ b/crates/core/component/stake/src/component/action_handler/undelegate_claim.rs
@@ -48,7 +48,8 @@ impl ActionHandler for UndelegateClaim {
                 &self.body.validator_identity,
                 self.body.unbonding_start_height,
             )
-            .await?;
+            .await?
+            .unwrap_or(current_height);
 
         let wait_blocks = allowed_unbonding_height.saturating_sub(current_height);
 

--- a/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
@@ -191,7 +191,8 @@ pub trait ValidatorManager: StateWrite {
                     Unbonding {
                         unbonds_at_height: self
                             .compute_unbonding_height(identity_key, unbonding_start_height)
-                            .await?,
+                            .await?
+                            .expect("active validators MUST be bonded"),
                     },
                 );
             }
@@ -213,7 +214,8 @@ pub trait ValidatorManager: StateWrite {
                 // unbonding period.
                 let unbonds_at_height = self
                     .compute_unbonding_height(identity_key, unbonding_start_height)
-                    .await?;
+                    .await?
+                    .expect("active validators MUST be bonded");
 
                 self.set_validator_bonding_state(identity_key, Unbonding { unbonds_at_height });
 
@@ -588,7 +590,8 @@ pub trait ValidatorManager: StateWrite {
         // If the pool is already unbonded, this will return the current epoch.
         let allowed_unbonding_height = self
             .compute_unbonding_height(validator_identity, from_height)
-            .await?;
+            .await?
+            .unwrap_or(from_height); // If the pool is unbonded, the unbonding height is the current height.
 
         tracing::debug!(
             ?pool_state,

--- a/crates/core/component/stake/src/component/validator_handler/validator_store.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_store.rs
@@ -60,7 +60,7 @@ pub trait ValidatorDataRead: StateRead {
             .expect("no deserialization error expected")
     }
 
-    /// Convenience method to assemble a [`ValidatorStatus`].
+    /// Convenience method to assemble a [`ValidatorStatus`](crate::validator::Status).
     async fn get_validator_status(
         &self,
         identity_key: &IdentityKey,
@@ -143,14 +143,13 @@ pub trait ValidatorDataRead: StateRead {
         }
     }
 
-    /// Compute the unbonding height for a hypothetical undelegation at `unbonding_start_height`,
+    /// Compute the unbonding height for an undelegation initiated at `start_height`,
     /// relative to the **current** state of the validator pool.
     ///
-    /// Returns `None` if the pool is [`Unbonded`][unbonded].
+    /// Returns `None` if the pool is [`Unbonded`](crate::validator::State).
     ///
     /// This can be used to check if the undelegation is allowed, or compute a penalty range,
     /// or to compute the epoch at which a delegation pool will be unbonded.
-    /// [unbonded]: validator::BondingState::Unbonded
     async fn compute_unbonding_height(
         &self,
         id: &IdentityKey,

--- a/crates/core/component/stake/src/rate.rs
+++ b/crates/core/component/stake/src/rate.rs
@@ -27,7 +27,7 @@ impl RateData {
     ///
     /// # Panics
     /// This method panics if the validator's funding streams exceed 100%.
-    /// The stateless checks in the [`ValidatorDefinition`] action handler
+    /// The stateless checks in the [`Definition`](crate::validator::Definition) action handler
     /// should prevent this from happening.
     pub fn next_epoch(
         &self,

--- a/crates/core/component/stake/src/validator.rs
+++ b/crates/core/component/stake/src/validator.rs
@@ -73,7 +73,7 @@ pub struct Validator {
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct ValidatorToml {
     /// The sequence number determines which validator data takes priority, and
-    /// prevents replay attacks.  The chain only accepts new [`Definition`]s with 
+    /// prevents replay attacks.  The chain only accepts new [`Definition`]s with
     /// with increasing sequence numbers, preventing a third-party from replaying
     /// previously valid but stale configuration data as an update.
     pub sequence_number: u32,

--- a/crates/core/component/stake/src/validator.rs
+++ b/crates/core/component/stake/src/validator.rs
@@ -22,8 +22,7 @@ pub use status::Status;
 
 /// Describes a Penumbra validator's configuration data.
 ///
-/// This data is unauthenticated; the
-/// [`ValidatorDefinition`](crate::action::ValidatorDefiniition) action includes
+/// This data is unauthenticated; the [`Definition`] action includes
 /// a signature over the transaction with the validator's identity key.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[serde(try_from = "pb::Validator", into = "pb::Validator")]
@@ -64,7 +63,7 @@ pub struct Validator {
 
     /// The sequence number determines which validator data takes priority, and
     /// prevents replay attacks.  The chain only accepts new
-    /// [`ValidatorDefinition`]s with increasing sequence numbers, preventing a
+    /// [`Definition`]s with increasing sequence numbers, preventing a
     /// third party from replaying previously valid but stale configuration data
     /// as an update.
     pub sequence_number: u32,
@@ -74,10 +73,9 @@ pub struct Validator {
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct ValidatorToml {
     /// The sequence number determines which validator data takes priority, and
-    /// prevents replay attacks.  The chain only accepts new
-    /// [`ValidatorDefinition`]s with increasing sequence numbers, preventing a
-    /// third party from replaying previously valid but stale configuration data
-    /// as an update.
+    /// prevents replay attacks.  The chain only accepts new [`Definition`]s with 
+    /// with increasing sequence numbers, preventing a third-party from replaying
+    /// previously valid but stale configuration data as an update.
     pub sequence_number: u32,
 
     /// Whether the validator is enabled or not.


### PR DESCRIPTION
This PR modifies the staking module logic responsible for determining the unbonding schedule, in particular it:
- returns the current height if a pool is unbonded
- change the `compute_unbonding_height` API to return an `Option<u64>` to allow callers to detect an unbonded pool

One tricky aspect of our unbonding mechanism is that we want to:
1. Bind unbonding notes to the economic effect of validator misbehavior for some window of blocks
2. Leave it to the application to decide when a note is allowed to be claimed

One thing to note is that this mechanism works relative to the _current_ bonding state of the pool. This is generally fine for the protocol security because this leads the application to "overshoot" the penalty window range since it cannot know the exact moment a note was allowed to unbond (since bonding the state could have changed). This means that when processing a claim, we detect if the pool is unbonded, and if so, we set the "allowed unbonding height" to the current height. 