### PR TITLE
tests(app): 🎇 mock consensus delegates, and undelegates, to a validator

### DIFF
--- a/crates/core/component/stake/src/delegate.rs
+++ b/crates/core/component/stake/src/delegate.rs
@@ -36,18 +36,27 @@ impl EffectingData for Delegate {
 impl Delegate {
     /// Return the balance resulting from issuing delegation tokens from staking tokens.
     pub fn balance(&self) -> Balance {
-        let stake = Balance::from(Value {
-            amount: self.unbonded_amount,
-            asset_id: STAKING_TOKEN_ASSET_ID.clone(),
-        });
-
-        let delegation = Balance::from(Value {
-            amount: self.delegation_amount,
-            asset_id: DelegationToken::new(self.validator_identity.clone()).id(),
-        });
+        let stake: Balance = self.unbonded_value().into();
+        let delegation: Balance = self.delegation_value().into();
 
         // We produce the delegation tokens and consume the staking tokens.
         delegation - stake
+    }
+
+    /// Returns the [`Value`] of the delegation [`Amount`].
+    pub fn delegation_value(&self) -> Value {
+        Value {
+            amount: self.delegation_amount,
+            asset_id: DelegationToken::new(self.validator_identity.clone()).id(),
+        }
+    }
+
+    /// Returns the [`Value`] of the unbonded [`Amount`].
+    pub fn unbonded_value(&self) -> Value {
+        Value {
+            amount: self.unbonded_amount,
+            asset_id: STAKING_TOKEN_ASSET_ID.clone(),
+        }
     }
 }
 

--- a/crates/core/component/stake/src/undelegate.rs
+++ b/crates/core/component/stake/src/undelegate.rs
@@ -36,15 +36,8 @@ impl EffectingData for Undelegate {
 impl Undelegate {
     /// Return the balance after consuming delegation tokens, and producing unbonding tokens.
     pub fn balance(&self) -> Balance {
-        let stake = Balance::from(Value {
-            amount: self.unbonded_amount,
-            asset_id: self.unbonding_token().id(),
-        });
-
-        let delegation = Balance::from(Value {
-            amount: self.delegation_amount,
-            asset_id: self.delegation_token().id(),
-        });
+        let stake: Balance = self.unbonded_value().into();
+        let delegation: Balance = self.delegation_value().into();
 
         // We consume the delegation tokens and produce the staking tokens.
         stake - delegation
@@ -57,8 +50,24 @@ impl Undelegate {
         )
     }
 
+    /// Returns the [`Value`] of the unbonded [`Amount`].
+    pub fn unbonded_value(&self) -> Value {
+        Value {
+            amount: self.unbonded_amount,
+            asset_id: self.unbonding_token().id(),
+        }
+    }
+
     pub fn delegation_token(&self) -> DelegationToken {
         DelegationToken::new(self.validator_identity.clone())
+    }
+
+    /// Returns the [`Value`] of the delegation [`Amount`].
+    pub fn delegation_value(&self) -> Value {
+        Value {
+            amount: self.delegation_amount,
+            asset_id: self.delegation_token().id(),
+        }
     }
 }
 


### PR DESCRIPTION
see https://github.com/penumbra-zone/penumbra/issues/3995.

this test now delegates to, and then undelegates from, a validator.

this does not yet include all of the assertions we would like to
exercise in this test, but it does show that a validator correctly
progresses through the active and defined states.

in further work, we will fill out the other assertions described
in https://github.com/penumbra-zone/penumbra/issues/3995, particularly w.r.t. voting power and validator uptime.