### PR TITLE
staking: move uptime tracking to NV storage

### DIFF
--- a/crates/proto/src/state/read.rs
+++ b/crates/proto/src/state/read.rs
@@ -26,6 +26,24 @@ pub trait StateReadProto: StateRead + Send + Sync {
         }
     }
 
+    /// Gets a value from the nonverifiable key-value store as a domain type.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(v))` if the value is present and parseable as a domain type `D`;
+    /// * `Ok(None)` if the value is missing;
+    /// * `Err(_)` if the value is present but not parseable as a domain type `D`, or if an underlying storage error occurred.
+    fn nonverifiable_get<D>(&self, key: &[u8]) -> DomainFuture<D, Self::GetRawFut>
+    where
+        D: DomainType + std::fmt::Debug,
+        anyhow::Error: From<<D as TryFrom<D::Proto>>::Error>,
+    {
+        DomainFuture {
+            inner: self.nonverifiable_get_raw(key),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
     /// Gets a value from the verifiable key-value store as a proto type.
     ///
     /// # Returns


### PR DESCRIPTION
Close #4030, I think we could also avoid deserializing into a domain type altogether, maybe other optimizations are possible. This takes care of the state-breaking part of the change.