### PR TITLE
tests(app): ⌛ shorten epoch length in staking test

### DIFF
--- a/crates/test/mock-consensus/src/lib.rs
+++ b/crates/test/mock-consensus/src/lib.rs
@@ -78,7 +78,7 @@ where
         skip(self),
         fields(fast_forward.blocks = %blocks)
     )]
-    pub async fn fast_forward(&mut self, blocks: usize) -> anyhow::Result<()> {
+    pub async fn fast_forward(&mut self, blocks: u64) -> anyhow::Result<()> {
         use {
             tap::Tap,
             tracing::{info, trace, trace_span, Instrument},


### PR DESCRIPTION
 ### 🚠 overview

in #4001 we added a test for the staking component (_see also #3995, and #3588_).

this shortens the epoch length, so that this test runs in less time, and importantly, so that debugging test failures does not entail sifting through many log lines.

 ### ➕ changes

* manually construct an `AppState` so that we use a shorter epoch. this test involves waiting for multiple epochs to pass, which takes many seconds with the default length of 719, see: <https://github.com/penumbra-zone/penumbra/blob/8be8e8266b312c2a9eb1b1522a937e8df12f3a4f/crates/core/component/sct/src/params.rs#L41>

* `TestNode<C>::fast_forward` now accepts a u64, mirroring the type used in the sct parameters.

 ### 🏃 runtime

on `main`...

```
    Starting 1 test across 1 binary
        PASS [  12.646s] penumbra-app::mock_consensus_staking mock_consensus_can_define_and_delegate_to_a_validator
------------
     Summary [  12.647s] 1 test run: 1 passed, 0 skipped
```

after these changes...

```
    Starting 1 test across 1 binary
        PASS [   0.420s] penumbra-app::mock_consensus_staking mock_consensus_can_define_and_delegate_to_a_validator
------------
     Summary [   0.420s] 1 test run: 1 passed, 0 skipped
```

 ### 🥙 log volume

on `main`...

```
; RUST_LOG='info' cargo nextest run -p penumbra-app --test mock_consensus_staking --no-capture | wc -l
    Finished test [unoptimized + debuginfo] target(s) in 0.16s
    Starting 1 test across 1 binary
       START             penumbra-app::mock_consensus_staking mock_consensus_can_define_and_delegate_to_a_validator
        PASS [  12.185s] penumbra-app::mock_consensus_staking mock_consensus_can_define_and_delegate_to_a_validator
------------
     Summary [  12.185s] 1 test run: 1 passed, 0 skipped
46082
```

```
; RUST_LOG='info' cargo nextest run -p penumbra-app --test mock_consensus_staking --no-capture | wc -l
    Finished test [unoptimized + debuginfo] target(s) in 0.15s
    Starting 1 test across 1 binary
       START             penumbra-app::mock_consensus_staking mock_consensus_can_define_and_delegate_to_a_validator
        PASS [   0.416s] penumbra-app::mock_consensus_staking mock_consensus_can_define_and_delegate_to_a_validator
------------
     Summary [   0.416s] 1 test run: 1 passed, 0 skipped
450
```