### PR TITLE
add comment to use `NullifierDerivationCircuit` client-side only

### DIFF
--- a/crates/core/component/shielded-pool/src/nullifier_derivation.rs
+++ b/crates/core/component/shielded-pool/src/nullifier_derivation.rs
@@ -74,6 +74,11 @@ fn check_circuit_satisfaction(
 }
 
 /// Groth16 proof for correct nullifier derivation.
+///
+/// # Safety
+///
+/// This proof is only for client-side use and not on chain. The nullifier-deriving
+/// key is not linked in the circuit to the address associated with the note commitment.
 #[derive(Clone, Debug)]
 pub struct NullifierDerivationCircuit {
     public: NullifierDerivationProofPublic,


### PR DESCRIPTION
add note for future maintainers to only use the `NullifierDerivationCircuit` on the client-side, since the nk is not actually demonstrated to be associated with the address on the note in circuit (related issue #3978)