### PR TITLE
cnidarium: use incremental jmt migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,6 +1409,7 @@ dependencies = [
  "parking_lot",
  "pbjson",
  "pin-project",
+ "proptest",
  "prost",
  "regex",
  "rocksdb",
@@ -1417,6 +1418,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "tendermint",
+ "test-strategy",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -7538,6 +7540,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "structmeta"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "structmeta-derive",
+ "syn 2.0.51",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.51",
+]
+
+[[package]]
 name = "strum"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7839,6 +7864,18 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "test-strategy"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "structmeta",
+ "syn 2.0.51",
+]
 
 [[package]]
 name = "textwrap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3603,8 +3603,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "jmt"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2950721a65dff82492e30fe67076127135d0d710aa0140f21efafda2aee7849"
+source = "git+https://github.com/penumbra-zone/jmt?branch=erwan/in_place_value_sets#5d551cf0984a3692a228ce6e3cdebed0834673cd"
 dependencies = [
  "anyhow",
  "borsh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,47 +1093,26 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.10.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
+checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.13.2",
+ "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.10.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
+checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
- "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.78",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
-dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 1.0.109",
+ "syn 2.0.51",
+ "syn_derive",
 ]
 
 [[package]]
@@ -1245,6 +1224,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chacha20"
@@ -3604,8 +3589,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jmt"
-version = "0.9.0"
-source = "git+https://github.com/penumbra-zone/jmt?branch=erwan/in_place_value_sets#5d551cf0984a3692a228ce6e3cdebed0834673cd"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a3bf1a303934c6f75533bd3a563730a0730f9361023c49ed6aee9fcb5b98f8"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6145,20 +6131,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml 0.5.11",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
  "toml_edit 0.20.7",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -7687,6 +7673,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error 1.0.4",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.51",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8172,6 +8170,17 @@ name = "toml_edit"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap 2.2.3",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.2.3",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ ibig                             = { version = "0.3" }
 ics23                            = { version = "0.11.0" }
 im                               = { version = "^15.1.0" }
 indicatif                        = { version = "0.16" }
-jmt                              = { version = "0.9" }
+jmt                              = { git = "https://github.com/penumbra-zone/jmt", branch = "erwan/in_place_value_sets", features = ["migration"] }
 metrics                          = { version = "0.22" }
 metrics-tracing-context          = { version = "0.15" }
 num-bigint                       = { version = "0.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ ibig                             = { version = "0.3" }
 ics23                            = { version = "0.11.0" }
 im                               = { version = "^15.1.0" }
 indicatif                        = { version = "0.16" }
-jmt                              = { git = "https://github.com/penumbra-zone/jmt", branch = "erwan/in_place_value_sets", features = ["migration"] }
+jmt                              = { version = "0.10", features = ["migration"] }
 metrics                          = { version = "0.22" }
 metrics-tracing-context          = { version = "0.15" }
 num-bigint                       = { version = "0.4" }

--- a/crates/cnidarium/Cargo.toml
+++ b/crates/cnidarium/Cargo.toml
@@ -37,6 +37,8 @@ tonic = {workspace = true, optional = true}
 tracing = {workspace = true}
 
 [dev-dependencies]
-tempfile = {workspace = true}
-tracing-subscriber = {workspace = true}
-tokio = {workspace = true}
+tempfile = { workspace = true }
+tracing-subscriber = { workspace = true }
+tokio = { workspace = true, features = ["full", "rt-multi-thread"] }
+proptest = "1.3.1"
+test-strategy = "0.3.1"

--- a/crates/cnidarium/Cargo.toml
+++ b/crates/cnidarium/Cargo.toml
@@ -12,7 +12,7 @@ rpc = ["dep:tonic", "dep:prost", "dep:serde", "dep:pbjson", "dep:ibc-proto"]
 [dependencies]
 anyhow = {workspace = true}
 async-trait = {workspace = true}
-borsh = "0.10.3"
+borsh = { version = "1.3.0" , features = ["derive", "de_strict_order"]}
 futures = {workspace = true}
 hex = {workspace = true}
 ibc-proto = {workspace = true, default-features = false, features = ["serde"], optional = true}

--- a/crates/cnidarium/Cargo.toml
+++ b/crates/cnidarium/Cargo.toml
@@ -5,6 +5,7 @@ edition = {workspace = true}
 
 [features]
 migration = []
+migration-proptests = ["migration"]
 default = ["metrics"]
 rpc = ["dep:tonic", "dep:prost", "dep:serde", "dep:pbjson", "dep:ibc-proto"]
 

--- a/crates/cnidarium/src/store/multistore.rs
+++ b/crates/cnidarium/src/store/multistore.rs
@@ -90,10 +90,13 @@ impl MultistoreConfig {
     /// # Examples
     /// `prefix_a/key` -> `key` in `substore_a`
     /// `prefix_a` -> `prefix_a` in `main_store`
-    /// `preifx_a/` -> `prefix_a/` in `main_store`
+    /// `prefix_a/` -> `prefix_a/` in `main_store`
     /// `nonexistent_prefix` -> `nonexistent_prefix` in `main_store`
     pub fn route_key_bytes<'a>(&self, key: &'a [u8]) -> (&'a [u8], Arc<SubstoreConfig>) {
         let config = self.find_substore(key);
+
+        // If the key is a total match for the prefix, we return the original key
+        // routed to the main store. This is where subtree root hashes are stored.
         if key == config.prefix.as_bytes() {
             return (key, self.main_store.clone());
         }

--- a/crates/cnidarium/src/store/substore.rs
+++ b/crates/cnidarium/src/store/substore.rs
@@ -397,7 +397,7 @@ impl SubstoreStorage {
                         // `rustfmt` panics on inlining the closure, so we use a helper function to skip the key.
                         let skip_key = |(keyhash, _key, some_value)| (keyhash, some_value);
 
-                        let (root_hash, batch)= if perform_migration {
+                        let (root_hash, batch) = if perform_migration {
                             jmt.append_value_set(unwritten_changes.into_iter().map(skip_key), write_version)?
                         } else {
                             jmt.put_value_set(unwritten_changes.into_iter().map(skip_key), write_version)?

--- a/crates/cnidarium/tests/migration.rs
+++ b/crates/cnidarium/tests/migration.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "migration")]
 use cnidarium::StateDelta;
-use cnidarium::StateRead;
 use cnidarium::StateWrite;
 use cnidarium::Storage;
 use ibc_types::core::commitment::MerklePath;
@@ -31,17 +30,22 @@ use tokio;
  * - prop_migration: property-based testing of the migration operation.
  *
  * Each test has the following pattern:
- * - Write a collection of keys, incrementing the version number at each step.
+ * Operation:
+ *              Write a collection of keys, incrementing the version number at each step.
+ * Checks:
  * - Check that the version number has incremented.
  * - Check that the keys are present in the latest snapshot.
  * - Check that the keys have valid proofs.
- * - Perform a migration, writing/removing a key in the main store and/or substores.
+ * Operation:
+ *              Perform a migration, writing/removing a key in the main store and/or substores.
  * - Check that the version number has not changed.
  * - Check that the root hash for the main store and/or substores has changed.
  * - Check that the migration key is present in the latest snapshot.
  * - Check that the migration key has a valid proof.
  * - Check that the migration key has the expected value.
- * - Write a new collection of keys, incrementing the version number at each step.
+ * Operation:
+ *              Write a new collection of keys, incrementing the version number at each step.
+ * Checks:
  * - Check that the version number has incremented.
  * - Check that the new keys are present in the latest snapshot.
  * - Check that the new keys have valid proofs.
@@ -87,7 +91,6 @@ async fn test_simple_migration() -> anyhow::Result<()> {
     }
 
     assert_eq!(counter, num_ops);
-
     counter = 0;
 
     // We don't _need_ to toss the storage instance, but let's be
@@ -137,8 +140,8 @@ async fn test_simple_migration() -> anyhow::Result<()> {
     /* perform the migration */
     /* ********************* */
     let mut delta = StateDelta::new(storage.latest_snapshot());
-    let migration_key = "migration".to_string();
-    let migration_value = "migration data".as_bytes().to_vec();
+    let migration_key = "banana".to_string();
+    let migration_value = "a good fruit".as_bytes().to_vec();
     delta.put_raw(migration_key.clone(), migration_value.clone());
     let postmigration_root = storage.commit_in_place(delta).await?;
 
@@ -249,42 +252,84 @@ async fn test_substore_migration() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
     let tmpdir = tempfile::tempdir()?;
     let db_path = tmpdir.into_path();
-    let substore_prefixes = vec!["ibc/".to_string(), "dex/".to_string(), "misc/".to_string()];
-    let all_substores = vec!["ibc/".to_string(), "dex/".to_string(), "".to_string()];
+    let substore_prefixes = vec!["ibc".to_string(), "dex".to_string(), "misc".to_string()];
     let storage = Storage::load(db_path.clone(), substore_prefixes.clone()).await?;
 
     let mut counter = 0;
-    let num_writes = 10;
+    let num_ops_per_substore = 10;
 
-    // Write to every substore, multiple times and check that we can read the values back out.
-    for i in 0..num_writes {
+    let mut kvs = vec![];
+
+    /* ************************ */
+    /*      write some keys     */
+    /*     in every substore    */
+    /* ************************ */
+    for i in 0..num_ops_per_substore {
         let mut delta = StateDelta::new(storage.latest_snapshot());
-        let mut keys: Vec<String> = vec![];
-        let mut values: Vec<Vec<u8>> = vec![];
-        for substore in all_substores.iter() {
+        for substore in substore_prefixes.iter() {
             let key = format!("{substore}/key_{i}");
             let value = format!("{substore}value_{i}").as_bytes().to_vec();
+            kvs.push((key.clone(), value.clone()));
             tracing::debug!(?key, "initializing substore {substore} with key-value pair");
             delta.put_raw(key.clone(), value.clone());
-            keys.push(key);
-            values.push(value);
         }
 
-        let _ = storage.commit(delta).await?;
+        let root_hash = storage.commit(delta).await?;
+        tracing::info!(?root_hash, version = %i, "committed key-value pair");
+        counter += 1;
+    }
+    let num_versions_pre_migration = counter;
+    assert_eq!(counter, num_ops_per_substore);
+    counter = 0;
+
+    // We don't _need_ to toss the storage instance, but let's be
+    // extra careful and make sure that things work if we reload it.
+    storage.release().await;
+    let storage = Storage::load(db_path.clone(), substore_prefixes.clone()).await?;
+
+    let premigration_root = storage
+        .latest_snapshot()
+        .root_hash()
+        .await
+        .expect("infaillible");
+
+    for (i, (key, value)) in kvs.clone().into_iter().enumerate() {
+        tracing::debug!(?key, "checking key-value pair");
         let snapshot = storage.latest_snapshot();
+        let (some_value, proof) = snapshot.get_with_proof(key.as_bytes().to_vec()).await?;
+        let retrieved_value = some_value.expect("key is found in the latest snapshot");
+        assert_eq!(retrieved_value, value);
 
-        for (key, value) in keys.iter().zip(values.iter()) {
-            let retrieved_value = snapshot.get_raw(key.as_str()).await?.unwrap();
-            assert_eq!(retrieved_value, *value);
-        }
+        // We split the key into its substore prefix and the key itself.
+        let merkle_path = MerklePath {
+            key_path: key.split('/').map(|s| s.to_string()).collect(),
+        };
+        let merkle_root = MerkleRoot {
+            hash: premigration_root.0.to_vec(),
+        };
+
+        proof
+            .verify_membership(
+                &FULL_PROOF_SPECS,
+                merkle_root,
+                merkle_path,
+                retrieved_value,
+                0,
+            )
+            .map_err(|e| tracing::error!(?e, key_index = ?i, "proof verification failed"))
+            .expect("membership proof verifies");
 
         counter += 1;
     }
-    assert_eq!(counter, num_writes);
+
+    assert_eq!(
+        counter,
+        substore_prefixes.len() as u64 * num_ops_per_substore
+    );
 
     let premigration_snapshot = storage.latest_snapshot();
     let mut old_root_hashes: Vec<RootHash> = vec![];
-    for substore in all_substores.iter() {
+    for substore in substore_prefixes.iter() {
         let root_hash = premigration_snapshot
             .prefix_root_hash(substore.as_str())
             .await
@@ -292,7 +337,7 @@ async fn test_substore_migration() -> anyhow::Result<()> {
         old_root_hashes.push(root_hash);
     }
 
-    let old_substore_versions: Vec<jmt::Version> = all_substores
+    let old_substore_versions: Vec<jmt::Version> = substore_prefixes
         .clone()
         .into_iter()
         .map(|prefix| {
@@ -304,7 +349,11 @@ async fn test_substore_migration() -> anyhow::Result<()> {
         .collect();
 
     let old_version = storage.latest_version();
-    assert_eq!(old_version, counter - 1); // -1 because we start at u64::MAX
+    assert_eq!(old_version, num_versions_pre_migration - 1); // -1 because we start at u64::MAX
+    let premigration_root_hash = premigration_snapshot
+        .root_hash()
+        .await
+        .expect("infaillible");
     drop(premigration_snapshot);
 
     /* ******************************* */
@@ -312,37 +361,57 @@ async fn test_substore_migration() -> anyhow::Result<()> {
     /* (write a key in every substore) */
     /* ******************************* */
     let mut delta = StateDelta::new(storage.latest_snapshot());
+    let mut migration_kvs = vec![];
 
     // Start by writing a key in every substore, including the main store.
-    for substore in all_substores.iter() {
-        let key = format!("{substore}/migration", substore = substore);
-        let value = format!("{substore}migration data", substore = substore)
+    for substore in substore_prefixes.iter() {
+        let key = format!("{substore}/banana", substore = substore);
+        let value = format!("{substore}", substore = substore)
             .as_bytes()
             .to_vec();
         tracing::debug!(?key, "migration: writing to substore {substore}");
-        delta.put_raw(key, value);
+        delta.put_raw(key.clone(), value.clone());
+        migration_kvs.push((key, value));
     }
 
     // Commit the migration.
     let _ = storage.commit_in_place(delta).await?;
 
-    // Note(erwan): when we perform a commit in-place, we do not update the
-    // snapshot cache. This means that querying `Storage::latest_snapshot()`
-    // will return a now-stale view of the state.
+    /* ************************ */
+    /*   check the migration    */
+    /* ************************ */
+    // Overview: We just wrote a key in every substore. Now we want to perform increasingly
+    // complex checks to ensure that the migration was successful.
+    // 1. Check that every root hash has changed
+    // 2. Check that no version number has changed
+    // 3. Check that we can read the migration key from every substore
+    // 4. Check that the migration key has a valid proof
+    // 5. Check that we can read every other key from every substore
+    // 6. Check that every other key has a valid proof
+
+    // We reload storage so that we can access the latest snapshot.
+    // The snapshot cache is not updated when we commit in place.
     storage.release().await;
-    let storage = Storage::load(db_path, substore_prefixes).await?;
+    let storage = Storage::load(db_path.clone(), substore_prefixes.clone()).await?;
 
     let postmigration_snapshot = storage.latest_snapshot();
     let new_version = storage.latest_version();
 
     assert_eq!(
         old_version, new_version,
-        "the global version number has changed!"
+        "the global version should not change"
     );
+
+    let postmigration_root_hash = postmigration_snapshot
+        .root_hash()
+        .await
+        .expect("infaillible");
+
+    assert_ne!(premigration_root_hash, postmigration_root_hash);
 
     // Check that the root hash for every substore has changed.
     let mut new_root_hashes: Vec<RootHash> = vec![];
-    for substore in all_substores.iter() {
+    for substore in substore_prefixes.iter() {
         let root_hash = postmigration_snapshot
             .prefix_root_hash(substore.as_str())
             .await
@@ -353,16 +422,25 @@ async fn test_substore_migration() -> anyhow::Result<()> {
     old_root_hashes
         .iter()
         .zip(new_root_hashes.iter())
-        .zip(all_substores.iter())
+        .zip(substore_prefixes.iter())
         .for_each(|((old, new), substore)| {
             assert_ne!(
                 old, new,
                 "migration did not effect the root hash for substore {substore}",
             );
+            let substore_version = postmigration_snapshot
+                .prefix_version(substore.as_str())
+                .expect("prefix exists")
+                .unwrap();
+            assert_eq!(
+                substore_version,
+                num_ops_per_substore - 1,
+                "substore version should not change"
+            );
         });
 
     // Check that the version number for every substore has NOT changed.
-    let new_substore_versions: Vec<jmt::Version> = all_substores
+    let new_substore_versions: Vec<jmt::Version> = substore_prefixes
         .clone()
         .into_iter()
         .map(|prefix| {
@@ -376,12 +454,131 @@ async fn test_substore_migration() -> anyhow::Result<()> {
     old_substore_versions
         .iter()
         .zip(new_substore_versions.iter())
-        .zip(all_substores.iter())
+        .zip(substore_prefixes.iter())
         .for_each(|((old, new), substore)| {
             assert_eq!(
                 old, new,
                 "the version number for substore {substore} has changed!",
             );
         });
+
+    // Check that the migration key is present in the latest snapshot.
+    for (migration_key, migration_value) in migration_kvs.clone().into_iter() {
+        let (some_value, proof) = postmigration_snapshot
+            .get_with_proof(migration_key.as_bytes().to_vec())
+            .await?;
+        let retrieved_value = some_value.expect("migration key is found in the latest snapshot");
+        assert_eq!(retrieved_value, migration_value);
+
+        let merkle_path = MerklePath {
+            key_path: migration_key.split('/').map(|s| s.to_string()).collect(),
+        };
+        let merkle_root = MerkleRoot {
+            hash: postmigration_root_hash.0.to_vec(),
+        };
+
+        proof
+            .verify_membership(
+                &FULL_PROOF_SPECS,
+                merkle_root,
+                merkle_path,
+                retrieved_value,
+                0,
+            )
+            .map_err(|e| tracing::error!("proof verification failed: {:?}", e))
+            .expect("membership proof verifies");
+    }
+
+    // Check that every other key is still present in the latest snapshot.
+    for (key, value) in kvs.clone().into_iter() {
+        let (some_value, proof) = postmigration_snapshot
+            .get_with_proof(key.as_bytes().to_vec())
+            .await?;
+        let retrieved_value = some_value.expect("key is found in the latest snapshot");
+        assert_eq!(retrieved_value, value);
+
+        let merkle_path = MerklePath {
+            key_path: key.split('/').map(|s| s.to_string()).collect(),
+        };
+        let merkle_root = MerkleRoot {
+            hash: postmigration_root_hash.0.to_vec(),
+        };
+
+        proof
+            .verify_membership(
+                &FULL_PROOF_SPECS,
+                merkle_root,
+                merkle_path,
+                retrieved_value,
+                0,
+            )
+            .map_err(|e| tracing::error!("proof verification failed: {:?}", e))
+            .expect("membership proof verifies");
+    }
+
+    /* ************************ */
+    /*      write some keys     */
+    /*     in every substore    */
+    /*        ... again ...     */
+    /* ************************ */
+    counter = 0;
+    for i in 0..num_ops_per_substore {
+        let mut delta = StateDelta::new(storage.latest_snapshot());
+        for substore in substore_prefixes.iter() {
+            let key = format!("{substore}/key_{i}");
+            let value = format!("{substore}value_{i}").as_bytes().to_vec();
+            kvs.push((key.clone(), value.clone()));
+            tracing::debug!(?key, "initializing substore {substore} with key-value pair");
+            delta.put_raw(key.clone(), value.clone());
+        }
+
+        let root_hash = storage.commit(delta).await?;
+        tracing::info!(?root_hash, version = %i, "committed key-value pair");
+        counter += 1;
+    }
+    assert_eq!(counter, num_ops_per_substore);
+    counter = 0;
+
+    let final_root = storage
+        .latest_snapshot()
+        .root_hash()
+        .await
+        .expect("infaillible");
+
+    for (i, (key, value)) in kvs.clone().into_iter().enumerate() {
+        tracing::debug!(?key, "checking key-value pair");
+        let snapshot = storage.latest_snapshot();
+        let (some_value, proof) = snapshot.get_with_proof(key.as_bytes().to_vec()).await?;
+        let retrieved_value = some_value.expect("key is found in the latest snapshot");
+        assert_eq!(retrieved_value, value);
+
+        // We split the key into its substore prefix and the key itself.
+        let merkle_path = MerklePath {
+            key_path: key.split('/').map(|s| s.to_string()).collect(),
+        };
+        let merkle_root = MerkleRoot {
+            hash: final_root.0.to_vec(),
+        };
+
+        proof
+            .verify_membership(
+                &FULL_PROOF_SPECS,
+                merkle_root,
+                merkle_path,
+                retrieved_value,
+                0,
+            )
+            .map_err(|e| tracing::error!(?e, key_index = ?i, "proof verification failed"))
+            .expect("membership proof verifies");
+
+        counter += 1;
+    }
+
+    assert_eq!(
+        counter,
+        // For each substore, we wrote `num_ops_per_substore` keys twice.
+        substore_prefixes.len() as u64 * num_ops_per_substore * 2
+    );
+
     Ok(())
 }

--- a/crates/cnidarium/tests/migration.rs
+++ b/crates/cnidarium/tests/migration.rs
@@ -633,6 +633,7 @@ async fn test_substore_migration() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "migration-proptests")]
 mod proptests {
     use proptest::{
         arbitrary::any,

--- a/crates/cnidarium/tests/migration.rs
+++ b/crates/cnidarium/tests/migration.rs
@@ -775,7 +775,7 @@ mod proptests {
 
             tracing::debug!(
                 prefix = storage_key.prefix(),
-                key = storage_key.abridged_key(),
+                key = storage_key.truncated_key(),
                 ?key_hash,
                 ?op,
                 ?phase,
@@ -804,7 +804,7 @@ mod proptests {
 
             tracing::debug!(
                 prefix = storage_key.prefix(),
-                key = storage_key.abridged_key(),
+                key = storage_key.truncated_key(),
                 ?key_hash,
                 ?phase,
                 "checking proofs"
@@ -831,7 +831,7 @@ mod proptests {
                 num_proofs = proof.proofs.len(),
                 spec_len = specs.len(),
                 ?key_hash,
-                abridged_key = storage_key.abridged_key(),
+                truncated_key = storage_key.truncated_key(),
                 is_existence = reference_value.is_some(),
                 "proof verification"
             );
@@ -1044,7 +1044,7 @@ mod proptests {
 
             tracing::debug!(
                 prefix = storage_key.prefix(),
-                key = &storage_key.abridged_key(),
+                key = &storage_key.truncated_key(),
                 ?key_hash,
                 ?op,
                 "nex: checking proofs"
@@ -1073,7 +1073,7 @@ mod proptests {
                 num_proofs = proof.proofs.len(),
                 spec_len = specs.len(),
                 ?key_hash,
-                abridged_key = &storage_key.abridged_key(),
+                truncated_key = &storage_key.truncated_key(),
                 "nex: proof verification"
             );
 
@@ -1143,7 +1143,7 @@ mod proptests {
             }
         }
 
-        fn abridged_key(&self) -> String {
+        fn truncated_key(&self) -> String {
             self.key.chars().take(5).collect()
         }
 

--- a/crates/cnidarium/tests/migration.rs
+++ b/crates/cnidarium/tests/migration.rs
@@ -68,6 +68,9 @@ async fn test_simple_migration() -> anyhow::Result<()> {
     let mut counter = 0;
     let num_ops = 10;
 
+    /* ************************ */
+    /*      write some keys     */
+    /* ************************ */
     let mut kvs = vec![];
     for i in 0..num_ops {
         /* write some value at version `i` */
@@ -155,7 +158,7 @@ async fn test_simple_migration() -> anyhow::Result<()> {
     );
 
     /* ************************ */
-    /*   Check the migration    */
+    /*   check the migration    */
     /* ************************ */
     let (some_value, proof) = storage
         .latest_snapshot()
@@ -182,6 +185,9 @@ async fn test_simple_migration() -> anyhow::Result<()> {
         .map_err(|e| tracing::error!("proof verification failed: {:?}", e))
         .expect("membership proof verifies");
 
+    /* ************************ */
+    /*      write new keys      */
+    /* ************************ */
     for i in num_ops..num_ops * 2 {
         /* write some value at version `i` */
         let mut delta = StateDelta::new(storage.latest_snapshot());

--- a/crates/cnidarium/tests/migration.rs
+++ b/crates/cnidarium/tests/migration.rs
@@ -633,7 +633,7 @@ async fn test_substore_migration() -> anyhow::Result<()> {
     Ok(())
 }
 
-// #[cfg(feature = "migration-proptests")]
+#[cfg(feature = "migration-proptests")]
 mod proptests {
     use proptest::{
         arbitrary::any,


### PR DESCRIPTION
Close #3506, this PR:
- use `jmt@0.10` which includes the `migration` feature
- bump `borsh` to `1.3.0` to be able to serialize jmt nodes
- revamp the substore migration tests to include basic tests and a proptest strategy
- notably, the proptest integration tests lay the groundwork for deeper/more targeted strategies