### PR TITLE
ci: fix middleware vars

### DIFF
--- a/deployments/charts/penumbra-node/values.yaml
+++ b/deployments/charts/penumbra-node/values.yaml
@@ -137,15 +137,6 @@ securityContext:
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
 
-# The chart uses a top-level `ingressRoute` rather than `ingress` value map,
-# because use of Traefik CRD `IngressRoute` is required for h2c support,
-# so that pd's gRPC service can have an HTTPS reverse proxy in front of it.
-ingressRoute:
-  enabled: false
-  hosts:
-    pd: grpc.chart-example.local
-    tm: rpc.chart-example.local
-
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
The ratelimiting on the HTTPS RPC frontend was getting dropped on chain resets, due to duplicated vars. I've been keeping an eye on performance and re-adding post-deploy, but only just identified the root cause, via manual lints. This oversight caused problems during a deploy of v0.68.0, during which an ad-hoc solo node was set up to sidestep the load. See #3336 for more work towards automatic solo nodes.