### PR TITLE
feat(pd): support archives for migrate and join

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,6 +2351,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4536,6 +4548,7 @@ dependencies = [
  "decaf377-rdsa",
  "directories",
  "ed25519-consensus",
+ "flate2",
  "fs_extra",
  "futures",
  "hex",
@@ -4584,6 +4597,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.8",
+ "tar",
  "tempfile",
  "tendermint",
  "tendermint-config",
@@ -6638,10 +6652,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
+ "tokio-util 0.7.10",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -7730,6 +7746,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8718,6 +8745,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8990,6 +9030,17 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time 0.3.34",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.4.13",
+ "rustix 0.38.31",
 ]
 
 [[package]]

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -50,6 +50,7 @@ decaf377                         = { workspace = true, features = ["parallel"], 
 decaf377-rdsa                    = { workspace = true }
 directories                      = { workspace = true }
 ed25519-consensus                = { workspace = true }
+flate2                           = "1.0.28"
 fs_extra                         = "1.3.0"
 futures                          = { workspace = true }
 hex                              = { workspace = true }
@@ -91,12 +92,13 @@ rand                             = { workspace = true }
 rand_chacha                      = { workspace = true }
 rand_core                        = { workspace = true, features = ["getrandom"] }
 regex                            = { workspace = true }
-reqwest                          = { version = "0.11", features = ["json"] }
+reqwest                          = { version = "0.11", features = ["json", "stream"] }
 rocksdb                          = { workspace = true }
 serde                            = { workspace = true, features = ["derive"] }
 serde_json                       = { workspace = true }
 serde_with                       = { workspace = true, features = ["hex"] }
 sha2                             = { workspace = true }
+tar                              = "0.4.40"
 tempfile                         = { workspace = true }
 tendermint                       = { workspace = true }
 tendermint-config                = { workspace = true }


### PR DESCRIPTION
Enables opt-in archive generation when performing:

* pd export
* pd migrate

The goal is to provide a standardized bottling-up of pd state, specifically the rocksdb directory. In the context of upgrades, only the "pd migrate" functionality change is what we care about: we want the archived dir to contain both rocksdb data and the modified genesis file.

Accordingly, `pd testnet join` is modified to support an optional archive URL. If set, the remote tar.gz archive will be downloaded and extracted, clobbering the cometbft config. A remote bootstrap node is still contacted, to learn about peers, otherwise the newly created node wouldn't be able to talk to the network.