### PR TITLE
staking(undelegate): remove obsolete comment in balance impl

### DIFF
--- a/crates/core/component/stake/src/penalty.rs
+++ b/crates/core/component/stake/src/penalty.rs
@@ -58,7 +58,7 @@ impl Penalty {
 
     /// Compound this `Penalty` with another `Penalty`.
     pub fn compound(&self, other: Penalty) -> Penalty {
-        Self((self.0 * other.0).expect("compounding penalities will not overflow"))
+        Self((self.0 * other.0).expect("compounding penalties will not overflow"))
     }
 
     /// Apply this `Penalty` to an `Amount` of unbonding tokens.

--- a/crates/core/component/stake/src/undelegate.rs
+++ b/crates/core/component/stake/src/undelegate.rs
@@ -36,14 +36,17 @@ impl EffectingData for Undelegate {
 impl Undelegate {
     /// Return the balance after consuming delegation tokens, and producing unbonding tokens.
     pub fn balance(&self) -> Balance {
-        let stake: Balance = self.unbonded_value().into();
+        let undelegation: Balance = self.unbonded_value().into();
         let delegation: Balance = self.delegation_value().into();
 
-        // We consume the delegation tokens and produce the staking tokens.
-        stake - delegation
+        // We consume the delegation tokens and produce the undelegation tokens.
+        undelegation - delegation
     }
 
     pub fn unbonding_token(&self) -> UnbondingToken {
+        // We produce undelegation tokens at a rate of 1:1 with the unbonded
+        // value of the delegated stake. When these tokens are claimed, we
+        // apply penalties that accumulated during the unbonding window.
         UnbondingToken::new(
             self.validator_identity.clone(),
             self.from_epoch.start_height,


### PR DESCRIPTION
This fix an obsolete varname and comment. 