### PR TITLE
fix: allow fetching archive-url from env var

### DIFF
--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -210,7 +210,7 @@ pub enum TestnetCommand {
         /// Optional URL of archived node state in .tar.gz format. The archive will be
         /// downloaded and extracted locally, allowing the node to join a network at a block height
         /// higher than 0.
-        #[clap(long)]
+        #[clap(long, env = "PENUMBRA_PD_ARCHIVE_URL")]
         archive_url: Option<Url>,
 
         /// Human-readable name to identify node on network

--- a/deployments/charts/penumbra-node/templates/statefulset.yaml
+++ b/deployments/charts/penumbra-node/templates/statefulset.yaml
@@ -125,6 +125,10 @@ spec:
               value: "{{ .Values.cometbft.config.p2p.max_num_outbound_peers }}"
             - name: PENUMBRA_COMETBFT_INDEXER
               value: "{{ .Values.cometbft.config.indexer }}"
+            {{- if .Values.penumbra_bootstrap_archive_url }}
+            - name: PENUMBRA_PD_ARCHIVE_URL
+              value: "{{ .Values.penumbra_bootstrap_archive_url }}"
+            {{- end }}
             {{- if .Values.postgres.credentialsSecretName }}
             - name: COMETBFT_POSTGRES_CONNECTION_URL
               valueFrom:

--- a/deployments/charts/penumbra-node/values.yaml
+++ b/deployments/charts/penumbra-node/values.yaml
@@ -14,6 +14,10 @@ image:
 # Consider using "preview" for bleeding edge, but make sure container tags match.
 penumbra_bootstrap_node_cometbft_rpc_url: "https://rpc.testnet.penumbra.zone"
 
+# Whether to fetch a remote archive for loading historical state,
+# e.g. post-upgrade.
+penumbra_bootstrap_archive_url: ""
+
 # Whether to preserve the LB service, in effect reserving the same IP
 # for subsequent deploys. This costs money! But sure is convenient.
 preserve_lb_svc: false


### PR DESCRIPTION
Follow-up to [0]. We've tested several times the creation and use of archive urls via cli, but hadn't yet added logic to deploy new nodes from archive URLs, as well. This change worked for adding a new-joining node to a bespoke devnet post-upgrade.

[0] https://github.com/penumbra-zone/penumbra/pull/4055