### PR TITLE
cnidarium: use `WriteBatch` when writing jmt nodes

### DIFF
--- a/crates/cnidarium/src/storage.rs
+++ b/crates/cnidarium/src/storage.rs
@@ -40,7 +40,6 @@ struct Inner {
     changes_rx: watch::Receiver<(jmt::Version, Arc<Cache>)>,
     snapshots: RwLock<SnapshotCache>,
     multistore_config: MultistoreConfig,
-    #[allow(dead_code)]
     /// A handle to the dispatcher task.
     /// This is used by `Storage::release` to wait for the task to terminate.
     jh_dispatcher: Option<tokio::task::JoinHandle<()>>,
@@ -375,7 +374,7 @@ impl Storage {
                 db: db.clone(),
             };
 
-            let substore_storage = SubstoreStorage { substore_snapshot };
+            let substore_storage = SubstoreStorage::from_snapshot(substore_snapshot);
 
             // Commit the substore and collect the root hash
             let (root_hash, substore_batch) = substore_storage
@@ -415,9 +414,7 @@ impl Storage {
             db: self.0.db.clone(),
         };
 
-        let main_store_storage = SubstoreStorage {
-            substore_snapshot: main_store_snapshot,
-        };
+        let main_store_storage = SubstoreStorage::from_snapshot(main_store_snapshot);
 
         let (global_root_hash, write_batch) = main_store_storage
             .commit(main_store_changes, write_batch, version, perform_migration)

--- a/crates/cnidarium/src/storage.rs
+++ b/crates/cnidarium/src/storage.rs
@@ -374,7 +374,7 @@ impl Storage {
                 db: db.clone(),
             };
 
-            let substore_storage = SubstoreStorage::from_snapshot(substore_snapshot);
+            let substore_storage = SubstoreStorage { substore_snapshot };
 
             // Commit the substore and collect the root hash
             let (root_hash, substore_batch) = substore_storage
@@ -414,7 +414,9 @@ impl Storage {
             db: self.0.db.clone(),
         };
 
-        let main_store_storage = SubstoreStorage::from_snapshot(main_store_snapshot);
+        let main_store_storage = SubstoreStorage {
+            substore_snapshot: main_store_snapshot,
+        };
 
         let (global_root_hash, write_batch) = main_store_storage
             .commit(main_store_changes, write_batch, version, perform_migration)

--- a/crates/cnidarium/src/storage.rs
+++ b/crates/cnidarium/src/storage.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, sync::Arc};
 // use tokio_stream::wrappers::WatchStream;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, ensure, Result};
 use parking_lot::RwLock;
 use rocksdb::{Options, DB};
 use tokio::sync::watch;
@@ -276,17 +276,22 @@ impl Storage {
     pub async fn commit(&self, delta: StateDelta<Snapshot>) -> Result<crate::RootHash> {
         // Extract the snapshot and the changes from the state delta
         let (snapshot, changes) = delta.flatten();
+        let prev_snapshot_version = snapshot.version();
 
         // We use wrapping_add here so that we can write `new_version = 0` by
         // overflowing `PRE_GENESIS_VERSION`.
-        let old_version = self.latest_version();
-        let new_version = old_version.wrapping_add(1);
-        tracing::debug!(old_version, new_version);
-        if old_version != snapshot.version() {
-            anyhow::bail!("version mismatch in commit: expected state forked from version {} but found state forked from version {}", old_version, snapshot.version());
-        }
+        let prev_storage_version = self.latest_version();
+        let next_storage_version = prev_storage_version.wrapping_add(1);
+        tracing::debug!(prev_storage_version, next_storage_version);
 
-        self.commit_inner(snapshot, changes, new_version, false)
+        ensure!(
+            prev_storage_version == prev_snapshot_version,
+            "trying to commit a delta forked from version {}, but the latest version is {}",
+            prev_snapshot_version,
+            prev_storage_version
+        );
+
+        self.commit_inner(snapshot, changes, next_storage_version, false)
             .await
     }
 
@@ -376,7 +381,7 @@ impl Storage {
 
             let substore_storage = SubstoreStorage { substore_snapshot };
 
-            // Commit the substore and collect the root hash
+            // Commit the substore and collect its root hash
             let (root_hash, substore_batch) = substore_storage
                 .commit(changeset, write_batch, version, perform_migration)
                 .await?;
@@ -391,7 +396,7 @@ impl Storage {
             substore_roots.push((config.clone(), root_hash, version));
         }
 
-        /* commit roots to main store */
+        // Add substore roots to the main store changeset
         let main_store_config = self.0.multistore_config.main_store.clone();
         let mut main_store_changes = changes_by_substore
             .remove(&main_store_config)
@@ -406,7 +411,7 @@ impl Storage {
                 .insert(config.prefix.to_string(), Some(root_hash.0.to_vec()));
         }
 
-        /* commit main substore */
+        // Commit the main store and collect the global root hash
         let main_store_snapshot = SubstoreSnapshot {
             config: main_store_config.clone(),
             rocksdb_snapshot: snapshot.0.snapshot.clone(),
@@ -426,9 +431,15 @@ impl Storage {
             ?version,
             "added main store to write batch"
         );
-        db.write(write_batch).expect("can write to db");
 
-        /* update multistore versions */
+        db.write(write_batch).expect("can write to db");
+        tracing::debug!(
+            ?global_root_hash,
+            ?version,
+            "committed main store and substores to db"
+        );
+
+        // Update the tracked versions for each substore.
         for (config, root_hash, new_version) in substore_roots {
             tracing::debug!(
                 ?root_hash,
@@ -442,38 +453,37 @@ impl Storage {
         tracing::debug!(?global_root_hash, ?version, "updating main store version");
         multistore_versions.set_version(main_store_config, version);
 
-        /* hydrate the snapshot cache */
-        if perform_migration {
+        // If we're not performing a migration, we should update the snapshot cache
+        if !perform_migration {
+            tracing::debug!("updating snapshot cache");
+
+            let latest_snapshot = Snapshot::new(db.clone(), version, multistore_versions);
+            // Obtain a write lock to the snapshot cache, and push the latest snapshot
+            // available. The lock guard is implicitly dropped immediately.
+            self.0
+                .snapshots
+                .write()
+                .try_push(latest_snapshot.clone())
+                .expect("should process snapshots with consecutive jmt versions");
+
+            tracing::debug!(?version, "dispatching snapshot");
+
+            // Send fails if the channel is closed (i.e., if there are no receivers);
+            // in this case, we should ignore the error, we have no one to notify.
+            let _ = self
+                .0
+                .dispatcher_tx
+                .send((latest_snapshot, (version, changes)));
+        } else {
             tracing::debug!("skipping snapshot cache update");
-            return Ok(global_root_hash);
         }
-
-        tracing::debug!("updating snapshot cache");
-
-        let latest_snapshot = Snapshot::new(db.clone(), version, multistore_versions);
-        // Obtain a write lock to the snapshot cache, and push the latest snapshot
-        // available. The lock guard is implicitly dropped immediately.
-        self.0
-            .snapshots
-            .write()
-            .try_push(latest_snapshot.clone())
-            .expect("should process snapshots with consecutive jmt versions");
-
-        tracing::debug!(?version, "dispatching snapshot");
-
-        // Send fails if the channel is closed (i.e., if there are no receivers);
-        // in this case, we should ignore the error, we have no one to notify.
-        let _ = self
-            .0
-            .dispatcher_tx
-            .send((latest_snapshot, (version, changes)));
 
         Ok(global_root_hash)
     }
 
     #[cfg(feature = "migration")]
-    /// Commits the provided [`StateDelta`] to persistent storage without increasing the version
-    /// of the chain state.
+    /// Commit the provided [`StateDelta`] to persistent storage without increasing the version
+    /// of the chain state, and skips the snapshot cache update.
     pub async fn commit_in_place(&self, delta: StateDelta<Snapshot>) -> Result<crate::RootHash> {
         let (snapshot, changes) = delta.flatten();
         let old_version = self.latest_version();

--- a/crates/cnidarium/src/store/substore.rs
+++ b/crates/cnidarium/src/store/substore.rs
@@ -356,10 +356,6 @@ pub struct SubstoreStorage {
 }
 
 impl SubstoreStorage {
-    pub fn from_snapshot(substore_snapshot: SubstoreSnapshot) -> Self {
-        Self { substore_snapshot }
-    }
-
     pub async fn commit(
         self,
         cache: Cache,

--- a/crates/cnidarium/src/store/substore.rs
+++ b/crates/cnidarium/src/store/substore.rs
@@ -1,5 +1,4 @@
 use std::{
-    cell::RefCell,
     fmt::{Display, Formatter},
     sync::Arc,
 };
@@ -354,23 +353,15 @@ impl HasPreimage for SubstoreSnapshot {
 
 pub struct SubstoreStorage {
     pub(crate) substore_snapshot: SubstoreSnapshot,
-    /// Internal: we accumulate writes into a [`rocksdb::WriteBatch`] and
-    /// return it to the caller so that they can commit it at their discretion.
-    /// We use this specific field as a workaround to avoid exposing RocksDB
-    /// types in the public API of the [`jmt::TreeWriter`] trait.
-    write_batch: Option<RefCell<rocksdb::WriteBatch>>,
 }
 
 impl SubstoreStorage {
     pub fn from_snapshot(substore_snapshot: SubstoreSnapshot) -> Self {
-        Self {
-            substore_snapshot,
-            write_batch: None,
-        }
+        Self { substore_snapshot }
     }
 
     pub async fn commit(
-        mut self,
+        self,
         cache: Cache,
         mut write_batch: rocksdb::WriteBatch,
         write_version: jmt::Version,
@@ -388,8 +379,11 @@ impl SubstoreStorage {
                             .into_iter()
                             .map(|(key, some_value)| (KeyHash::with::<sha2::Sha256>(&key), key, some_value))
                             .collect();
+
                         let cf_jmt_keys = self.substore_snapshot.config.cf_jmt_keys(&self.substore_snapshot.db);
                         let cf_jmt_keys_by_keyhash = self.substore_snapshot.config.cf_jmt_keys_by_keyhash(&self.substore_snapshot.db);
+                        let cf_jmt = self.substore_snapshot.config.cf_jmt(&self.substore_snapshot.db);
+                        let cf_jmt_values = self.substore_snapshot.config.cf_jmt_values(&self.substore_snapshot.db);
 
                         /* Keyhash and pre-image indices */
                         for (keyhash, key_preimage, value) in unwritten_changes.iter() {
@@ -416,16 +410,21 @@ impl SubstoreStorage {
                             jmt.put_value_set(unwritten_changes.into_iter().map(skip_key), write_version)?
                         };
 
-                        // Our high-level goal is to accumulate the node changes in the write batch.
-                        // We want to do this by implementing the `TreeWriter` trait, but without leaking
-                        // RocksDB-specific types in the public API of the JMT.
-                        //
-                        // To do this, we wrap the write batch in a `RefCell` and set it internally.
-                        self.write_batch = Some(std::cell::RefCell::new(write_batch));
-                        // The `write_node_batch` implementation will accumulate the changes in the write batch.
-                        self.write_node_batch(&batch.node_batch)?;
-                        // Now, we can pull the write batch out of the `RefCell` and pretend this never happened.
-                        let mut write_batch = self.write_batch.take().expect("write batch must be set by caller").into_inner();
+                        /* JMT nodes and values */
+                        for (node_key, node) in batch.node_batch.nodes() {
+                            let db_node_key_bytes= DbNodeKey::encode_from_node_key(node_key)?;
+                            let value_bytes = borsh::to_vec(node)?;
+                            tracing::trace!(?db_node_key_bytes, value_bytes = ?hex::encode(&value_bytes));
+                            write_batch.put_cf(cf_jmt, db_node_key_bytes, value_bytes);
+                        }
+
+
+                        for ((version, key_hash), some_value) in batch.node_batch.values() {
+                            let key_bytes = VersionedKeyHash::encode_from_keyhash(key_hash, version);
+                            let value_bytes = borsh::to_vec(some_value)?;
+                            tracing::trace!(?key_bytes, value_bytes = ?hex::encode(&value_bytes));
+                            write_batch.put_cf(cf_jmt_values, key_bytes, value_bytes);
+                        }
 
                         tracing::trace!(?root_hash, "accumulated node changes in the write batch");
 
@@ -451,59 +450,22 @@ impl SubstoreStorage {
 }
 
 impl TreeWriter for SubstoreStorage {
-    /// Write a collection of nodes ([`NodeBatch`]) into an internal write batch.
-    /// The write batch will be committed to the backing store at the application's discretion.
-    ///
-    /// Schema:
-    /// - JMT nodes are stored in the `cf_jmt` column family: `DbNodeKey` -> `Node`.
-    /// - JMT values are stored in the `cf_jmt_values` column family: `VersionedKeyHash` -> `Option<Vec<u8>>`.
-    ///
-    /// # Errors
-    /// This method errors if the write batch is not set by the caller,
-    /// or, because of a serialization error.
-    ///
-    /// # Panics
-    /// This method panics if multiple mutable borrows are attempted on the write batch.
-    fn write_node_batch(&self, node_batch: &jmt::storage::NodeBatch) -> Result<()> {
-        let Some(write_batch) = self.write_batch.as_ref() else {
-            anyhow::bail!("write batch must be set by caller");
-        };
-
-        let mut write_batch = write_batch.borrow_mut();
-
-        let cf_jmt = self
-            .substore_snapshot
-            .config
-            .cf_jmt(&self.substore_snapshot.db);
-
-        for (node_key, node) in node_batch.nodes() {
-            let db_node_key = DbNodeKey::from(node_key.clone());
-            let db_node_key_bytes = db_node_key.encode()?;
-            let value_bytes = borsh::to_vec(node)?;
-            tracing::trace!(?db_node_key_bytes, value_bytes = ?hex::encode(&value_bytes));
-            write_batch.put_cf(cf_jmt, db_node_key_bytes, value_bytes);
-        }
-
-        let cf_jmt_values = self
-            .substore_snapshot
-            .config
-            .cf_jmt_values(&self.substore_snapshot.db);
-
-        for ((version, key_hash), some_value) in node_batch.values() {
-            let versioned_key = VersionedKeyHash::new(*version, *key_hash);
-            let key_bytes = &versioned_key.encode();
-            let value_bytes = borsh::to_vec(some_value)?;
-            tracing::trace!(?key_bytes, value_bytes = ?hex::encode(&value_bytes));
-            write_batch.put_cf(cf_jmt_values, key_bytes, value_bytes);
-        }
-
-        Ok(())
+    fn write_node_batch(&self, _node_batch: &jmt::storage::NodeBatch) -> Result<()> {
+        // The "write"-part of the `TreeReader + TreeWriter` jmt architecture does not work
+        // well with a deferred write strategy.
+        // What we would like to do is to accumulate the changes in a write batch, and then commit
+        // them all at once. This isn't possible to do easily because the `TreeWriter` trait
+        // rightfully does not expose RocksDB-specific types in its API.
+        //
+        // The alternative is to use interior mutability but the semantics become
+        // so implementation specific that we lose the benefits of the trait abstraction.
+        unimplemented!("We inline the tree writing logic in the `commit` method")
     }
 }
 
 /// An ordered node key is a node key that is encoded in a way that
 /// preserves the order of the node keys in the database.
-pub struct DbNodeKey(NodeKey);
+pub struct DbNodeKey(pub NodeKey);
 
 impl DbNodeKey {
     pub fn from(node_key: NodeKey) -> Self {
@@ -515,9 +477,13 @@ impl DbNodeKey {
     }
 
     pub fn encode(&self) -> Result<Vec<u8>> {
+        Self::encode_from_node_key(&self.0)
+    }
+
+    pub fn encode_from_node_key(node_key: &NodeKey) -> Result<Vec<u8>> {
         let mut bytes = Vec::new();
-        bytes.extend_from_slice(&self.0.version().to_be_bytes()); // encode version as big-endian
-        let rest = borsh::to_vec(&self.0)?;
+        bytes.extend_from_slice(&node_key.version().to_be_bytes()); // encode version as big-endian
+        let rest = borsh::to_vec(node_key)?;
         bytes.extend_from_slice(&rest);
         Ok(bytes)
     }
@@ -542,13 +508,13 @@ pub struct VersionedKeyHash {
 }
 
 impl VersionedKeyHash {
-    pub fn new(version: jmt::Version, key_hash: KeyHash) -> Self {
-        Self { version, key_hash }
+    pub fn encode(&self) -> Vec<u8> {
+        VersionedKeyHash::encode_from_keyhash(&self.key_hash, &self.version)
     }
 
-    pub fn encode(&self) -> Vec<u8> {
-        let mut buf: Vec<u8> = self.key_hash.0.to_vec();
-        buf.extend_from_slice(&self.version.to_be_bytes());
+    pub fn encode_from_keyhash(key_hash: &KeyHash, version: &jmt::Version) -> Vec<u8> {
+        let mut buf: Vec<u8> = key_hash.0.to_vec();
+        buf.extend_from_slice(&version.to_be_bytes());
         buf
     }
 


### PR DESCRIPTION
This PR is a prelude to implementing "staged" writes to our storage layer (cc @noot #4095 ). Specifically, it:
- inline the `write_node_batch` logic inside of `SubstoreStorage::commit`
- make sure that nodes are inserted into the `rocksdb::WriteBatch` rather than immediately written to disk

The last point was a bug, we want to commit to a set of writes atomically, but the tree changes were written ahead of the rest of the transaction. By inserting a `panic!` statement between the tree write and the `write(node_batch` statement and restarting the full node I was able to observe a consistency discrepancy. This PR fixes this.