### PR TITLE
dex: streamline `PositionManager`

### DIFF
--- a/crates/core/component/dex/src/component/action_handler/position/open.rs
+++ b/crates/core/component/dex/src/component/action_handler/position/open.rs
@@ -2,11 +2,9 @@ use anyhow::Result;
 use async_trait::async_trait;
 use cnidarium::StateWrite;
 use cnidarium_component::ActionHandler;
-use penumbra_proto::StateWriteProto as _;
 
 use crate::{
-    component::{PositionManager, PositionRead, ValueCircuitBreaker},
-    event,
+    component::PositionManager,
     lp::{action::PositionOpen, position},
 };
 
@@ -31,17 +29,7 @@ impl ActionHandler for PositionOpen {
     }
 
     async fn check_and_execute<S: StateWrite>(&self, mut state: S) -> Result<()> {
-        // Validate that the position ID doesn't collide
-        state.check_position_id_unused(&self.position.id()).await?;
-
-        // Credit the DEX for the inflows from this position.
-        // TODO: in a future PR, split current PositionManager to PositionManagerInner
-        // and fold this into a position open method
-        state.vcb_credit(self.position.reserves_1()).await?;
-        state.vcb_credit(self.position.reserves_2()).await?;
-
-        state.put_position(self.position.clone()).await?;
-        state.record_proto(event::position_open(self));
+        state.open_position(self.position.clone()).await?;
         Ok(())
     }
 }

--- a/crates/core/component/dex/src/component/action_handler/position/withdraw.rs
+++ b/crates/core/component/dex/src/component/action_handler/position/withdraw.rs
@@ -1,16 +1,11 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use ark_ff::Zero;
 use async_trait::async_trait;
 use cnidarium::StateWrite;
 use cnidarium_component::ActionHandler;
 use decaf377::Fr;
-use penumbra_proto::StateWriteProto;
 
-use crate::{
-    component::{PositionManager, PositionRead, ValueCircuitBreaker},
-    event,
-    lp::{action::PositionWithdraw, position, Reserves},
-};
+use crate::{component::PositionManager, lp::action::PositionWithdraw};
 
 #[async_trait]
 /// Debits a closed position NFT and credits a withdrawn position NFT and the final reserves.
@@ -27,25 +22,22 @@ impl ActionHandler for PositionWithdraw {
         // we need to ensure that we're checking the reserves at the moment we execute
         // the withdrawal, to prevent any possibility of TOCTOU attacks.
 
-        let mut metadata = state
-            .position_by_id(&self.position_id)
-            .await?
-            .ok_or_else(|| anyhow!("withdrew from unknown position {}", self.position_id))?;
+        // Execute the withdrawal, extracting the reserves from the position.
+        let actual_reserves = state
+            .withdraw_position(self.position_id, self.sequence)
+            .await?;
 
-        // First, check that the commitment to the amount the user is
+        // Next, and CRITICALLY, check that the commitment to the amount the user is
         // withdrawing is correct.
         //
         // Unlike other actions, where a balance commitment is used for
         // shielding a value, this commitment is used for compression, giving a
         // single commitment rather than a list of token amounts.
-
+        //
         // Note: since this is forming a commitment only to the reserves,
         // we are implicitly setting the reward amount to 0. However, we can
         // add support for rewards in the future without client changes.
-        let expected_reserves_commitment = metadata
-            .reserves
-            .balance(&metadata.phi.pair)
-            .commit(Fr::zero());
+        let expected_reserves_commitment = actual_reserves.commit(Fr::zero());
 
         if self.reserves_commitment != expected_reserves_commitment {
             anyhow::bail!(
@@ -54,58 +46,6 @@ impl ActionHandler for PositionWithdraw {
                 expected_reserves_commitment
             );
         }
-
-        // Next, check that the withdrawal is consistent with the position state.
-        // This should be redundant with the value balance mechanism (clients should
-        // only be able to get the required input LPNFTs if the state transitions are
-        // consistent), but we check it here for defense in depth.
-        if self.sequence == 0 {
-            if metadata.state != position::State::Closed {
-                anyhow::bail!(
-                    "attempted to withdraw position {} with state {}, expected Closed",
-                    self.position_id,
-                    metadata.state
-                );
-            }
-        } else {
-            if let position::State::Withdrawn { sequence } = metadata.state {
-                if sequence + 1 != self.sequence {
-                    anyhow::bail!(
-                        "attempted to withdraw position {} with sequence {}, expected {}",
-                        self.position_id,
-                        self.sequence,
-                        sequence + 1
-                    );
-                }
-            } else {
-                anyhow::bail!(
-                    "attempted to withdraw position {} with state {}, expected Withdrawn",
-                    self.position_id,
-                    metadata.state
-                );
-            }
-        }
-
-        // Record an event prior to updating the position state, so we have access to
-        // the current reserves.
-        state.record_proto(event::position_withdraw(self, &metadata));
-
-        // Debit the DEX for the outflows from this position.
-        // TODO: in a future PR, split current PositionManager to PositionManagerInner
-        // and fold this into a position open method
-        state.vcb_debit(metadata.reserves_1()).await?;
-        state.vcb_debit(metadata.reserves_2()).await?;
-
-        // Finally, update the position. This has two steps:
-        // - update the state with the correct sequence number;
-        // - zero out the reserves, to prevent double-withdrawals.
-        metadata.state = position::State::Withdrawn {
-            // We just checked that the supplied sequence number is incremented by 1 from prev.
-            sequence: self.sequence,
-        };
-        metadata.reserves = Reserves::zero();
-
-        state.put_position(metadata).await?;
 
         Ok(())
     }

--- a/crates/core/component/dex/src/component/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/component/circuit_breaker/value.rs
@@ -52,7 +52,7 @@ mod tests {
     use crate::component::{StateReadExt as _, StateWriteExt as _};
     use crate::lp::plan::PositionWithdrawPlan;
     use crate::{
-        component::{router::limit_buy, tests::TempStorageExt, PositionManager as _},
+        component::{router::limit_buy, tests::TempStorageExt},
         state_key, DirectedUnitPair,
     };
     use crate::{BatchSwapOutputData, PositionOpen};
@@ -224,7 +224,7 @@ mod tests {
 
         let id = buy_1.id();
 
-        let position = state_tx.handle_limit_order(&None, buy_1);
+        let position = buy_1;
         state_tx.index_position_by_price(&position);
         state_tx
             .update_available_liquidity(&position, &None)

--- a/crates/core/component/dex/src/component/router/fill_route.rs
+++ b/crates/core/component/dex/src/component/router/fill_route.rs
@@ -412,11 +412,11 @@ impl<S: StateRead + StateWrite> Frontier<S> {
 
     async fn save(&mut self) -> Result<()> {
         for position in &self.positions {
-            self.state.put_position(position.clone()).await?;
+            self.state.position_execution(position.clone()).await?;
 
             // Create an ABCI event signaling that the position was executed against
             self.state
-                .record_proto(event::position_execution(position.clone()));
+                .record_proto(event::position_execution(&position));
         }
         Ok(())
     }
@@ -492,7 +492,7 @@ impl<S: StateRead + StateWrite> Frontier<S> {
         // frontier.  The other positions will be written out either when
         // they're fully consumed, or when we finish filling.
         self.state
-            .put_position(self.positions[index].clone())
+            .position_execution(self.positions[index].clone())
             .await
             .expect("writing to storage should not fail");
 

--- a/crates/core/component/dex/src/component/router/path_search.rs
+++ b/crates/core/component/dex/src/component/router/path_search.rs
@@ -9,7 +9,7 @@ use penumbra_num::fixpoint::U128x128;
 use tokio::task::JoinSet;
 use tracing::{instrument, Instrument};
 
-use crate::component::PositionManager;
+use crate::component::PositionRead as _;
 
 use super::{Path, PathCache, PathEntry, RoutingParams, SharedPathCache};
 

--- a/crates/core/component/dex/src/component/router/tests.rs
+++ b/crates/core/component/dex/src/component/router/tests.rs
@@ -8,7 +8,6 @@ use penumbra_num::{fixpoint::U128x128, Amount};
 use rand_core::OsRng;
 use std::sync::Arc;
 
-use crate::component::ValueCircuitBreaker;
 use crate::lp::SellOrder;
 use crate::DexParameters;
 use crate::{
@@ -326,16 +325,16 @@ async fn create_test_positions_basic<S: StateWrite>(s: &mut S, misprice: bool) {
         },
     );
 
-    s.put_position(position_1).await.unwrap();
-    s.put_position(position_2).await.unwrap();
-    s.put_position(position_3).await.unwrap();
-    s.put_position(position_4).await.unwrap();
-    s.put_position(position_5).await.unwrap();
+    s.open_position(position_1).await.unwrap();
+    s.open_position(position_2).await.unwrap();
+    s.open_position(position_3).await.unwrap();
+    s.open_position(position_4).await.unwrap();
+    s.open_position(position_5).await.unwrap();
     if misprice {
-        s.put_position(position_6).await.unwrap();
+        s.open_position(position_6).await.unwrap();
     }
-    s.put_position(position_7).await.unwrap();
-    s.put_position(position_8).await.unwrap();
+    s.open_position(position_7).await.unwrap();
+    s.open_position(position_8).await.unwrap();
 }
 
 /// Create a `Position` to buy `asset_1` using `asset_2` with explicit p/q.
@@ -436,8 +435,8 @@ async fn position_get_best_price() -> anyhow::Result<()> {
             r2: 0u64.into(),
         },
     );
-    state_tx.put_position(position_1.clone()).await.unwrap();
-    state_tx.put_position(position_2.clone()).await.unwrap();
+    state_tx.open_position(position_1.clone()).await.unwrap();
+    state_tx.open_position(position_2.clone()).await.unwrap();
 
     let positions = state_tx
         .positions_by_price(&pair)
@@ -494,8 +493,8 @@ async fn test_multiple_similar_position() -> anyhow::Result<()> {
     let mut buy_2 = limit_buy(pair_1.clone(), 1u64.into(), price1);
     buy_1.nonce = [1u8; 32];
     buy_2.nonce = [2u8; 32];
-    state_tx.put_position(buy_1.clone()).await.unwrap();
-    state_tx.put_position(buy_2.clone()).await.unwrap();
+    state_tx.open_position(buy_1.clone()).await.unwrap();
+    state_tx.open_position(buy_2.clone()).await.unwrap();
 
     let mut p_1 = state_tx
         .best_position(&pair_1.into_directed_trading_pair())
@@ -504,7 +503,7 @@ async fn test_multiple_similar_position() -> anyhow::Result<()> {
         .expect("we just posted two positions");
     assert_eq!(p_1.nonce, buy_1.nonce);
     p_1.reserves = p_1.reserves.flip();
-    state_tx.put_position(p_1).await.unwrap();
+    state_tx.position_execution(p_1).await.unwrap();
 
     let mut p_2 = state_tx
         .best_position(&pair_1.into_directed_trading_pair())
@@ -513,7 +512,7 @@ async fn test_multiple_similar_position() -> anyhow::Result<()> {
         .expect("there is one position remaining");
     assert_eq!(p_2.nonce, buy_2.nonce);
     p_2.reserves = p_2.reserves.flip();
-    state_tx.put_position(p_2).await.unwrap();
+    state_tx.position_execution(p_2).await.unwrap();
 
     assert!(state_tx
         .best_position(&pair_1.into_directed_trading_pair())
@@ -568,8 +567,8 @@ async fn fill_route_constraint_stacked() -> anyhow::Result<()> {
 
     let buy_1 = limit_buy(pair_1.clone(), 3u64.into(), price2);
     let buy_2 = limit_buy(pair_1.clone(), 1u64.into(), price1);
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
 
     /* pair 2 */
     let price2 = Amount::from(2u64);
@@ -579,10 +578,10 @@ async fn fill_route_constraint_stacked() -> anyhow::Result<()> {
     let buy_3 = limit_buy(pair_2.clone(), 50u64.into(), price1);
     let buy_4 = limit_buy(pair_2.clone(), 50u64.into(), price1);
 
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
-    state_tx.put_position(buy_3).await.unwrap();
-    state_tx.put_position(buy_4).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_3).await.unwrap();
+    state_tx.open_position(buy_4).await.unwrap();
 
     /* pair 3 */
     let price2000 = 2000u64.into();
@@ -597,11 +596,11 @@ async fn fill_route_constraint_stacked() -> anyhow::Result<()> {
     let buy_4 = limit_buy(pair_3.clone(), 1u64.into(), price3100);
     let buy_5 = limit_buy(pair_3.clone(), 1u64.into(), price10000);
 
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
-    state_tx.put_position(buy_3).await.unwrap();
-    state_tx.put_position(buy_4).await.unwrap();
-    state_tx.put_position(buy_5).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_3).await.unwrap();
+    state_tx.open_position(buy_4).await.unwrap();
+    state_tx.open_position(buy_5).await.unwrap();
 
     let delta_1 = Value {
         asset_id: gm.id(),
@@ -678,7 +677,7 @@ async fn fill_route_constraint_1() -> anyhow::Result<()> {
     let price1 = one;
 
     let buy_1 = limit_buy(pair_1.clone(), 200u64.into(), price1);
-    state_tx.put_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
 
     /* pair 2 */
     let price2 = Amount::from(2u64);
@@ -688,10 +687,10 @@ async fn fill_route_constraint_1() -> anyhow::Result<()> {
     let buy_3 = limit_buy(pair_2.clone(), 50u64.into(), price2);
     let buy_4 = limit_buy(pair_2.clone(), 50u64.into(), price2);
 
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
-    state_tx.put_position(buy_3).await.unwrap();
-    state_tx.put_position(buy_4).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_3).await.unwrap();
+    state_tx.open_position(buy_4).await.unwrap();
 
     /* pair 3 */
     let price2000 = 2000u64.into();
@@ -706,11 +705,11 @@ async fn fill_route_constraint_1() -> anyhow::Result<()> {
     let buy_4 = limit_buy(pair_3.clone(), 1u64.into(), price3100);
     let buy_5 = limit_buy(pair_3.clone(), 1u64.into(), price10000);
 
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
-    state_tx.put_position(buy_3).await.unwrap();
-    state_tx.put_position(buy_4).await.unwrap();
-    state_tx.put_position(buy_5).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_3).await.unwrap();
+    state_tx.open_position(buy_4).await.unwrap();
+    state_tx.open_position(buy_5).await.unwrap();
 
     let delta_1 = Value {
         asset_id: gm.id(),
@@ -782,13 +781,13 @@ async fn fill_route_unconstrained() -> anyhow::Result<()> {
     let price1 = one;
     let buy_1 = limit_buy(pair_1.clone(), 1u64.into(), price1);
     let buy_2 = limit_buy(pair_1.clone(), 1u64.into(), price1);
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
 
     let buy_1 = limit_buy(pair_2.clone(), 1u64.into(), price1);
     let buy_2 = limit_buy(pair_2.clone(), 1u64.into(), price1);
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
 
     let price1500 = 1500u64.into();
     let buy_1 = limit_buy(pair_3.clone(), 1u64.into(), price1500);
@@ -796,11 +795,11 @@ async fn fill_route_unconstrained() -> anyhow::Result<()> {
     let buy_3 = limit_buy(pair_3.clone(), 1u64.into(), price1500);
     let buy_4 = limit_buy(pair_3.clone(), 1u64.into(), price1500);
     let buy_5 = limit_buy(pair_3.clone(), 1u64.into(), price1500);
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
-    state_tx.put_position(buy_3).await.unwrap();
-    state_tx.put_position(buy_4).await.unwrap();
-    state_tx.put_position(buy_5).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_3).await.unwrap();
+    state_tx.open_position(buy_4).await.unwrap();
+    state_tx.open_position(buy_5).await.unwrap();
 
     let delta_1 = Value {
         asset_id: gm.id(),
@@ -876,15 +875,15 @@ async fn fill_route_hit_spill_price() -> anyhow::Result<()> {
     let price1 = one;
     let buy_1 = limit_buy(pair_1.clone(), 1u64.into(), price1);
     let buy_2 = limit_buy(pair_1.clone(), 2u64.into(), price1);
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
 
     let buy_1 = limit_buy(pair_2.clone(), one, price1);
     let buy_2 = limit_buy(pair_2.clone(), one, price1);
     let buy_3 = limit_buy(pair_2.clone(), one, price1);
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
-    state_tx.put_position(buy_3).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_3).await.unwrap();
 
     let price1500 = Amount::from(1500u64);
     let price1400 = Amount::from(1400u64);
@@ -893,9 +892,9 @@ async fn fill_route_hit_spill_price() -> anyhow::Result<()> {
     let buy_1 = limit_buy(pair_3.clone(), one, price1500);
     let buy_2 = limit_buy(pair_3.clone(), one, price1400);
     let buy_3 = limit_buy(pair_3.clone(), one, price1300);
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
-    state_tx.put_position(buy_3).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_3).await.unwrap();
 
     let delta_1 = Value {
         asset_id: gm.id(),
@@ -953,7 +952,7 @@ async fn simple_route() -> anyhow::Result<()> {
 
     // Create a single 1:1 gn:penumbra position (i.e. buy 1 gn at 1 penumbra).
     let buy_1 = limit_buy(pair_1.clone(), 1u64.into(), 1u64.into());
-    state_tx.put_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
     state_tx.apply();
 
     // We should be able to call path_search and route through that position.
@@ -988,20 +987,7 @@ async fn best_position_route_and_fill() -> anyhow::Result<()> {
 
     // Create a single 1:1 gn:penumbra position (i.e. buy 1 gn at 1 penumbra).
     let buy_1 = limit_buy(pair_1.clone(), 1u64.into(), 1u64.into());
-    state_tx.put_position(buy_1).await.unwrap();
-    // TODO: later, this should be folded into an open_position method
-    state_tx
-        .vcb_credit(Value {
-            asset_id: gn.id(),
-            amount: Amount::from(1u64) * gn.unit_amount(),
-        })
-        .await?;
-    state_tx
-        .vcb_credit(Value {
-            asset_id: penumbra.id(),
-            amount: Amount::from(1u64) * penumbra.unit_amount(),
-        })
-        .await?;
+    state_tx.open_position(buy_1).await.unwrap();
     state_tx.apply();
 
     // We should be able to call path_search and route through that position.
@@ -1077,27 +1063,6 @@ async fn multi_hop_route_and_fill() -> anyhow::Result<()> {
     let pair_gn_gm = DirectedUnitPair::new(gn.clone(), gm.clone());
     let pair_gm_penumbra = DirectedUnitPair::new(gm.clone(), penumbra.clone());
 
-    // TEMP TODO: disable VCB for this test. Later, remove this code once we restructure
-    // the position manager.
-    let infinite_gm = Value {
-        asset_id: gm.id(),
-        amount: Amount::from(100000u128) * gm.unit_amount(),
-    };
-
-    let infinite_gn = Value {
-        asset_id: gn.id(),
-        amount: Amount::from(100000u128) * gn.unit_amount(),
-    };
-
-    let infinite_penumbra = Value {
-        asset_id: penumbra.id(),
-        amount: Amount::from(100000u128) * penumbra.unit_amount(),
-    };
-
-    state_tx.vcb_credit(infinite_gm).await?;
-    state_tx.vcb_credit(infinite_gn).await?;
-    state_tx.vcb_credit(infinite_penumbra).await?;
-
     // Create a 2:1 penumbra:gm position (i.e. buy 20 gm at 2 penumbra each).
     let buy_1 = limit_buy_pq(
         pair_gm_penumbra.clone(),
@@ -1106,7 +1071,7 @@ async fn multi_hop_route_and_fill() -> anyhow::Result<()> {
         2u64.into(),
         0u32,
     );
-    state_tx.put_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
 
     // Create a 2.1:1 penumbra:gm position (i.e. buy 40 gm at 2.1 penumbra each).
     let buy_2 = limit_buy_pq(
@@ -1116,7 +1081,7 @@ async fn multi_hop_route_and_fill() -> anyhow::Result<()> {
         2100000u64.into(),
         0u32,
     );
-    state_tx.put_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
 
     // Create a 2.2:1 penumbra:gm position (i.e. buy 160 gm at 2.2 penumbra each).
     let buy_3 = limit_buy_pq(
@@ -1126,7 +1091,7 @@ async fn multi_hop_route_and_fill() -> anyhow::Result<()> {
         2200000u64.into(),
         0u32,
     );
-    state_tx.put_position(buy_3).await.unwrap();
+    state_tx.open_position(buy_3).await.unwrap();
 
     // Create a 1:1 gm:gn position (i.e. buy 100 gm at 1 gn each).
     let buy_4 = limit_buy_pq(
@@ -1137,7 +1102,7 @@ async fn multi_hop_route_and_fill() -> anyhow::Result<()> {
         // with 20bps fee
         20u32,
     );
-    state_tx.put_position(buy_4).await.unwrap();
+    state_tx.open_position(buy_4).await.unwrap();
 
     // Create a 1.9:1 penumbra:gn position (i.e. buy 160 gn at 1.9 penumbra each).
     let buy_5 = Position::new(
@@ -1151,7 +1116,7 @@ async fn multi_hop_route_and_fill() -> anyhow::Result<()> {
             r2: 80000000u32.into(),
         },
     );
-    state_tx.put_position(buy_5).await.unwrap();
+    state_tx.open_position(buy_5).await.unwrap();
 
     // Create a 1:1 gm:gn position (i.e. buy 100 gn at 1 gm each).
     let buy_6 = limit_buy_pq(
@@ -1162,7 +1127,7 @@ async fn multi_hop_route_and_fill() -> anyhow::Result<()> {
         // with 20bps fee
         20u32,
     );
-    state_tx.put_position(buy_6).await.unwrap();
+    state_tx.open_position(buy_6).await.unwrap();
 
     state_tx.apply();
 
@@ -1250,8 +1215,8 @@ async fn fill_dust_route() -> anyhow::Result<()> {
     let price1 = one;
     let buy_1 = limit_buy(pair_1.clone(), 1u64.into(), price1);
     let buy_2 = limit_buy(pair_1.clone(), 1u64.into(), price1);
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
     let dust_constraint = Position::new(
         OsRng,
         pair_2.into_directed_trading_pair(),
@@ -1263,7 +1228,7 @@ async fn fill_dust_route() -> anyhow::Result<()> {
             r2: 1u64.into(),
         },
     );
-    state_tx.put_position(dust_constraint).await.unwrap();
+    state_tx.open_position(dust_constraint).await.unwrap();
 
     let delta_1 = Value {
         asset_id: gm.id(),
@@ -1315,8 +1280,8 @@ async fn fill_route_dust() {
     let price1 = one;
     let buy_1 = limit_buy(pair_1.clone(), 1u64.into(), price1);
     let buy_2 = limit_buy(pair_1.clone(), 1u64.into(), price1);
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
     let dust_constraint = Position::new(
         OsRng,
         pair_2.into_directed_trading_pair(),
@@ -1328,7 +1293,7 @@ async fn fill_route_dust() {
             r2: 1u64.into(),
         },
     );
-    state_tx.put_position(dust_constraint).await.unwrap();
+    state_tx.open_position(dust_constraint).await.unwrap();
 
     let delta_1 = Value {
         asset_id: gm.id(),
@@ -1380,8 +1345,8 @@ async fn fill_route_with_dust_constraint() -> anyhow::Result<()> {
     let price1 = one;
     let buy_1 = limit_buy(pair_1.clone(), 1u64.into(), price1);
     let buy_2 = limit_buy(pair_1.clone(), 1u64.into(), price1);
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
 
     let dust_constraint = Position::new(
         OsRng,
@@ -1407,10 +1372,10 @@ async fn fill_route_with_dust_constraint() -> anyhow::Result<()> {
         },
     );
 
-    state_tx.put_position(dust_constraint).await.unwrap();
-    state_tx.put_position(normal_order).await.unwrap();
+    state_tx.open_position(dust_constraint).await.unwrap();
+    state_tx.open_position(normal_order).await.unwrap();
     let buy_1 = limit_buy(pair_3, 100u64.into(), 1400u64.into());
-    state_tx.put_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
 
     let delta_1 = Value {
         asset_id: gm.id(),
@@ -1468,8 +1433,8 @@ async fn fill_route_with_stacked_dust_constraint() -> anyhow::Result<()> {
     let price1 = one;
     let buy_1 = limit_buy(pair_1.clone(), 1u64.into(), price1);
     let buy_2 = limit_buy(pair_1.clone(), 1u64.into(), price1);
-    state_tx.put_position(buy_1).await.unwrap();
-    state_tx.put_position(buy_2).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_2).await.unwrap();
 
     let dust_constraint_p2 = Position::new(
         OsRng,
@@ -1495,8 +1460,8 @@ async fn fill_route_with_stacked_dust_constraint() -> anyhow::Result<()> {
         },
     );
 
-    state_tx.put_position(dust_constraint_p2).await.unwrap();
-    state_tx.put_position(normal_order_p2).await.unwrap();
+    state_tx.open_position(dust_constraint_p2).await.unwrap();
+    state_tx.open_position(normal_order_p2).await.unwrap();
 
     let dust_constraint_p3 = Position::new(
         OsRng,
@@ -1522,11 +1487,11 @@ async fn fill_route_with_stacked_dust_constraint() -> anyhow::Result<()> {
         },
     );
 
-    state_tx.put_position(dust_constraint_p3).await.unwrap();
-    state_tx.put_position(normal_order_p3).await.unwrap();
+    state_tx.open_position(dust_constraint_p3).await.unwrap();
+    state_tx.open_position(normal_order_p3).await.unwrap();
 
     let buy_1 = limit_buy(pair_4, 100u64.into(), 1400u64.into());
-    state_tx.put_position(buy_1).await.unwrap();
+    state_tx.open_position(buy_1).await.unwrap();
 
     let delta_1 = Value {
         asset_id: gm.id(),
@@ -1633,12 +1598,12 @@ async fn path_search_testnet_53_1_reproduction() -> anyhow::Result<()> {
         .unwrap()
         .into_position(OsRng);
 
-    state.put_position(s_a).await.unwrap();
-    state.put_position(a_t).await.unwrap();
-    state.put_position(s_b).await.unwrap();
-    state.put_position(b_t).await.unwrap();
-    state.put_position(s_c).await.unwrap();
-    state.put_position(c_t).await.unwrap();
+    state.open_position(s_a).await.unwrap();
+    state.open_position(a_t).await.unwrap();
+    state.open_position(s_b).await.unwrap();
+    state.open_position(b_t).await.unwrap();
+    state.open_position(s_c).await.unwrap();
+    state.open_position(c_t).await.unwrap();
 
     let cache = PathCache::begin(penumbra.id(), state.fork());
     let mut cache_guard = cache.lock();
@@ -1801,15 +1766,15 @@ async fn path_search_commutative() -> anyhow::Result<()> {
         .unwrap()
         .into_position(OsRng);
 
-    state.put_position(s_a).await.unwrap();
-    state.put_position(s_c).await.unwrap();
-    state.put_position(a_b).await.unwrap();
-    state.put_position(a_t).await.unwrap();
-    state.put_position(b_t).await.unwrap();
-    state.put_position(b_c).await.unwrap();
-    state.put_position(c_t).await.unwrap();
-    state.put_position(c_d).await.unwrap();
-    state.put_position(d_t).await.unwrap();
+    state.open_position(s_a).await.unwrap();
+    state.open_position(s_c).await.unwrap();
+    state.open_position(a_b).await.unwrap();
+    state.open_position(a_t).await.unwrap();
+    state.open_position(b_t).await.unwrap();
+    state.open_position(b_c).await.unwrap();
+    state.open_position(c_t).await.unwrap();
+    state.open_position(c_d).await.unwrap();
+    state.open_position(d_t).await.unwrap();
 
     let cache = PathCache::begin(btc.id(), state.fork());
     let mut cache_guard = cache.lock();
@@ -1993,10 +1958,10 @@ async fn path_search_unique() -> anyhow::Result<()> {
         .unwrap()
         .into_position(OsRng);
 
-    state.put_position(s_a).await.unwrap();
-    state.put_position(s_b).await.unwrap();
-    state.put_position(a_t).await.unwrap();
-    state.put_position(b_t).await.unwrap();
+    state.open_position(s_a).await.unwrap();
+    state.open_position(s_b).await.unwrap();
+    state.open_position(a_t).await.unwrap();
+    state.open_position(b_t).await.unwrap();
 
     let cache = PathCache::begin(pen.id(), state.fork());
     let mut cache_guard = cache.lock();

--- a/crates/core/component/dex/src/event.rs
+++ b/crates/core/component/dex/src/event.rs
@@ -1,6 +1,6 @@
 use crate::{
     lp::{
-        action::{PositionClose, PositionOpen, PositionWithdraw},
+        action::PositionClose,
         position::{self, Position},
     },
     swap::Swap,
@@ -30,13 +30,13 @@ pub fn swap_claim(swap_claim: &SwapClaim) -> pb::EventSwapClaim {
     }
 }
 
-pub fn position_open(position_open: &PositionOpen) -> pb::EventPositionOpen {
+pub fn position_open(position: &Position) -> pb::EventPositionOpen {
     pb::EventPositionOpen {
-        position_id: Some(position_open.position.id().into()),
-        trading_pair: Some(position_open.position.phi.pair.into()),
-        reserves_1: Some(position_open.position.reserves.r1.into()),
-        reserves_2: Some(position_open.position.reserves.r2.into()),
-        trading_fee: position_open.position.phi.component.fee,
+        position_id: Some(position.id().into()),
+        trading_pair: Some(position.phi.pair.into()),
+        reserves_1: Some(position.reserves.r1.into()),
+        reserves_2: Some(position.reserves.r2.into()),
+        trading_fee: position.phi.component.fee,
     }
 }
 
@@ -49,7 +49,7 @@ pub fn position_close(action: &PositionClose) -> pb::EventPositionClose {
 }
 
 pub fn position_withdraw(
-    position_withdraw: &PositionWithdraw,
+    position_id: position::Id,
     final_position_state: &Position,
 ) -> pb::EventPositionWithdraw {
     let sequence = if let position::State::Withdrawn { sequence, .. } = final_position_state.state {
@@ -58,7 +58,7 @@ pub fn position_withdraw(
         0
     };
     pb::EventPositionWithdraw {
-        position_id: Some(position_withdraw.position_id.into()),
+        position_id: Some(position_id.into()),
         trading_pair: Some(final_position_state.phi.pair.into()),
         reserves_1: Some(final_position_state.reserves.r1.into()),
         reserves_2: Some(final_position_state.reserves.r2.into()),
@@ -66,7 +66,7 @@ pub fn position_withdraw(
     }
 }
 
-pub fn position_execution(post_execution_state: Position) -> pb::EventPositionExecution {
+pub fn position_execution(post_execution_state: &Position) -> pb::EventPositionExecution {
     pb::EventPositionExecution {
         position_id: Some(post_execution_state.id().into()),
         trading_pair: Some(post_execution_state.phi.pair.into()),

--- a/crates/core/component/dex/src/lp/position.rs
+++ b/crates/core/component/dex/src/lp/position.rs
@@ -33,7 +33,7 @@ pub struct Position {
     /// sequence of stateful NFTs based on the [`Id`].
     pub nonce: [u8; 32],
     /// Set to `true` if a position is a limit-order, meaning that it will be closed after being
-    /// filled against. Note that this is not currently supported in the dex state machine.
+    /// filled against.
     pub close_on_fill: bool,
 }
 


### PR DESCRIPTION
This implements an API suggestion originally made by @cronokirby to expose context-specific methods for updating positions.

We maintain a single `put_position` method on the `Inner` trait so that we're
able to have a single point where we edit any necessary indexes, but this is
now not exposed to callers. Instead they call a scope-specific method that
calls `put_position` internally.

Currently there's still room to improve the API safety but we'll want to
potentially change the signature of `put_position` to ensure that this remains
efficient. It would be ideal if it were possible to do all reads up front and
concurrently. Further investigation on this point would be desirable.

This commit has a security-critical change in that the logic for position
withdrawals' balance commitment changes, and it'd be good to get review on that
part in particular.