### PR TITLE
ibc: use outbound_ics20_transfers_enabled chain parameter

### DIFF
--- a/crates/core/app/src/action_handler/actions.rs
+++ b/crates/core/app/src/action_handler/actions.rs
@@ -92,7 +92,7 @@ impl AppActionHandler for Action {
                     .await?
                     .outbound_ics20_transfers_enabled
                 {
-                    anyhow::bail!("transaction contains IBC actions, but IBC is not enabled");
+                    anyhow::bail!("transaction an ICS20 withdrawal, but outbound ICS20 withdrawals are not enabled");
                 }
                 action.check_historical(state).await
             }


### PR DESCRIPTION
this uses the existing outbound_ics20_transfers_enabled to gate ics20 withdrawals