### PR TITLE
upgrades: write a migration script for #4084

### DIFF
--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -13,7 +13,7 @@ use cnidarium::{StateDelta, Storage};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use pd::{
     cli::{Opt, RootCommand, TestnetCommand},
-    migrate::Migration::SimpleMigration,
+    migrate::Migration::Testnet70,
     testnet::{
         config::{get_testnet_dir, parse_tm_address, url_has_necessary_parts},
         generate::TestnetConfig,
@@ -442,7 +442,7 @@ async fn main() -> anyhow::Result<()> {
             migrate_archive,
         } => {
             tracing::info!("migrating state in {}", target_directory.display());
-            SimpleMigration
+            Testnet70
                 .migrate(target_directory.clone(), genesis_start)
                 .await
                 .context("failed to upgrade state")?;


### PR DESCRIPTION
This implements a migration for #4084 and makes it the default command in `pd migrate`.