### PR TITLE
fee: gate `penumbra-proto/rpc` on component feature

### DIFF
--- a/crates/core/component/fee/Cargo.toml
+++ b/crates/core/component/fee/Cargo.toml
@@ -9,6 +9,7 @@ component = [
     "cnidarium",
     "penumbra-proto/cnidarium",
     "tonic",
+    "penumbra-proto/rpc"
 ]
 default = ["std", "component"]
 std = ["ark-ff/std"]
@@ -27,7 +28,7 @@ decaf377-rdsa = {workspace = true}
 metrics = {workspace = true}
 penumbra-asset = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}
-penumbra-proto = {workspace = true, features = ["rpc"], default-features = false}
+penumbra-proto = {workspace = true, default-features = false}
 rand = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}
 serde = {workspace = true, features = ["derive"]}


### PR DESCRIPTION
After deploying testnet 70, we discovered that an OS specific crate popped up in the dependency tree of the `wasm` crate (used by the web extension). We typically use the `component` feature to prevent this from happening (e.g. mio relies on a variety of platform specific syscalls that simply don't exist in a wasm environment) but one slipped through.