### PR TITLE
ci: add component contract check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,18 +9,27 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
       - name: Install nextest
         uses: taiki-e/install-action@nextest
+
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
+
       - name: Run cargo check, failing on warnings
         run: cargo check --release --all-targets
         env:
           # The `-D warnings` option causes an error on warnings;
           # we must duplicate the rustflags from `.cargo/config.toml`.
           RUSTFLAGS: "-D warnings --cfg tokio_unstable"
+
+      - name: Check wasm compatibility
+        run: ./deployments/scripts/check-wasm-compat.sh
 
       # If a dependency was modified, Cargo.lock may flap if not committed.
       - name: Check for diffs
@@ -35,6 +44,7 @@ jobs:
           else
               echo "OK: no uncommitted changes detected"
           fi
+
       - name: Run tests with nextest
         run: cargo nextest run --release --features migration
         env:

--- a/deployments/scripts/check-wasm-compat.sh
+++ b/deployments/scripts/check-wasm-compat.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# CI script for checking that the Penumbra monorepo does not accidentally
+# break compatibility with downstream web APIs, via the WASM crate.
+# Historically, this breakage has taken the form of inadvertently introducing
+# dependencies on std, e.g. via `mio`.
+#
+# More broadly, we want to ensure that monorepo crates with the "component"
+# feature build without that (default) feature enabled. Testing this on the wasm
+# target will help ensure compat.
+set -euo pipefail
+
+
+# Consider checking the web repo's wasm Cargo.toml periodically:
+#
+#   ❯ rg ^penumbra packages/wasm/crate/Cargo.toml --no-line-number | cut -f1 -d' '  | sort
+#
+# to make sure at least all of those crates are tracked here.
+
+packages=(
+    penumbra-asset
+    penumbra-community-pool
+    penumbra-compact-block
+    penumbra-dex
+    penumbra-distributions
+    penumbra-fee
+    penumbra-funding
+    penumbra-governance
+    penumbra-ibc
+    penumbra-keys
+    penumbra-sct
+    penumbra-shielded-pool
+    penumbra-stake
+    penumbra-tct
+    penumbra-transaction
+    penumbra-txhash
+    # N.B. we can't include those ones because they rely on `getrandom`,
+    # but there's a `js` feature...
+    # decaf377-fmd
+    # decaf377-frost
+    # decaf377-ka
+    # penumbra-num
+    # penumbra-proof-params
+    # penumbra-proto
+)
+
+# We intentionally loop over the packages one by one to make error-reporting clearer.
+# Ostensibly this would be slow, but in CI with a warm cache it's quick.
+for p in "${packages[@]}" ; do
+    echo "Checking package for wasm compat: $p ..."
+    if ! cargo check --release --target wasm32-unknown-unknown --no-default-features --package "$p" ; then
+        >&2 echo "ERROR: package appears not to be wasm-compatible: '$p'"
+        exit 1
+    fi
+done


### PR DESCRIPTION
This add a quick `cargo check` to avoid leaking platform specific dependencies in our workspace, and breaking downstream dependencies like the `wasm` crate used by the extension.

The script itself could be refactored into a one-liner, but the current structure makes it easy to observe which crate fails to build for the special target. 