### PR TITLE
cnidarium: implement deferred commits via `StagedWriteBatch`

### DIFF
--- a/crates/cnidarium/src/lib.rs
+++ b/crates/cnidarium/src/lib.rs
@@ -70,6 +70,7 @@ mod store;
 mod tests;
 mod utils;
 mod write;
+mod write_batch;
 
 #[cfg(feature = "metrics")]
 pub use crate::metrics::register_metrics;
@@ -81,6 +82,7 @@ pub use read::StateRead;
 pub use snapshot::Snapshot;
 pub use storage::{Storage, TempStorage};
 pub use write::StateWrite;
+pub use write_batch::StagedWriteBatch;
 
 pub mod future;
 

--- a/crates/cnidarium/src/storage.rs
+++ b/crates/cnidarium/src/storage.rs
@@ -306,7 +306,7 @@ impl Storage {
     }
 
     /// Prepares a commit for the provided [`StateDelta`], returning a [`StagedWriteBatch`].
-    /// The batch can be committed to the database using the [`Storage::commit`] method.
+    /// The batch can be committed to the database using the [`Storage::commit_batch`] method.
     pub async fn prepare_commit(&self, delta: StateDelta<Snapshot>) -> Result<StagedWriteBatch> {
         // Extract the snapshot and the changes from the state delta
         let (snapshot, changes) = delta.flatten();
@@ -529,10 +529,6 @@ impl Storage {
         for (config, new_version) in &multistore_versions.substores {
             if config.prefix.is_empty() {
                 // this is the main store, ignore
-                // TODO: is the main store supposed to be stored in `multistore_versions`?
-                // the previous `commit` implementation did set the main store version
-                // in `multistore_versions`, but that seems unnecessary as the main store
-                // version is already stored in the snapshot.
                 continue;
             }
 

--- a/crates/cnidarium/src/storage.rs
+++ b/crates/cnidarium/src/storage.rs
@@ -46,6 +46,9 @@ struct Inner {
     db: Arc<DB>,
 }
 
+/// A staged write batch that can be committed to RocksDB.
+///
+/// This allows for write batches to be prepared and committed at a later time.
 pub struct StagedWriteBatch {
     /// The write batch to commit to RocksDB.
     pub(crate) write_batch: rocksdb::WriteBatch,
@@ -63,6 +66,18 @@ pub struct StagedWriteBatch {
     /// A lightweight copy of the changeset, this is useful to provide
     /// a stream of changes to subscribers.
     pub(crate) changes: Arc<Cache>,
+}
+
+impl StagedWriteBatch {
+    /// Returns the new version of the chain state corresponding to this set of changes.
+    pub fn version(&self) -> jmt::Version {
+        self.version
+    }
+
+    /// Returns the root hash of the jmt corresponding to this set of changes.
+    pub fn root_hash(&self) -> &RootHash {
+        &self.root_hash
+    }
 }
 
 impl Storage {

--- a/crates/cnidarium/src/store/multistore.rs
+++ b/crates/cnidarium/src/store/multistore.rs
@@ -15,13 +15,12 @@ impl MultistoreConfig {
     }
 
     /// Returns the substore matching the key's prefix, return `None` otherwise.
-    pub fn find_substore(&self, key: &[u8]) -> Arc<SubstoreConfig> {
+    pub fn find_substore(&self, key: &[u8]) -> Option<Arc<SubstoreConfig>> {
         // Note: This is a linear search, but the number of substores is small.
         self.substores
             .iter()
             .find(|s| key.starts_with(s.prefix.as_bytes()))
             .cloned()
-            .unwrap_or(self.main_store.clone())
     }
 
     /// Route a key to a substore, and return the truncated key and the corresponding `SubstoreConfig`.
@@ -46,7 +45,12 @@ impl MultistoreConfig {
     /// `prefix_a/` -> `prefix_a/` in `main_store
     /// `nonexistent_prefix` -> `nonexistent_prefix` in `main_store`
     pub fn route_key_str<'a>(&self, key: &'a str) -> (&'a str, Arc<SubstoreConfig>) {
-        let config = self.find_substore(key.as_bytes());
+        let config = self
+            .find_substore(key.as_bytes())
+            .unwrap_or_else(|| self.main_store.clone());
+
+        // If the key is a total match, we want to return the key bound to the
+        // main store. This is where the root hash of the prefix tree is located.
         if key == config.prefix {
             return (key, self.main_store.clone());
         }
@@ -93,7 +97,9 @@ impl MultistoreConfig {
     /// `prefix_a/` -> `prefix_a/` in `main_store`
     /// `nonexistent_prefix` -> `nonexistent_prefix` in `main_store`
     pub fn route_key_bytes<'a>(&self, key: &'a [u8]) -> (&'a [u8], Arc<SubstoreConfig>) {
-        let config = self.find_substore(key);
+        let config = self
+            .find_substore(key)
+            .unwrap_or_else(|| self.main_store.clone());
 
         // If the key is a total match for the prefix, we return the original key
         // routed to the main store. This is where subtree root hashes are stored.
@@ -136,7 +142,9 @@ impl MultistoreConfig {
     /// `prefix_a/` -> "" in `substore_a`
     /// `nonexistent_prefix` -> "" in `main_store`
     pub fn match_prefix_str<'a>(&self, prefix: &'a str) -> (&'a str, Arc<SubstoreConfig>) {
-        let config = self.find_substore(prefix.as_bytes());
+        let config = self
+            .find_substore(prefix.as_bytes())
+            .unwrap_or_else(|| self.main_store.clone());
 
         let truncated_prefix = prefix
             .strip_prefix(&config.prefix)
@@ -162,7 +170,9 @@ impl MultistoreConfig {
     /// `prefix_a/` -> "" in `substore_a`
     /// `nonexistent_prefix` -> "" in `main_store`
     pub fn match_prefix_bytes<'a>(&self, prefix: &'a [u8]) -> (&'a [u8], Arc<SubstoreConfig>) {
-        let config = self.find_substore(prefix);
+        let config = self
+            .find_substore(prefix)
+            .unwrap_or_else(|| self.main_store.clone());
 
         let truncated_prefix = prefix
             .strip_prefix(config.prefix.as_bytes())

--- a/crates/cnidarium/src/store/multistore.rs
+++ b/crates/cnidarium/src/store/multistore.rs
@@ -16,6 +16,10 @@ impl MultistoreConfig {
 
     /// Returns the substore matching the key's prefix, return `None` otherwise.
     pub fn find_substore(&self, key: &[u8]) -> Option<Arc<SubstoreConfig>> {
+        if key.is_empty() {
+            return Some(self.main_store.clone());
+        }
+
         // Note: This is a linear search, but the number of substores is small.
         self.substores
             .iter()

--- a/crates/cnidarium/src/store/substore.rs
+++ b/crates/cnidarium/src/store/substore.rs
@@ -18,7 +18,7 @@ use jmt::storage::TreeWriter;
 
 /// Specifies the configuration of a substore, which is a prefixed subset of
 /// the main store with its own merkle tree, nonverifiable data, preimage index, etc.
-#[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct SubstoreConfig {
     /// The prefix of the substore. If empty, it is the root-level store config.
     pub prefix: String,

--- a/crates/cnidarium/src/write_batch.rs
+++ b/crates/cnidarium/src/write_batch.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use std::collections::HashMap;
 
-use crate::RootHash;
 use crate::{
     cache::Cache,
     store::{multistore, substore::SubstoreConfig},
+    RootHash,
 };
 
 /// A staged write batch that can be committed to RocksDB.
@@ -39,5 +39,19 @@ impl StagedWriteBatch {
     /// Returns the root hash of the jmt corresponding to this set of changes.
     pub fn root_hash(&self) -> &RootHash {
         &self.root_hash
+    }
+
+    /// Returns the version of a substore in this batch, if it exists
+    /// and `None` otherwise.
+    pub fn substore_version(&self, prefix: &str) -> Option<jmt::Version> {
+        let Some(substore_config) = self
+            .multistore_versions
+            .config
+            .find_substore(prefix.as_bytes())
+        else {
+            return None;
+        };
+
+        self.multistore_versions.get_version(&substore_config)
     }
 }

--- a/crates/cnidarium/src/write_batch.rs
+++ b/crates/cnidarium/src/write_batch.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use std::collections::HashMap;
+
+use crate::RootHash;
+use crate::{
+    cache::Cache,
+    store::{multistore, substore::SubstoreConfig},
+};
+
+/// A staged write batch that can be committed to RocksDB.
+///
+/// This allows for write batches to be prepared and committed at a later time.
+pub struct StagedWriteBatch {
+    /// The write batch to commit to RocksDB.
+    pub(crate) write_batch: rocksdb::WriteBatch,
+    /// The new version of the chain state.
+    pub(crate) version: jmt::Version,
+    /// The new versions of each substore.
+    pub(crate) multistore_versions: multistore::MultistoreCache,
+    /// The root hash of the chain state corresponding to this set of changes.
+    pub(crate) root_hash: RootHash,
+    /// The configs, root hashes, and new versions of each substore
+    /// that was updated in this batch.
+    pub(crate) substore_roots: HashMap<Arc<SubstoreConfig>, (RootHash, u64)>,
+    /// Whether or not to perform a migration.
+    pub(crate) perform_migration: bool,
+    /// A lightweight copy of the changeset, this is useful to provide
+    /// a stream of changes to subscribers.
+    pub(crate) changes: Arc<Cache>,
+}
+
+impl StagedWriteBatch {
+    /// Returns the new version of the chain state corresponding to this set of changes.
+    pub fn version(&self) -> jmt::Version {
+        self.version
+    }
+
+    /// Returns the root hash of the jmt corresponding to this set of changes.
+    pub fn root_hash(&self) -> &RootHash {
+        &self.root_hash
+    }
+}

--- a/crates/cnidarium/tests/write_batch.rs
+++ b/crates/cnidarium/tests/write_batch.rs
@@ -1,0 +1,288 @@
+use anyhow::Result;
+use cnidarium::StateDelta;
+use cnidarium::StateWrite;
+use cnidarium::Storage;
+// use ibc_types::core::commitment::{MerklePath, MerkleRoot};
+// use jmt::RootHash;
+// use once_cell::sync::Lazy;
+use tempfile;
+use tokio;
+
+#[tokio::test]
+/// A simple test that checks that we cannot commit a stale batch to storage.
+/// Strategy:
+/// Create three state deltas, one that writes no keys, and two others that do.
+/// The test persists the first batch, and checks that substore writes don't interfere.
+pub async fn test_write_batch_stale_version_substores() -> Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+    let tmpdir = tempfile::tempdir()?;
+    let db_path = tmpdir.into_path();
+    let substore_prefixes = vec![
+        "ibc".to_string(),
+        "dex".to_string(),
+        "misc".to_string(),
+        "cometbft-data".to_string(),
+    ];
+    let storage = Storage::load(db_path.clone(), substore_prefixes.clone()).await?;
+    let initial_snapshot = storage.latest_snapshot();
+    let initial_version = initial_snapshot.version();
+    let initial_root_hash = initial_snapshot.root_hash().await?;
+    assert_eq!(
+        initial_version,
+        u64::MAX,
+        "initial version should be u64::MAX"
+    );
+    assert_eq!(initial_root_hash.0, [0u8; 32]);
+
+    /* ************************ Prepare three deltas ************************** */
+    // Our goal is to check that we can't commit a batch with a stale version.
+    // We create three deltas:
+    // 1. Empty delta
+    // 2. Delta that writes to one substore
+    // 3. Delta that writes to each substore and also writes to the main store
+
+    /* We create an empty delta that writes no keys. */
+    let delta_1 = StateDelta::new(initial_snapshot);
+    let write_batch_1 = storage.prepare_commit(delta_1).await?;
+    let version_1 = write_batch_1.version();
+    let root_hash_1 = write_batch_1.root_hash().clone();
+    assert_eq!(version_1, initial_version.wrapping_add(1));
+    assert_ne!(root_hash_1.0, initial_root_hash.0);
+
+    // We check that merely preparing a batch does not write anything.
+    let state_snapshot = storage.latest_snapshot();
+    assert_eq!(state_snapshot.version(), initial_version);
+    assert_eq!(state_snapshot.root_hash().await?.0, initial_root_hash.0);
+    for prefix in substore_prefixes.iter() {
+        // We didn't write to any substores, so their version should be unchanged.
+        assert_eq!(write_batch_1.substore_version(prefix), u64::MAX)
+    }
+
+    /* We create a new delta that writes to a single substore. */
+    let mut delta_2 = StateDelta::new(state_snapshot.clone());
+    delta_2.put_raw("ibc/key".to_string(), [1u8; 32].to_vec());
+    let write_batch_2 = storage.prepare_commit(delta_2).await?;
+    let version_2 = write_batch_2.version();
+    let root_hash_2 = write_batch_2.root_hash();
+    assert_eq!(version_2, initial_version.wrapping_add(1));
+    assert_ne!(root_hash_2.0, initial_root_hash.0);
+
+    // Now, we check that the version for the main store is incremented, and
+    // only the version for the ibc substore is incremented.
+    assert_eq!(write_batch_2.version(), initial_version.wrapping_add(1));
+    assert_eq!(
+        write_batch_2.substore_version("ibc"),
+        initial_version.wrapping_add(1)
+    );
+    for prefix in substore_prefixes.iter().filter(|p| *p != "ibc") {
+        assert_eq!(write_batch_2.substore_version(prefix), u64::MAX)
+    }
+
+    /* We create a new delta that writes to each substore. */
+    let mut delta_3 = StateDelta::new(state_snapshot);
+    for substore_prefix in substore_prefixes.iter() {
+        let key = format!("{}/key", substore_prefix);
+        tracing::debug!(?key, "adding to delta_1");
+        delta_3.put_raw(key, [1u8; 32].to_vec());
+    }
+    let write_batch_3 = storage.prepare_commit(delta_3).await?;
+    let version_3 = write_batch_3.version();
+    let root_hash_3 = write_batch_3.root_hash().clone();
+
+    // Once again, we check that we incremented the main store version.
+    assert_eq!(version_3, initial_version.wrapping_add(1));
+    assert_ne!(root_hash_3.0, initial_root_hash.0);
+    // In addition to that, we check that we incremented the version of each substore.
+    for prefix in substore_prefixes.iter() {
+        assert_eq!(
+            write_batch_3.substore_version(prefix),
+            initial_version.wrapping_add(1)
+        )
+    }
+
+    /* Persist `write_batch_1` and check that the two other (stale) deltas cannot be applied. */
+    let final_root = storage
+        .commit_batch(write_batch_1)
+        .await
+        .expect("committing batch 3 should work");
+    let final_snapshot = storage.latest_snapshot();
+    assert_eq!(root_hash_1.0, final_root.0);
+    assert_eq!(root_hash_1.0, final_snapshot.root_hash().await?.0);
+    assert_eq!(version_1, final_snapshot.version());
+    assert!(
+        storage.commit_batch(write_batch_2).await.is_err(),
+        "committing batch 2 should fail"
+    );
+    assert!(
+        storage.commit_batch(write_batch_3).await.is_err(),
+        "committing batch 3 should fail"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+/// Test that we can commit a batch without incrementing the substore versions if there are no
+/// keys to write.
+pub async fn test_two_empty_writes() -> Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+    let tmpdir = tempfile::tempdir()?;
+    let db_path = tmpdir.into_path();
+    let substore_prefixes = vec![
+        "ibc".to_string(),
+        "dex".to_string(),
+        "misc".to_string(),
+        "cometbft-data".to_string(),
+    ];
+    let storage = Storage::load(db_path.clone(), substore_prefixes.clone()).await?;
+    let initial_snapshot = storage.latest_snapshot();
+    let initial_version = initial_snapshot.version();
+    let initial_root_hash = initial_snapshot.root_hash().await?;
+    assert_eq!(
+        initial_version,
+        u64::MAX,
+        "initial version should be u64::MAX"
+    );
+    assert_eq!(initial_root_hash.0, [0u8; 32]);
+
+    let mut delta_1 = StateDelta::new(initial_snapshot);
+    for substore_prefix in substore_prefixes.iter() {
+        let key = format!("{}/key", substore_prefix);
+        tracing::debug!(?key, "adding to delta_1");
+        delta_1.put_raw(key, [1u8; 12].to_vec());
+    }
+    let write_batch_1 = storage.prepare_commit(delta_1).await?;
+    let version_1 = write_batch_1.version();
+    let root_hash_1 = write_batch_1.root_hash().clone();
+
+    assert_eq!(version_1, initial_version.wrapping_add(1));
+    assert_ne!(root_hash_1.0, initial_root_hash.0);
+    for prefix in substore_prefixes.iter() {
+        assert_eq!(
+            write_batch_1.substore_version(prefix),
+            initial_version.wrapping_add(1)
+        )
+    }
+
+    // We check that merely preparing a batch does not write anything.
+    let state_snapshot = storage.latest_snapshot();
+    assert_eq!(state_snapshot.version(), initial_version);
+    assert_eq!(state_snapshot.root_hash().await?.0, initial_root_hash.0);
+
+    /* We create a new delta that writes no keys */
+    let delta_2 = StateDelta::new(state_snapshot.clone());
+    let write_batch_2 = storage.prepare_commit(delta_2).await?;
+    let version_2 = write_batch_2.version();
+    let root_hash_2 = write_batch_2.root_hash();
+    assert_eq!(version_2, initial_version.wrapping_add(1));
+    assert_ne!(root_hash_2.0, initial_root_hash.0);
+    assert_eq!(write_batch_2.version(), initial_version.wrapping_add(1));
+    for prefix in substore_prefixes.iter() {
+        assert_eq!(write_batch_2.substore_version(prefix), initial_version)
+    }
+
+    let block_1_root = storage
+        .commit_batch(write_batch_1)
+        .await
+        .expect("committing batch 3 should work");
+    let block_1_snapshot = storage.latest_snapshot();
+    let block_1_version = block_1_snapshot.version();
+    assert_eq!(root_hash_1.0, block_1_root.0);
+    assert_eq!(root_hash_1.0, block_1_snapshot.root_hash().await?.0);
+    assert_eq!(version_1, block_1_version);
+    assert!(
+        storage.commit_batch(write_batch_2).await.is_err(),
+        "committing batch 2 should fail"
+    );
+
+    /* We create an empty delta that writes no keys. */
+    let delta_3 = StateDelta::new(block_1_snapshot);
+    let write_batch_3 = storage.prepare_commit(delta_3).await?;
+    let version_3 = write_batch_3.version();
+    let root_hash_3 = write_batch_3.root_hash().clone();
+    assert_eq!(version_3, block_1_version.wrapping_add(1));
+
+    /* Check that we can apply `write_batch_3` */
+    let block_2_root = storage
+        .commit_batch(write_batch_3)
+        .await
+        .expect("committing batch 3 should work");
+    let block_2_snapshot = storage.latest_snapshot();
+    let block_2_version = block_2_snapshot.version();
+    assert_eq!(root_hash_3.0, block_2_root.0);
+    assert_eq!(root_hash_3.0, block_2_snapshot.root_hash().await?.0);
+    assert_eq!(version_3, block_2_version);
+    Ok(())
+}
+
+#[tokio::test]
+/// Test that we can write prepare-commit batches that write to every
+/// substore.
+/// Intuition: we want to make sure that the version check that guards us from
+/// writing stale batches, is working as expected.
+pub async fn test_batch_substore() -> Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+    let tmpdir = tempfile::tempdir()?;
+    let db_path = tmpdir.into_path();
+    let substore_prefixes = vec![
+        "ibc".to_string(),
+        "dex".to_string(),
+        "misc".to_string(),
+        "cometbft-data".to_string(),
+    ];
+    let storage = Storage::load(db_path.clone(), substore_prefixes.clone()).await?;
+    let initial_snapshot = storage.latest_snapshot();
+    let initial_version = initial_snapshot.version();
+    let initial_root_hash = initial_snapshot.root_hash().await?;
+    assert_eq!(
+        initial_version,
+        u64::MAX,
+        "initial version should be u64::MAX"
+    );
+    assert_eq!(initial_root_hash.0, [0u8; 32]);
+
+    for i in 0..100 {
+        let snapshot = storage.latest_snapshot();
+        let prev_version = snapshot.version();
+        let prev_root = snapshot
+            .root_hash()
+            .await
+            .expect("a root hash is available");
+
+        let mut delta = StateDelta::new(snapshot);
+        for substore_prefix in substore_prefixes.iter() {
+            let key = format!("{}/key_{i}", substore_prefix);
+            tracing::debug!(?key, index = i, "adding to delta");
+            delta.put_raw(key, [1u8; 12].to_vec());
+        }
+        let write_batch = storage.prepare_commit(delta).await?;
+        let next_version = write_batch.version();
+        let next_root = write_batch.root_hash().clone();
+
+        assert_eq!(next_version, prev_version.wrapping_add(1));
+        assert_ne!(next_root.0, prev_root.0);
+        for prefix in substore_prefixes.iter() {
+            assert_eq!(
+                write_batch.substore_version(prefix),
+                prev_version.wrapping_add(1)
+            )
+        }
+
+        // We check that merely preparing a batch does not write anything.
+        let state_snapshot = storage.latest_snapshot();
+        assert_eq!(state_snapshot.version(), prev_version);
+        assert_eq!(state_snapshot.root_hash().await?.0, prev_root.0);
+
+        let block_root = storage
+            .commit_batch(write_batch)
+            .await
+            .expect("committing batch 3 should work");
+        let block_snapshot = storage.latest_snapshot();
+        let block_version = block_snapshot.version();
+        assert_eq!(next_root.0, block_root.0);
+        assert_eq!(next_root.0, block_snapshot.root_hash().await?.0);
+        assert_eq!(next_version, block_version);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
refactor `commit` into `prepare_commit` and `commit_batch`. this allows a `StagedWriteBatch` to be prepared via `prepare_commit` and the actual writing the `StagedWriteBatch` to disk to occur in `commit_batch`. this allows us to get the root hash of the changes without requiring the data to be fully committed.

closes  #4095