### PR TITLE
app: increment halt counter

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,3 +1,4 @@
 | Application version (Name)| Penumbra crate version | CometBFT | Protobuf |
 | ------------------------- | ---------------------- | -------- | -------- |
-| 1 (Testnet 69)            | v0.69.1                | v0.37.5  | v1       |
+| 1 (Testnet 70)            | v0.70.x                | v0.37.5  |   v1     |
+| 2 (Testnet 71)            | v0.71.x                | v0.37.5  |   v1     |

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -619,7 +619,7 @@ impl App {
 ///
 /// Increment this manually after fixing the root cause for a chain halt: updated nodes will then be
 /// able to proceed past the block height of the halt.
-const TOTAL_HALT_COUNT: u64 = 0;
+const TOTAL_HALT_COUNT: u64 = 1;
 
 #[async_trait]
 pub trait StateReadExt: StateRead {

--- a/crates/core/app/src/lib.rs
+++ b/crates/core/app/src/lib.rs
@@ -19,7 +19,9 @@ pub use crate::{
 
 use once_cell::sync::Lazy;
 
-pub const APP_VERSION: u64 = 1;
+/// Representation of the Penumbra application version. Notably, this is distinct
+/// from the crate version(s). This number should only ever be incremented.
+pub const APP_VERSION: u64 = 2;
 
 pub static SUBSTORE_PREFIXES: Lazy<Vec<String>> = Lazy::new(|| {
     vec![


### PR DESCRIPTION
## Describe your changes

This increments the `TOTAL_HALT_COUNTER` for `v0.71.0`

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  >  This is an internal counter.