### PR TITLE
fix(pd): minifront asset directory subpath

### DIFF
--- a/assets/minifront.zip
+++ b/assets/minifront.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86a561124bfdfab9e421c209af183f6163acaacf338279c4a323c69814ae5943
-size 2902443
+oid sha256:4f1cc4f47b93cf1aee49f540b291ad0af3c069455197c27dd7f41c176605a1c9
+size 2901211

--- a/assets/node-status.zip
+++ b/assets/node-status.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e201c0593227760480a6ffdb5bb5cc7fc6df1f96326a51fe06fab4efffe5ce0
-size 2692222
+oid sha256:e831bf9ae8896aeac6a177979584248b9295d819255c14054e4f007fd78931a1
+size 2691710

--- a/crates/bin/pd/tests/network_integration.rs
+++ b/crates/bin/pd/tests/network_integration.rs
@@ -4,6 +4,8 @@
 //! headers in all contexts. Does NOT evaluate application logic; see the
 //! integration tests for pcli/pclientd for that.
 
+use http::StatusCode;
+
 #[ignore]
 #[tokio::test]
 /// Confirm that permissive CORS headers are returned in HTTP responses
@@ -19,5 +21,21 @@ async fn check_cors_headers() -> anyhow::Result<()> {
         r.headers().get("access-control-expose-headers").unwrap(),
         "*"
     );
+    Ok(())
+}
+
+#[ignore]
+#[tokio::test]
+/// Confirm that the a naive GET on the gRPC route returns a 200,
+/// as a sanity check that we haven't badly broken the minifront static asset bundling.
+/// This check does *not* confirm that page works correctly, but it does confirm
+/// it's at least loading, which guards against path regressions in the asset building.
+/// See GH4139 for context.
+async fn check_minifront_http_ok() -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+    let pd_url =
+        std::env::var("PENUMBRA_NODE_PD_URL").unwrap_or("http://localhost:8080".to_string());
+    let r = client.get(pd_url).send().await?;
+    assert_eq!(r.status(), StatusCode::OK);
     Ok(())
 }


### PR DESCRIPTION
## Describe your changes
The previous .zip files had a subdirectory of the same name as the file itself. These updated files don't.

We should be creating zip files via a script — see https://github.com/penumbra-zone/web/issues/857. This will avoid issues like this in the future.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > No code related to consensus