### PR TITLE
feat(staking): 🎽 `IdentityKey` is internally represented as bytes

### DIFF
--- a/crates/bin/pcli/src/command/validator.rs
+++ b/crates/bin/pcli/src/command/validator.rs
@@ -158,11 +158,11 @@ impl ValidatorCmd {
 
         match self {
             ValidatorCmd::Identity { base64 } => {
-                let ik = IdentityKey(fvk.spend_verification_key().clone());
+                let ik: IdentityKey = fvk.spend_verification_key().into();
 
                 if *base64 {
                     use base64::{display::Base64Display, engine::general_purpose::STANDARD};
-                    println!("{}", Base64Display::new(&ik.0.to_bytes(), &STANDARD));
+                    println!("{}", Base64Display::new(ik.as_bytes(), &STANDARD));
                 } else {
                     println!("{ik}");
                 }
@@ -276,7 +276,7 @@ impl ValidatorCmd {
                 reason,
                 signature_file,
             }) => {
-                let identity_key = IdentityKey(fvk.spend_verification_key().clone());
+                let identity_key = fvk.spend_verification_key().into();
                 let governance_key = app.config.governance_key();
 
                 let (proposal, vote): (u64, Vote) = (*vote).into();
@@ -323,7 +323,7 @@ impl ValidatorCmd {
                 reason,
                 signature,
             }) => {
-                let identity_key = IdentityKey(fvk.spend_verification_key().clone());
+                let identity_key = fvk.spend_verification_key().into();
                 let governance_key = app.config.governance_key();
 
                 let (proposal, vote): (u64, Vote) = (*vote).into();
@@ -385,7 +385,7 @@ impl ValidatorCmd {
                 tendermint_validator_keyfile,
             }) => {
                 let (address, _dtk) = fvk.incoming().payment_address(0u32.into());
-                let identity_key = IdentityKey(fvk.spend_verification_key().clone());
+                let identity_key = fvk.spend_verification_key().into();
                 // By default, the template sets the governance key to the same verification key as
                 // the identity key, but a validator can change this if they want to use different
                 // key material.
@@ -473,7 +473,7 @@ impl ValidatorCmd {
                 }
             }
             ValidatorCmd::Definition(DefinitionCmd::Fetch { file }) => {
-                let identity_key = IdentityKey(fvk.spend_verification_key().clone());
+                let identity_key = fvk.spend_verification_key().into();
                 super::query::ValidatorCmd::Definition {
                     file: file.clone(),
                     identity_key: identity_key.to_string(),

--- a/crates/bin/pd/src/testnet/generate.rs
+++ b/crates/bin/pd/src/testnet/generate.rs
@@ -457,8 +457,8 @@ impl TestnetValidator {
         let ivk = fvk.incoming();
         let (dest, _dtk_d) = ivk.payment_address(0u32.into());
 
-        let identity_key: IdentityKey = IdentityKey(fvk.spend_verification_key().clone());
-        let delegation_denom = DelegationToken::from(&identity_key).denom();
+        let identity_key: IdentityKey = fvk.spend_verification_key().into();
+        let delegation_denom = DelegationToken::from(identity_key).denom();
         Ok(Allocation {
             address: dest,
             // Add an initial allocation of 25,000 delegation tokens,
@@ -540,7 +540,7 @@ impl TryFrom<&TestnetValidator> for Validator {
             // Currently there's no way to set validator keys beyond
             // manually editing the genesis.json. Otherwise they
             // will be randomly generated keys.
-            identity_key: IdentityKey(tv.keys.validator_id_vk),
+            identity_key: tv.keys.validator_id_vk.into(),
             governance_key: GovernanceKey(tv.keys.validator_id_vk),
             consensus_key: tv.keys.validator_cons_pk,
             name: tv.name.clone(),

--- a/crates/core/app/tests/app_can_define_and_delegate_to_a_validator.rs
+++ b/crates/core/app/tests/app_can_define_and_delegate_to_a_validator.rs
@@ -76,7 +76,7 @@ async fn app_can_define_and_delegate_to_a_validator() -> anyhow::Result<()> {
         unexpected => panic!("there should be one validator, got: {unexpected:?}"),
     };
 
-    let existing_validator_id = existing_validator.identity_key;
+    let existing_validator_id = existing_validator.identity_key.clone();
 
     // Check that we are now in a new epoch.
     {
@@ -105,7 +105,7 @@ async fn app_can_define_and_delegate_to_a_validator() -> anyhow::Result<()> {
         use penumbra_stake::component::ConsensusIndexRead;
         let start = snapshot_start.get_consensus_set().await?;
         let end = snapshot_end.get_consensus_set().await?;
-        let expected = [existing_validator_id];
+        let expected = [existing_validator_id.clone()];
         assert_eq!(
             start, expected,
             "validator should start in the consensus set"
@@ -116,7 +116,7 @@ async fn app_can_define_and_delegate_to_a_validator() -> anyhow::Result<()> {
     // To define a validator, we need to define two keypairs: an identity key
     // for the Penumbra application and a consensus key for cometbft.
     let new_validator_id_sk = SigningKey::<SpendAuth>::new(OsRng);
-    let new_validator_id = IdentityKey(new_validator_id_sk.into());
+    let new_validator_id = IdentityKey::from(new_validator_id_sk);
     let new_validator_consensus_sk = ed25519_consensus::SigningKey::new(OsRng);
     let new_validator_consensus = new_validator_consensus_sk.verification_key();
 
@@ -405,7 +405,7 @@ async fn app_can_define_and_delegate_to_a_validator() -> anyhow::Result<()> {
             .ok_or(anyhow!("new validator has a rate"))?
             .tap(|rate| tracing::info!(?rate, "got new validator rate"));
 
-        let undelegation_id = DelegationToken::new(new_validator_id).id();
+        let undelegation_id = DelegationToken::new(new_validator_id.clone()).id();
         let note = client
             .notes
             .values()

--- a/crates/core/app/tests/app_can_undelegate_from_a_validator.rs
+++ b/crates/core/app/tests/app_can_undelegate_from_a_validator.rs
@@ -96,7 +96,7 @@ async fn app_can_undelegate_from_a_validator() -> anyhow::Result<()> {
         [v] => v.clone(),
         unexpected => panic!("there should be one validator, got: {unexpected:?}"),
     }; // ..and note the asset id for delegation tokens tied to this validator.
-    let delegate_token_id = penumbra_stake::DelegationToken::new(identity_key).id();
+    let delegate_token_id = penumbra_stake::DelegationToken::new(identity_key.clone()).id();
 
     // Sync the mock client, using the test wallet's spend key, to the latest snapshot.
     let mut client = MockClient::new(test_keys::SPEND_KEY.clone())
@@ -228,7 +228,7 @@ async fn app_can_undelegate_from_a_validator() -> anyhow::Result<()> {
         };
         let snapshot = storage.latest_snapshot();
         client.sync_to_latest(snapshot.clone()).await?;
-        let undelegation_id = DelegationToken::new(identity_key).id();
+        let undelegation_id = DelegationToken::new(identity_key.clone()).id();
         let note = client
             .notes
             .values()

--- a/crates/core/app/tests/common/test_node_builder_ext.rs
+++ b/crates/core/app/tests/common/test_node_builder_ext.rs
@@ -91,7 +91,7 @@ fn generate_penumbra_validator(
         .incoming()
         .payment_address(0u32.into());
 
-    let ik = penumbra_stake::IdentityKey(validator_id_vk);
+    let ik = penumbra_stake::IdentityKey::from(validator_id_vk);
     let delegation_denom = DelegationToken::from(ik).denom();
 
     let allocation = Allocation {

--- a/crates/core/app/tests/init_chain.rs
+++ b/crates/core/app/tests/init_chain.rs
@@ -40,9 +40,8 @@ async fn mock_consensus_can_define_a_genesis_validator() -> anyhow::Result<()> {
         .await?;
     match validators.as_slice() {
         [v] => {
-            let identity_key = v.identity_key;
             let status = snapshot
-                .get_validator_state(&identity_key)
+                .get_validator_state(&v.identity_key)
                 .await?
                 .ok_or_else(|| anyhow!("could not find validator status"))?;
             assert_eq!(

--- a/crates/core/component/governance/src/action_handler/delegator_vote.rs
+++ b/crates/core/component/governance/src/action_handler/delegator_vote.rs
@@ -88,7 +88,7 @@ impl ActionHandler for DelegatorVote {
             .await;
         let identity_key = state.validator_by_delegation_asset(value.asset_id).await?;
         state
-            .cast_delegator_vote(*proposal, identity_key, *vote, nullifier, *unbonded_amount)
+            .cast_delegator_vote(*proposal, &identity_key, *vote, nullifier, *unbonded_amount)
             .await?;
 
         state.record_proto(event::delegator_vote(self));

--- a/crates/core/component/governance/src/action_handler/validator_vote.rs
+++ b/crates/core/component/governance/src/action_handler/validator_vote.rs
@@ -76,7 +76,7 @@ impl ActionHandler for ValidatorVote {
         }
 
         tracing::debug!(validator_identity = %identity_key, proposal = %proposal, "cast validator vote");
-        state.cast_validator_vote(*proposal, *identity_key, *vote, reason.clone());
+        state.cast_validator_vote(*proposal, identity_key, *vote, reason.clone());
 
         // Emergency proposals are passed immediately after receiving +2/3 of
         // validator votes. These include the eponymous `Emergency` proposal but

--- a/crates/core/component/governance/src/component/rpc.rs
+++ b/crates/core/component/governance/src/component/rpc.rs
@@ -342,7 +342,7 @@ impl QueryService for Server {
             let voting_power = state
                 .get_proto::<u64>(&state_key::voting_power_at_proposal_start(
                     proposal_id,
-                    identity_key,
+                    &identity_key,
                 ))
                 .await
                 .map_err(|e| tonic::Status::internal(format!("error accessing storage: {}", e)))?;

--- a/crates/core/component/governance/src/state_key.rs
+++ b/crates/core/component/governance/src/state_key.rs
@@ -50,7 +50,7 @@ pub fn voted_nullifier_lookup_for_proposal(proposal_id: u64, nullifier: &Nullifi
     format!("governance/proposal/{proposal_id:020}/voted_nullifiers/{nullifier}")
 }
 
-pub fn rate_data_at_proposal_start(proposal_id: u64, identity_key: IdentityKey) -> String {
+pub fn rate_data_at_proposal_start(proposal_id: u64, identity_key: &IdentityKey) -> String {
     format!("governance/proposal/{proposal_id:020}/rate_data_at_start/{identity_key}")
 }
 
@@ -59,7 +59,7 @@ pub fn all_rate_data_at_proposal_start(proposal_id: u64) -> String {
     format!("governance/proposal/{proposal_id:020}/rate_data_at_start/")
 }
 
-pub fn voting_power_at_proposal_start(proposal_id: u64, identity_key: IdentityKey) -> String {
+pub fn voting_power_at_proposal_start(proposal_id: u64, identity_key: &IdentityKey) -> String {
     format!("governance/proposal/{proposal_id:020}/voting_power_at_start/{identity_key}")
 }
 
@@ -68,11 +68,11 @@ pub fn all_voting_power_at_proposal_start(proposal_id: u64) -> String {
     format!("governance/proposal/{proposal_id:020}/voting_power_at_start/")
 }
 
-pub fn validator_vote(proposal_id: u64, identity_key: IdentityKey) -> String {
+pub fn validator_vote(proposal_id: u64, identity_key: &IdentityKey) -> String {
     format!("governance/validator_vote/{proposal_id:020}/{identity_key}")
 }
 
-pub fn validator_vote_reason(proposal_id: u64, identity_key: IdentityKey) -> String {
+pub fn validator_vote_reason(proposal_id: u64, identity_key: &IdentityKey) -> String {
     format!("governance/validator_vote_reason/{proposal_id:020}/{identity_key}")
 }
 
@@ -81,7 +81,7 @@ pub fn all_validator_votes_for_proposal(proposal_id: u64) -> String {
     format!("governance/validator_vote/{proposal_id:020}/")
 }
 
-pub fn tallied_delegator_votes(proposal_id: u64, identity_key: IdentityKey) -> String {
+pub fn tallied_delegator_votes(proposal_id: u64, identity_key: &IdentityKey) -> String {
     format!("governance/tallied_delegator_votes/{proposal_id:020}/{identity_key}")
 }
 
@@ -92,7 +92,7 @@ pub fn all_tallied_delegator_votes_for_proposal(proposal_id: u64) -> String {
 
 pub fn untallied_delegator_vote(
     proposal_id: u64,
-    identity_key: IdentityKey,
+    identity_key: &IdentityKey,
     nullifier: &Nullifier,
 ) -> String {
     format!("governance/untallied_delegator_vote/{proposal_id:020}/{identity_key}/{nullifier}")

--- a/crates/core/component/stake/src/component/action_handler/delegate.rs
+++ b/crates/core/component/stake/src/component/action_handler/delegate.rs
@@ -92,7 +92,7 @@ impl ActionHandler for Delegate {
 
         // (end of former check_historical checks)
 
-        let validator = self.validator_identity;
+        let validator = &self.validator_identity;
         let unbonded_delegation = self.unbonded_amount;
 
         // This action is executed in two phases:

--- a/crates/core/component/stake/src/component/action_handler/undelegate_claim.rs
+++ b/crates/core/component/stake/src/component/action_handler/undelegate_claim.rs
@@ -15,7 +15,7 @@ impl ActionHandler for UndelegateClaim {
     type CheckStatelessContext = ();
     async fn check_stateless(&self, _context: ()) -> Result<()> {
         let unbonding_id = UnbondingToken::new(
-            self.body.validator_identity,
+            self.body.validator_identity.clone(),
             self.body.unbonding_start_height,
         )
         .id();

--- a/crates/core/component/stake/src/component/action_handler/validator_definition.rs
+++ b/crates/core/component/stake/src/component/action_handler/validator_definition.rs
@@ -38,7 +38,7 @@ impl ActionHandler for validator::Definition {
         let definition_bytes = self.validator.encode_to_vec();
         self.validator
             .identity_key
-            .0
+            .key()?
             .verify(&definition_bytes, &self.auth_sig)
             .context("validator definition signature failed to verify")?;
 
@@ -119,7 +119,7 @@ impl ActionHandler for validator::Definition {
                     "should be able to update validator during validator definition execution",
                 )?;
         } else {
-            let validator_key = new_validator.identity_key;
+            let validator_key = new_validator.identity_key.clone();
 
             // The validator starts with a reward rate of 0 and an exchange rate
             // of 1, expressed in bps^2 (i.e. 1_0000_0000 is 1.0).

--- a/crates/core/component/stake/src/component/epoch_handler.rs
+++ b/crates/core/component/stake/src/component/epoch_handler.rs
@@ -55,7 +55,7 @@ pub trait EpochHandler: StateWriteExt + ConsensusIndexRead {
             for d in changes.delegations {
                 let validator_identity = d.validator_identity.clone();
                 let delegation_tally = delegations_by_validator
-                    .entry(validator_identity)
+                    .entry(validator_identity.clone())
                     .or_default()
                     .saturating_add(&d.delegation_amount);
                 delegations_by_validator.insert(validator_identity, delegation_tally);
@@ -63,7 +63,7 @@ pub trait EpochHandler: StateWriteExt + ConsensusIndexRead {
             for u in changes.undelegations {
                 let validator_identity = u.validator_identity.clone();
                 let undelegation_tally = undelegations_by_validator
-                    .entry(validator_identity)
+                    .entry(validator_identity.clone())
                     .or_default()
                     .saturating_add(&u.delegation_amount);
 

--- a/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_manager.rs
@@ -465,7 +465,7 @@ pub trait ValidatorManager: StateWrite {
         self.register_consensus_key(&validator_identity, &validator.consensus_key)
             .await;
         // We register the validator's delegation token in the token registry...
-        self.register_denom(&DelegationToken::from(&validator_identity).denom())
+        self.register_denom(&DelegationToken::from(validator_identity.clone()).denom())
             .await;
         // ... and its reward rate data in the JMT.
         self.set_validator_rate_data(&validator_identity, initial_rate_data);

--- a/crates/core/component/stake/src/delegation_token.rs
+++ b/crates/core/component/stake/src/delegation_token.rs
@@ -18,12 +18,6 @@ impl From<IdentityKey> for DelegationToken {
     }
 }
 
-impl From<&IdentityKey> for DelegationToken {
-    fn from(v: &IdentityKey) -> Self {
-        DelegationToken::new(*v)
-    }
-}
-
 impl DelegationToken {
     /// Returns a new [`DelegationToken`] with the provided identity.
     pub fn new(validator_identity: IdentityKey) -> Self {
@@ -52,9 +46,9 @@ impl DelegationToken {
         self.base_denom.id()
     }
 
-    /// Returns the identity key of the validator this delegation token is associated with.
-    pub fn validator(&self) -> IdentityKey {
-        self.validator_identity
+    /// Returns the [`IdentityKey`] of the validator this delegation token is associated with.
+    pub fn validator(&self) -> &IdentityKey {
+        &self.validator_identity
     }
 }
 
@@ -131,7 +125,8 @@ mod tests {
     fn delegation_token_denomination_round_trip() {
         use rand_core::OsRng;
 
-        let ik = IdentityKey(SigningKey::<SpendAuth>::new(OsRng).into());
+        let sk = SigningKey::<SpendAuth>::new(OsRng);
+        let ik = IdentityKey::from(sk);
 
         let token = DelegationToken::new(ik);
 

--- a/crates/core/component/stake/src/identity_key.rs
+++ b/crates/core/component/stake/src/identity_key.rs
@@ -1,3 +1,7 @@
+// TODO(kate):
+// decompressed: std::sync::OnceLock<VerificationKey<SpendAuth>>,
+
+use decaf377_rdsa::{SigningKey, SpendAuth, VerificationKey, VerificationKeyBytes};
 use penumbra_proto::{
     core::component::stake::v1::CurrentValidatorRateRequest,
     // TODO: why is this not in the keys crate?
@@ -6,8 +10,7 @@ use penumbra_proto::{
     DomainType,
 };
 use serde::{Deserialize, Serialize};
-
-use decaf377_rdsa::{SpendAuth, VerificationKey};
+use std::sync::OnceLock;
 
 /// The root of a validator's identity.
 ///
@@ -18,11 +21,83 @@ use decaf377_rdsa::{SpendAuth, VerificationKey};
 ///
 /// Using a [`SpendAuth`] key means that validators can reuse code and processes
 /// designed for custodying funds to protect their identity.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "pb::IdentityKey", into = "pb::IdentityKey")]
-pub struct IdentityKey(pub VerificationKey<SpendAuth>);
+pub struct IdentityKey {
+    /// The *compressed* bytes of the identity verification key.
+    bytes: VerificationKeyBytes<SpendAuth>,
+    // The *decompressed* identity verification key.
+    key: OnceLock<DecompressionResult>,
+}
+
+type DecompressionResult = Result<VerificationKey<SpendAuth>, decaf377_rdsa::Error>;
+
+impl PartialOrd for IdentityKey {
+    /// [`IdentityKey`]s are partially ordered according to their compressed bytes.
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.bytes.partial_cmp(&other.bytes)
+    }
+}
+
+impl Ord for IdentityKey {
+    /// [`IdentityKey`]s are totally ordered according to their compressed bytes.
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.bytes.cmp(&other.bytes)
+    }
+}
+
+impl From<SigningKey<SpendAuth>> for IdentityKey {
+    /// An [`IdentityKey`] can be constructed from a [`decaf377_rdsa::SigningKey`].
+    fn from(sk: SigningKey<SpendAuth>) -> Self {
+        let vk: VerificationKey<SpendAuth> = sk.into();
+        Self::from(vk)
+    }
+}
+
+impl<'sk> From<&'sk SigningKey<SpendAuth>> for IdentityKey {
+    /// An [`IdentityKey`] can be constructed from a reference to a [`decaf377_rdsa::SigningKey`].
+    fn from(sk: &'sk SigningKey<SpendAuth>) -> Self {
+        Self::from(*sk)
+    }
+}
+
+impl From<VerificationKey<SpendAuth>> for IdentityKey {
+    /// An [`IdentityKey`] can be constructed from a [`decaf377_rdsa::VerificationKey`].
+    fn from(vk: VerificationKey<SpendAuth>) -> Self {
+        let bytes: VerificationKeyBytes<SpendAuth> = vk.into();
+        let key: OnceLock<_> = Ok(vk).into();
+
+        Self { bytes, key }
+    }
+}
+
+impl<'vk> From<&'vk VerificationKey<SpendAuth>> for IdentityKey {
+    /// An [`IdentityKey`] can be constructed from a reference to a [`decaf377_rdsa::VerificationKey`].
+    fn from(vk: &'vk VerificationKey<SpendAuth>) -> Self {
+        Self::from(*vk)
+    }
+}
+
+impl IdentityKey {
+    /// Decompresses this identity key, returning a [`VerificationKey`].
+    ///
+    /// This is idempotent and can be called repeatedly, and the bytes will only decompressed
+    /// once.
+    pub fn key(&self) -> Result<VerificationKey<SpendAuth>, decaf377_rdsa::Error> {
+        let Self { bytes, ref key } = *self;
+        key.get_or_init(|| VerificationKey::try_from(bytes)).clone()
+    }
+
+    /// Returns the compressed bytes of this identity key.
+    ///
+    /// This can be used as an alternative to [`AsRef`] when type inference fails.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.as_ref()
+    }
+}
 
 // IMPORTANT: Changing this implementation is state-breaking.
+// TODO(kate): lazily decoding bytes may be a state-breaking change.
 impl std::str::FromStr for IdentityKey {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -34,10 +109,11 @@ impl std::str::FromStr for IdentityKey {
 }
 
 // IMPORTANT: Changing this implementation is state-breaking.
+// TODO(kate): lazily decoding bytes may be a state-breaking change.
 impl std::fmt::Display for IdentityKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&bech32str::encode(
-            &self.0.to_bytes(),
+            &self.bytes.as_ref().as_slice(),
             BECH32_PREFIX,
             bech32str::Bech32m,
         ))
@@ -57,7 +133,7 @@ impl DomainType for IdentityKey {
 impl From<IdentityKey> for pb::IdentityKey {
     fn from(ik: IdentityKey) -> Self {
         pb::IdentityKey {
-            ik: ik.0.to_bytes().to_vec(),
+            ik: ik.bytes.as_ref().to_vec(),
         }
     }
 }
@@ -65,7 +141,27 @@ impl From<IdentityKey> for pb::IdentityKey {
 impl TryFrom<pb::IdentityKey> for IdentityKey {
     type Error = anyhow::Error;
     fn try_from(ik: pb::IdentityKey) -> Result<Self, Self::Error> {
-        Ok(Self(ik.ik.as_slice().try_into()?))
+        Self::try_from(ik.ik)
+    }
+}
+
+impl TryFrom<Vec<u8>> for IdentityKey {
+    type Error = anyhow::Error;
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(bytes.as_slice())
+    }
+}
+
+impl TryFrom<&[u8]> for IdentityKey {
+    type Error = anyhow::Error;
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        bytes
+            .try_into()
+            .map(|bytes| Self {
+                bytes,
+                key: OnceLock::new(),
+            })
+            .map_err(Into::into)
     }
 }
 
@@ -84,5 +180,24 @@ impl TryFrom<CurrentValidatorRateRequest> for IdentityKey {
             .identity_key
             .ok_or_else(|| anyhow::anyhow!("empty CurrentValidatorRateRequest message"))?
             .try_into()
+    }
+}
+
+impl AsRef<VerificationKeyBytes<SpendAuth>> for IdentityKey {
+    fn as_ref(&self) -> &VerificationKeyBytes<SpendAuth> {
+        &self.bytes
+    }
+}
+
+// TODO(kate): define this 32 as a constant upstream in decaf377_rdsa.
+impl AsRef<[u8; 32]> for IdentityKey {
+    fn as_ref(&self) -> &[u8; 32] {
+        self.bytes.as_ref()
+    }
+}
+
+impl AsRef<[u8]> for IdentityKey {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
     }
 }

--- a/crates/core/component/stake/src/rate.rs
+++ b/crates/core/component/stake/src/rate.rs
@@ -401,7 +401,7 @@ mod tests {
     #[test]
     fn slash_rate_by_penalty() {
         let sk = rdsa::SigningKey::new(OsRng);
-        let ik = IdentityKey((&sk).into());
+        let ik = IdentityKey::from(sk);
 
         let rate_data = RateData {
             identity_key: ik,

--- a/crates/core/component/stake/src/state_key.rs
+++ b/crates/core/component/stake/src/state_key.rs
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn penalty_in_epoch_padding() {
         let sk = rdsa::SigningKey::new(OsRng);
-        let ik = IdentityKey((&sk).into());
+        let ik = IdentityKey::from(sk);
 
         assert_eq!(
             penalty::for_id_in_epoch(&ik, 791),
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn penalty_in_epoch_sorting() {
         let sk = rdsa::SigningKey::new(OsRng);
-        let ik = IdentityKey((&sk).into());
+        let ik = IdentityKey::from(sk);
 
         let k791 = penalty::for_id_in_epoch(&ik, 791);
         let k792 = penalty::for_id_in_epoch(&ik, 792);

--- a/crates/core/component/stake/src/unbonding_token.rs
+++ b/crates/core/component/stake/src/unbonding_token.rs
@@ -144,7 +144,8 @@ mod tests {
     fn unbonding_token_denomination_round_trip() {
         use rand_core::OsRng;
 
-        let ik = IdentityKey(SigningKey::<SpendAuth>::new(OsRng).into());
+        let sk = SigningKey::<SpendAuth>::new(OsRng);
+        let ik = IdentityKey::from(sk);
         let start = 782;
 
         let token = UnbondingToken::new(ik, start);

--- a/crates/core/component/stake/src/undelegate_claim/plan.rs
+++ b/crates/core/component/stake/src/undelegate_claim/plan.rs
@@ -45,7 +45,7 @@ impl UndelegateClaimPlan {
     /// Construct the [`UndelegateClaimBody`] described by this [`UndelegateClaimPlan`].
     pub fn undelegate_claim_body(&self) -> UndelegateClaimBody {
         UndelegateClaimBody {
-            validator_identity: self.validator_identity,
+            validator_identity: self.validator_identity.clone(),
             unbonding_start_height: self.unbonding_start_height,
             penalty: self.penalty,
             balance_commitment: self.balance().commit(self.balance_blinding),
@@ -72,7 +72,7 @@ impl UndelegateClaimPlan {
     }
 
     pub fn unbonding_token(&self) -> UnbondingToken {
-        UnbondingToken::new(self.validator_identity, self.unbonding_start_height)
+        UnbondingToken::new(self.validator_identity.clone(), self.unbonding_start_height)
     }
 
     pub fn unbonding_id(&self) -> asset::Id {

--- a/crates/core/component/stake/src/undelegate_claim/proof.rs
+++ b/crates/core/component/stake/src/undelegate_claim/proof.rs
@@ -124,7 +124,7 @@ mod tests {
             let (pk, vk) = generate_prepared_test_parameters::<ConvertCircuit>(&mut rng);
 
             let sk = rdsa::SigningKey::new_from_field(validator_randomness);
-            let validator_identity = IdentityKey((&sk).into());
+            let validator_identity = IdentityKey::from(sk);
             let unbonding_amount = Amount::from(value1_amount);
 
             let start_epoch_index = 1;

--- a/crates/view/src/storage.rs
+++ b/crates/view/src/storage.rs
@@ -991,7 +991,8 @@ impl Storage {
 
                 let identity_key = DelegationToken::from_str(&denom)
                     .context("invalid delegation token denom")?
-                    .validator();
+                    .validator()
+                    .to_owned();
 
                 results.push((record, identity_key));
             }


### PR DESCRIPTION
work in progress.

fixes #2304.
