### PR TITLE
ci: use nightly rust for mdbook installation

### DIFF
--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -30,7 +30,8 @@ jobs:
       # Ostensibly building from source, but the cache-loading above
       # ensures we don't need to rebuild frequently.
       - name: Install mdbook dependencies
-        run: cargo install mdbook mdbook-katex mdbook-mermaid mdbook-linkcheck
+        # Make sure to install with `+nightly`, because that's the toolchain we'll use for building docs.
+        run: cargo +nightly install mdbook mdbook-katex mdbook-mermaid mdbook-linkcheck
 
       - name: Build software guide
         run: cd docs/guide && mdbook build


### PR DESCRIPTION
## Describe your changes

Docs builds broke after merge of [0], not because its settings were incompatible, but because its inclusion of a `rust-toolchain.toml` file busted the CI cache, and caused the `mdbook` dep to be freshly installed, rather than retrieved from cache. We don't version-lock mdbook and friends, and the latest version evidently bumped MSRV to 1.74, which is newer than what we set for MSRV. We should probably bump MSRV too, but I'll do that separately. This commit is to unbreak the docs builds.

[0] https://github.com/penumbra-zone/penumbra/pull/4145

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > CI-only, docs-building logic. 
