### PR TITLE
pcli: bump colored_json to 4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,15 +1440,13 @@ dependencies = [
 
 [[package]]
 name = "colored_json"
-version = "2.1.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd32eb54d016e203b7c2600e3a7802c75843a92e38ccc4869aefeca21771a64"
+checksum = "79cff32df5cfea75e6484eeff0b4e48ad3977fb6582676a7862b3590dddc7a87"
 dependencies = [
- "ansi_term",
- "atty",
- "libc",
  "serde",
  "serde_json",
+ "yansi",
 ]
 
 [[package]]
@@ -9025,6 +9023,12 @@ dependencies = [
  "linux-raw-sys 0.4.13",
  "rustix 0.38.31",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yasna"

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -40,7 +40,7 @@ bytes = {workspace = true}
 camino = {workspace = true}
 clap = {workspace = true, features = ["derive", "env"]}
 colored = "2.1.0"
-colored_json = "2.1"
+colored_json = "4.1"
 comfy-table = "5"
 decaf377 = {workspace = true, default-features = true}
 decaf377-rdsa = {workspace = true}


### PR DESCRIPTION
## Describe your changes
Bump the version of colored_json used by pcli to 4.1.

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This is a dependency upgrade that mainly just removes subdependencies and bumps the edition to 2021.
