### PR TITLE
ci: add per-crate checks via cargo-hack

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,3 +62,18 @@ jobs:
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
       - run: cargo fmt --all -- --check
+
+  check:
+    name: Check all crate features
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Load rust cache
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
+      - name: install cargo-hack
+        run: cargo install cargo-hack
+      # Build each crate separately, to validate that the feature-gating is working.
+      # This is a lighter-weight version of `cargo check-all-features --workspace --release`.
+      - run: ./deployments/scripts/check-crate-feature-sets

--- a/crates/core/component/compact-block/Cargo.toml
+++ b/crates/core/component/compact-block/Cargo.toml
@@ -12,6 +12,7 @@ component = [
     "tokio-stream",
     "tokio",
     "penumbra-governance/component",
+    "penumbra-dex/component",
 ]
 # proving-keys = ["penumbra-proof-params/proving-keys"]
 default = ["std", "component"]

--- a/crates/core/component/compact-block/src/component/manager.rs
+++ b/crates/core/component/compact-block/src/component/manager.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use cnidarium::StateWrite;
+#[cfg(feature = "component")]
 use penumbra_dex::component::{StateReadExt, SwapManager as _};
 use penumbra_fee::component::StateReadExt as _;
 use penumbra_governance::StateReadExt as _;

--- a/crates/misc/measure/Cargo.toml
+++ b/crates/misc/measure/Cargo.toml
@@ -20,7 +20,7 @@ penumbra-compact-block = {workspace = true, default-features = false}
 penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
 serde_json = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
-tonic = {workspace = true}
+tonic = {workspace = true, features = ["tls"]}
 tracing = {workspace = true}
 tracing-subscriber = {workspace = true, features = ["env-filter"]}
 url = {workspace = true}

--- a/crates/test/mock-consensus/Cargo.toml
+++ b/crates/test/mock-consensus/Cargo.toml
@@ -18,6 +18,6 @@ ed25519-consensus = { workspace = true }
 rand_core = { workspace = true }
 sha2 = { workspace = true }
 tap = { workspace = true }
-tendermint = { workspace = true }
+tendermint = { workspace = true, default-features = true }
 tower = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/deployments/scripts/check-crate-feature-sets
+++ b/deployments/scripts/check-crate-feature-sets
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# CI script to verify that each crate in the monorepo builds independently.
+# This helps us ensure that the feature-gating for e.g. "component" is
+# declared explicitly.
+set -euo pipefail
+
+
+if ! hash cargo-hack >/dev/null 2>&1 ; then
+    >&2 echo "ERROR: cargo-hack not found. Install it with: cargo install cargo-hack"
+    exit 1
+fi
+
+cargo hack check --workspace --all-targets --all-features --release


### PR DESCRIPTION
# Describe your changes
Suggested by @erwanor, based on the Astria CI config [0]. The goal is to ensure that our default feature sets actually work, by compiling each crate in the workspace individually.

[0] https://github.com/astriaorg/astria/blob/6cc8e2b828f8f5ee65e03c2b3383c4252b4c6b81/.github/workflows/test.yml#L64-L68

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > The changes to crate content are explicitly declaring which imports should be activated based on feature sets. The rest of the diff is CI-only logic.
