### PR TITLE
penumbra: remove `Builder` factory

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,5 @@
 [build]
 # Enable Tokio's `tracing` support for `tokio-console`
-rustflags = ["--cfg", "tokio_unstable"]
+# rustflags = ["--cfg", "tokio_unstable"]
+# Note(erwan): We decided to disable it for the time being,
+# I'm keeping this around to be able to reactivate it on a whim.

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -120,10 +120,9 @@ async fn main() -> anyhow::Result<()> {
                 "starting pd"
             );
 
-            let abci_server = tokio::task::Builder::new()
-                .name("abci_server")
-                .spawn(penumbra_app::server::new(storage.clone()).listen_tcp(abci_bind))
-                .expect("failed to spawn abci server");
+            let abci_server = tokio::task::spawn(
+                penumbra_app::server::new(storage.clone()).listen_tcp(abci_bind),
+            );
 
             let grpc_server =
                 penumbra_app::rpc::router(&storage, cometbft_addr, enable_expensive_rpc)?;
@@ -148,10 +147,7 @@ async fn main() -> anyhow::Result<()> {
             // resolver if auto-https has been enabled.
             macro_rules! spawn_grpc_server {
                 ($server:expr) => {
-                    tokio::task::Builder::new()
-                        .name("grpc_server")
-                        .spawn($server.serve(make_svc))
-                        .expect("failed to spawn grpc server")
+                    tokio::task::spawn($server.serve(make_svc))
                 };
             }
             let grpc_server = axum_server::bind(grpc_bind);

--- a/crates/cnidarium/src/store/substore.rs
+++ b/crates/cnidarium/src/store/substore.rs
@@ -365,9 +365,8 @@ impl SubstoreStorage {
     ) -> Result<(RootHash, rocksdb::WriteBatch)> {
         let span = Span::current();
 
-        tokio::task::Builder::new()
-                .name("Storage::commit_inner_substore")
-                .spawn_blocking(move || {
+        tokio::task
+                ::spawn_blocking(move || {
                     span.in_scope(|| {
                         let jmt = jmt::Sha256Jmt::new(&self.substore_snapshot);
                         let unwritten_changes: Vec<_> = cache
@@ -440,7 +439,7 @@ impl SubstoreStorage {
 
                         Ok((root_hash, write_batch))
                     })
-                })?
+                })
                 .await?
     }
 }


### PR DESCRIPTION
## Describe your changes

We use named tasks in `pd` and `cnidarium` via `tokio::task::Builder`. This is a great feature that improves `tokio-console` rendering and has proved valuable in the past. However, since tracing integration in tokio is still unstable, using this requires a special cargo configuration to run rustc with a special `tokio_unstable` flag.

We have received a lot of direct feedback that this is 1/ surprising 2/ cumbersome, and since it seem like there are no immediate plans to stabilize tracing in tokio, we are removing it for now.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Internal only.