### PR TITLE
tests(app): 😌 deduplicate staking test boilerplate

### DIFF
--- a/crates/core/app/src/genesis.rs
+++ b/crates/core/app/src/genesis.rs
@@ -164,6 +164,30 @@ impl DomainType for AppState {
     type Proto = pb::GenesisAppState;
 }
 
+impl Content {
+    pub fn with_epoch_duration(self, epoch_duration: u64) -> Self {
+        Self {
+            sct_content: penumbra_sct::genesis::Content {
+                sct_params: penumbra_sct::params::SctParameters { epoch_duration },
+            },
+            ..self
+        }
+    }
+
+    pub fn with_unbonding_delay(self, unbonding_delay: u64) -> Self {
+        Self {
+            stake_content: penumbra_stake::genesis::Content {
+                stake_params: penumbra_stake::params::StakeParameters {
+                    unbonding_delay,
+                    ..self.stake_content.stake_params
+                },
+                ..self.stake_content
+            },
+            ..self
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/core/app/tests/app_can_define_and_delegate_to_a_validator.rs
+++ b/crates/core/app/tests/app_can_define_and_delegate_to_a_validator.rs
@@ -59,17 +59,12 @@ async fn app_can_define_and_delegate_to_a_validator() -> anyhow::Result<()> {
     let snapshot_end = storage.latest_snapshot();
 
     // Retrieve the validator definition from the latest snapshot.
-    let existing_validator = match snapshot_end
-        .validator_definitions()
-        .tap(|_| info!("getting validator definitions"))
+    let [existing_validator_id] = storage
+        .latest_snapshot()
+        .validator_identity_keys()
         .await?
-        .as_slice()
-    {
-        [v] => v.clone(),
-        unexpected => panic!("there should be one validator, got: {unexpected:?}"),
-    };
-
-    let existing_validator_id = existing_validator.identity_key;
+        .try_into()
+        .map_err(|keys| anyhow::anyhow!("expected one key, got: {keys:?}"))?;
 
     // Check that we are now in a new epoch.
     {

--- a/crates/core/app/tests/app_can_define_and_delegate_to_a_validator.rs
+++ b/crates/core/app/tests/app_can_define_and_delegate_to_a_validator.rs
@@ -5,7 +5,10 @@ use {
     anyhow::{anyhow, Context},
     cnidarium::TempStorage,
     decaf377_rdsa::{SigningKey, SpendAuth, VerificationKey},
-    penumbra_app::{genesis::AppState, server::consensus::Consensus},
+    penumbra_app::{
+        genesis::{self, AppState},
+        server::consensus::Consensus,
+    },
     penumbra_keys::test_keys,
     penumbra_mock_client::MockClient,
     penumbra_mock_consensus::TestNode,
@@ -31,14 +34,8 @@ async fn app_can_define_and_delegate_to_a_validator() -> anyhow::Result<()> {
     let storage = TempStorage::new().await?;
 
     // Configure an AppState with slightly shorter epochs than usual.
-    let app_state = AppState::Content(penumbra_app::genesis::Content {
-        sct_content: penumbra_sct::genesis::Content {
-            sct_params: penumbra_sct::params::SctParameters {
-                epoch_duration: EPOCH_DURATION,
-            },
-        },
-        ..Default::default()
-    });
+    let app_state =
+        AppState::Content(genesis::Content::default().with_epoch_duration(EPOCH_DURATION));
 
     // Start the test node.
     let mut node = {

--- a/crates/core/app/tests/app_can_undelegate_from_a_validator.rs
+++ b/crates/core/app/tests/app_can_undelegate_from_a_validator.rs
@@ -1,5 +1,3 @@
-use penumbra_num::fixpoint::U128x128;
-
 mod common;
 
 use {
@@ -7,10 +5,14 @@ use {
     anyhow::anyhow,
     ark_ff::UniformRand,
     cnidarium::TempStorage,
-    penumbra_app::{genesis::AppState, server::consensus::Consensus},
+    penumbra_app::{
+        genesis::{self, AppState},
+        server::consensus::Consensus,
+    },
     penumbra_keys::test_keys,
     penumbra_mock_client::MockClient,
     penumbra_mock_consensus::TestNode,
+    penumbra_num::fixpoint::U128x128,
     penumbra_proto::DomainType,
     penumbra_sct::component::clock::EpochRead as _,
     penumbra_stake::{
@@ -58,21 +60,11 @@ async fn app_can_undelegate_from_a_validator() -> anyhow::Result<()> {
     };
 
     // Configure an AppState with slightly shorter epochs than usual.
-    let app_state = AppState::Content(penumbra_app::genesis::Content {
-        sct_content: penumbra_sct::genesis::Content {
-            sct_params: penumbra_sct::params::SctParameters {
-                epoch_duration: EPOCH_DURATION,
-            },
-        },
-        stake_content: penumbra_stake::genesis::Content {
-            stake_params: penumbra_stake::params::StakeParameters {
-                unbonding_delay: UNBONDING_DELAY,
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        ..Default::default()
-    });
+    let app_state = AppState::Content(
+        genesis::Content::default()
+            .with_epoch_duration(EPOCH_DURATION)
+            .with_unbonding_delay(UNBONDING_DELAY),
+    );
 
     // Start the test node.
     let mut node = {

--- a/crates/core/app/tests/app_can_undelegate_from_a_validator.rs
+++ b/crates/core/app/tests/app_can_undelegate_from_a_validator.rs
@@ -1,7 +1,5 @@
-mod common;
-
 use {
-    self::common::BuilderExt,
+    self::common::{BuilderExt, TestNodeExt},
     anyhow::anyhow,
     ark_ff::UniformRand,
     cnidarium::TempStorage,
@@ -26,6 +24,8 @@ use {
     tap::Tap,
     tracing::{error_span, info, Instrument},
 };
+
+mod common;
 
 /// The length of the [`penumbra_sct`] epoch.
 ///
@@ -195,12 +195,7 @@ async fn app_can_undelegate_from_a_validator() -> anyhow::Result<()> {
     }
 
     // Fast forward to the next epoch.
-    {
-        let start = get_latest_epoch().await.index;
-        while get_latest_epoch().await.index < start {
-            node.block().execute().await?;
-        }
-    }
+    node.fast_forward_to_next_epoch(&storage).await?;
 
     // Build a transaction that will now undelegate from the validator.
     let undelegate_rate = storage

--- a/crates/core/app/tests/app_tracks_uptime_for_genesis_validator_signing_blocks.rs
+++ b/crates/core/app/tests/app_tracks_uptime_for_genesis_validator_signing_blocks.rs
@@ -1,17 +1,15 @@
-mod common;
-
 use {
     self::common::BuilderExt,
     anyhow::Context,
     cnidarium::TempStorage,
     penumbra_app::{genesis::AppState, server::consensus::Consensus},
     penumbra_mock_consensus::TestNode,
-    penumbra_stake::{
-        component::validator_handler::validator_store::ValidatorDataRead, validator::Validator,
-    },
+    penumbra_stake::component::validator_handler::validator_store::ValidatorDataRead,
     tap::Tap,
-    tracing::{error_span, info, Instrument},
+    tracing::{error_span, Instrument},
 };
+
+mod common;
 
 #[tokio::test]
 async fn app_tracks_uptime_for_genesis_validator_missing_blocks() -> anyhow::Result<()> {
@@ -31,16 +29,12 @@ async fn app_tracks_uptime_for_genesis_validator_missing_blocks() -> anyhow::Res
     }?;
 
     // Retrieve the validator definition from the latest snapshot.
-    let Validator { identity_key, .. } = match storage
+    let [identity_key] = storage
         .latest_snapshot()
-        .validator_definitions()
-        .tap(|_| info!("getting validator definitions"))
+        .validator_identity_keys()
         .await?
-        .as_slice()
-    {
-        [v] => v.clone(),
-        unexpected => panic!("there should be one validator, got: {unexpected:?}"),
-    };
+        .try_into()
+        .map_err(|keys| anyhow::anyhow!("expected one key, got: {keys:?}"))?;
     let get_uptime = || async {
         storage
             .latest_snapshot()

--- a/crates/core/app/tests/app_tracks_uptime_for_validators_only_once_active.rs
+++ b/crates/core/app/tests/app_tracks_uptime_for_validators_only_once_active.rs
@@ -4,7 +4,10 @@ use {
     self::common::BuilderExt,
     cnidarium::TempStorage,
     decaf377_rdsa::{SigningKey, SpendAuth, VerificationKey},
-    penumbra_app::{genesis::AppState, server::consensus::Consensus},
+    penumbra_app::{
+        genesis::{self, AppState},
+        server::consensus::Consensus,
+    },
     penumbra_keys::test_keys,
     penumbra_mock_client::MockClient,
     penumbra_mock_consensus::TestNode,
@@ -31,14 +34,8 @@ async fn app_tracks_uptime_for_validators_only_once_active() -> anyhow::Result<(
     let storage = TempStorage::new().await?;
 
     // Configure an AppState with slightly shorter epochs than usual.
-    let app_state = AppState::Content(penumbra_app::genesis::Content {
-        sct_content: penumbra_sct::genesis::Content {
-            sct_params: penumbra_sct::params::SctParameters {
-                epoch_duration: EPOCH_DURATION,
-            },
-        },
-        ..Default::default()
-    });
+    let app_state =
+        AppState::Content(genesis::Content::default().with_epoch_duration(EPOCH_DURATION));
 
     // Start the test node.
     let mut node = {

--- a/crates/core/app/tests/common/mod.rs
+++ b/crates/core/app/tests/common/mod.rs
@@ -89,3 +89,46 @@ impl TempStorageExt for TempStorage {
         self.apply_genesis(Default::default()).await
     }
 }
+
+#[async_trait]
+pub trait TestNodeExt: Sized {
+    async fn fast_forward_to_next_epoch(
+        &mut self,
+        storage: &TempStorage,
+    ) -> anyhow::Result<penumbra_sct::epoch::Epoch>;
+}
+
+#[async_trait]
+impl<C> TestNodeExt for TestNode<C>
+where
+    C: tower::Service<
+            tendermint::v0_37::abci::ConsensusRequest,
+            Response = tendermint::v0_37::abci::ConsensusResponse,
+            Error = tower::BoxError,
+        > + Send
+        + Clone
+        + 'static,
+    C::Future: Send + 'static,
+    C::Error: Sized,
+{
+    async fn fast_forward_to_next_epoch(
+        &mut self,
+        storage: &TempStorage,
+    ) -> Result<penumbra_sct::epoch::Epoch, anyhow::Error> {
+        use {penumbra_sct::component::clock::EpochRead, tap::Tap};
+
+        let get_epoch = || async { storage.latest_snapshot().get_current_epoch().await };
+        let start = get_epoch()
+            .await?
+            .tap(|start| tracing::info!(?start, "fast forwarding to next epoch"));
+
+        loop {
+            self.block().execute().await?;
+            let current = get_epoch().await?;
+            if current != start {
+                tracing::debug!(end = ?current, ?start, "reached next epoch");
+                return Ok(current);
+            }
+        }
+    }
+}

--- a/crates/core/component/stake/src/component/validator_handler/validator_store.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_store.rs
@@ -235,6 +235,15 @@ pub trait ValidatorDataRead: StateRead {
             .try_collect()
             .await
     }
+
+    /// Returns a list of **all** known validators identity keys.
+    async fn validator_identity_keys(&self) -> Result<Vec<IdentityKey>> {
+        self.prefix(state_key::validators::definitions::prefix())
+            .map_ok(|(_key, validator)| validator)
+            .map_ok(|validator: Validator| validator.identity_key)
+            .try_collect()
+            .await
+    }
 }
 
 impl<T: StateRead + ?Sized> ValidatorDataRead for T {}


### PR DESCRIPTION
this branch adds some small tweaks to cut down on common boilerplate code found
in many of the staking component tests. this allows us to (a) easily set the
epoch duration, (b) fast forward to the end of an epoch, and (c) obtain the
identity keys of the currently defined validators. 

## changes

#### f3ecf6d5806e9b99de9fa98e0e0b85076840bef0 tests(app): 🔶 add genesis content setters
    
this is some common glue code in integration tests for the staking component.
in order to smooth the inspection of component logic that runs at epoch
boundaries, the defaults for `AppState`'s inner settings for e.g. epoch
duration are overriden to shorter values.

as is, this requres stating object literals that are somewhat verbose, even
with `..T::default()` elision. this commit adds some small `with_` helpers to
allow test cases to manipulate these settings succinctly.

#### bf8f4d14253878a38bdd1589fb15d414f4745094 tests(app): 🏃 add fast forward to next epoch helper
    
this adds an extension method that can be used to fast forward to the next
epoch. this is a very common part of test logic that exercises the staking
component.

this allows test cases to invoke an extension method to jump ahead, without
needing to import the clock component and write a loop inspecting the current
epoch after creating and executing an empty block.

#### 1c5b90a23 tests(app): 🔑 use `validator_identity_keys` accessor

this adds a `ValidatorDataRead::validator_identity_keys()` trait method.

frequently, test logic needs to keep track of validators by their identity
keys. this led to a bit of common glue code that would get the latest snapshot,
the set of all validator definitions, assert that only one validator is
present, and then take the identity key of that single validator.

now we can just get the keys, bind that single entry to a variable, or return
an error if something went wrong.

---

### checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the
  "consensus-breaking" label. Otherwise, I declare my belief that there are not
  consensus-breaking changes, for the following reason:

> this is only additive changes, or adjusting test code.

