### PR TITLE
summonerd: disable console by default

### DIFF
--- a/tools/summonerd/src/main.rs
+++ b/tools/summonerd/src/main.rs
@@ -87,7 +87,7 @@ operating the orchestration.
 )]
 struct Opt {
     /// Enable Tokio Console support.
-    #[clap(long, default_value = "false")]
+    #[clap(long)]
     tokio_console: bool,
     /// Command to run.
     #[clap(subcommand)]


### PR DESCRIPTION
## Describe your changes

The `tokio-console` flag for `summonerd` defaults to `"false"` which evaluates to `true`. I'm leaving the console subscriber so that we can activate the unstable flag on a whim, but we should not have it run by default. 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Internal CLI change
