### PR TITLE
penumbra: completely remove `console-subscriber`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,43 +1484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console-api"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787"
-dependencies = [
- "futures-core",
- "prost",
- "prost-types",
- "tonic",
- "tracing-core",
-]
-
-[[package]]
-name = "console-subscriber"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7481d4c57092cd1c19dd541b92bdce883de840df30aa5d03fd48a3935c01842e"
-dependencies = [
- "console-api",
- "crossbeam-channel",
- "crossbeam-utils",
- "futures-task",
- "hdrhistogram",
- "humantime",
- "prost-types",
- "serde",
- "serde_json",
- "thread_local",
- "tokio",
- "tokio-stream",
- "tonic",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.3.18",
-]
-
-[[package]]
 name = "const-crc32"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,15 +1611,6 @@ name = "critical-section"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-deque"
@@ -2805,10 +2759,7 @@ version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
- "base64 0.21.7",
  "byteorder",
- "flate2",
- "nom",
  "num-traits",
 ]
 
@@ -2991,12 +2942,6 @@ name = "humansize"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -4540,7 +4485,6 @@ dependencies = [
  "chrono",
  "clap",
  "cnidarium",
- "console-subscriber",
  "csv",
  "decaf377 0.5.0",
  "decaf377-rdsa",
@@ -7599,7 +7543,6 @@ dependencies = [
  "camino",
  "chrono",
  "clap",
- "console-subscriber",
  "decaf377 0.5.0",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,6 @@ chrono                           = { default-features = false, version = "0.4" }
 clap                             = { version = "3.2" }
 cnidarium                        = { default-features = false, path = "crates/cnidarium" }
 cnidarium-component              = { default-features = false, path = "crates/cnidarium-component" }
-console-subscriber               = { version = "0.2" }
 criterion                        = { version = "0.4" }
 decaf377                         = { default-features = false, version = "0.5" }
 decaf377-fmd                     = { path = "crates/crypto/decaf377-fmd" }

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -44,7 +44,6 @@ bytes                            = { workspace = true }
 chrono                           = { workspace = true, default-features = false, features = ["serde"] }
 clap                             = { workspace = true, features = ["derive", "env"] }
 cnidarium                        = { workspace = true, features = ["migration", "rpc"], default-features = true }
-console-subscriber               = { workspace = true }
 csv                              = "1.1"
 decaf377                         = { workspace = true, features = ["parallel"], default-features = true }
 decaf377-rdsa                    = { workspace = true }

--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -9,9 +9,6 @@ use {
 #[derive(Debug, Parser)]
 #[clap(name = "pd", about = "The Penumbra daemon.", version)]
 pub struct Opt {
-    /// Enable Tokio Console support.
-    #[clap(long)]
-    pub tokio_console: bool,
     /// Command to run.
     #[clap(subcommand)]
     pub cmd: RootCommand,

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -4,7 +4,6 @@
 use std::error::Error;
 use std::io::IsTerminal as _;
 
-use console_subscriber::ConsoleLayer;
 use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
 use metrics_util::layers::Stack;
 
@@ -32,7 +31,7 @@ use url::Url;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Validate options immediately.
-    let Opt { tokio_console, cmd } = <Opt as clap::Parser>::parse();
+    let Opt { cmd } = <Opt as clap::Parser>::parse();
 
     // Instantiate tracing layers.
     // The MetricsLayer handles enriching metrics output with labels from tracing spans.
@@ -49,14 +48,7 @@ async fn main() -> anyhow::Result<()> {
         .with(filter_layer)
         .with(fmt_layer)
         .with(metrics_layer);
-    if tokio_console {
-        // The ConsoleLayer enables collection of data for `tokio-console`.
-        // The `spawn` call will panic if AddrInUse, so we only spawn if enabled.
-        let console_layer = ConsoleLayer::builder().with_default_env().spawn();
-        registry.with(console_layer).init();
-    } else {
-        registry.init();
-    }
+    registry.init();
 
     tracing::info!(?cmd, version = env!("CARGO_PKG_VERSION"), "running command");
     match cmd {

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -43,7 +43,7 @@ async fn main() -> anyhow::Result<()> {
     // The `EnvFilter` layer is used to filter events based on `RUST_LOG`.
     let filter_layer = EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("info"))?;
 
-    // Register the tracing subscribers, conditionally enabling tokio console support
+    // Register the tracing subscribers.
     let registry = tracing_subscriber::registry()
         .with(filter_layer)
         .with(fmt_layer)

--- a/tools/summonerd/Cargo.toml
+++ b/tools/summonerd/Cargo.toml
@@ -21,7 +21,6 @@ bytes = {workspace = true}
 camino = {workspace = true}
 chrono = {workspace = true}
 clap = {workspace = true, features = ["derive", "env", "color"]}
-console-subscriber = {workspace = true}
 decaf377 = {workspace = true}
 futures = {workspace = true}
 hex = {workspace = true}


### PR DESCRIPTION
## Describe your changes

This completely removes `console-subscriber` and the associated flag, on second thought it is worse to leave it around if it requires knowing about a secret compile flag to actually exercise. This also fix the summoner smoke test... 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Internal change.
