### PR TITLE
dex: refactor internal indexing into ext traits

### DIFF
--- a/crates/core/component/dex/src/component/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/component/circuit_breaker/value.rs
@@ -47,7 +47,6 @@ impl<T: StateWrite + ?Sized> ValueCircuitBreaker for T {}
 mod tests {
     use std::sync::Arc;
 
-    use crate::component::position_manager::base_liquidity_index::AssetByLiquidityIndex as _;
     use crate::component::position_manager::price_index::PositionByPriceIndex;
     use crate::component::router::HandleBatchSwaps as _;
     use crate::component::{StateReadExt as _, StateWriteExt as _};
@@ -229,10 +228,6 @@ mod tests {
         state_tx
             .update_position_by_price_index(&None, &position, &position.id())
             .expect("can update price index");
-        state_tx
-            .update_asset_by_base_liquidity_index(&None, &position, &position.id())
-            .await
-            .expect("able to update liquidity");
         state_tx.put(state_key::position_by_id(&id), position);
 
         // Now there's a position in the state, but the circuit breaker is not aware of it.

--- a/crates/core/component/dex/src/component/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/component/circuit_breaker/value.rs
@@ -226,7 +226,9 @@ mod tests {
         let id = buy_1.id();
 
         let position = buy_1;
-        state_tx.index_position_by_price(&position, &position.id());
+        state_tx
+            .update_position_by_price_index(&None, &position, &position.id())
+            .expect("can update price index");
         state_tx
             .update_asset_by_base_liquidity_index(&None, &position, &position.id())
             .await

--- a/crates/core/component/dex/src/component/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/component/circuit_breaker/value.rs
@@ -228,7 +228,7 @@ mod tests {
         let position = buy_1;
         state_tx.index_position_by_price(&position, &position.id());
         state_tx
-            .update_available_liquidity(&None, &position)
+            .update_asset_by_base_liquidity_index(&None, &position, &position.id())
             .await
             .expect("able to update liquidity");
         state_tx.put(state_key::position_by_id(&id), position);

--- a/crates/core/component/dex/src/component/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/component/circuit_breaker/value.rs
@@ -47,7 +47,8 @@ impl<T: StateWrite + ?Sized> ValueCircuitBreaker for T {}
 mod tests {
     use std::sync::Arc;
 
-    use crate::component::position_manager::Inner as _;
+    use crate::component::position_manager::base_liquidity_index::AssetByLiquidityIndex as _;
+    use crate::component::position_manager::price_index::PositionByPriceIndex;
     use crate::component::router::HandleBatchSwaps as _;
     use crate::component::{StateReadExt as _, StateWriteExt as _};
     use crate::lp::plan::PositionWithdrawPlan;

--- a/crates/core/component/dex/src/component/mod.rs
+++ b/crates/core/component/dex/src/component/mod.rs
@@ -19,8 +19,6 @@ pub(crate) use arb::Arbitrage;
 pub use circuit_breaker::ExecutionCircuitBreaker;
 pub(crate) use circuit_breaker::ValueCircuitBreaker;
 pub use dex::{Dex, StateReadExt, StateWriteExt};
-// TODO(erwan): exposing a DEX interface to other components
-// is useful but maybe we should restrict it to open/queue/close positions
 pub use position_manager::{PositionManager, PositionRead};
 pub use swap_manager::SwapManager;
 #[cfg(test)]

--- a/crates/core/component/dex/src/component/mod.rs
+++ b/crates/core/component/dex/src/component/mod.rs
@@ -11,16 +11,16 @@ mod arb;
 pub(crate) mod circuit_breaker;
 mod dex;
 mod flow;
-pub(crate) mod position_counter;
-pub(crate) mod position_manager;
+mod position_manager;
 mod swap_manager;
 
 pub use self::metrics::register_metrics;
-pub use arb::Arbitrage;
+pub(crate) use arb::Arbitrage;
 pub use circuit_breaker::ExecutionCircuitBreaker;
 pub(crate) use circuit_breaker::ValueCircuitBreaker;
 pub use dex::{Dex, StateReadExt, StateWriteExt};
-pub use position_manager::{PositionManager, PositionRead};
+pub(crate) use position_manager::PositionManager;
+pub use position_manager::PositionRead;
 pub use swap_manager::SwapManager;
 #[cfg(test)]
 pub(crate) mod tests;

--- a/crates/core/component/dex/src/component/mod.rs
+++ b/crates/core/component/dex/src/component/mod.rs
@@ -19,8 +19,9 @@ pub(crate) use arb::Arbitrage;
 pub use circuit_breaker::ExecutionCircuitBreaker;
 pub(crate) use circuit_breaker::ValueCircuitBreaker;
 pub use dex::{Dex, StateReadExt, StateWriteExt};
-pub(crate) use position_manager::PositionManager;
-pub use position_manager::PositionRead;
+// TODO(erwan): exposing a DEX interface to other components
+// is useful but maybe we should restrict it to open/queue/close positions
+pub use position_manager::{PositionManager, PositionRead};
 pub use swap_manager::SwapManager;
 #[cfg(test)]
 pub(crate) mod tests;

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -233,9 +233,6 @@ pub trait PositionManager: StateWrite + PositionRead {
             );
         }
 
-        // Increase the position counter
-        self.increment_position_counter(&position.phi.pair).await?;
-
         // Credit the DEX for the inflows from this position.
         self.vcb_credit(position.reserves_1()).await?;
         self.vcb_credit(position.reserves_2()).await?;

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -27,9 +27,9 @@ use crate::{event, state_key};
 
 const DYNAMIC_ASSET_LIMIT: usize = 10;
 
-pub(crate) mod base_liquidity_index;
-pub(crate) mod counter;
-pub(crate) mod inventory_index;
+mod base_liquidity_index;
+mod counter;
+mod inventory_index;
 pub(crate) mod price_index;
 
 #[async_trait]

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -387,7 +387,7 @@ pub trait PositionManager: StateWrite + PositionRead {
 impl<T: StateWrite + ?Sized> PositionManager for T {}
 
 #[async_trait]
-pub(crate) trait Inner: StateWrite {
+trait Inner: StateWrite {
     /// Writes a position to the state, updating all necessary indexes.
     ///
     /// This should be the SOLE ENTRYPOINT for writing positions to the state.

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -124,9 +124,9 @@ pub trait PositionRead: StateRead {
     /// Returns a stream of [`asset::Id`] routable from a given asset, ordered by liquidity.
     fn ordered_routable_assets(
         &self,
-        from: &asset::Id,
+        start: &asset::Id,
     ) -> Pin<Box<dyn Stream<Item = Result<asset::Id>> + Send + 'static>> {
-        let prefix = engine::routable_assets::prefix(from);
+        let prefix = engine::routable_assets::starting_from(start);
         tracing::trace!(prefix = ?EscapedByteSlice(&prefix), "searching for routable assets by liquidity");
         self.nonverifiable_prefix_raw(&prefix)
             .map(|entry| match entry {

--- a/crates/core/component/dex/src/component/position_manager/base_liquidity_index.rs
+++ b/crates/core/component/dex/src/component/position_manager/base_liquidity_index.rs
@@ -1,0 +1,174 @@
+use anyhow::Result;
+use cnidarium::StateWrite;
+use penumbra_num::Amount;
+
+use crate::lp::position::{Position, State};
+use crate::state_key::engine;
+use crate::DirectedTradingPair;
+use penumbra_proto::DomainType;
+
+pub(crate) trait AssetByLiquidityIndex: StateWrite {
+    /// Updates the nonverifiable liquidity indices given a [`Position`] in the direction specified by the [`DirectedTradingPair`].
+    /// An [`Option<Position>`] may be specified to allow for the case where a position is being updated.
+    async fn update_liquidity_index(
+        &mut self,
+        pair: DirectedTradingPair,
+        position: &Position,
+        prev: &Option<Position>,
+    ) -> Result<()> {
+        tracing::debug!(?pair, "updating available liquidity indices");
+
+        let (new_a_from_b, current_a_from_b) = match (position.state, prev) {
+            (State::Opened, None) => {
+                // Add the new position's contribution to the index, no cancellation of the previous version necessary.
+
+                // Query the current available liquidity for this trading pair, or zero if the trading pair
+                // has no current liquidity.
+                let current_a_from_b = self
+                    .nonverifiable_get_raw(&engine::routable_assets::a_from_b(&pair))
+                    .await?
+                    .map(|bytes| {
+                        Amount::from_be_bytes(
+                            bytes
+                                .try_into()
+                                .expect("liquidity index amount can always be parsed"),
+                        )
+                    })
+                    .unwrap_or_default();
+
+                // Use the new reserves to compute `new_position_contribution`,
+                // the amount of asset A contributed by the position (i.e. the reserves of asset A).
+                let new_position_contribution = position
+                    .reserves_for(pair.start)
+                    .expect("specified position should match provided trading pair");
+
+                // Compute `new_A_from_B`.
+                let new_a_from_b =
+                    // Add the contribution from the updated version.
+                    current_a_from_b.saturating_add(&new_position_contribution);
+
+                tracing::debug!(?pair, current_liquidity = ?current_a_from_b, ?new_position_contribution, "newly opened position, adding contribution to existing available liquidity for trading pair");
+
+                (new_a_from_b, current_a_from_b)
+            }
+            (State::Opened, Some(prev)) => {
+                // Add the new position's contribution to the index, deleting the previous version's contribution.
+
+                // Query the current available liquidity for this trading pair, or zero if the trading pair
+                // has no current liquidity.
+                let current_a_from_b = self
+                    .nonverifiable_get_raw(&engine::routable_assets::a_from_b(&pair))
+                    .await?
+                    .map(|bytes| {
+                        Amount::from_be_bytes(
+                            bytes
+                                .try_into()
+                                .expect("liquidity index amount can always be parsed"),
+                        )
+                    })
+                    .unwrap_or_default();
+
+                // Use the previous reserves to compute `prev_position_contribution` (denominated in asset_1).
+                let prev_position_contribution = prev
+                    .reserves_for(pair.start)
+                    .expect("specified position should match provided trading pair");
+
+                // Use the new reserves to compute `new_position_contribution`,
+                // the amount of asset A contributed by the position (i.e. the reserves of asset A).
+                let new_position_contribution = position
+                    .reserves_for(pair.start)
+                    .expect("specified position should match provided trading pair");
+
+                // Compute `new_A_from_B`.
+                let new_a_from_b =
+                // Subtract the previous version of the position's contribution to represent that position no longer
+                // being correct, and add the contribution from the updated version.
+                (current_a_from_b.saturating_sub(&prev_position_contribution)).saturating_add(&new_position_contribution);
+
+                tracing::debug!(?pair, current_liquidity = ?current_a_from_b, ?new_position_contribution, ?prev_position_contribution, "updated position, adding new contribution and subtracting previous contribution to existing available liquidity for trading pair");
+
+                (new_a_from_b, current_a_from_b)
+            }
+            (State::Closed, Some(prev)) => {
+                // Compute the previous contribution and erase it from the current index
+
+                // Query the current available liquidity for this trading pair, or zero if the trading pair
+                // has no current liquidity.
+                let current_a_from_b = self
+                    .nonverifiable_get_raw(&engine::routable_assets::a_from_b(&pair))
+                    .await?
+                    .map(|bytes| {
+                        Amount::from_be_bytes(
+                            bytes
+                                .try_into()
+                                .expect("liquidity index amount can always be parsed"),
+                        )
+                    })
+                    .unwrap_or_default();
+
+                // Use the previous reserves to compute `prev_position_contribution` (denominated in asset_1).
+                let prev_position_contribution = prev
+                    .reserves_for(pair.start)
+                    .expect("specified position should match provided trading pair");
+
+                // Compute `new_A_from_B`.
+                let new_a_from_b =
+                // Subtract the previous version of the position's contribution to represent that position no longer
+                // being correct, and since the updated version is Closed, it has no contribution.
+                current_a_from_b.saturating_sub(&prev_position_contribution);
+
+                tracing::debug!(?pair, current_liquidity = ?current_a_from_b, ?prev_position_contribution, "closed position, subtracting previous contribution to existing available liquidity for trading pair");
+
+                (new_a_from_b, current_a_from_b)
+            }
+            (State::Withdrawn { .. }, _) | (State::Closed, None) => {
+                // The position already went through the `Closed` state or was opened in the `Closed` state, so its contribution has already been subtracted.
+                return Ok(());
+            }
+        };
+
+        // Delete the existing key for this position if the reserve amount has changed.
+        if new_a_from_b != current_a_from_b {
+            self.nonverifiable_delete(
+                engine::routable_assets::key(&pair.start, current_a_from_b).to_vec(),
+            );
+        }
+
+        // Write the new key indicating that asset B is routable from asset A with `new_a_from_b` liquidity.
+        self.nonverifiable_put_raw(
+            engine::routable_assets::key(&pair.start, new_a_from_b).to_vec(),
+            pair.end.encode_to_vec(),
+        );
+        tracing::debug!(start = ?pair.start, end = ?pair.end, "marking routable from start -> end");
+
+        // Write the new lookup index storing `new_a_from_b` for this trading pair.
+        self.nonverifiable_put_raw(
+            engine::routable_assets::a_from_b(&pair).to_vec(),
+            new_a_from_b.to_be_bytes().to_vec(),
+        );
+        tracing::debug!(available_liquidity = ?new_a_from_b, ?pair, "marking available liquidity for trading pair");
+
+        Ok(())
+    }
+
+    async fn update_available_liquidity(
+        &mut self,
+        prev_position: &Option<Position>,
+        position: &Position,
+    ) -> Result<()> {
+        // Since swaps may be performed in either direction, the available liquidity indices
+        // need to be calculated and stored for both the A -> B and B -> A directions.
+        let (a, b) = (position.phi.pair.asset_1(), position.phi.pair.asset_2());
+
+        // A -> B
+        self.update_liquidity_index(DirectedTradingPair::new(a, b), position, prev_position)
+            .await?;
+        // B -> A
+        self.update_liquidity_index(DirectedTradingPair::new(b, a), position, prev_position)
+            .await?;
+
+        Ok(())
+    }
+}
+
+impl<T: StateWrite + ?Sized> AssetByLiquidityIndex for T {}

--- a/crates/core/component/dex/src/component/position_manager/base_liquidity_index.rs
+++ b/crates/core/component/dex/src/component/position_manager/base_liquidity_index.rs
@@ -164,4 +164,4 @@ trait Inner: StateWrite {
     }
 }
 
-impl<T: AssetByLiquidityIndex + ?Sized> Inner for T {}
+impl<T: StateWrite + ?Sized> Inner for T {}

--- a/crates/core/component/dex/src/component/position_manager/base_liquidity_index.rs
+++ b/crates/core/component/dex/src/component/position_manager/base_liquidity_index.rs
@@ -1,171 +1,94 @@
 use anyhow::Result;
 use cnidarium::StateWrite;
 use penumbra_num::Amount;
+use position::State::*;
 
 use crate::lp::position::{self, Position, State};
 use crate::state_key::engine;
 use crate::DirectedTradingPair;
-use penumbra_proto::DomainType;
+use penumbra_proto::{StateReadProto, StateWriteProto};
 
 pub(crate) trait AssetByLiquidityIndex: StateWrite {
-    /// Updates the nonverifiable liquidity indices given a [`Position`] in the direction specified by the [`DirectedTradingPair`].
-    /// An [`Option<Position>`] may be specified to allow for the case where a position is being updated.
-    async fn update_liquidity_index(
-        &mut self,
-        pair: DirectedTradingPair,
-        position: &Position,
-        prev: &Option<Position>,
-    ) -> Result<()> {
-        tracing::debug!(?pair, "updating available liquidity indices");
-
-        let (new_a_from_b, current_a_from_b) = match (position.state, prev) {
-            (State::Opened, None) => {
-                // Add the new position's contribution to the index, no cancellation of the previous version necessary.
-
-                // Query the current available liquidity for this trading pair, or zero if the trading pair
-                // has no current liquidity.
-                let current_a_from_b = self
-                    .nonverifiable_get_raw(&engine::routable_assets::a_from_b(&pair))
-                    .await?
-                    .map(|bytes| {
-                        Amount::from_be_bytes(
-                            bytes
-                                .try_into()
-                                .expect("liquidity index amount can always be parsed"),
-                        )
-                    })
-                    .unwrap_or_default();
-
-                // Use the new reserves to compute `new_position_contribution`,
-                // the amount of asset A contributed by the position (i.e. the reserves of asset A).
-                let new_position_contribution = position
-                    .reserves_for(pair.start)
-                    .expect("specified position should match provided trading pair");
-
-                // Compute `new_A_from_B`.
-                let new_a_from_b =
-                    // Add the contribution from the updated version.
-                    current_a_from_b.saturating_add(&new_position_contribution);
-
-                tracing::debug!(?pair, current_liquidity = ?current_a_from_b, ?new_position_contribution, "newly opened position, adding contribution to existing available liquidity for trading pair");
-
-                (new_a_from_b, current_a_from_b)
-            }
-            (State::Opened, Some(prev)) => {
-                // Add the new position's contribution to the index, deleting the previous version's contribution.
-
-                // Query the current available liquidity for this trading pair, or zero if the trading pair
-                // has no current liquidity.
-                let current_a_from_b = self
-                    .nonverifiable_get_raw(&engine::routable_assets::a_from_b(&pair))
-                    .await?
-                    .map(|bytes| {
-                        Amount::from_be_bytes(
-                            bytes
-                                .try_into()
-                                .expect("liquidity index amount can always be parsed"),
-                        )
-                    })
-                    .unwrap_or_default();
-
-                // Use the previous reserves to compute `prev_position_contribution` (denominated in asset_1).
-                let prev_position_contribution = prev
-                    .reserves_for(pair.start)
-                    .expect("specified position should match provided trading pair");
-
-                // Use the new reserves to compute `new_position_contribution`,
-                // the amount of asset A contributed by the position (i.e. the reserves of asset A).
-                let new_position_contribution = position
-                    .reserves_for(pair.start)
-                    .expect("specified position should match provided trading pair");
-
-                // Compute `new_A_from_B`.
-                let new_a_from_b =
-                // Subtract the previous version of the position's contribution to represent that position no longer
-                // being correct, and add the contribution from the updated version.
-                (current_a_from_b.saturating_sub(&prev_position_contribution)).saturating_add(&new_position_contribution);
-
-                tracing::debug!(?pair, current_liquidity = ?current_a_from_b, ?new_position_contribution, ?prev_position_contribution, "updated position, adding new contribution and subtracting previous contribution to existing available liquidity for trading pair");
-
-                (new_a_from_b, current_a_from_b)
-            }
-            (State::Closed, Some(prev)) => {
-                // Compute the previous contribution and erase it from the current index
-
-                // Query the current available liquidity for this trading pair, or zero if the trading pair
-                // has no current liquidity.
-                let current_a_from_b = self
-                    .nonverifiable_get_raw(&engine::routable_assets::a_from_b(&pair))
-                    .await?
-                    .map(|bytes| {
-                        Amount::from_be_bytes(
-                            bytes
-                                .try_into()
-                                .expect("liquidity index amount can always be parsed"),
-                        )
-                    })
-                    .unwrap_or_default();
-
-                // Use the previous reserves to compute `prev_position_contribution` (denominated in asset_1).
-                let prev_position_contribution = prev
-                    .reserves_for(pair.start)
-                    .expect("specified position should match provided trading pair");
-
-                // Compute `new_A_from_B`.
-                let new_a_from_b =
-                // Subtract the previous version of the position's contribution to represent that position no longer
-                // being correct, and since the updated version is Closed, it has no contribution.
-                current_a_from_b.saturating_sub(&prev_position_contribution);
-
-                tracing::debug!(?pair, current_liquidity = ?current_a_from_b, ?prev_position_contribution, "closed position, subtracting previous contribution to existing available liquidity for trading pair");
-
-                (new_a_from_b, current_a_from_b)
-            }
-            (State::Withdrawn { .. }, _) | (State::Closed, None) => {
-                // The position already went through the `Closed` state or was opened in the `Closed` state, so its contribution has already been subtracted.
-                return Ok(());
-            }
-        };
-
-        // Delete the existing key for this position if the reserve amount has changed.
-        if new_a_from_b != current_a_from_b {
-            self.nonverifiable_delete(
-                engine::routable_assets::key(&pair.start, current_a_from_b).to_vec(),
-            );
-        }
-
-        // Write the new key indicating that asset B is routable from asset A with `new_a_from_b` liquidity.
-        self.nonverifiable_put_raw(
-            engine::routable_assets::key(&pair.start, new_a_from_b).to_vec(),
-            pair.end.encode_to_vec(),
-        );
-        tracing::debug!(start = ?pair.start, end = ?pair.end, "marking routable from start -> end");
-
-        // Write the new lookup index storing `new_a_from_b` for this trading pair.
-        self.nonverifiable_put_raw(
-            engine::routable_assets::a_from_b(&pair).to_vec(),
-            new_a_from_b.to_be_bytes().to_vec(),
-        );
-        tracing::debug!(available_liquidity = ?new_a_from_b, ?pair, "marking available liquidity for trading pair");
-
-        Ok(())
-    }
-
+    /// Update the base liquidity index, used by the DEX engine during path search.
+    ///
+    /// # Overview
+    /// Given a directed trading pair `A -> B`, the index tracks the amount of
+    /// liquidity available to convert the quote asset B, into a base asset A.
+    ///
+    /// # Index schema
+    /// The liquidity index schema is as follow:
+    /// - A primary index that maps a "start" asset A (aka. base asset)
+    ///   to an "end" asset B (aka. quote asset) ordered by the amount of
+    ///   liquidity available for B -> A (not a typo).
+    /// - An auxilliary index that maps a directed trading pair `A -> B`
+    ///   to the aggregate liquidity for B -> A (used in the primary composite key)
+    ///
+    /// # Diagram
+    ///                                                                     
+    ///    Liquidity index:                                                 
+    ///    For an asset `A`, surface asset                                  
+    ///    `B` with the best liquidity                                      
+    ///    score.                                                           
+    ///                             ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐     
+    ///                                                                     
+    ///           ┌──┐              ▼            ┌─────────┐          │     
+    ///     ▲     │  │    ┌──────────────────┐   │         │                
+    ///     │     │ ─┼───▶│{asset_A}{agg_liq}│──▶│{asset_B}│          │     
+    ///     │     ├──┤    └──────────────────┘   │         │                
+    ///   sorted  │  │                           └─────────┘          │     
+    ///   by agg  │  │                                                      
+    ///    liq    ├──┤                                                │     
+    ///     │     │  │                                           used in the
+    ///     │     ├──┤                                            composite
+    ///     │     │  │                                               key    
+    ///     │     │  │       Auxiliary look-up index:                 │     
+    ///     │     │  │       "Find the aggregate liquidity                 
+    ///     │     │  │       per directed trading pair"               │      
+    ///     │     │  │       ┌───────┐                           ┌─────────┐
+    ///     │     │  │       ├───────┤  ┌──────────────────┐     │         │
+    ///     │     │  │       │   ────┼─▶│{asset_A}{asset_B}│────▶│{agg_liq}│
+    ///     │     ├──┤       ├───────┤  └──────────────────┘     │         │
+    ///     │     │  │       ├───────┤                           └─────────┘
+    ///     │     │  │       ├───────┤                                      
+    ///     │     │  │       ├───────┤                                      
+    ///     │     ├──┤       └───────┘                                      
+    ///     │     │  │                                                      
+    ///     │     │  │                                                      
+    ///     │     └──┘                                                      
     async fn update_asset_by_base_liquidity_index(
         &mut self,
         prev_state: &Option<Position>,
         new_state: &Position,
-        _id: &position::Id,
+        id: &position::Id,
     ) -> Result<()> {
-        // Since swaps may be performed in either direction, the available liquidity indices
-        // need to be calculated and stored for both the A -> B and B -> A directions.
-        let (a, b) = (new_state.phi.pair.asset_1(), new_state.phi.pair.asset_2());
+        match prev_state {
+            Some(prev_state) => match (prev_state.state, new_state.state) {
+                // We only want to update the index when we process active positions.
+                (Opened, Closed) => {}
+                (Opened, Opened) => {}
+                _ => return Ok(()),
+            },
+            None => {}
+        }
+
+        let canonical_pair = new_state.phi.pair;
+        let pair_ab = DirectedTradingPair::new(canonical_pair.asset_1(), canonical_pair.asset_2());
+
+        let (prev_a, prev_b) = prev_state
+            .as_ref()
+            .map(|p| {
+                (
+                    p.reserves_for(pair_ab.start).expect("asset ids match"),
+                    p.reserves_for(pair_ab.end).expect("asset ids match"),
+                )
+            })
+            .unwrap_or_else(|| (Amount::zero(), Amount::zero()));
 
         // A -> B
-        self.update_liquidity_index(DirectedTradingPair::new(a, b), new_state, prev_state)
+        self.update_asset_by_base_liquidity_index_inner(id, pair_ab, prev_a, new_state)
             .await?;
         // B -> A
-        self.update_liquidity_index(DirectedTradingPair::new(b, a), new_state, prev_state)
+        self.update_asset_by_base_liquidity_index_inner(id, pair_ab.flip(), prev_b, new_state)
             .await?;
 
         Ok(())
@@ -173,3 +96,72 @@ pub(crate) trait AssetByLiquidityIndex: StateWrite {
 }
 
 impl<T: StateWrite + ?Sized> AssetByLiquidityIndex for T {}
+
+trait Inner: StateWrite {
+    async fn update_asset_by_base_liquidity_index_inner(
+        &mut self,
+        id: &position::Id,
+        pair: DirectedTradingPair,
+        old_contrib: Amount,
+        new_position: &Position,
+    ) -> Result<()> {
+        let aggregate_key = &engine::routable_assets::lookup_base_liquidity_by_pair(&pair);
+
+        let prev_tally: Amount = self
+            .nonverifiable_get(aggregate_key)
+            .await?
+            .unwrap_or_default();
+
+        // The previous contribution for this position is supplied to us by
+        // the caller. This default to zero if the position was just created.
+        // We use this to compute a view of the tally that excludes the position
+        // we are currently processing (and avoid double-counting).
+        let old_contrib = old_contrib;
+
+        // The updated contribution is the total amount of base asset routable
+        // from an adjacent asset.
+        let new_contrib = new_position
+            .reserves_for(pair.start)
+            .expect("asset ids should match");
+
+        let new_tally = match new_position.state {
+            State::Opened => prev_tally
+                .saturating_sub(&old_contrib)
+                .saturating_add(&new_contrib),
+            State::Closed => prev_tally.saturating_sub(&old_contrib),
+            _ => unreachable!("inner impl is guarded"),
+        };
+
+        // If the update operation is a no-op, we can skip the update
+        // and return early.
+        if prev_tally == new_tally {
+            tracing::debug!(
+                ?prev_tally,
+                ?pair,
+                ?id,
+                "skipping routable asset index update"
+            );
+            return Ok(());
+        }
+
+        // Update the primary and auxiliary indices:
+        let old_primary_key = engine::routable_assets::key(&pair.start, prev_tally).to_vec();
+        // This could make the `StateDelta` more expensive to scan, but this doesn't show on profiles yet.
+        self.nonverifiable_delete(old_primary_key);
+
+        let new_primary_key = engine::routable_assets::key(&pair.start, new_tally).to_vec();
+        self.nonverifiable_put(new_primary_key, pair.end);
+        tracing::debug!(?pair, ?new_tally, "base liquidity entry updated");
+
+        let auxiliary_key = engine::routable_assets::lookup_base_liquidity_by_pair(&pair).to_vec();
+        self.nonverifiable_put(auxiliary_key, new_tally);
+        tracing::debug!(
+            ?pair,
+            "base liquidity heuristic marked directed pair as routable"
+        );
+
+        Ok(())
+    }
+}
+
+impl<T: AssetByLiquidityIndex + ?Sized> Inner for T {}

--- a/crates/core/component/dex/src/component/position_manager/counter.rs
+++ b/crates/core/component/dex/src/component/position_manager/counter.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, ensure};
+use anyhow::{bail};
 use async_trait::async_trait;
 use cnidarium::{StateRead, StateWrite};
 
@@ -51,15 +51,10 @@ pub(crate) trait PositionCounter: StateWrite {
                 (Opened, Closed) => {
                     let _ = self.decrement_position_counter(&trading_pair).await?;
                 }
-                _ => { /* no-op */ }
+                _ => {}
             },
 
             None => {
-                ensure!(
-                    matches!(new_state.state, Opened),
-                    "fresh position must start in the `Opened` state, found: {:?}",
-                    new_state.state
-                );
                 let _ = self.increment_position_counter(&trading_pair).await?;
             }
         }

--- a/crates/core/component/dex/src/component/position_manager/counter.rs
+++ b/crates/core/component/dex/src/component/position_manager/counter.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail};
+use anyhow::bail;
 use async_trait::async_trait;
 use cnidarium::{StateRead, StateWrite};
 

--- a/crates/core/component/dex/src/component/position_manager/counter.rs
+++ b/crates/core/component/dex/src/component/position_manager/counter.rs
@@ -60,7 +60,10 @@ pub(crate) trait PositionCounter: StateWrite {
         }
         Ok(())
     }
+}
+impl<T: StateWrite + ?Sized> PositionCounter for T {}
 
+trait Inner: StateWrite {
     /// Increment the number of position for a [`TradingPair`].
     /// Returns the updated total, or an error if overflow occurred.
     async fn increment_position_counter(&mut self, trading_pair: &TradingPair) -> Result<u16> {
@@ -87,7 +90,8 @@ pub(crate) trait PositionCounter: StateWrite {
         Ok(new_total)
     }
 }
-impl<T: StateWrite + ?Sized> PositionCounter for T {}
+
+impl<T: StateWrite + ?Sized> Inner for T {}
 
 // For some reason, `rust-analyzer` is complaining about used imports.
 // Silence the warnings until I find a fix.
@@ -96,7 +100,9 @@ mod tests {
     use cnidarium::{StateDelta, TempStorage};
     use penumbra_asset::{asset::REGISTRY, Value};
 
-    use crate::component::position_manager::counter::{PositionCounter, PositionCounterRead};
+    use crate::component::position_manager::counter::{
+        Inner, PositionCounter, PositionCounterRead,
+    };
     use crate::TradingPair;
 
     #[tokio::test]

--- a/crates/core/component/dex/src/component/position_manager/counter.rs
+++ b/crates/core/component/dex/src/component/position_manager/counter.rs
@@ -11,12 +11,12 @@ use anyhow::Result;
 pub(super) trait PositionCounterRead: StateRead {
     /// Returns the number of position for a [`TradingPair`].
     /// If there were no counter initialized for a given pair, this default to zero.
-    async fn get_position_count(&self, trading_pair: &TradingPair) -> u16 {
+    async fn get_position_count(&self, trading_pair: &TradingPair) -> u32 {
         let path = engine::counter::num_positions::by_trading_pair(trading_pair);
         self.get_position_count_from_key(path).await
     }
 
-    async fn get_position_count_from_key(&self, path: [u8; 99]) -> u16 {
+    async fn get_position_count_from_key(&self, path: [u8; 99]) -> u32 {
         let Some(raw_count) = self
             .nonverifiable_get_raw(&path)
             .await
@@ -26,10 +26,10 @@ pub(super) trait PositionCounterRead: StateRead {
         };
 
         // This is safe because we only increment the counter via [`Self::increase_position_counter`].
-        let raw_count: [u8; 2] = raw_count
+        let raw_count: [u8; 4] = raw_count
             .try_into()
             .expect("position counter is at most two bytes");
-        u16::from_be_bytes(raw_count)
+        u32::from_be_bytes(raw_count)
     }
 }
 
@@ -45,18 +45,17 @@ pub(crate) trait PositionCounter: StateWrite {
     ) -> Result<()> {
         use position::State::*;
         let trading_pair = new_state.phi.pair;
-
-        match prev_state {
-            Some(prev_state) => match (prev_state.state, new_state.state) {
-                (Opened, Closed) => {
-                    let _ = self.decrement_position_counter(&trading_pair).await?;
-                }
-                _ => {}
-            },
-
-            None => {
+        match (prev_state.as_ref().map(|p| p.state), new_state.state) {
+            // Increment the counter whenever a new position is opened
+            (None, Opened) => {
                 let _ = self.increment_position_counter(&trading_pair).await?;
             }
+            // Decrement the counter whenever an opened position is closed
+            (Some(Opened), Closed) => {
+                let _ = self.decrement_position_counter(&trading_pair).await?;
+            }
+            // Other state transitions don't affect the opened position counter
+            _ => {}
         }
         Ok(())
     }
@@ -66,7 +65,7 @@ impl<T: StateWrite + ?Sized> PositionCounter for T {}
 trait Inner: StateWrite {
     /// Increment the number of position for a [`TradingPair`].
     /// Returns the updated total, or an error if overflow occurred.
-    async fn increment_position_counter(&mut self, trading_pair: &TradingPair) -> Result<u16> {
+    async fn increment_position_counter(&mut self, trading_pair: &TradingPair) -> Result<u32> {
         let path = engine::counter::num_positions::by_trading_pair(trading_pair);
         let prev = self.get_position_count_from_key(path).await;
 
@@ -79,7 +78,7 @@ trait Inner: StateWrite {
 
     /// Decrement the number of positions for a [`TradingPair`], unless it would underflow.
     /// Returns the updated total, or an error if underflow occurred.
-    async fn decrement_position_counter(&mut self, trading_pair: &TradingPair) -> Result<u16> {
+    async fn decrement_position_counter(&mut self, trading_pair: &TradingPair) -> Result<u32> {
         let path = engine::counter::num_positions::by_trading_pair(trading_pair);
         let prev = self.get_position_count_from_key(path).await;
 
@@ -97,12 +96,13 @@ impl<T: StateWrite + ?Sized> Inner for T {}
 // Silence the warnings until I find a fix.
 #[allow(unused_imports)]
 mod tests {
-    use cnidarium::{StateDelta, TempStorage};
+    use cnidarium::{StateDelta, StateWrite, TempStorage};
     use penumbra_asset::{asset::REGISTRY, Value};
 
     use crate::component::position_manager::counter::{
         Inner, PositionCounter, PositionCounterRead,
     };
+    use crate::state_key::engine;
     use crate::TradingPair;
 
     #[tokio::test]
@@ -114,22 +114,20 @@ mod tests {
 
         let storage = TempStorage::new().await?;
         let mut delta = StateDelta::new(storage.latest_snapshot());
+        let path = engine::counter::num_positions::by_trading_pair(&trading_pair);
+        // Manually set the counter to the maximum value
+        delta.nonverifiable_put_raw(path.to_vec(), u32::MAX.to_be_bytes().to_vec());
 
-        for i in 0..u16::MAX {
-            let total = delta.increment_position_counter(&trading_pair).await?;
+        // Check that the counter is at the maximum value
+        let total = delta.get_position_count(&trading_pair).await;
+        assert_eq!(total, u32::MAX);
 
-            anyhow::ensure!(
-                total == i + 1,
-                "the total amount should be total={}, found={total}",
-                i + 1
-            );
-        }
-
+        // Check that we can handle an overflow
         assert!(delta
             .increment_position_counter(&trading_pair)
             .await
             .is_err());
-        assert_eq!(delta.get_position_count(&trading_pair).await, u16::MAX);
+        assert_eq!(delta.get_position_count(&trading_pair).await, u32::MAX);
 
         Ok(())
     }
@@ -148,7 +146,7 @@ mod tests {
         assert!(maybe_total.is_err());
 
         let counter = delta.get_position_count(&trading_pair).await;
-        assert_eq!(counter, 0u16);
+        assert_eq!(counter, 0u32);
         Ok(())
     }
 }

--- a/crates/core/component/dex/src/component/position_manager/counter.rs
+++ b/crates/core/component/dex/src/component/position_manager/counter.rs
@@ -8,7 +8,7 @@ use crate::TradingPair;
 use anyhow::Result;
 
 #[async_trait]
-pub(crate) trait PositionCounterRead: StateRead {
+pub(super) trait PositionCounterRead: StateRead {
     /// Returns the number of position for a [`TradingPair`].
     /// If there were no counter initialized for a given pair, this default to zero.
     async fn get_position_count(&self, trading_pair: &TradingPair) -> u16 {

--- a/crates/core/component/dex/src/component/position_manager/inventory_index.rs
+++ b/crates/core/component/dex/src/component/position_manager/inventory_index.rs
@@ -9,7 +9,7 @@ use crate::{
 use anyhow::Result;
 use position::State::*;
 
-pub(crate) trait PositionByInventoryIndex: StateWrite {
+pub(super) trait PositionByInventoryIndex: StateWrite {
     fn update_position_by_inventory_index(
         &mut self,
         prev_state: &Option<Position>,

--- a/crates/core/component/dex/src/component/position_manager/inventory_index.rs
+++ b/crates/core/component/dex/src/component/position_manager/inventory_index.rs
@@ -1,0 +1,59 @@
+use cnidarium::StateWrite;
+
+use crate::{
+    lp::position::{self},
+    state_key::eviction_queue,
+    DirectedTradingPair,
+};
+
+pub(crate) trait PositionByInventoryIndex: StateWrite {
+    fn index_position_by_inventory(&mut self, position: &position::Position, id: &position::Id) {
+        tracing::debug!("indexing position by inventory");
+        let canonical_pair = position.phi.pair;
+        // A position is bound to an unordered trading pair: A <> B.
+        // We want to index the position by inventory for each direction:
+        // A -> B
+        let pair_ab = DirectedTradingPair::new(canonical_pair.asset_1(), canonical_pair.asset_2());
+        let inventory_a = position
+            .reserves_for(pair_ab.start)
+            .expect("the directed trading pair is correct");
+        let key_ab = eviction_queue::inventory_index::key(&pair_ab, inventory_a, id).to_vec();
+        self.nonverifiable_put_raw(key_ab, vec![]);
+
+        // B -> A
+        let pair_ba = pair_ab.flip();
+        let inventory_b = position
+            .reserves_for(pair_ba.start)
+            .expect("the directed trading pair is correct");
+        let key_ba = eviction_queue::inventory_index::key(&pair_ba, inventory_b, id).to_vec();
+        self.nonverifiable_put_raw(key_ba, vec![]);
+    }
+
+    fn deindex_position_by_inventory(
+        &mut self,
+        prev_position: &position::Position,
+        id: &position::Id,
+    ) {
+        let canonical_pair = prev_position.phi.pair;
+
+        // To deindex the position, we need to reconstruct the tuple of keys
+        // that correspond to each direction of the trading pair:
+        // A -> B
+        let pair_ab = DirectedTradingPair::new(canonical_pair.asset_1(), canonical_pair.asset_2());
+        let inventory_a = prev_position
+            .reserves_for(pair_ab.start)
+            .expect("the directed trading pair is correct");
+        let key_ab = eviction_queue::inventory_index::key(&pair_ab, inventory_a, id).to_vec();
+        self.nonverifiable_delete(key_ab);
+
+        // B -> A
+        let pair_ba = pair_ab.flip();
+        let inventory_b = prev_position
+            .reserves_for(pair_ba.start)
+            .expect("the directed trading pair is correct");
+        let key_ba = eviction_queue::inventory_index::key(&pair_ba, inventory_b, id).to_vec();
+        self.nonverifiable_delete(key_ba);
+    }
+}
+
+impl<T: StateWrite + ?Sized> PositionByInventoryIndex for T {}

--- a/crates/core/component/dex/src/component/position_manager/inventory_index.rs
+++ b/crates/core/component/dex/src/component/position_manager/inventory_index.rs
@@ -16,7 +16,7 @@ pub(crate) trait PositionByInventoryIndex: StateWrite {
         new_state: &Position,
         position_id: &position::Id,
     ) -> Result<()> {
-        // Clear an existing index of the position, since changes to the
+        // Clear an existing record of the position, since changes to the
         // reserves or the position state might have invalidated it.
         if let Some(prev_lp) = prev_state {
             self.deindex_position_by_inventory(prev_lp, position_id);
@@ -28,7 +28,11 @@ pub(crate) trait PositionByInventoryIndex: StateWrite {
 
         Ok(())
     }
+}
 
+impl<T: StateWrite + ?Sized> PositionByInventoryIndex for T {}
+
+trait Inner: StateWrite {
     fn index_position_by_inventory(&mut self, position: &position::Position, id: &position::Id) {
         tracing::debug!("indexing position by inventory");
         let canonical_pair = position.phi.pair;
@@ -77,5 +81,4 @@ pub(crate) trait PositionByInventoryIndex: StateWrite {
         self.nonverifiable_delete(key_ba);
     }
 }
-
-impl<T: StateWrite + ?Sized> PositionByInventoryIndex for T {}
+impl<T: StateWrite + ?Sized> Inner for T {}

--- a/crates/core/component/dex/src/component/position_manager/price_index.rs
+++ b/crates/core/component/dex/src/component/position_manager/price_index.rs
@@ -16,7 +16,7 @@ pub(crate) trait PositionByPriceIndex: StateWrite {
         new_state: &Position,
         position_id: &position::Id,
     ) -> Result<()> {
-        // Clear an existing index of the position, since changes to the
+        // Clear an existing record for the position, since changes to the
         // reserves or the position state might have invalidated it.
         if let Some(prev_lp) = prev_state {
             self.deindex_position_by_price(prev_lp, position_id);
@@ -29,6 +29,25 @@ pub(crate) trait PositionByPriceIndex: StateWrite {
         Ok(())
     }
 
+    fn deindex_position_by_price(&mut self, position: &Position, id: &position::Id) {
+        tracing::debug!("deindexing position");
+        let pair12 = DirectedTradingPair {
+            start: position.phi.pair.asset_1(),
+            end: position.phi.pair.asset_2(),
+        };
+        let phi12 = position.phi.component.clone();
+        let pair21 = DirectedTradingPair {
+            start: position.phi.pair.asset_2(),
+            end: position.phi.pair.asset_1(),
+        };
+        let phi21 = position.phi.component.flip();
+        self.nonverifiable_delete(engine::price_index::key(&pair12, &phi12, &id));
+        self.nonverifiable_delete(engine::price_index::key(&pair21, &phi21, &id));
+    }
+}
+impl<T: StateWrite + ?Sized> PositionByPriceIndex for T {}
+
+trait Inner: StateWrite {
     fn index_position_by_price(&mut self, position: &position::Position, id: &position::Id) {
         let (pair, phi) = (position.phi.pair, &position.phi);
         if position.reserves.r2 != 0u64.into() {
@@ -53,21 +72,6 @@ pub(crate) trait PositionByPriceIndex: StateWrite {
             tracing::debug!("indexing position for 2=>1 trades");
         }
     }
-
-    fn deindex_position_by_price(&mut self, position: &Position, id: &position::Id) {
-        tracing::debug!("deindexing position");
-        let pair12 = DirectedTradingPair {
-            start: position.phi.pair.asset_1(),
-            end: position.phi.pair.asset_2(),
-        };
-        let phi12 = position.phi.component.clone();
-        let pair21 = DirectedTradingPair {
-            start: position.phi.pair.asset_2(),
-            end: position.phi.pair.asset_1(),
-        };
-        let phi21 = position.phi.component.flip();
-        self.nonverifiable_delete(engine::price_index::key(&pair12, &phi12, &id));
-        self.nonverifiable_delete(engine::price_index::key(&pair21, &phi21, &id));
-    }
 }
-impl<T: StateWrite + ?Sized> PositionByPriceIndex for T {}
+
+impl<T: StateWrite + ?Sized> Inner for T {}

--- a/crates/core/component/dex/src/component/position_manager/price_index.rs
+++ b/crates/core/component/dex/src/component/position_manager/price_index.rs
@@ -1,0 +1,51 @@
+use cnidarium::StateWrite;
+
+use crate::{
+    lp::position::{self, Position},
+    state_key::engine,
+    DirectedTradingPair,
+};
+
+pub(crate) trait PositionByPriceIndex: StateWrite {
+    fn index_position_by_price(&mut self, position: &position::Position, id: &position::Id) {
+        let (pair, phi) = (position.phi.pair, &position.phi);
+        if position.reserves.r2 != 0u64.into() {
+            // Index this position for trades FROM asset 1 TO asset 2, since the position has asset 2 to give out.
+            let pair12 = DirectedTradingPair {
+                start: pair.asset_1(),
+                end: pair.asset_2(),
+            };
+            let phi12 = phi.component.clone();
+            self.nonverifiable_put_raw(engine::price_index::key(&pair12, &phi12, &id), vec![]);
+            tracing::debug!("indexing position for 1=>2 trades");
+        }
+
+        if position.reserves.r1 != 0u64.into() {
+            // Index this position for trades FROM asset 2 TO asset 1, since the position has asset 1 to give out.
+            let pair21 = DirectedTradingPair {
+                start: pair.asset_2(),
+                end: pair.asset_1(),
+            };
+            let phi21 = phi.component.flip();
+            self.nonverifiable_put_raw(engine::price_index::key(&pair21, &phi21, &id), vec![]);
+            tracing::debug!("indexing position for 2=>1 trades");
+        }
+    }
+
+    fn deindex_position_by_price(&mut self, position: &Position, id: &position::Id) {
+        tracing::debug!("deindexing position");
+        let pair12 = DirectedTradingPair {
+            start: position.phi.pair.asset_1(),
+            end: position.phi.pair.asset_2(),
+        };
+        let phi12 = position.phi.component.clone();
+        let pair21 = DirectedTradingPair {
+            start: position.phi.pair.asset_2(),
+            end: position.phi.pair.asset_1(),
+        };
+        let phi21 = position.phi.component.flip();
+        self.nonverifiable_delete(engine::price_index::key(&pair12, &phi12, &id));
+        self.nonverifiable_delete(engine::price_index::key(&pair21, &phi21, &id));
+    }
+}
+impl<T: StateWrite + ?Sized> PositionByPriceIndex for T {}

--- a/crates/core/component/dex/src/component/router/path.rs
+++ b/crates/core/component/dex/src/component/router/path.rs
@@ -73,7 +73,7 @@ impl<S: StateRead + 'static> Path<S> {
         };
         // Deindex the position we "consumed" in this and all descendant state forks,
         // ensuring we don't double-count liquidity while traversing cycles.
-        use super::super::position_manager::Inner as _;
+        use crate::component::position_manager::price_index::PositionByPriceIndex;
         self.state
             .deindex_position_by_price(&best_price_position, &best_price_position.id());
 

--- a/crates/core/component/dex/src/state_key.rs
+++ b/crates/core/component/dex/src/state_key.rs
@@ -109,9 +109,9 @@ pub(crate) mod engine {
 
         use super::*;
 
-        /// A prefix key that takes a start asset `A` (aka. base asset) and surface adjacent
-        /// assets `B` (aka. quote asset), in ascending order of the base liquidity available.
-        ///
+        // An ordered encoding of every asset `B` routable from `A` based on the
+        // aggregate liquidity available to route from `B` to `A` (aka. the base liquidity).
+        //
         /// # Encoding
         /// The prefix key is encoded as `domain || A`.
         pub(crate) fn starting_from(from: &asset::Id) -> [u8; 39] {
@@ -121,9 +121,8 @@ pub(crate) mod engine {
             key
         }
 
-        /// An entry in the routable asset index that implements the mapping between
-        /// a base asset `A` and a quote asset `B`, based on the aggregate liquidity
-        /// available to route from `B` to `A` (aka. the base liquidity).
+        /// A record that an asset `A` is routable to an asset `B` and contains the
+        /// aggregate liquidity available to route from `B` to `A` (aka. the base liquidity).
         ///
         /// # Encoding
         /// The full key is encoded as: `prefix || BE(aggregate_base_liquidity)`
@@ -136,7 +135,8 @@ pub(crate) mod engine {
         }
 
         /// A lookup index used to reconstruct and update the primary index entries.
-        /// It maps a directed trading pair `A -> B` to the current base liquidity available.
+        /// It maps a directed trading pair `A -> B` to the aggregate liquidity available
+        /// to route from `B` to `A` (aka. the base asset liquidity).
         ///
         /// # Encoding
         /// The lookup key is encoded as `prefix_lookup || start_asset|| end_asset`.


### PR DESCRIPTION
## Describe your changes

This PR:
- break out indexing methods from the `Inner` position manager trait into submodules with crate visibility
- refactor `update_position` to delegate indexing checks to `update_*_index` methods
- add a redundant guard against invalid transitions in `PositionManager::update_position`
- streamline the base liquidity index, fixing a bug with double counting closed positions

This PR contain changes to critical parts of the DEX engine internals.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This is technically consensus breaking because we fix a bug in the base liquidity index logic, which could trickle down into different DEX execution in some rare cases.
