### PR TITLE
ci: update several eol actions

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -54,12 +54,8 @@ jobs:
         with:
           lfs: true
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: false
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - uses: bufbuild/buf-setup-action@v1
         with:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -23,32 +23,29 @@ jobs:
           lfs: true
 
       - name: Log in to the Docker Hub container registry (for pulls)
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to the GitHub container registry (for pushes)
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/penumbra-zone/penumbra
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64
@@ -69,13 +66,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Docker Hub container registry (for pulls)
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to the GitHub container registry (for pushes)
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -83,12 +80,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/penumbra-zone/grafana
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64
@@ -96,27 +93,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-  osiris:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    needs:
-      - penumbra
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      # We use the GHA Repository Dispatch functionality to trigger a container
-      # build in the penumbra-zone/osiris repo.
-      - name: Trigger remote build
-        shell: bash
-        env:
-          GITHUB_PAT: ${{ secrets.GH_PAT }}
-        run: |-
-          export PENUMBRA_VERSION='${{ github.event.inputs.image_tag || github.ref_name }}'
-          cd deployments/
-          ./scripts/gha-repository-dispatch penumbra-zone/osiris
 
   galileo:
     runs-on: ubuntu-latest
@@ -145,42 +121,3 @@ jobs:
           fi
           cd deployments/
           ./scripts/gha-repository-dispatch penumbra-zone/galileo
-
-  relayer:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log in to the Docker Hub container registry (for pulls)
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Log in to the GitHub container registry (for pushes)
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/penumbra-zone/relayer
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/amd64
-          file: deployments/containerfiles/Dockerfile-relayer
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -50,14 +50,14 @@ jobs:
           service_account: 'github-actions@penumbra-sl-testnet.iam.gserviceaccount.com'
 
       - name: get gke credentials
-        uses: google-github-actions/get-gke-credentials@v1
+        uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: testnet
           project_id: penumbra-sl-testnet
           location: us-central1
 
       - name: install helmfile
-        uses: mamezou-tech/setup-helmfile@v1.3.0
+        uses: mamezou-tech/setup-helmfile@v2.0.0
         with:
           helmfile-version: "v0.157.0"
 

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -42,14 +42,14 @@ jobs:
           service_account: 'github-actions@penumbra-sl-testnet.iam.gserviceaccount.com'
 
       - name: get gke credentials
-        uses: google-github-actions/get-gke-credentials@v1
+        uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: testnet
           project_id: penumbra-sl-testnet
           location: us-central1
 
       - name: install helmfile
-        uses: mamezou-tech/setup-helmfile@v1.3.0
+        uses: mamezou-tech/setup-helmfile@v2.0.0
         with:
           helmfile-version: "v0.157.0"
 

--- a/.github/workflows/disable-faucet.yml
+++ b/.github/workflows/disable-faucet.yml
@@ -28,7 +28,7 @@ jobs:
           service_account: 'github-actions@penumbra-sl-testnet.iam.gserviceaccount.com'
 
       - name: get gke credentials
-        uses: google-github-actions/get-gke-credentials@v1
+        uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: testnet
           project_id: penumbra-sl-testnet

--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -21,11 +21,11 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
       - name: Load Rust caching
         uses: astriaorg/buildjet-rust-cache@v2.5.1
-      - name: Load get-version action to grab version component of deployment path
-        uses: battila7/get-version-action@v2
-        id: get_version
+
+      # Previously we used a GHA helper to look up the version, which was overkill.
+      # Let's still log the version of the docs we intend to build.
       - name: Print version component of deployment path
-        run: echo ${{ steps.get_version.outputs.version }}
+        run: echo ${{ github.event.inputs.image_tag || github.ref_name }}
 
       # Ostensibly building from source, but the cache-loading above
       # ensures we don't need to rebuild frequently.
@@ -41,7 +41,7 @@ jobs:
           cd docs/guide
           rm -rf firebase-tmp
           mkdir firebase-tmp
-          mv book/html firebase-tmp/${{ steps.get_version.outputs.version }}
+          mv book/html firebase-tmp/${{ github.event.inputs.image_tag || github.ref_name }}
           tree firebase-tmp
 
       - name: Deploy software guide to firebase
@@ -61,7 +61,7 @@ jobs:
           cd docs/protocol
           rm -rf firebase-tmp
           mkdir firebase-tmp
-          mv book/html firebase-tmp/${{ steps.get_version.outputs.version }}
+          mv book/html firebase-tmp/${{ github.event.inputs.image_tag || github.ref_name }}
           tree firebase-tmp
 
       - name: Deploy protocol spec to firebase
@@ -80,9 +80,9 @@ jobs:
           cd docs/rustdoc
           if [ -d "firebase-tmp" ]; then rm -rf firebase-tmp; fi
           mkdir firebase-tmp
-          mv ../../target/doc firebase-tmp/${{ steps.get_version.outputs.version }}
+          mv ../../target/doc firebase-tmp/${{ github.event.inputs.image_tag || github.ref_name }}
           # Copy in the static index file
-          cp index.html firebase-tmp/${{ steps.get_version.outputs.version }}
+          cp index.html firebase-tmp/${{ github.event.inputs.image_tag || github.ref_name }}
 
       - name: Deploy API docs to firebase
         uses: w9jds/firebase-action@v12.9.0

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -16,18 +16,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
+
       - name: Install cometbft binary
         run: ./deployments/scripts/install-cometbft
+
       - name: Run the smoke test suite
         run: |
           export PATH="$HOME/bin:$PATH"
           ./deployments/scripts/smoke-test.sh
+
       - name: Display comet logs
         if: always()
         run: cat deployments/logs/comet.log

--- a/.github/workflows/summoner_smoke.yml
+++ b/.github/workflows/summoner_smoke.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
 


### PR DESCRIPTION


## Describe your changes

Changes made:

  * docker/login-action v2 -> v3
  * docker/metadata-action v4 -> v5
  * docker/build-push-action v3 -> v5
  * get-gke-credentials v1 -> v2
  * helmfile v1 -> v2
  * migrate actions-rs/toolchain -> dtolnay/rust-toolchain
  * remove docker/setup-qemu-action
  * remove battila7/get-version-action
  * removes unused container builds

All of these were showing warnings. These upgrades *should* have zero side-effects for our CI, but I'll check post-merge and confirm that.


## Issue ticket number and link


Refs #3769, but does not close it: follow-up may be necessary post-merge, plus corresponding updates should be made across our repos.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > CI-only, no code changes
