### PR TITLE
feat(ci): 🔖 add `needs-refinement` label to new issues

### DIFF
--- a/.github/workflows/new-issues-labeled-needs-refinement.yml
+++ b/.github/workflows/new-issues-labeled-needs-refinement.yml
@@ -1,0 +1,20 @@
+# Adds the `needs-refinement` label to newly opened issues.
+name: New issues need refinement
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          # Separate multiple labels with commas if other labels are ever
+          # needed e.g., `needs-refinement,foo`.
+          LABELS: needs-refinement


### PR DESCRIPTION
the Penumbra team meets regularly to refine and discuss our backlog of tasks. this adds a workflow so that newly opened issues are accordingly labeled `needs-refinement`, so that they can be easily filtered in our refinement meeting.

this workflow is heavily inspired by the example workflow shown here: https://docs.github.com/en/actions/managing-issues-and-pull-requests/adding-labels-to-issues

#### checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > only changes github workflows