### PR TITLE
auction: define action balances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4742,6 +4742,7 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bitvec",
+ "blake2b_simd 1.0.2",
  "cnidarium",
  "cnidarium-component",
  "decaf377 0.5.0",

--- a/crates/core/asset/src/asset/registry.rs
+++ b/crates/core/asset/src/asset/registry.rs
@@ -417,5 +417,13 @@ pub static REGISTRY: Lazy<Registry> = Lazy::new(|| {
                     },
                 ])
             }) as for<'r> fn(&'r str) -> _)
+            .add_asset(
+                "^auctionnft_(?P<seq_num>[0-9]+)_(?P<auction_id>paucid1[a-zA-HJ-NP-Z0-9]+)$",
+                &[ /* no display units - nft, unit 1 */ ],
+                (|data: &str| {
+                    assert!(!data.is_empty());
+                    denom_metadata::Inner::new(format!("auctionnft_{data}"), vec![])
+                }) as for<'r> fn(&'r str) -> _,
+            )
         .build()
 });

--- a/crates/core/component/auction/Cargo.toml
+++ b/crates/core/component/auction/Cargo.toml
@@ -45,6 +45,7 @@ bech32 = {workspace = true}
 bitvec = {workspace = true}
 cnidarium = {workspace = true, default-features = false, optional = true}
 cnidarium-component = {workspace = true, default-features = false, optional = true}
+blake2b_simd = {workspace = true}
 decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
 decaf377-rdsa = {workspace = true}
 futures = {workspace = true, optional = true}

--- a/crates/core/component/auction/src/auction.rs
+++ b/crates/core/component/auction/src/auction.rs
@@ -1,3 +1,6 @@
 pub mod dutch;
 pub mod id;
 pub mod nft;
+
+pub use id::AuctionId;
+pub use nft::AuctionNft;

--- a/crates/core/component/auction/src/auction/dutch.rs
+++ b/crates/core/component/auction/src/auction/dutch.rs
@@ -9,7 +9,7 @@ use crate::auction::AuctionId;
 
 pub mod actions;
 
-pub const DUTCH_AUCTION_DOMAIN_SEP: &[u8] = b"penumbra_dutch_auction_nft";
+pub const DUTCH_AUCTION_DOMAIN_SEP: &[u8] = b"penumbra_DA_nft";
 
 /// A deployed Dutch Auction, containing an immutable description
 /// and stateful data about its current state.

--- a/crates/core/component/auction/src/auction/dutch.rs
+++ b/crates/core/component/auction/src/auction/dutch.rs
@@ -9,6 +9,8 @@ use crate::auction::AuctionId;
 
 pub mod actions;
 
+pub const DUTCH_AUCTION_DOMAIN_SEP: &[u8] = b"penumbra_dutch_auction_nft";
+
 /// A deployed Dutch Auction, containing an immutable description
 /// and stateful data about its current state.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -71,7 +73,7 @@ impl DutchAuctionDescription {
     /// Compute the unique identifier for the auction description.
     pub fn id(&self) -> AuctionId {
         let mut state = blake2b_simd::Params::default()
-            .personal(b"penumbra_dutch_auction_nft")
+            .personal(DUTCH_AUCTION_DOMAIN_SEP)
             .to_state();
 
         state.update(&self.nonce);

--- a/crates/core/component/auction/src/auction/dutch/actions/end.rs
+++ b/crates/core/component/auction/src/auction/dutch/actions/end.rs
@@ -15,8 +15,17 @@ pub struct ActionDutchAuctionEnd {
 }
 
 impl ActionDutchAuctionEnd {
+    /// Compute the value balance for this action
+    ///
+    /// # Diagram
+    ///
+    ///  ┌────────────────────┬──────────────────────┐
+    ///  │      Burn (-)      │       Mint (+)       │
+    ///  ├────────────────────┼──────────────────────┤
+    ///  │ opened auction nft │  closed auction nft  │
+    ///  └────────────────────┴──────────────────────┘
     pub fn balance(&self) -> Balance {
-        let schedule_auction = Value {
+        let start_auction = Value {
             amount: 1u128.into(),
             asset_id: AuctionNft::new(self.auction_id, 0u64).asset_id(),
         };
@@ -26,7 +35,7 @@ impl ActionDutchAuctionEnd {
             asset_id: AuctionNft::new(self.auction_id, 1u64).asset_id(),
         };
 
-        Balance::from(end_auction) - Balance::from(schedule_auction)
+        Balance::from(end_auction) - Balance::from(start_auction)
     }
 }
 

--- a/crates/core/component/auction/src/auction/dutch/actions/end.rs
+++ b/crates/core/component/auction/src/auction/dutch/actions/end.rs
@@ -1,8 +1,9 @@
 use anyhow::anyhow;
+use penumbra_asset::{Balance, Value};
 use penumbra_proto::{core::component::auction::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
-use crate::auction::id::AuctionId;
+use crate::auction::{id::AuctionId, AuctionNft};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(
@@ -11,6 +12,22 @@ use crate::auction::id::AuctionId;
 )]
 pub struct ActionDutchAuctionEnd {
     pub auction_id: AuctionId,
+}
+
+impl ActionDutchAuctionEnd {
+    pub fn balance(&self) -> Balance {
+        let schedule_auction = Value {
+            amount: 1u128.into(),
+            asset_id: AuctionNft::new(self.auction_id, 0u64).asset_id(),
+        };
+
+        let end_auction = Value {
+            amount: 1u128.into(),
+            asset_id: AuctionNft::new(self.auction_id, 1u64).asset_id(),
+        };
+
+        Balance::from(end_auction) - Balance::from(schedule_auction)
+    }
 }
 
 /* Protobuf impls */

--- a/crates/core/component/auction/src/auction/dutch/actions/mod.rs
+++ b/crates/core/component/auction/src/auction/dutch/actions/mod.rs
@@ -1,14 +1,8 @@
 pub mod schedule;
 pub use schedule::ActionDutchAuctionSchedule;
 
-pub mod schedule_view;
-pub use schedule_view::ActionDutchAuctionScheduleView;
-
 pub mod end;
 pub use end::ActionDutchAuctionEnd;
 
 pub mod withdraw;
 pub use withdraw::ActionDutchAuctionWithdraw;
-
-pub mod withdraw_view;
-pub use withdraw_view::ActionDutchAuctionWithdrawView;

--- a/crates/core/component/auction/src/auction/dutch/actions/schedule.rs
+++ b/crates/core/component/auction/src/auction/dutch/actions/schedule.rs
@@ -14,8 +14,15 @@ pub struct ActionDutchAuctionSchedule {
 }
 
 impl ActionDutchAuctionSchedule {
-    /// Compute a commitment to the value this action contributes to its transaction
-    /// MERGEBLOCK(erwan): add balancing table
+    /// Compute the value balance corresponding to this action:
+    ///
+    /// # Diagram
+    ///
+    ///  ┌────────────────────┬──────────────────────┐
+    ///  │      Burn (-)      │       Mint (+)       │
+    ///  ├────────────────────┼──────────────────────┤
+    ///  │    input value     │  opened auction nft  │
+    ///  └────────────────────┴──────────────────────┘                  
     pub fn balance(&self) -> Balance {
         let opened_auction_nft = AuctionNft::new(self.description.id(), 0u64);
         let opened_auction_nft_value = Value {

--- a/crates/core/component/auction/src/auction/dutch/actions/schedule.rs
+++ b/crates/core/component/auction/src/auction/dutch/actions/schedule.rs
@@ -1,5 +1,6 @@
-use crate::auction::dutch::DutchAuctionDescription;
+use crate::auction::{dutch::DutchAuctionDescription, nft::AuctionNft};
 use anyhow::anyhow;
+use penumbra_asset::{Balance, Value};
 use penumbra_proto::{core::component::auction::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
@@ -10,6 +11,23 @@ use serde::{Deserialize, Serialize};
 )]
 pub struct ActionDutchAuctionSchedule {
     pub description: DutchAuctionDescription,
+}
+
+impl ActionDutchAuctionSchedule {
+    /// Compute a commitment to the value this action contributes to its transaction
+    /// MERGEBLOCK(erwan): add balancing table
+    pub fn balance(&self) -> Balance {
+        let opened_auction_nft = AuctionNft::new(self.description.id(), 0u64);
+        let opened_auction_nft_value = Value {
+            asset_id: opened_auction_nft.metadata.id(),
+            amount: 1u128.into(),
+        };
+
+        let output_nft_balance = Balance::from(opened_auction_nft_value);
+        let input_balance = Balance::from(self.description.input);
+
+        output_nft_balance - input_balance
+    }
 }
 
 /* Protobuf impls */

--- a/crates/core/component/auction/src/auction/dutch/actions/withdraw.rs
+++ b/crates/core/component/auction/src/auction/dutch/actions/withdraw.rs
@@ -1,6 +1,6 @@
-use crate::auction::id::AuctionId;
+use crate::auction::{id::AuctionId, AuctionNft};
 use anyhow::anyhow;
-use penumbra_asset::balance;
+use penumbra_asset::{balance, Balance, Value};
 use penumbra_proto::{core::component::auction::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +13,24 @@ pub struct ActionDutchAuctionWithdraw {
     pub auction_id: AuctionId,
     pub seq: u64,
     pub reserves_commitment: balance::Commitment,
+}
+
+impl ActionDutchAuctionWithdraw {
+    pub fn balance(&self) -> Balance {
+        let prev_auction_nft: Balance = Value {
+            amount: 1u128.into(),
+            asset_id: AuctionNft::new(self.auction_id, self.seq.saturating_sub(1)).asset_id(),
+        }
+        .into();
+
+        let next_auction_nft: Balance = Value {
+            amount: 1u128.into(),
+            asset_id: AuctionNft::new(self.auction_id, self.seq).asset_id(),
+        }
+        .into();
+
+        next_auction_nft - prev_auction_nft
+    }
 }
 
 /* Protobuf impls */

--- a/crates/core/component/auction/src/auction/dutch/actions/withdraw.rs
+++ b/crates/core/component/auction/src/auction/dutch/actions/withdraw.rs
@@ -1,5 +1,7 @@
 use crate::auction::{id::AuctionId, AuctionNft};
 use anyhow::anyhow;
+use ark_ff::Zero;
+use decaf377_rdsa::Fr;
 use penumbra_asset::{balance, Balance, Value};
 use penumbra_proto::{core::component::auction::v1alpha1 as pb, DomainType};
 use serde::{Deserialize, Serialize};
@@ -16,20 +18,20 @@ pub struct ActionDutchAuctionWithdraw {
 }
 
 impl ActionDutchAuctionWithdraw {
-    pub fn balance(&self) -> Balance {
-        let prev_auction_nft: Balance = Value {
+    pub fn balance_commitment(&self) -> balance::Commitment {
+        let prev_auction_nft = Balance::from(Value {
             amount: 1u128.into(),
             asset_id: AuctionNft::new(self.auction_id, self.seq.saturating_sub(1)).asset_id(),
-        }
-        .into();
+        })
+        .commit(Fr::zero());
 
-        let next_auction_nft: Balance = Value {
+        let next_auction_nft = Balance::from(Value {
             amount: 1u128.into(),
             asset_id: AuctionNft::new(self.auction_id, self.seq).asset_id(),
-        }
-        .into();
+        })
+        .commit(Fr::zero());
 
-        next_auction_nft - prev_auction_nft
+        self.reserves_commitment + next_auction_nft - prev_auction_nft
     }
 }
 

--- a/crates/core/component/auction/src/auction/nft.rs
+++ b/crates/core/component/auction/src/auction/nft.rs
@@ -11,7 +11,7 @@ pub struct AuctionNft {
     /// The state of an auction, its specific semantics depend on the
     /// type of auction the NFT resolves to.
     pub seq: u64,
-    /// The metadata corresponding to the Nft's denomination.
+    /// The metadata corresponding to the nft denom.
     pub metadata: asset::Metadata,
 }
 
@@ -21,6 +21,10 @@ impl AuctionNft {
             .parse_denom(&format!("auctionnft_{seq}_{id}"))
             .expect("auction nft denom is valid");
         AuctionNft { id, seq, metadata }
+    }
+
+    pub fn asset_id(&self) -> asset::Id {
+        self.metadata.id()
     }
 }
 

--- a/crates/core/component/auction/src/auction/nft.rs
+++ b/crates/core/component/auction/src/auction/nft.rs
@@ -6,10 +6,10 @@ use penumbra_proto::{core::component::auction::v1alpha1 as pb, DomainType};
 #[derive(Debug, Clone)]
 pub struct AuctionNft {
     /// The unique identifier for the auction this nft resolves to.
-    id: AuctionId,
+    pub id: AuctionId,
     /// The state of an auction, its specific semantics depend on the
     /// type of auction the NFT resolves to.
-    seq: u64,
+    pub seq: u64,
 }
 
 /* Protobuf impls ;*/

--- a/crates/core/component/auction/src/auction/nft.rs
+++ b/crates/core/component/auction/src/auction/nft.rs
@@ -1,5 +1,6 @@
 use crate::auction::id::AuctionId;
 use anyhow::{anyhow, Result};
+use penumbra_asset::asset::{self};
 use penumbra_proto::{core::component::auction::v1alpha1 as pb, DomainType};
 
 /// An non-fungible token (NFT) tracking the state and ownership of an auction.
@@ -10,6 +11,17 @@ pub struct AuctionNft {
     /// The state of an auction, its specific semantics depend on the
     /// type of auction the NFT resolves to.
     pub seq: u64,
+    /// The metadata corresponding to the Nft's denomination.
+    pub metadata: asset::Metadata,
+}
+
+impl AuctionNft {
+    pub fn new(id: AuctionId, seq: u64) -> AuctionNft {
+        let metadata = asset::REGISTRY
+            .parse_denom(&format!("auctionnft_{seq}_{id}"))
+            .expect("auction nft denom is valid");
+        AuctionNft { id, seq, metadata }
+    }
 }
 
 /* Protobuf impls ;*/
@@ -30,12 +42,11 @@ impl TryFrom<pb::AuctionNft> for AuctionNft {
     type Error = anyhow::Error;
 
     fn try_from(msg: pb::AuctionNft) -> Result<Self, Self::Error> {
-        Ok(Self {
-            id: msg
-                .id
-                .ok_or_else(|| anyhow!("AuctionNft message is missing an auction id"))?
-                .try_into()?,
-            seq: msg.seq,
-        })
+        let id: AuctionId = msg
+            .id
+            .ok_or_else(|| anyhow!("AuctionNft message is missing an auction id"))?
+            .try_into()?;
+        let seq = msg.seq;
+        Ok(AuctionNft::new(id, seq))
     }
 }

--- a/crates/core/transaction/src/is_action.rs
+++ b/crates/core/transaction/src/is_action.rs
@@ -1,7 +1,9 @@
 use ark_ff::Zero;
 use decaf377::Fr;
 use penumbra_asset::{balance, Value};
-use penumbra_auction::auction::dutch::actions::ActionDutchAuctionSchedule;
+use penumbra_auction::auction::dutch::actions::{
+    ActionDutchAuctionEnd, ActionDutchAuctionSchedule, ActionDutchAuctionWithdraw,
+};
 use penumbra_community_pool::{CommunityPoolDeposit, CommunityPoolOutput, CommunityPoolSpend};
 use penumbra_dex::{
     lp::{
@@ -411,6 +413,26 @@ impl IsAction for SwapClaim {
 impl IsAction for ActionDutchAuctionSchedule {
     fn balance_commitment(&self) -> balance::Commitment {
         self.balance().commit(Fr::zero())
+    }
+
+    fn view_from_perspective(&self, _txp: &TransactionPerspective) -> ActionView {
+        todo!()
+    }
+}
+
+impl IsAction for ActionDutchAuctionEnd {
+    fn balance_commitment(&self) -> balance::Commitment {
+        self.balance().commit(Fr::zero())
+    }
+
+    fn view_from_perspective(&self, _txp: &TransactionPerspective) -> ActionView {
+        todo!()
+    }
+}
+
+impl IsAction for ActionDutchAuctionWithdraw {
+    fn balance_commitment(&self) -> balance::Commitment {
+        self.balance_commitment()
     }
 
     fn view_from_perspective(&self, _txp: &TransactionPerspective) -> ActionView {

--- a/crates/core/transaction/src/is_action.rs
+++ b/crates/core/transaction/src/is_action.rs
@@ -410,10 +410,10 @@ impl IsAction for SwapClaim {
 
 impl IsAction for ActionDutchAuctionSchedule {
     fn balance_commitment(&self) -> balance::Commitment {
-        todo!()
+        self.balance().commit(Fr::zero())
     }
 
-    fn view_from_perspective(&self, txp: &TransactionPerspective) -> ActionView {
+    fn view_from_perspective(&self, _txp: &TransactionPerspective) -> ActionView {
         todo!()
     }
 }

--- a/crates/core/transaction/src/is_action.rs
+++ b/crates/core/transaction/src/is_action.rs
@@ -1,6 +1,7 @@
 use ark_ff::Zero;
 use decaf377::Fr;
 use penumbra_asset::{balance, Value};
+use penumbra_auction::auction::dutch::actions::ActionDutchAuctionSchedule;
 use penumbra_community_pool::{CommunityPoolDeposit, CommunityPoolOutput, CommunityPoolSpend};
 use penumbra_dex::{
     lp::{
@@ -404,5 +405,15 @@ impl IsAction for SwapClaim {
                 ActionView::SwapClaim(swap_claim_view)
             }
         }
+    }
+}
+
+impl IsAction for ActionDutchAuctionSchedule {
+    fn balance_commitment(&self) -> balance::Commitment {
+        todo!()
+    }
+
+    fn view_from_perspective(&self, txp: &TransactionPerspective) -> ActionView {
+        todo!()
     }
 }

--- a/docs/protocol/src/transactions/actions.md
+++ b/docs/protocol/src/transactions/actions.md
@@ -4,15 +4,15 @@ This page is a quick-reference list of transaction actions. Not all actions have
 
 ## Actions by Proof Statement
 
-| Proof | Action |
-| ----- | ------ |
-| Spend | [`core.component.shielded_pool.v1.Spend`](../shielded_pool/action/spend.md) |
-| Output | [`core.component.shielded_pool.v1.Output`](../shielded_pool/action/output.md) |
-| Convert | [`core.component.stake.v1.UndelegateClaim`](../stake/action/undelegate_claim.md) |
-| Delegator Vote | [`core.component.governance.v1.DelegatorVote`](../governance/action/delegator_vote.md) |
-| Swap | [`core.component.dex.v1.Swap`](../dex/action/swap.md) |
-| Swap Claim | [`core.component.dex.v1.SwapClaim`](../dex/action/swap_claim.md) |
-| Nullifier Derivation | Not used in actions, intended for verifiable transaction perspectives |
+| Proof                | Action                                                                                 |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| Spend                | [`core.component.shielded_pool.v1.Spend`](../shielded_pool/action/spend.md)            |
+| Output               | [`core.component.shielded_pool.v1.Output`](../shielded_pool/action/output.md)          |
+| Convert              | [`core.component.stake.v1.UndelegateClaim`](../stake/action/undelegate_claim.md)       |
+| Delegator Vote       | [`core.component.governance.v1.DelegatorVote`](../governance/action/delegator_vote.md) |
+| Swap                 | [`core.component.dex.v1.Swap`](../dex/action/swap.md)                                  |
+| Swap Claim           | [`core.component.dex.v1.SwapClaim`](../dex/action/swap_claim.md)                       |
+| Nullifier Derivation | Not used in actions, intended for verifiable transaction perspectives                  |
 
 ## All Actions
 
@@ -23,27 +23,30 @@ separately, though they are handled by the same mechanism: the chain forms
 commitments with a zero blinding factor to accumulate transparent and shielded
 contributions together.
 
-| Action | Description | Shielded Balance | Transparent Balance |
-| ------ | ----------- | ------------- | -- |
-| [`shielded_pool.v1.Spend`](../shielded_pool/action/spend.md) | Spends a note previously included on-chain, releasing its value into the transaction | $+$ (value of spent note) | |
-| [`shielded_pool.v1.Output`](../shielded_pool/action/output.md) | Produces a new note controlled by a specified address and adds it to the chain state | $-$ (value of new note) | |
-| [`dex.v1.Swap`](../dex/action/swap.md) | Submits a swap intent to the chain for batch execution | $-$ (prepaid claim fee) | $-$ (swap inputs)
-| [`dex.v1.SwapClaim`](../dex/action/swap_claim.md) | Claims the outputs of a swap once the clearing price is known, producing new output notes directly | | $+$ (prepaid claim fee) |
-| `stake.v1.ValidatorDefinition` | Uploads a new validator definition to the chain | | |
-| `stake.v1.Delegate` | Delegates stake to a validator, exchanging the staking token for that validator's delegation token | | $-$ (staking token) $+$ (delegation token)
-| `stake.v1.Undelegate` | Undelegates stake from a validator, exchanging delegation tokens for unbonding tokens | | $-$ (delegation token) $+$ (unbonding token) |
-| [`stake.v1.UndelegateClaim`](../stake/action/undelegate_claim.md) | Converts unbonding tokens to staking tokens after unbonding completes, at a 1:1 rate unless there are slashing penalties | $-$ (unbonding token) $+$ (staking token) |
-| `ibc.v1.IbcRelay` | Relays IBC messages from a counterparty chain | | |
-| `ibc.v1.Ics20Withdrawal` | Initiates an outbound ICS-20 token transfer | | $-$ (transfer amount) |
-| `dex.v1.PositionOpen` | Opens a liquidity position | | $-$ (initial reserves) $+$ (opened LPNFT) |
-| `dex.v1.PositionClose` | Closes a liquidity position | | $-$ (opened LPNFT) $+$ (closed LPNFT) |
-| `dex.v1.PositionWithdraw` | Withdraws reserves or rewards from a liquidity position, with sequence number $n$ | | $-$ (withdrawn seq $n-1$ LPNFT) $+$ (withdrawn seq $n$ LPNFT) $+$ (current position reserves) |
-| `dex.v1.PositionRewardClaim` | Deprecated and unused | | |
-| `governance.v1.ProposalSubmit` | Submits a governance proposal for voting | | $-$ (deposit amount) $+$ (voting proposal NFT) |
-| `governance.v1.ProposalWithdraw` | Withdraws a governance proposal from voting | | $-$ (voting proposal NFT) $+$ (withdrawn proposal NFT) |
-| `governance.v1.ValidatorVote` | Performs a governance vote as a validator | | |
-| [`governance.v1.DelegatorVote`](../governance/action/delegator_vote.md) | Performs a governance vote as a delegator | | $+$ (Voting Receipt Token) |
-| `governance.v1.ProposalDepositClaim` | Claims a proposal deposit once voting has finished | | $-$ (voting/withdrawn proposal NFT) $+$ (claimed proposal NFT) $+$ (deposit amount, if not slashed) |
-| `governance.v1.CommunityPoolSpend` | Spends funds from the community pool | | $+$ (spent value) |
-| `governance.v1.CommunityPoolOutput` | Like `Output`, but transparent | | $-$ (value of new note)
-| `governance.v1.CommunityPoolDeposit` | Allows deposits into the community pool | | $-$ (value of deposit) |
+| Action                                                                  | Description                                                                                                              | Shielded Balance                          | Transparent Balance                                                                                                         |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| [`shielded_pool.v1.Spend`](../shielded_pool/action/spend.md)            | Spends a note previously included on-chain, releasing its value into the transaction                                     | $+$ (value of spent note)                 |                                                                                                                             |
+| [`shielded_pool.v1.Output`](../shielded_pool/action/output.md)          | Produces a new note controlled by a specified address and adds it to the chain state                                     | $-$ (value of new note)                   |                                                                                                                             |
+| [`dex.v1.Swap`](../dex/action/swap.md)                                  | Submits a swap intent to the chain for batch execution                                                                   | $-$ (prepaid claim fee)                   | $-$ (swap inputs)                                                                                                           |
+| [`dex.v1.SwapClaim`](../dex/action/swap_claim.md)                       | Claims the outputs of a swap once the clearing price is known, producing new output notes directly                       |                                           | $+$ (prepaid claim fee)                                                                                                     |
+| `stake.v1.ValidatorDefinition`                                          | Uploads a new validator definition to the chain                                                                          |                                           |                                                                                                                             |
+| `stake.v1.Delegate`                                                     | Delegates stake to a validator, exchanging the staking token for that validator's delegation token                       |                                           | $-$ (staking token) $+$ (delegation token)                                                                                  |
+| `stake.v1.Undelegate`                                                   | Undelegates stake from a validator, exchanging delegation tokens for unbonding tokens                                    |                                           | $-$ (delegation token) $+$ (unbonding token)                                                                                |
+| [`stake.v1.UndelegateClaim`](../stake/action/undelegate_claim.md)       | Converts unbonding tokens to staking tokens after unbonding completes, at a 1:1 rate unless there are slashing penalties | $-$ (unbonding token) $+$ (staking token) |                                                                                                                             |
+| `ibc.v1.IbcRelay`                                                       | Relays IBC messages from a counterparty chain                                                                            |                                           |                                                                                                                             |
+| `ibc.v1.Ics20Withdrawal`                                                | Initiates an outbound ICS-20 token transfer                                                                              |                                           | $-$ (transfer amount)                                                                                                       |
+| `dex.v1.PositionOpen`                                                   | Opens a liquidity position                                                                                               |                                           | $-$ (initial reserves) $+$ (opened LPNFT)                                                                                   |
+| `dex.v1.PositionClose`                                                  | Closes a liquidity position                                                                                              |                                           | $-$ (opened LPNFT) $+$ (closed LPNFT)                                                                                       |
+| `dex.v1.PositionWithdraw`                                               | Withdraws reserves or rewards from a liquidity position, with sequence number $n$                                        |                                           | $-$ (withdrawn seq $n-1$ LPNFT) $+$ (withdrawn seq $n$ LPNFT) $+$ (current position reserves)                               |
+| `dex.v1.PositionRewardClaim`                                            | Deprecated and unused                                                                                                    |                                           |                                                                                                                             |
+| `governance.v1.ProposalSubmit`                                          | Submits a governance proposal for voting                                                                                 |                                           | $-$ (deposit amount) $+$ (voting proposal NFT)                                                                              |
+| `governance.v1.ProposalWithdraw`                                        | Withdraws a governance proposal from voting                                                                              |                                           | $-$ (voting proposal NFT) $+$ (withdrawn proposal NFT)                                                                      |
+| `governance.v1.ValidatorVote`                                           | Performs a governance vote as a validator                                                                                |                                           |                                                                                                                             |
+| [`governance.v1.DelegatorVote`](../governance/action/delegator_vote.md) | Performs a governance vote as a delegator                                                                                |                                           | $+$ (Voting Receipt Token)                                                                                                  |
+| `governance.v1.ProposalDepositClaim`                                    | Claims a proposal deposit once voting has finished                                                                       |                                           | $-$ (voting/withdrawn proposal NFT) $+$ (claimed proposal NFT) $+$ (deposit amount, if not slashed)                         |
+| `governance.v1.CommunityPoolSpend`                                      | Spends funds from the community pool                                                                                     |                                           | $+$ (spent value)                                                                                                           |
+| `governance.v1.CommunityPoolOutput`                                     | Like `Output`, but transparent                                                                                           |                                           | $-$ (value of new note)                                                                                                     |
+| `governance.v1.CommunityPoolDeposit`                                    | Allows deposits into the community pool                                                                                  |                                           | $-$ (value of deposit)                                                                                                      |
+| `auction.v1alpha1.ActionDutchAuctionSchedule`                           | Schedule a Dutch auction                                                                                                 |                                           | $-$ (initial reserves) $+$ (opened auction NFT)                                                                             |
+| `auction.v1alpha1.ActionDutchAuctionEnd`                                | Terminate a Dutch auction                                                                                                |                                           | $-$ (opened auction NFT) $+$ (closed auction NFT)                                                                           |
+| `auction.v1alpha1.ActionDutchAuctionWithdraw`                           | Withdraw a Dutch auction, with a sequence number $n$                                                                     |                                           | $-$ (closed/withdrawn auction nft with sequence $n-1$) $+$ (withdrawn auction NFT with sequence $n$) $+$ (auction reserves) |


### PR DESCRIPTION
## Describe your changes

This PR:
- add `auctionnft`s to the asset registry
- augment `AuctionNft` with denom metadata
- implements `DutchAuctionDescription::id`
- implements value `balance` for each action
- implements computing the balance commitment for the withdraw action

## Issue ticket number and link
This is a prelude to #4212 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This isn't connected to the rest of the app yet. 
