### PR TITLE
auction: `ActionDutchAuction*` validation and component impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4764,6 +4764,8 @@ dependencies = [
  "penumbra-tct",
  "penumbra-txhash",
  "proptest",
+ "prost",
+ "prost-types",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "regex",

--- a/crates/core/component/auction/Cargo.toml
+++ b/crates/core/component/auction/Cargo.toml
@@ -31,6 +31,8 @@ parallel = [
 ]
 
 [dependencies]
+prost = {workspace = true}
+prost-types = {workspace = true}
 anyhow = {workspace = true}
 ark-ff = {workspace = true, default-features = false}
 ark-groth16 = {workspace = true, default-features = false}

--- a/crates/core/component/auction/src/auction/dutch.rs
+++ b/crates/core/component/auction/src/auction/dutch.rs
@@ -8,12 +8,13 @@ use serde::{Deserialize, Serialize};
 use crate::auction::AuctionId;
 
 pub mod actions;
+pub use actions::{ActionDutchAuctionEnd, ActionDutchAuctionSchedule, ActionDutchAuctionWithdraw};
 
 pub const DUTCH_AUCTION_DOMAIN_SEP: &[u8] = b"penumbra_DA_nft";
 
 /// A deployed Dutch Auction, containing an immutable description
 /// and stateful data about its current state.
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 #[serde(try_from = "pb::DutchAuction", into = "pb::DutchAuction")]
 pub struct DutchAuction {
     pub description: DutchAuctionDescription,
@@ -162,7 +163,7 @@ impl TryFrom<pb::DutchAuctionDescription> for DutchAuctionDescription {
 ///  Opened                                   
 ///     │                                     
 ///
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
 #[serde(try_from = "pb::DutchAuctionState", into = "pb::DutchAuctionState")]
 pub struct DutchAuctionState {
     pub sequence: u64,

--- a/crates/core/component/auction/src/component/action_handler/dutch/end.rs
+++ b/crates/core/component/auction/src/component/action_handler/dutch/end.rs
@@ -5,6 +5,8 @@ use cnidarium_component::ActionHandler;
 
 use crate::auction::dutch::ActionDutchAuctionEnd;
 use crate::component::AuctionStoreRead;
+use crate::component::DutchAuctionManager;
+
 use anyhow::{bail, Context};
 
 #[async_trait]
@@ -14,7 +16,7 @@ impl ActionHandler for ActionDutchAuctionEnd {
         Ok(())
     }
 
-    async fn check_and_execute<S: StateWrite>(&self, state: S) -> Result<()> {
+    async fn check_and_execute<S: StateWrite>(&self, mut state: S) -> Result<()> {
         let auction_id = self.auction_id;
 
         let auction_state = state
@@ -32,6 +34,8 @@ impl ActionHandler for ActionDutchAuctionEnd {
             "auction MUST have a sequence number set to opened (0) or closed (1) (got: {})",
             auction.state.sequence
         );
+
+        state.close_auction(auction).await?;
         Ok(())
     }
 }

--- a/crates/core/component/auction/src/component/action_handler/dutch/end.rs
+++ b/crates/core/component/auction/src/component/action_handler/dutch/end.rs
@@ -1,9 +1,11 @@
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use async_trait::async_trait;
 use cnidarium::StateWrite;
 use cnidarium_component::ActionHandler;
 
-use crate::auction::dutch::actions::ActionDutchAuctionEnd;
+use crate::auction::dutch::ActionDutchAuctionEnd;
+use crate::component::AuctionStoreRead;
+use anyhow::{bail, Context};
 
 #[async_trait]
 impl ActionHandler for ActionDutchAuctionEnd {
@@ -12,7 +14,24 @@ impl ActionHandler for ActionDutchAuctionEnd {
         Ok(())
     }
 
-    async fn check_and_execute<S: StateWrite>(&self, mut _state: S) -> Result<()> {
+    async fn check_and_execute<S: StateWrite>(&self, state: S) -> Result<()> {
+        let auction_id = self.auction_id;
+
+        let auction_state = state
+            .get_dutch_auction_by_id(auction_id)
+            .await
+            .context("the auction associated with this id is not a dutch auction")?;
+
+        let Some(auction) = auction_state else {
+            bail!("no auction found for id {auction_id}")
+        };
+
+        // Check that the sequence number for the auction state is 0 (opened) or 1 (closed).
+        ensure!(
+            auction.state.sequence <= 1,
+            "auction MUST have a sequence number set to opened (0) or closed (1) (got: {})",
+            auction.state.sequence
+        );
         Ok(())
     }
 }

--- a/crates/core/component/auction/src/component/action_handler/dutch/end.rs
+++ b/crates/core/component/auction/src/component/action_handler/dutch/end.rs
@@ -30,7 +30,7 @@ impl ActionHandler for ActionDutchAuctionEnd {
 
         // Check that the sequence number for the auction state is 0 (opened) or 1 (closed).
         ensure!(
-            auction.state.sequence <= 1,
+            matches!(auction.state.sequence, 0 | 1),
             "auction MUST have a sequence number set to opened (0) or closed (1) (got: {})",
             auction.state.sequence
         );

--- a/crates/core/component/auction/src/component/action_handler/dutch/schedule.rs
+++ b/crates/core/component/auction/src/component/action_handler/dutch/schedule.rs
@@ -1,7 +1,9 @@
-use anyhow::Result;
+use crate::component::auction::StateReadExt;
+use anyhow::{ensure, Result};
 use async_trait::async_trait;
 use cnidarium::StateWrite;
 use cnidarium_component::ActionHandler;
+use penumbra_sct::component::clock::EpochRead; // AuctionRead?
 
 use crate::auction::dutch::actions::ActionDutchAuctionSchedule;
 
@@ -9,10 +11,61 @@ use crate::auction::dutch::actions::ActionDutchAuctionSchedule;
 impl ActionHandler for ActionDutchAuctionSchedule {
     type CheckStatelessContext = ();
     async fn check_stateless(&self, _context: ()) -> Result<()> {
+        let schedule = self;
+        let end_height = schedule.description.end_height;
+        let start_height = schedule.description.start_height;
+        let step_count = schedule.description.step_count;
+
+        // Check that the start and end height are valid.
+        ensure!(
+            start_height < end_height,
+            "the start height MUST be strictly less than the end height (got: start={} >= end={})",
+            start_height,
+            end_height
+        );
+
+        // Check that the step count is positive.
+        ensure!(
+            step_count > 0,
+            "step count MUST be greater than zero (got: {step_count})"
+        );
+
+        // Check that the step count is less than 1000.
+        ensure!(
+            step_count <= 1000,
+            "the dutch auction step count MUST be less than 1000 (got: {step_count})",
+        );
+
+        // Check that height delta is a multiple of `step_count`.
+        let block_window = end_height - start_height;
+        ensure!(
+            (block_window % step_count) == 0,
+            "the block window ({block_window}) MUST be a multiple of the step count ({step_count})"
+        );
+
         Ok(())
     }
 
-    async fn check_and_execute<S: StateWrite>(&self, mut _state: S) -> Result<()> {
+    async fn check_and_execute<S: StateWrite>(&self, mut state: S) -> Result<()> {
+        let schedule = self;
+
+        // Check that `start_height` is in the future.
+        let current_height = state.get_block_height().await?;
+        let start_height = schedule.description.start_height;
+        ensure!(
+            start_height > current_height,
+            "dutch auction MUST start in the future (start={}, current={})",
+            start_height,
+            current_height
+        );
+
+        // Check that the `auction_id` is unused.
+        let id = schedule.description.id();
+        ensure!(
+            !state.auction_id_exists(id).await,
+            "the supplied auction id is already known to the chain (id={id})"
+        );
+
         Ok(())
     }
 }

--- a/crates/core/component/auction/src/component/action_handler/dutch/schedule.rs
+++ b/crates/core/component/auction/src/component/action_handler/dutch/schedule.rs
@@ -24,6 +24,9 @@ impl ActionHandler for ActionDutchAuctionSchedule {
             nonce: _,
         } = self.description;
 
+        // Fail fast if the step count is zero
+        ensure!(step_count > 0, "step count MUST be positive (got zero)");
+
         // Check that we disallow identical input/output ids.
         ensure!(
             input.asset_id != output_id,

--- a/crates/core/component/auction/src/component/action_handler/dutch/schedule.rs
+++ b/crates/core/component/auction/src/component/action_handler/dutch/schedule.rs
@@ -1,11 +1,12 @@
-use crate::{auction::dutch::DutchAuctionDescription, component::auction::StateReadExt};
+use crate::auction::dutch::DutchAuctionDescription;
+use crate::component::AuctionStoreRead;
 use anyhow::{ensure, Result};
 use async_trait::async_trait;
 use cnidarium::StateWrite;
 use cnidarium_component::ActionHandler;
 use penumbra_sct::component::clock::EpochRead; // AuctionRead?
 
-use crate::auction::dutch::actions::ActionDutchAuctionSchedule;
+use crate::auction::dutch::ActionDutchAuctionSchedule;
 
 #[async_trait]
 impl ActionHandler for ActionDutchAuctionSchedule {

--- a/crates/core/component/auction/src/component/action_handler/dutch/schedule.rs
+++ b/crates/core/component/auction/src/component/action_handler/dutch/schedule.rs
@@ -7,6 +7,7 @@ use cnidarium_component::ActionHandler;
 use penumbra_sct::component::clock::EpochRead; // AuctionRead?
 
 use crate::auction::dutch::ActionDutchAuctionSchedule;
+use crate::component::DutchAuctionManager;
 
 #[async_trait]
 impl ActionHandler for ActionDutchAuctionSchedule {
@@ -68,7 +69,7 @@ impl ActionHandler for ActionDutchAuctionSchedule {
         Ok(())
     }
 
-    async fn check_and_execute<S: StateWrite>(&self, state: S) -> Result<()> {
+    async fn check_and_execute<S: StateWrite>(&self, mut state: S) -> Result<()> {
         let schedule = self;
 
         // Check that `start_height` is in the future.
@@ -88,6 +89,7 @@ impl ActionHandler for ActionDutchAuctionSchedule {
             "the supplied auction id is already known to the chain (id={id})"
         );
 
+        state.schedule_auction(schedule.description.clone()).await;
         Ok(())
     }
 }

--- a/crates/core/component/auction/src/component/action_handler/dutch/schedule.rs
+++ b/crates/core/component/auction/src/component/action_handler/dutch/schedule.rs
@@ -63,7 +63,11 @@ impl ActionHandler for ActionDutchAuctionSchedule {
         );
 
         // Check that height delta is a multiple of `step_count`.
-        let block_window = end_height - start_height;
+        let block_window = end_height.checked_sub(start_height).ok_or_else(|| {
+            anyhow::anyhow!(
+                "underflow ({end_height} < {start_height}) - the validation rules are incoherent!"
+            )
+        })?;
         ensure!(
             (block_window % step_count) == 0,
             "the block window ({block_window}) MUST be a multiple of the step count ({step_count})"

--- a/crates/core/component/auction/src/component/action_handler/dutch/withdraw.rs
+++ b/crates/core/component/auction/src/component/action_handler/dutch/withdraw.rs
@@ -1,18 +1,61 @@
-use anyhow::Result;
+use crate::auction::dutch::ActionDutchAuctionWithdraw;
+use crate::component::AuctionStoreRead;
+use anyhow::{bail, ensure, Context, Result};
+use ark_ff::Zero;
 use async_trait::async_trait;
 use cnidarium::StateWrite;
 use cnidarium_component::ActionHandler;
-
-use crate::auction::dutch::actions::ActionDutchAuctionWithdraw;
+use decaf377::Fr;
+use penumbra_asset::{Balance, Value};
 
 #[async_trait]
 impl ActionHandler for ActionDutchAuctionWithdraw {
     type CheckStatelessContext = ();
     async fn check_stateless(&self, _context: ()) -> Result<()> {
+        ensure!(
+            self.seq >= 1,
+            "the sequence number MUST be greater or equal to 1 (got: {})",
+            self.seq
+        );
+
         Ok(())
     }
 
-    async fn check_and_execute<S: StateWrite>(&self, mut _state: S) -> Result<()> {
+    async fn check_and_execute<S: StateWrite>(&self, state: S) -> Result<()> {
+        let auction_id = self.auction_id;
+
+        let auction_state = state
+            .get_dutch_auction_by_id(auction_id)
+            .await
+            .context("the auction associated with this id is not a dutch auction")?;
+
+        let Some(auction_state) = auction_state else {
+            bail!("no auction found for id {auction_id}")
+        };
+
+        let auction_input_reserves = Value {
+            amount: auction_state.state.input_reserves,
+            asset_id: auction_state.description.input.asset_id,
+        };
+
+        let auction_output_reserves = Value {
+            amount: auction_state.state.output_reserves,
+            asset_id: auction_state.description.output_id,
+        };
+
+        let reserves_balance =
+            Balance::from(auction_input_reserves) + Balance::from(auction_output_reserves);
+
+        let expected_reserve_commitment = reserves_balance.commit(Fr::zero());
+
+        ensure!(
+            self.reserves_commitment == expected_reserve_commitment,
+            "the reported reserve commitment is incorrect"
+        );
+
+        // When we execute, it will be critical write back an auction state with zeroed out
+        // reserves.
+
         Ok(())
     }
 }

--- a/crates/core/component/auction/src/component/action_handler/dutch/withdraw.rs
+++ b/crates/core/component/auction/src/component/action_handler/dutch/withdraw.rs
@@ -18,12 +18,18 @@ impl ActionHandler for ActionDutchAuctionWithdraw {
             self.seq
         );
 
+        ensure!(
+            self.seq < u64::MAX,
+            "the sequence number maximum is `u64::MAX`"
+        );
+
         Ok(())
     }
 
     async fn check_and_execute<S: StateWrite>(&self, state: S) -> Result<()> {
         let auction_id = self.auction_id;
 
+        // Check that the auction exists and is a Dutch auction.
         let auction_state = state
             .get_dutch_auction_by_id(auction_id)
             .await
@@ -33,6 +39,15 @@ impl ActionHandler for ActionDutchAuctionWithdraw {
             bail!("no auction found for id {auction_id}")
         };
 
+        // Check that sequence number is incremented by one.
+        ensure!(
+            self.seq == auction_state.state.sequence.saturating_add(1),
+            "the action sequence number MUST be incremented by one (previous: {}, action: {})",
+            self.seq,
+            auction_state.state.sequence
+        );
+
+        // Check that the reported balance commitment, match the recorded reserves.
         let auction_input_reserves = Value {
             amount: auction_state.state.input_reserves,
             asset_id: auction_state.description.input.asset_id,

--- a/crates/core/component/auction/src/component/auction.rs
+++ b/crates/core/component/auction/src/component/auction.rs
@@ -6,10 +6,7 @@ use std::sync::Arc;
 use tendermint::v0_37::abci;
 use tracing::instrument;
 
-use crate::{auction::id::AuctionId, state_key};
-
 pub struct Auction {}
-impl Auction {}
 
 #[async_trait]
 impl Component for Auction {
@@ -46,13 +43,7 @@ impl Component for Auction {
 /// Extension trait providing read access to auction data.
 #[async_trait]
 pub trait StateReadExt: StateRead {
-    /// Returns `true` if the suppied `auction_id` is already used.
-    async fn auction_id_exists(&self, auction_id: AuctionId) -> bool {
-        self.get_raw(&state_key::auction_store::by_id(auction_id))
-            .await
-            .expect("no storage errors")
-            .map_or(false, |_| true)
-    }
+    // Params accessors
 }
 
 impl<T: StateRead + ?Sized> StateReadExt for T {}

--- a/crates/core/component/auction/src/component/auction.rs
+++ b/crates/core/component/auction/src/component/auction.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 use tendermint::v0_37::abci;
 use tracing::instrument;
 
+use crate::{auction::id::AuctionId, state_key};
+
 pub struct Auction {}
 impl Auction {}
 
@@ -43,7 +45,15 @@ impl Component for Auction {
 
 /// Extension trait providing read access to auction data.
 #[async_trait]
-pub trait StateReadExt: StateRead {}
+pub trait StateReadExt: StateRead {
+    /// Returns `true` if the suppied `auction_id` is already used.
+    async fn auction_id_exists(&self, auction_id: AuctionId) -> bool {
+        self.get_raw(&state_key::auction_store::by_id(auction_id))
+            .await
+            .expect("no storage errors")
+            .map_or(false, |_| true)
+    }
+}
 
 impl<T: StateRead + ?Sized> StateReadExt for T {}
 

--- a/crates/core/component/auction/src/component/auction_store.rs
+++ b/crates/core/component/auction/src/component/auction_store.rs
@@ -1,0 +1,62 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use cnidarium::{StateRead, StateWrite};
+use cnidarium_component::Component;
+use penumbra_proto::core::component::auction::v1alpha1 as pb;
+use penumbra_proto::DomainType;
+use penumbra_proto::Name;
+use penumbra_proto::StateReadProto;
+use prost_types::Any;
+use std::sync::Arc;
+use tendermint::v0_37::abci;
+use tracing::instrument;
+
+use crate::{
+    auction::{dutch::DutchAuction, id::AuctionId},
+    state_key,
+};
+
+/// Extension trait providing read access to auction data.
+#[async_trait]
+pub trait AuctionStoreRead: StateRead {
+    /// Returns whether the supplied `auction_id` exists in the chain state.
+    async fn auction_id_exists(&self, auction_id: AuctionId) -> bool {
+        self.get_raw_auction(auction_id).await.is_some()
+    }
+
+    /// Fetch a [`DutchAuction`] from storage, returning `None` if none
+    /// were found with the provided identifier.
+    ///
+    /// # Errors
+    /// This method returns an error if the auction state associated with the
+    /// specified `auction_id` is *not* of type `DutchAuction`.
+    async fn get_dutch_auction_by_id(&self, auction_id: AuctionId) -> Result<Option<DutchAuction>> {
+        let Some(any_auction) = self.get_raw_auction(auction_id).await else {
+            return Ok(None);
+        };
+
+        let dutch_auction_type_str = pb::DutchAuction::full_name();
+
+        anyhow::ensure!(
+            any_auction.type_url == dutch_auction_type_str,
+            "error deserializing auction state, expected type to be {}, but got: {}",
+            dutch_auction_type_str,
+            any_auction.type_url
+        );
+
+        Ok(Some(DutchAuction::decode(any_auction.value.as_ref())?))
+    }
+
+    /// Returns raw auction data if found under the specified `auction_id`,
+    /// and `None` otherwise
+    async fn get_raw_auction(&self, auction_id: AuctionId) -> Option<Any> {
+        self.get_proto(&state_key::auction_store::by_id(auction_id))
+            .await
+            .expect("no storage errors")
+    }
+}
+
+impl<T: StateRead + ?Sized> AuctionStoreRead for T {}
+
+#[cfg(tests)]
+mod tests {}

--- a/crates/core/component/auction/src/component/auction_store.rs
+++ b/crates/core/component/auction/src/component/auction_store.rs
@@ -1,24 +1,20 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use cnidarium::{StateRead, StateWrite};
-use cnidarium_component::Component;
+use cnidarium::StateRead;
 use penumbra_proto::core::component::auction::v1alpha1 as pb;
 use penumbra_proto::DomainType;
 use penumbra_proto::Name;
 use penumbra_proto::StateReadProto;
 use prost_types::Any;
-use std::sync::Arc;
-use tendermint::v0_37::abci;
-use tracing::instrument;
 
 use crate::{
     auction::{dutch::DutchAuction, id::AuctionId},
     state_key,
 };
 
-/// Extension trait providing read access to auction data.
+/// Provide access to internal auction data.
 #[async_trait]
-pub trait AuctionStoreRead: StateRead {
+pub(crate) trait AuctionStoreRead: StateRead {
     /// Returns whether the supplied `auction_id` exists in the chain state.
     async fn auction_id_exists(&self, auction_id: AuctionId) -> bool {
         self.get_raw_auction(auction_id).await.is_some()

--- a/crates/core/component/auction/src/component/dutch_auction.rs
+++ b/crates/core/component/auction/src/component/dutch_auction.rs
@@ -1,0 +1,252 @@
+use crate::auction::dutch::{DutchAuction, DutchAuctionDescription, DutchAuctionState};
+use crate::auction::AuctionId;
+use crate::component::AuctionStoreRead;
+use crate::state_key;
+use anyhow::Result;
+use async_trait::async_trait;
+use cnidarium::StateWrite;
+use penumbra_num::Amount;
+use penumbra_proto::core::component::auction::v1alpha1 as pb;
+use penumbra_sct::component::clock::EpochRead;
+use prost::{Message, Name};
+
+#[async_trait]
+pub(crate) trait DutchAuctionManager: StateWrite {
+    /// Schedule an auction with the specified [`DutchAuctionDescritpion`].
+    async fn schedule_auction(&mut self, description: DutchAuctionDescription) {
+        let DutchAuctionDescription {
+            input: _,
+            output_id: _,
+            max_output: _,
+            min_output: _,
+            start_height,
+            end_height,
+            step_count,
+            nonce: _,
+        } = description;
+
+        let next_trigger = Self::compute_next_trigger(TriggerData {
+            start_height,
+            end_height,
+            step_count,
+            current_height: self
+                .get_block_height()
+                .await
+                .expect("block height is not missing"),
+        })
+        .expect("infaillible because of action validation")
+        .expect("action validation guarantees the auction is not expired");
+
+        let state = DutchAuctionState {
+            sequence: 0,
+            current_position: None,
+            next_trigger,
+            input_reserves: description.input.amount,
+            output_reserves: Amount::zero(),
+        };
+
+        let dutch_auction = DutchAuction { description, state };
+
+        // Set the triggger
+        // Write position to state
+        self.write_dutch_auction_state(dutch_auction);
+    }
+
+    /// Terminate a Dutch auction associated with the specified [`AuctionId`].
+    ///
+    /// # Errors
+    /// This method returns an error if the id is not found, or if the
+    /// recorded entry is not of type `DutchAuction`.
+    async fn close_auction_by_id(&mut self, id: AuctionId) -> Result<()> {
+        let auction = self
+            .get_dutch_auction_by_id(id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("auction not found"))?;
+        self.close_auction(auction)
+    }
+
+    /// Terminate and update the supplied auction state.
+    fn close_auction(&mut self, auction_to_close: DutchAuction) -> Result<()> {
+        let DutchAuctionState {
+            sequence,
+            current_position,
+            next_trigger,
+            input_reserves,
+            output_reserves,
+        } = auction_to_close.state;
+
+        // Short-circuit to no-op if the auction is already closed.
+        if sequence >= 1 {
+            return Ok(());
+        }
+
+        let auction_id = auction_to_close.description.id();
+
+        // We close and retire the DEX position owned by this auction state,
+        // and return the respective amount of input and output we should credit
+        // to the total tracked amount, so that it can be returned to its bearer.
+        let (input_from_position, output_from_position) = if let Some(_position) = current_position
+        {
+            // Get position state
+            // Withdraw position from the dex
+            // Return reserves so that we can credit them to i/o rs.
+            (Amount::zero(), Amount::zero())
+        } else {
+            (Amount::zero(), Amount::zero())
+        };
+
+        if let Some(_position) = current_position {
+            // Close position from the dex.
+            // Withdraw position from the dex.
+            // Credit balances to total input/output
+        }
+
+        // If a `next_trigger` entry is set, we remove it.
+        if next_trigger != 0 {
+            self.unset_trigger_for_id(auction_id, next_trigger)
+        }
+
+        let total_input_reserves = input_reserves + input_from_position;
+        let total_output_reserves = output_reserves + output_from_position;
+
+        let closed_auction = DutchAuction {
+            description: auction_to_close.description,
+            state: DutchAuctionState {
+                sequence: 1u64,
+                current_position: None,
+                next_trigger: 0,
+                input_reserves: total_input_reserves,
+                output_reserves: total_output_reserves,
+            },
+        };
+        self.write_dutch_auction_state(closed_auction);
+        Ok(())
+    }
+
+    /// Withdraw a dutch auction, zero-ing out its reserves and increasing its sequence
+    /// number.
+    ///
+    /// # Errors
+    /// This method errors if the auction id is not found, or if the associated
+    /// entry is not of type [`DutchAuction`].
+    async fn withdraw_auction_by_id(&mut self, id: AuctionId) -> Result<()> {
+        let auction = self
+            .get_dutch_auction_by_id(id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("auction not found"))?;
+        self.withdraw_auction(auction);
+        Ok(())
+    }
+
+    fn withdraw_auction(&mut self, mut auction: DutchAuction) {
+        auction.state.sequence = auction.state.sequence.saturating_add(1);
+        auction.state.current_position = None;
+        auction.state.input_reserves = Amount::zero();
+        auction.state.output_reserves = Amount::zero();
+        self.write_dutch_auction_state(auction)
+    }
+}
+
+impl<T: StateWrite + ?Sized> DutchAuctionManager for T {}
+
+trait Inner: StateWrite {
+    /// Serialize a `DutchAuction` as an `Any` into chain state.
+    fn write_dutch_auction_state(&mut self, new_state: DutchAuction) {
+        let id = new_state.description.id();
+        let key = state_key::auction_store::by_id(id);
+        let pb_state: pb::DutchAuction = new_state.into();
+        let raw_auction = pb_state.encode_length_delimited_to_vec();
+
+        let any_auction = prost_types::Any {
+            type_url: pb::DutchAuction::full_name(),
+            value: raw_auction,
+        };
+
+        let raw_any = any_auction.encode_length_delimited_to_vec();
+
+        self.put_raw(key, raw_any);
+    }
+
+    /// Compute the next trigger height, return `None` if the step count
+    /// has been reached and the auction should be retired.
+    ///
+    /// # Errors
+    /// This method errors if the block interval is not a multiple of the
+    /// specified `step_count`, or if it operates over an invalid block
+    /// interval (which should NEVER happen unless validation is broken).
+    ///
+    // TODO(erwan): doing everything checked at least for now, will remove as
+    // i fill the tests module.
+    fn compute_next_trigger(trigger_data: TriggerData) -> Result<Option<u64>> {
+        let block_interval = trigger_data
+            .end_height
+            .checked_sub(trigger_data.start_height)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "block interval calculation has underflowed (end={}, start={})",
+                    trigger_data.end_height,
+                    trigger_data.start_height
+                )
+            })?;
+
+        // Compute the step size, based on the block interval and the number of
+        // discrete steps the auction specifies.
+        let step_size = block_interval
+            .checked_div(trigger_data.step_count)
+            .ok_or_else(|| anyhow::anyhow!("step count is zero"))?;
+
+        // Compute the step index for the current height, this should work even if
+        // the supplied height does not fall perfectly on a step boundary. First, we
+        // "clamp it" to a previous step index, then we increment by 1 to compute the
+        // next one, and finally we determine a concrete trigger height based off that.
+        let prev_step_index = trigger_data
+            .current_height
+            .checked_div(step_size)
+            .ok_or_else(|| anyhow::anyhow!("step size is zero"))?;
+
+        if prev_step_index >= trigger_data.step_count {
+            return Ok(None);
+        }
+
+        let next_step_index = prev_step_index
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("step index has overflowed"))?;
+
+        let next_step_size_from_start =
+            step_size.checked_mul(next_step_index).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "next step size from start has overflowed (step_size={}, next_step_index={})",
+                    step_size,
+                    next_step_index
+                )
+            })?;
+
+        Ok(trigger_data
+            .start_height
+            .checked_add(next_step_size_from_start))
+    }
+
+    /// Set the trigger for an auction.
+    fn set_trigger_for_id(&mut self, auction_id: AuctionId, trigger_height: u64) {
+        let trigger_path = state_key::dutch::trigger::auction_at_height(auction_id, trigger_height);
+        self.put_raw(trigger_path, vec![]);
+    }
+
+    /// Delete the trigger for an auction and height
+    fn unset_trigger_for_id(&mut self, auction_id: AuctionId, trigger_height: u64) {
+        let trigger_path = state_key::dutch::trigger::auction_at_height(auction_id, trigger_height);
+        self.delete(trigger_path);
+    }
+}
+
+impl<T: StateWrite + ?Sized> Inner for T {}
+
+struct TriggerData {
+    pub start_height: u64,
+    pub end_height: u64,
+    pub current_height: u64,
+    pub step_count: u64,
+}
+
+#[cfg(tests)]
+mod tests {}

--- a/crates/core/component/auction/src/component/dutch_auction.rs
+++ b/crates/core/component/auction/src/component/dutch_auction.rs
@@ -239,6 +239,7 @@ trait Inner: StateWrite {
 
 impl<T: StateWrite + ?Sized> Inner for T {}
 
+#[allow(unused)] // Spurious warning that this is not used.
 struct TriggerData {
     pub start_height: u64,
     pub end_height: u64,

--- a/crates/core/component/auction/src/component/mod.rs
+++ b/crates/core/component/auction/src/component/mod.rs
@@ -1,8 +1,9 @@
 pub mod action_handler;
 mod auction;
+mod auction_store;
+mod dutch_auction;
 pub mod metrics;
 pub mod rpc;
 
-pub use self::auction::{StateReadExt, StateWriteExt};
-mod auction_store;
+pub use auction::{StateReadExt, StateWriteExt};
 pub(crate) use auction_store::AuctionStoreRead;

--- a/crates/core/component/auction/src/component/mod.rs
+++ b/crates/core/component/auction/src/component/mod.rs
@@ -4,3 +4,5 @@ pub mod metrics;
 pub mod rpc;
 
 pub use self::auction::{StateReadExt, StateWriteExt};
+mod auction_store;
+pub(crate) use auction_store::AuctionStoreRead;

--- a/crates/core/component/auction/src/component/mod.rs
+++ b/crates/core/component/auction/src/component/mod.rs
@@ -7,3 +7,4 @@ pub mod rpc;
 
 pub use auction::{StateReadExt, StateWriteExt};
 pub(crate) use auction_store::AuctionStoreRead;
+pub(crate) use dutch_auction::DutchAuctionManager;

--- a/crates/core/component/auction/src/state_key.rs
+++ b/crates/core/component/auction/src/state_key.rs
@@ -8,11 +8,11 @@ pub mod parameters {
     }
 }
 
-pub mod store {
+pub mod auction_store {
     use crate::auction::id::AuctionId;
 
     pub fn prefix() -> &'static str {
-        "auction/store/"
+        "auction/auction_store/"
     }
 
     pub fn by_id(auction_id: AuctionId) -> String {


### PR DESCRIPTION
## Describe your changes

This PR adds validation logic for:
- `ActionDutchAuctionSchedule`
- `ActionDutchAuctionEnd`
- `ActionDutchAuctionWithdraw`

and a component implementation, on a model similar-but-simpler to the DEX:

- a `DutchAuctionManager` extension trait defines a crate-level API to effect a validated action
- an `Inner` internal implementation manages writing to the state
- internal data can be accessed via a general `AuctionStoreRead` trait which manage tentatively deserializing raw auction state (wkt `Any`) into a useful domain type.

## Issue ticket number and link

#4211 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Those actions are not integrated in our transaction system, our application impl. 
