### PR TITLE
dex: add checks to disable swaps and opening positions when the dex is disabled

### DIFF
--- a/crates/core/component/dex/src/component/action_handler/swap.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use async_trait::async_trait;
 use cnidarium::StateWrite;
 use cnidarium_component::ActionHandler;
@@ -34,6 +34,14 @@ impl ActionHandler for Swap {
     }
 
     async fn check_and_execute<S: StateWrite>(&self, mut state: S) -> Result<()> {
+        // Only execute the swap if the dex is enabled in the dex params.
+        let dex_params = state.get_dex_params().await?;
+
+        ensure!(
+            dex_params.is_enabled,
+            "Dex MUST be enabled to process swap actions."
+        );
+
         let swap_start = std::time::Instant::now();
         let swap = self;
 


### PR DESCRIPTION
## Describe your changes

Closes #4078 

Unsure if `anyhow::bail!` is the ideal behavior for swaps & position opens when the dex is disabled, but it seems right to display an explanatory message as to why the swap or open does not occur.

## Issue ticket number and link

https://github.com/penumbra-zone/penumbra/issues/4078

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This will alter the dex behavior across the change boundary (acceptance/rejection of swaps & position opens) so it should break consensus between versions.
