### PR TITLE
auction: add `GasCost` impls for actions

### DIFF
--- a/crates/core/app/src/action_handler/actions.rs
+++ b/crates/core/app/src/action_handler/actions.rs
@@ -21,11 +21,9 @@ impl AppActionHandler for Action {
 
     async fn check_stateless(&self, context: TransactionContext) -> Result<()> {
         match self {
-            // These actions require a context
             Action::SwapClaim(action) => action.check_stateless(context).await,
             Action::Spend(action) => action.check_stateless(context).await,
             Action::DelegatorVote(action) => action.check_stateless(context).await,
-            // These actions don't require a context
             Action::Delegate(action) => action.check_stateless(()).await,
             Action::Undelegate(action) => action.check_stateless(()).await,
             Action::UndelegateClaim(action) => action.check_stateless(()).await,
@@ -50,6 +48,9 @@ impl AppActionHandler for Action {
             Action::CommunityPoolSpend(action) => action.check_stateless(()).await,
             Action::CommunityPoolOutput(action) => action.check_stateless(()).await,
             Action::CommunityPoolDeposit(action) => action.check_stateless(()).await,
+            Action::ActionDutchAuctionSchedule(_) => todo!(),
+            Action::ActionDutchAuctionEnd(_) => todo!(),
+            Action::ActionDutchAuctionWithdraw(_) => todo!(),
         }
     }
 
@@ -72,12 +73,9 @@ impl AppActionHandler for Action {
             Action::Spend(action) => action.check_historical(state).await,
             Action::Output(action) => action.check_historical(state).await,
             Action::IbcRelay(action) => {
-                // SAFETY: this is safe to check in parallel because IBC enablement cannot
-                // change during transaction execution.
                 if !state.get_ibc_params().await?.ibc_enabled {
                     anyhow::bail!("transaction contains IBC actions, but IBC is not enabled");
                 }
-
                 action
                     .clone()
                     .with_handler::<Ics20Transfer, PenumbraHost>()
@@ -85,8 +83,6 @@ impl AppActionHandler for Action {
                     .await
             }
             Action::Ics20Withdrawal(action) => {
-                // SAFETY: this is safe to check in parallel because IBC enablement cannot
-                // change during transaction execution.
                 if !state
                     .get_ibc_params()
                     .await?
@@ -99,6 +95,9 @@ impl AppActionHandler for Action {
             Action::CommunityPoolSpend(action) => action.check_historical(state).await,
             Action::CommunityPoolOutput(action) => action.check_historical(state).await,
             Action::CommunityPoolDeposit(action) => action.check_historical(state).await,
+            Action::ActionDutchAuctionSchedule(_) => todo!(),
+            Action::ActionDutchAuctionEnd(_) => todo!(),
+            Action::ActionDutchAuctionWithdraw(_) => todo!(),
         }
     }
 
@@ -131,6 +130,9 @@ impl AppActionHandler for Action {
             Action::CommunityPoolSpend(action) => action.check_and_execute(state).await,
             Action::CommunityPoolOutput(action) => action.check_and_execute(state).await,
             Action::CommunityPoolDeposit(action) => action.check_and_execute(state).await,
+            Action::ActionDutchAuctionSchedule(_) => todo!(),
+            Action::ActionDutchAuctionEnd(_) => todo!(),
+            Action::ActionDutchAuctionWithdraw(_) => todo!(),
         }
     }
 }

--- a/crates/core/app/src/action_handler/actions/submit.rs
+++ b/crates/core/app/src/action_handler/actions/submit.rs
@@ -99,21 +99,12 @@ impl AppActionHandler for ProposalSubmit {
                     match action {
                         Spend(_) | Output(_) | Swap(_) | SwapClaim(_) | DelegatorVote(_)
                         | UndelegateClaim(_) => {
-                            // These actions all require proving, so they are banned from Community Pool spend
-                            // proposals to prevent DoS attacks.
-                            anyhow::bail!(
-                                "invalid action in Community Pool spend proposal (would require proving)"
-                            )
+                            anyhow::bail!("invalid action in Community Pool spend proposal (would require proving)")
                         }
                         Delegate(_) | Undelegate(_) => {
-                            // Delegation and undelegation is disallowed due to Undelegateclaim requiring proving.
-                            anyhow::bail!(
-                                "invalid action in Community Pool spend proposal (can't claim outputs of undelegation)"
-                            )
+                            anyhow::bail!("invalid action in Community Pool spend proposal (can't claim outputs of undelegation)")
                         }
                         ProposalSubmit(_) | ProposalWithdraw(_) | ProposalDepositClaim(_) => {
-                            // These actions manipulate proposals, so they are banned from Community Pool spend
-                            // actions because they could cause recursion.
                             anyhow::bail!("invalid action in Community Pool spend proposal (not allowed to manipulate proposals from within proposals)")
                         }
                         ValidatorDefinition(_)
@@ -125,10 +116,10 @@ impl AppActionHandler for ProposalSubmit {
                         | CommunityPoolSpend(_)
                         | CommunityPoolOutput(_)
                         | Ics20Withdrawal(_)
-                        | CommunityPoolDeposit(_) => {
-                            // These actions are all valid for Community Pool spend proposals, because they
-                            // don't require proving, so they don't represent a DoS vector.
-                        }
+                        | CommunityPoolDeposit(_) => {}
+                        ActionDutchAuctionSchedule(_) => todo!(),
+                        ActionDutchAuctionEnd(_) => todo!(),
+                        ActionDutchAuctionWithdraw(_) => todo!(),
                     }
                 }
             }

--- a/crates/core/transaction/src/action.rs
+++ b/crates/core/transaction/src/action.rs
@@ -1,5 +1,7 @@
 use anyhow::anyhow;
-use penumbra_auction::auction::dutch::actions::{ActionDutchAuctionEnd, ActionDutchAuctionSchedule, ActionDutchAuctionWithdraw};
+use penumbra_auction::auction::dutch::actions::{
+    ActionDutchAuctionEnd, ActionDutchAuctionSchedule, ActionDutchAuctionWithdraw,
+};
 use penumbra_txhash::{EffectHash, EffectingData};
 use std::convert::{TryFrom, TryInto};
 

--- a/crates/core/transaction/src/action.rs
+++ b/crates/core/transaction/src/action.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use penumbra_auction::auction::dutch::actions::{ActionDutchAuctionEnd, ActionDutchAuctionSchedule, ActionDutchAuctionWithdraw};
 use penumbra_txhash::{EffectHash, EffectingData};
 use std::convert::{TryFrom, TryInto};
 
@@ -38,6 +39,10 @@ pub enum Action {
     CommunityPoolSpend(penumbra_community_pool::CommunityPoolSpend),
     CommunityPoolOutput(penumbra_community_pool::CommunityPoolOutput),
     CommunityPoolDeposit(penumbra_community_pool::CommunityPoolDeposit),
+
+    ActionDutchAuctionSchedule(ActionDutchAuctionSchedule),
+    ActionDutchAuctionEnd(ActionDutchAuctionEnd),
+    ActionDutchAuctionWithdraw(ActionDutchAuctionWithdraw),
 }
 
 impl EffectingData for Action {
@@ -64,6 +69,10 @@ impl EffectingData for Action {
             Action::CommunityPoolSpend(d) => d.effect_hash(),
             Action::CommunityPoolOutput(d) => d.effect_hash(),
             Action::CommunityPoolDeposit(d) => d.effect_hash(),
+            // TODO: fill in skeleton
+            Action::ActionDutchAuctionSchedule(_) => todo!(),
+            Action::ActionDutchAuctionEnd(_) => todo!(),
+            Action::ActionDutchAuctionWithdraw(_) => todo!(),
         }
     }
 }
@@ -108,6 +117,10 @@ impl Action {
             Action::CommunityPoolDeposit(_) => tracing::info_span!("CommunityPoolDeposit", ?idx),
             Action::CommunityPoolSpend(_) => tracing::info_span!("CommunityPoolSpend", ?idx),
             Action::CommunityPoolOutput(_) => tracing::info_span!("CommunityPoolOutput", ?idx),
+            // TODO: fill in skeleton
+            Action::ActionDutchAuctionSchedule(_) => todo!(),
+            Action::ActionDutchAuctionEnd(_) => todo!(),
+            Action::ActionDutchAuctionWithdraw(_) => todo!(),
         }
     }
 }
@@ -138,6 +151,10 @@ impl IsAction for Action {
             // value balance unchanged.
             Action::IbcRelay(x) => x.balance_commitment(),
             Action::ValidatorDefinition(_) => balance::Commitment::default(),
+            // TODO: fill in skeleton
+            Action::ActionDutchAuctionSchedule(_) => todo!(),
+            Action::ActionDutchAuctionEnd(_) => todo!(),
+            Action::ActionDutchAuctionWithdraw(_) => todo!(),
         }
     }
 
@@ -165,6 +182,10 @@ impl IsAction for Action {
             // TODO: figure out where to implement the actual decryption methods for these? where are their action definitions?
             Action::ValidatorDefinition(x) => ActionView::ValidatorDefinition(x.to_owned()),
             Action::IbcRelay(x) => ActionView::IbcRelay(x.to_owned()),
+            // TODO: fill in skeleton
+            Action::ActionDutchAuctionSchedule(_) => todo!(),
+            Action::ActionDutchAuctionEnd(_) => todo!(),
+            Action::ActionDutchAuctionWithdraw(_) => todo!(),
         }
     }
 }
@@ -239,6 +260,10 @@ impl From<Action> for pb::Action {
             Action::CommunityPoolDeposit(inner) => pb::Action {
                 action: Some(pb::action::Action::CommunityPoolDeposit(inner.into())),
             },
+            // TODO: fill in skeleton
+            Action::ActionDutchAuctionSchedule(_) => todo!(),
+            Action::ActionDutchAuctionEnd(_) => todo!(),
+            Action::ActionDutchAuctionWithdraw(_) => todo!(),
         }
     }
 }

--- a/crates/core/transaction/src/gas.rs
+++ b/crates/core/transaction/src/gas.rs
@@ -45,10 +45,9 @@ pub fn spend_gas_cost() -> Gas {
         // penumbra.crypto.decaf377_rdsa.v1.SpendVerificationKey `rk`     = 32 bytes
         // penumbra.crypto.decaf377_rdsa.v1.SpendAuthSignature `auth_sig` = 64 bytes
         // ZKSpendProof `proof`                                           = 192 bytes
-        // ````````````````````````````` 352 bytes ``````````````````````````````````
 
         // The block space measured as the byte length of the encoded action.
-        block_space: 160 + ZKPROOF_SIZE,
+        block_space: 160 + ZKPROOF_SIZE, // 352 bytes
         // The compact block space cost is based on the byte size of the data the [`Action`] adds
         // to the compact block. For a `Spend`, this is the byte size of a `Nullifier`.
         compact_block_space: NULLIFIER_SIZE,
@@ -66,10 +65,9 @@ pub fn output_gas_cost() -> Gas {
         // wrapped_memo_key `wrapped_memo_key`                           = 48 bytes
         // ovk_wrapped_key `ovk_wrapped_key`                             = 48 bytes
         // ZKOutputProof `proof`                                         = 192 bytes
-        // ````````````````````````````` 560 bytes ``````````````````````````````````
 
         // The block space measured as the byte length of the encoded action.
-        block_space: 128 + NOTEPAYLOAD_SIZE + ZKPROOF_SIZE,
+        block_space: 128 + NOTEPAYLOAD_SIZE + ZKPROOF_SIZE, // 560 bytes
         // The compact block space cost is based on the byte size of the data the [`Action`] adds
         // to the compact block.
         compact_block_space: NOTEPAYLOAD_SIZE,
@@ -120,10 +118,9 @@ fn undelegate_claim_gas_cost() -> Gas {
         // penumbra.core.asset.v1.BalanceCommitment `balance_commitment`  = 32 bytes
         // uint64 `unbonding_start_height`                                = 8 bytes
         // ZKSpendProof `proof`                                           = 192 bytes
-        // ````````````````````````````` 304 bytes ``````````````````````````````````
 
         // The block space measured as the byte length of the encoded action.
-        block_space: 112 + ZKPROOF_SIZE,
+        block_space: 112 + ZKPROOF_SIZE, // 304 bytes
         // The compact block space cost is based on the byte size of the data the [`Action`] adds
         // to the compact block.
         // For an `UndelegateClaim`, nothing is added to the compact block directly. The associated [`Action::Output`]
@@ -160,10 +157,9 @@ fn swap_gas_cost() -> Gas {
         // SwapPayload `payload`                                     = 304 bytes
         // ZKSwapProof `proof`                                       = 192 bytes
         // Batch swap output data                                    = 104 bytes
-        // ````````````````````````````` 728 bytes ``````````````````````````````
 
         // The block space measured as the byte length of the encoded action.
-        block_space: 128 + ZKPROOF_SIZE + SWAPPAYLOAD_SIZE + BSOD_SIZE,
+        block_space: 128 + ZKPROOF_SIZE + SWAPPAYLOAD_SIZE + BSOD_SIZE, // 728 bytes
         // The compact block space cost is based on the byte size of the data the [`Action`] adds
         // to the compact block.
         // For a `Swap` this is the byte size of a [`StatePayload`] and a [`BatchSwapOutputData`].
@@ -189,10 +185,9 @@ pub fn swap_claim_gas_cost() -> Gas {
         // uint64 `epoch_duration`                                        = 8 bytes
         // ZKSwapClaimProof `proof`                                       = 192 bytes
         // Batch swap output data                                          = 104 bytes
-        // ````````````````````````````` 624 bytes ```````````````````````````````````
 
         // The block space measured as the byte length of the encoded action.
-        block_space: 328 + ZKPROOF_SIZE + BSOD_SIZE,
+        block_space: 328 + ZKPROOF_SIZE + BSOD_SIZE, // 624 bytes
         // The compact block space cost is based on the byte size of the data the [`Action`] adds
         // to the compact block.
         // For a `SwapClaim`, nothing is added to the compact block directly. The associated [`Action::Spend`]
@@ -216,10 +211,9 @@ fn delegator_vote_gas_cost() -> Gas {
         // penumbra.crypto.decaf377_rdsa.v1.SpendVerificationKey `rk`       = 32 bytes
         // penumbra.crypto.decaf377_rdsa.v1.SpendAuthSignature `auth_sig`   = 64 bytes
         // ZKDelegatorVoteProof `proof`                                     = 192 bytes
-        // ````````````````````````````` 401 bytes ````````````````````````````````````
 
         // The block space measured as the byte length of the encoded action.
-        block_space: 209 + ZKPROOF_SIZE,
+        block_space: 209 + ZKPROOF_SIZE, // 401 bytes
         // The compact block space cost is based on the byte size of the data the [`Action`] adds
         // to the compact block.
         // For a DelegatorVote the compact block is not modified.
@@ -236,10 +230,9 @@ fn position_withdraw_gas_cost() -> Gas {
         // PositionId `position_id`                                        = 32 bytes
         // penumbra.core.asset.v1.BalanceCommitment `reserves_commitment`  = 32 bytes
         // uint64 `sequence`                                               = 8 bytes
-        // ````````````````````````````` 72 bytes ````````````````````````````````````
 
         // The block space measured as the byte length of the encoded action.
-        block_space: 72,
+        block_space: 72, // 72 bytes
         // The compact block space cost is based on the byte size of the data the [`Action`] adds
         // to the compact block.
         // For a PositionWithdraw the compact block is not modified.
@@ -251,30 +244,51 @@ fn position_withdraw_gas_cost() -> Gas {
     }
 }
 
-fn dutch_auction_schedule_gas_cost() -> Gas {
+fn dutch_auction_schedule_gas_cost(dutch_action_schedule: &ActionDutchAuctionSchedule) -> Gas {
     Gas {
-        block_space: todo!(),
-        compact_block_space: todo!(),
-        verification: todo!(),
-        execution: todo!(),
+        // penumbra.core.asset.v1.Value `input` = 48 bytes
+        // penumbra.core.asset.v1.AssetId `output_id` = 32 bytes
+        // penumbra.core.num.v1.Amount `max_output` = 16 bytes
+        // penumbra.core.num.v1.Amount `min_output` = 16 bytes
+        // uint64 `start_height` = 8 bytes
+        // uint64 `end_height` = 8 bytes
+        // uint64 `step_count` = 8 bytes
+        // bytes `nonce` = 32 bytes
+
+        // TODO: Multidimentional fees will enable gas fees to dynamically be based on both `block_space`
+        // and `execution`, where execution cost is roughly proportional to computational cost,
+        // while block space is proportional to the space the action takes up in a block.
+        // We can therefore separately price the resource of “work performed during execution”
+        // and “bandwidth between nodes”.
+        //
+        // Currently we make the execution cost for DA actions proportional to the number of steps
+        // and costs of position open/close in dutch action.
+        block_space: 168, // 168 bytes
+        compact_block_space: 0,
+        verification: 50,
+        execution: 2 * dutch_action_schedule.description.step_count * 20,
     }
 }
 
 fn dutch_auction_end_gas_cost() -> Gas {
     Gas {
-        block_space: todo!(),
-        compact_block_space: todo!(),
-        verification: todo!(),
-        execution: todo!(),
+        // AuctionId `auction_id` = 32 bytes
+        block_space: 32, // 32 bytes
+        compact_block_space: 0,
+        verification: 0,
+        execution: 10,
     }
 }
 
 fn dutch_auction_withdraw_gas_cost() -> Gas {
     Gas {
-        block_space: todo!(),
-        compact_block_space: todo!(),
-        verification: todo!(),
-        execution: todo!(),
+        // AuctionId `auction_id` = 32 bytes
+        // uint64 `seq`= 8 bytes
+        // penumbra.core.asset.v1.BalanceCommitment `reserves_commitment` = 32 bytes
+        block_space: 72, // 72 bytes
+        compact_block_space: 0,
+        verification: 0,
+        execution: 10,
     }
 }
 
@@ -311,7 +325,7 @@ impl GasCost for ActionPlan {
             ActionPlan::SwapClaim(_) => swap_claim_gas_cost(),
             ActionPlan::DelegatorVote(_) => delegator_vote_gas_cost(),
             ActionPlan::PositionWithdraw(_) => position_withdraw_gas_cost(),
-            ActionPlan::ActionDutchAuctionSchedule(_) => dutch_auction_schedule_gas_cost(),
+            ActionPlan::ActionDutchAuctionSchedule(das) => das.gas_cost(),
             ActionPlan::ActionDutchAuctionEnd(_) => dutch_auction_end_gas_cost(),
             ActionPlan::ActionDutchAuctionWithdraw(_) => dutch_auction_withdraw_gas_cost(),
 
@@ -622,7 +636,7 @@ impl GasCost for ValidatorDefinition {
 
 impl GasCost for ActionDutchAuctionSchedule {
     fn gas_cost(&self) -> Gas {
-        dutch_auction_schedule_gas_cost()
+        dutch_auction_schedule_gas_cost(&self)
     }
 }
 

--- a/crates/core/transaction/src/gas.rs
+++ b/crates/core/transaction/src/gas.rs
@@ -239,7 +239,9 @@ fn position_withdraw_gas_cost() -> Gas {
         compact_block_space: 0,
         // Does not include a zk-SNARK proof, so there's no verification cost.
         verification: 0,
-        // Execution cost is currently hardcoded at 10 for all Action variants.
+        // Execution cost is currently hardcoded at 10 for all `Action`` variants.
+        // Reminder: Any change to this execution gas vector must also be reflected 
+        // in updates to the dutch auction gas vectors.
         execution: 10,
     }
 }
@@ -254,19 +256,15 @@ fn dutch_auction_schedule_gas_cost(dutch_action_schedule: &ActionDutchAuctionSch
         // uint64 `end_height` = 8 bytes
         // uint64 `step_count` = 8 bytes
         // bytes `nonce` = 32 bytes
-
-        // TODO: Multidimentional fees will enable gas fees to dynamically be based on both `block_space`
-        // and `execution`, where execution cost is roughly proportional to computational cost,
-        // while block space is proportional to the space the action takes up in a block.
-        // We can therefore separately price the resource of “work performed during execution”
-        // and “bandwidth between nodes”.
-        //
-        // Currently we make the execution cost for DA actions proportional to the number of steps
-        // and costs of position open/close in dutch action.
-        block_space: 168, // 168 bytes
+        
+        // TODO(erwan): sanity check if this block space fee calculation is correct -- more dex context needed. 
+        block_space: 168 * dutch_action_schedule.description.step_count, // (168 * step_count) bytes
         compact_block_space: 0,
         verification: 50,
-        execution: 2 * dutch_action_schedule.description.step_count * 20,
+        // Currently, we make the execution cost for DA actions proportional to the number of steps
+        // and costs of position open/close in dutch action. The gas cost is calculated by:
+        // 2 * step_count * (`PositionOpen`` + `PositionClose` cost).
+        execution: 2 * dutch_action_schedule.description.step_count * (10 + 10),
     }
 }
 
@@ -513,6 +511,8 @@ impl GasCost for PositionOpen {
             // There are some small validations performed so a token amount of gas is charged.
             verification: 50,
             // Execution cost is currently hardcoded at 10 for all Action variants.
+            // Reminder: Any change to this execution gas vector must also be reflected 
+            // in updates to the dutch auction gas vectors.
             execution: 10,
         }
     }
@@ -530,6 +530,8 @@ impl GasCost for PositionClose {
             // Does not include a zk-SNARK proof, so there's no verification cost.
             verification: 0,
             // Execution cost is currently hardcoded at 10 for all Action variants.
+            // Reminder: Any change to this execution gas vector must also be reflected 
+            // in updates to the dutch auction gas vectors.
             execution: 10,
         }
     }

--- a/crates/core/transaction/src/gas.rs
+++ b/crates/core/transaction/src/gas.rs
@@ -1,3 +1,4 @@
+use penumbra_auction::auction::dutch::actions::{ActionDutchAuctionEnd, ActionDutchAuctionSchedule, ActionDutchAuctionWithdraw};
 use penumbra_community_pool::{CommunityPoolDeposit, CommunityPoolOutput, CommunityPoolSpend};
 use penumbra_dex::{PositionClose, PositionOpen, PositionWithdraw, Swap, SwapClaim};
 use penumbra_fee::Gas;
@@ -231,6 +232,18 @@ fn position_withdraw_gas_cost() -> Gas {
     }
 }
 
+fn dutch_auction_schedule_gas_cost() -> Gas {
+    Gas { block_space: todo!(), compact_block_space: todo!(), verification: todo!(), execution: todo!() }
+}
+
+fn dutch_auction_end_gas_cost() -> Gas {
+    Gas { block_space: todo!(), compact_block_space: todo!(), verification: todo!(), execution: todo!() }
+}
+
+fn dutch_auction_withdraw_gas_cost() -> Gas {
+    Gas { block_space: todo!(), compact_block_space: todo!(), verification: todo!(), execution: todo!() }
+}
+
 impl GasCost for Transaction {
     fn gas_cost(&self) -> Gas {
         self.actions().map(GasCost::gas_cost).sum()
@@ -264,6 +277,9 @@ impl GasCost for ActionPlan {
             ActionPlan::SwapClaim(_) => swap_claim_gas_cost(),
             ActionPlan::DelegatorVote(_) => delegator_vote_gas_cost(),
             ActionPlan::PositionWithdraw(_) => position_withdraw_gas_cost(),
+            ActionPlan::ActionDutchAuctionSchedule(_) => dutch_auction_schedule_gas_cost(),
+            ActionPlan::ActionDutchAuctionEnd(_) => dutch_auction_end_gas_cost(),
+            ActionPlan::ActionDutchAuctionWithdraw(_) => dutch_auction_withdraw_gas_cost(),
 
             ActionPlan::Delegate(d) => d.gas_cost(),
             ActionPlan::Undelegate(u) => u.gas_cost(),
@@ -307,6 +323,9 @@ impl GasCost for Action {
             Action::CommunityPoolOutput(output) => output.gas_cost(),
             Action::IbcRelay(x) => x.gas_cost(),
             Action::ValidatorDefinition(x) => x.gas_cost(),
+            Action::ActionDutchAuctionSchedule(action_dutch_auction_schedule) => action_dutch_auction_schedule.gas_cost(),
+            Action::ActionDutchAuctionEnd(action_dutch_auction_end) => action_dutch_auction_end.gas_cost(),
+            Action::ActionDutchAuctionWithdraw(action_dutch_auction_withdraw) => action_dutch_auction_withdraw.gas_cost(),
         }
     }
 }
@@ -558,5 +577,24 @@ impl GasCost for IbcRelay {
 impl GasCost for ValidatorDefinition {
     fn gas_cost(&self) -> Gas {
         validator_definition_gas_cost(&self)
+    }
+}
+
+impl GasCost for ActionDutchAuctionSchedule {
+    fn gas_cost(&self) -> Gas {
+        dutch_auction_schedule_gas_cost()
+    }
+}
+
+impl GasCost for ActionDutchAuctionEnd {
+    fn gas_cost(&self) -> Gas {
+        dutch_auction_end_gas_cost()
+    }
+}
+
+
+impl GasCost for ActionDutchAuctionWithdraw {
+    fn gas_cost(&self) -> Gas {
+        dutch_auction_withdraw_gas_cost()
     }
 }

--- a/crates/core/transaction/src/gas.rs
+++ b/crates/core/transaction/src/gas.rs
@@ -256,9 +256,7 @@ fn dutch_auction_schedule_gas_cost(dutch_action_schedule: &ActionDutchAuctionSch
         // uint64 `end_height` = 8 bytes
         // uint64 `step_count` = 8 bytes
         // bytes `nonce` = 32 bytes
-
-        // TODO(erwan): sanity check if this block space fee calculation is correct -- more dex context needed.
-        block_space: 168 * dutch_action_schedule.description.step_count, // (168 * step_count) bytes
+        block_space: 168,
         compact_block_space: 0,
         verification: 50,
         // Currently, we make the execution cost for DA actions proportional to the number of steps

--- a/crates/core/transaction/src/gas.rs
+++ b/crates/core/transaction/src/gas.rs
@@ -240,7 +240,7 @@ fn position_withdraw_gas_cost() -> Gas {
         // Does not include a zk-SNARK proof, so there's no verification cost.
         verification: 0,
         // Execution cost is currently hardcoded at 10 for all `Action`` variants.
-        // Reminder: Any change to this execution gas vector must also be reflected 
+        // Reminder: Any change to this execution gas vector must also be reflected
         // in updates to the dutch auction gas vectors.
         execution: 10,
     }
@@ -256,8 +256,8 @@ fn dutch_auction_schedule_gas_cost(dutch_action_schedule: &ActionDutchAuctionSch
         // uint64 `end_height` = 8 bytes
         // uint64 `step_count` = 8 bytes
         // bytes `nonce` = 32 bytes
-        
-        // TODO(erwan): sanity check if this block space fee calculation is correct -- more dex context needed. 
+
+        // TODO(erwan): sanity check if this block space fee calculation is correct -- more dex context needed.
         block_space: 168 * dutch_action_schedule.description.step_count, // (168 * step_count) bytes
         compact_block_space: 0,
         verification: 50,
@@ -511,7 +511,7 @@ impl GasCost for PositionOpen {
             // There are some small validations performed so a token amount of gas is charged.
             verification: 50,
             // Execution cost is currently hardcoded at 10 for all Action variants.
-            // Reminder: Any change to this execution gas vector must also be reflected 
+            // Reminder: Any change to this execution gas vector must also be reflected
             // in updates to the dutch auction gas vectors.
             execution: 10,
         }
@@ -530,7 +530,7 @@ impl GasCost for PositionClose {
             // Does not include a zk-SNARK proof, so there's no verification cost.
             verification: 0,
             // Execution cost is currently hardcoded at 10 for all Action variants.
-            // Reminder: Any change to this execution gas vector must also be reflected 
+            // Reminder: Any change to this execution gas vector must also be reflected
             // in updates to the dutch auction gas vectors.
             execution: 10,
         }

--- a/crates/core/transaction/src/plan/action.rs
+++ b/crates/core/transaction/src/plan/action.rs
@@ -4,6 +4,9 @@ use anyhow::{anyhow, Context, Result};
 use ark_ff::Zero;
 use decaf377::Fr;
 use penumbra_asset::Balance;
+use penumbra_auction::auction::dutch::actions::ActionDutchAuctionEnd;
+use penumbra_auction::auction::dutch::actions::ActionDutchAuctionSchedule;
+use penumbra_auction::auction::dutch::actions::ActionDutchAuctionWithdraw;
 use penumbra_community_pool::{CommunityPoolDeposit, CommunityPoolOutput, CommunityPoolSpend};
 use penumbra_txhash::{EffectHash, EffectingData};
 
@@ -75,6 +78,10 @@ pub enum ActionPlan {
     CommunityPoolDeposit(CommunityPoolDeposit),
 
     Ics20Withdrawal(Ics20Withdrawal),
+
+    ActionDutchAuctionSchedule(ActionDutchAuctionSchedule),
+    ActionDutchAuctionEnd(ActionDutchAuctionEnd),
+    ActionDutchAuctionWithdraw(ActionDutchAuctionWithdraw),
 }
 
 impl ActionPlan {
@@ -152,8 +159,11 @@ impl ActionPlan {
             CommunityPoolSpend(plan) => Action::CommunityPoolSpend(plan.clone()),
             CommunityPoolOutput(plan) => Action::CommunityPoolOutput(plan.clone()),
             CommunityPoolDeposit(plan) => Action::CommunityPoolDeposit(plan.clone()),
-            // Fixme: action name
             Ics20Withdrawal(plan) => Action::Ics20Withdrawal(plan.clone()),
+            // TODO: fill in skeleton
+            ActionDutchAuctionSchedule(_) => todo!(),
+            ActionDutchAuctionEnd(_) => todo!(),
+            ActionDutchAuctionWithdraw(_) => todo!(),
         })
     }
 
@@ -181,6 +191,10 @@ impl ActionPlan {
             Ics20Withdrawal(withdrawal) => withdrawal.balance(),
             // None of these contribute to transaction balance:
             IbcAction(_) | ValidatorDefinition(_) | ValidatorVote(_) => Balance::default(),
+            // TODO: fill in skeleton
+            ActionDutchAuctionSchedule(_) => todo!(),
+            ActionDutchAuctionEnd(_) => todo!(),
+            ActionDutchAuctionWithdraw(_) => todo!(),
         }
     }
 
@@ -209,6 +223,10 @@ impl ActionPlan {
             CommunityPoolOutput(_) => Fr::zero(),
             CommunityPoolDeposit(_) => Fr::zero(),
             Ics20Withdrawal(_) => Fr::zero(),
+            // TODO: fill in skeleton
+            ActionDutchAuctionSchedule(_) => todo!(),
+            ActionDutchAuctionEnd(_) => todo!(),
+            ActionDutchAuctionWithdraw(_) => todo!(),
         }
     }
 
@@ -238,6 +256,10 @@ impl ActionPlan {
             CommunityPoolOutput(plan) => plan.effect_hash(),
             CommunityPoolDeposit(plan) => plan.effect_hash(),
             Ics20Withdrawal(plan) => plan.effect_hash(),
+            // TODO: fill in skeleton
+            ActionDutchAuctionSchedule(_) => todo!(),
+            ActionDutchAuctionEnd(_) => todo!(),
+            ActionDutchAuctionWithdraw(_) => todo!(),
         }
     }
 }
@@ -418,6 +440,10 @@ impl From<ActionPlan> for pb_t::ActionPlan {
             ActionPlan::Ics20Withdrawal(inner) => pb_t::ActionPlan {
                 action: Some(pb_t::action_plan::Action::Ics20Withdrawal(inner.into())),
             },
+            // TODO: fill in skeleton
+            ActionPlan::ActionDutchAuctionSchedule(_) => todo!(),
+            ActionPlan::ActionDutchAuctionEnd(_) => todo!(),
+            ActionPlan::ActionDutchAuctionWithdraw(_) => todo!(),
         }
     }
 }

--- a/crates/core/transaction/src/transaction.rs
+++ b/crates/core/transaction/src/transaction.rs
@@ -258,6 +258,9 @@ impl Transaction {
                 | Action::CommunityPoolSpend(_)
                 | Action::CommunityPoolOutput(_)
                 | Action::CommunityPoolDeposit(_) => {}
+                | Action::ActionDutchAuctionSchedule(_) => {}
+                | Action::ActionDutchAuctionEnd(_) => {}
+                | Action::ActionDutchAuctionWithdraw(_) => {}
             }
         }
 

--- a/crates/core/transaction/src/transaction.rs
+++ b/crates/core/transaction/src/transaction.rs
@@ -258,9 +258,9 @@ impl Transaction {
                 | Action::CommunityPoolSpend(_)
                 | Action::CommunityPoolOutput(_)
                 | Action::CommunityPoolDeposit(_) => {}
-                | Action::ActionDutchAuctionSchedule(_) => {}
-                | Action::ActionDutchAuctionEnd(_) => {}
-                | Action::ActionDutchAuctionWithdraw(_) => {}
+                Action::ActionDutchAuctionSchedule(_) => {}
+                Action::ActionDutchAuctionEnd(_) => {}
+                Action::ActionDutchAuctionWithdraw(_) => {}
             }
         }
 


### PR DESCRIPTION
## Describe your changes
Add `GasCost` vectors for DA actions, add`Action` / `ActionPlan` skeletons, and make gas fee costs consistent with protobuf encodings (https://github.com/penumbra-zone/penumbra/issues/3940)

## Issue ticket number and link
References #4212

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:
