### PR TITLE
dex(base_liq): add `async_trait` to `BaseLiquidityIndex`

### DIFF
--- a/crates/core/component/dex/src/component/position_manager/base_liquidity_index.rs
+++ b/crates/core/component/dex/src/component/position_manager/base_liquidity_index.rs
@@ -6,8 +6,10 @@ use position::State::*;
 use crate::lp::position::{self, Position};
 use crate::state_key::engine;
 use crate::DirectedTradingPair;
+use async_trait::async_trait;
 use penumbra_proto::{StateReadProto, StateWriteProto};
 
+#[async_trait]
 pub(crate) trait AssetByLiquidityIndex: StateWrite {
     /// Update the base liquidity index, used by the DEX engine during path search.
     ///


### PR DESCRIPTION
## Describe your changes

This slipped when doing #4188. I'm not completely sure yet why CI didn't catch this. 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Internal
