### PR TITLE
build: bump msrv 1.73 -> 1.75

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install Rust
-        run: rustup update "1.73" --no-self-update && rustup default "1.73"
+        run: rustup update "1.75" --no-self-update && rustup default "1.75"
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.5.0/cargo-dist-installer.sh | sh"
       - id: plan
@@ -111,7 +111,7 @@ jobs:
         with:
           lfs: true
       - name: Install Rust
-        run: rustup update "1.73" --no-self-update && rustup default "1.73"
+        run: rustup update "1.75" --no-self-update && rustup default "1.75"
       - uses: swatinem/rust-cache@v2
       - name: Install cargo-dist
         run: ${{ matrix.install_dist }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ members = [
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.5.0"
 # The preferred Rust toolchain to use in CI (rustup toolchain syntax)
-rust-toolchain-version = "1.73"
+rust-toolchain-version = "1.75"
 # CI backends to support
 ci = ["github"]
 # Target platforms to build apps for (Rust target-triple syntax)

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -8,7 +8,7 @@ repository = {workspace = true}
 homepage = {workspace = true}
 license = {workspace = true}
 publish = false
-rust-version = "1.73"
+rust-version = "1.75"
 
 [package.metadata.dist]
 dist = true

--- a/deployments/containerfiles/Dockerfile
+++ b/deployments/containerfiles/Dockerfile
@@ -1,5 +1,5 @@
 # N.B. the RUST_VERSION should match MSRV in crates/bin/pd/Cargo.toml
-ARG RUST_VERSION=1.73.0
+ARG RUST_VERSION=1.75.0
 FROM docker.io/rust:${RUST_VERSION}-slim-bookworm AS build-env
 
 # Install build dependencies. These packages should match what's recommended on

--- a/docs/guide/src/dev/build.md
+++ b/docs/guide/src/dev/build.md
@@ -7,12 +7,12 @@ consider using [WSL] instead.
 
 ### Installing the Rust toolchain
 
-This requires that you install a recent (>= 1.73) stable version
+This requires that you install a recent (>= 1.75) stable version
 of the Rust compiler, installation instructions for which you can find
 [here](https://www.rust-lang.org/learn/get-started). Don't forget to reload your shell so that
 `cargo` is available in your `$PATH`!
 
-You can verify the rust compiler version by running `rustc --version` which should indicate version 1.73 or later.
+You can verify the rust compiler version by running `rustc --version` which should indicate version 1.75 or later.
 
 ### Installing build prerequisites
 


### PR DESCRIPTION


## Describe your changes
Use of async fns in traits was stabilized in Rust 1.75 [0], git-bisect showed that [1] began breaking container builds, where we pin an explicit version of rust.

We recently added a `rust-toolchain.toml`; perhaps we should hard-code a specific version of rust there, to avoid surprises. Not doing that now.

[0] https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html
[1] c8c980da4b922ce2914cd5237b2debeef156c0c0
## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > No source code changes, only CI and build logic.
