### PR TITLE
docs: add a few redirects

### DIFF
--- a/docs/guide/book.toml
+++ b/docs/guide/book.toml
@@ -27,3 +27,17 @@ warning-policy = "error"
 # The buf.build website doesn't support HTTP HEAD calls, returning 405.
 # Only relevant when `follow-web-links=true`.
 exclude = ['buf\.build']
+
+[output.html.redirect]
+# Renames in GH4215.
+"pd.html" = "node/pd.html"
+"pd/chain-upgrade.html" = "node/pd/chain-upgrade.html"
+"pd/debugging.html" = "node/pd/debugging.html"
+"pd/install.html" = "node/pd/install.html"
+"pd/join-testnet.html" = "node/pd/join-testnet.html"
+"pd/requirements.html" = "node/pd/requirements.html"
+"pd/validator.html" = "node/pd/validator.html"
+"pclientd.html" = "node/pclientd.html"
+"pclientd/build_transaction.html" = "node/pclientd/build_transaction.html"
+"pclientd/configure.html" = "node/pclientd/configure.html"
+"pclientd/rpc.html" = "node/pclientd/rpc.html"


### PR DESCRIPTION


## Describe your changes

Follow-up to #4215, in which we reorganized the guide for readability. Some of the existing content got shuffled into subroutes, and already one person in Discord has pointed out that we broken URLs. Tacking on some http redirects via mdbook [0].

[0] https://rust-lang.github.io/mdBook/format/configuration/renderers.html#outputhtmlredirect
## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > docs-only, no code changes.
