### PR TITLE
pcli: fix terminal input in pcli threshold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3669,6 +3669,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4107,6 +4118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4405,6 +4422,7 @@ dependencies = [
  "simple-base64",
  "tempfile",
  "tendermint",
+ "termion",
  "time 0.3.34",
  "tokio",
  "tokio-stream",
@@ -6554,13 +6572,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
+
+[[package]]
 name = "redox_users"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom 0.2.12",
- "libredox",
+ "libredox 0.0.1",
  "thiserror",
 ]
 
@@ -7873,6 +7897,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termion"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417813675a504dfbbf21bfde32c03e5bf9f2413999962b479023c02848c1c7a5"
+dependencies = [
+ "libc",
+ "libredox 0.0.2",
+ "numtoa",
+ "redox_termios",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,7 @@ tendermint-config                = { version = "0.34.0" }
 tendermint-light-client-verifier = { version = "0.34.0" }
 tendermint-proto                 = { version = "0.34.0" }
 tendermint-rpc                   = { version = "0.34.0" }
+termion                          = { version = "3" }
 thiserror                        = { version = "1.0" }
 tokio                            = { version = "1.3" }
 tokio-stream                     = { version = "0.1.8" }

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -97,6 +97,7 @@ tokio-util = {workspace = true}
 toml = {workspace = true, features = ["preserve_order"]}
 tonic = {workspace = true, features = ["tls-webpki-roots", "tls"]}
 tower = {workspace = true, features = ["full"]}
+termion = {workspace = true}
 tracing = {workspace = true}
 tracing-subscriber = {workspace = true, features = ["env-filter", "ansi"]}
 url = {workspace = true, features = ["serde"]}

--- a/crates/bin/pcli/src/terminal.rs
+++ b/crates/bin/pcli/src/terminal.rs
@@ -1,6 +1,7 @@
+use std::io::{Read, Write};
+
 use anyhow::Result;
 use penumbra_custody::threshold::{SigningRequest, Terminal};
-use tokio::io::{self, AsyncBufReadExt};
 use tonic::async_trait;
 
 /// For threshold custody, we need to implement this weird terminal abstraction.
@@ -40,11 +41,37 @@ impl Terminal for ActualTerminal {
     }
 
     async fn next_response(&self) -> Result<Option<String>> {
-        let stdin = io::stdin();
-        let mut stdin = io::BufReader::new(stdin);
+        // Use raw mode to allow reading more than 1KB/4KB of data at a time
+        // See https://unix.stackexchange.com/questions/204815/terminal-does-not-accept-pasted-or-typed-lines-of-more-than-1024-characters
+        use termion::raw::IntoRawMode;
+        tracing::debug!("about to enter raw mode for long pasted input");
 
-        let mut line = String::new();
-        stdin.read_line(&mut line).await?;
+        // In raw mode, the input is not mirrored into the terminal, so we need
+        // to read char-by-char and echo it back.
+        let mut stdout = std::io::stdout().into_raw_mode()?;
+
+        let mut bytes = Vec::with_capacity(8192);
+        for b in std::io::stdin().bytes() {
+            let b = b?;
+            // In raw mode, the enter key might generate \r or \n, check either.
+            if b == b'\n' || b == b'\r' {
+                break;
+            }
+            bytes.push(b);
+            stdout.write(&[b]).unwrap();
+            // Flushing may not be the most efficient but performance isn't critical here.
+            stdout.flush()?;
+        }
+        // Drop _stdout to restore the terminal to normal mode
+        std::mem::drop(stdout);
+        // We consumed a newline of some kind but didn't echo it, now print
+        // one out so subsequent output is guaranteed to be on a new line.
+        println!("");
+
+        tracing::debug!("exited raw mode and returned to cooked mode");
+
+        let line = String::from_utf8(bytes)?;
+        tracing::debug!(?line, "read response line");
 
         if line.is_empty() {
             return Ok(None);


### PR DESCRIPTION


## Describe your changes

When reading input from the terminal in `pcli threshold` commands, circumvent OS-imposed restrictions on line length (required for interactive editing and notably low on MacOS) by dropping into "raw mode", reading the input a byte at a time and manually printing out the read byte to the user, then return to "cooked mode" (yes, that's what it's called) after detecting `\n` or `\r`.

## Issue ticket number and link

Closes #4230, which I confirmed through my own testing.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > only changes to `pcli` terminal handling
