### PR TITLE
feat(app): 🎋 add missing `Sct` component hooks

### DIFF
--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -382,6 +382,7 @@ impl App {
 
         tracing::debug!("running app components' `end_block` hooks");
         let mut arc_state_tx = Arc::new(state_tx);
+        Sct::end_block(&mut arc_state_tx, end_block).await;
         ShieldedPool::end_block(&mut arc_state_tx, end_block).await;
         Distributions::end_block(&mut arc_state_tx, end_block).await;
         Ibc::end_block(&mut arc_state_tx, end_block).await;
@@ -485,6 +486,9 @@ impl App {
 
             let mut arc_state_tx = Arc::new(state_tx);
 
+            Sct::end_epoch(&mut arc_state_tx)
+                .await
+                .expect("able to call end_epoch on Sct component");
             Distributions::end_epoch(&mut arc_state_tx)
                 .await
                 .expect("able to call end_epoch on Distributions component");


### PR DESCRIPTION
fixes #3739.

the `App` only ever invokes the Sct component's `init_chain` and `begin_block` hooks.

this isn't currently a bug, since its `end_block` and `end_epoch` hooks are noöps, but could easily lead to a surprising outcome in the future, if more logic was introduced to those trait methods.

#### checklist before requesting a review

- [x] if this code contains consensus-breaking changes, i have added the "consensus-breaking" label. otherwise, i declare my belief that there are not consensus-breaking changes, for the following reason:

  > while this **does** change the control flow of consensus-critical logic, this does **not**
 change the execution of incoming data. the hooks introduced here are noöps.