### PR TITLE
feat(app): 🎣 add missing `Dex` component hook

### DIFF
--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -257,6 +257,7 @@ impl App {
             begin_block,
         )
         .await;
+        Dex::begin_block(&mut arc_state_tx, begin_block).await;
         CommunityPool::begin_block(&mut arc_state_tx, begin_block).await;
         Governance::begin_block(&mut arc_state_tx, begin_block).await;
         Staking::begin_block(&mut arc_state_tx, begin_block).await;


### PR DESCRIPTION
see #3739, and #4246.

while wiring up a pair of missing component hooks for the `Sct` component, i found another (noöp) hook that we do not include in the `App`'s control flow.

this isn't currently a bug, since `<Dex as Component>::begin_block()` is a noöps but could easily lead to a surprising outcome in the future, if more logic was introduced to that trait method.

#### checklist before requesting a review

- [x] if this code contains consensus-breaking changes, i have added the "consensus-breaking" label. otherwise, i declare my belief that there are not consensus-breaking changes, for the following reason:

  > while this **does** change the control flow of consensus-critical logic, this does **not**
 change the execution of incoming data. the hooks introduced here are noöps.
