### PR TITLE
feat(pd): add --gas-price-simple flag to generate

### DIFF
--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -172,6 +172,13 @@ pub enum TestnetCommand {
         /// can be voted on.
         #[clap(long)]
         proposal_voting_blocks: Option<u64>,
+        /// The fixed gas price for all transactions on the network.
+        /// Described as "simple" because the single value will be reused
+        /// for all gas price types: block space, compact block space, verification, and execution.
+        /// The numeric value is one-thousandths of the staking token,
+        /// so `--gas-price-simple=1000` means all transactions will have a cost of 1penumbra.
+        #[clap(long)]
+        gas_price_simple: Option<u64>,
         /// Base hostname for a validator's p2p service. If multiple validators
         /// exist in the genesis, e.g. via `--validators-input-file`, then
         /// numeric suffixes are automatically added, e.g. "-0", "-1", etc.

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -305,6 +305,7 @@ async fn main() -> anyhow::Result<()> {
                     allocations_input_file,
                     validators_input_file,
                     chain_id,
+                    gas_price_simple,
                     preserve_chain_id,
                     external_addresses,
                     proposal_voting_blocks,
@@ -364,6 +365,7 @@ async fn main() -> anyhow::Result<()> {
                 epoch_duration,
                 unbonding_delay,
                 proposal_voting_blocks,
+                gas_price_simple,
             )?;
             tracing::info!(
                 n_validators = t.validators.len(),

--- a/deployments/scripts/smoke-test.sh
+++ b/deployments/scripts/smoke-test.sh
@@ -48,7 +48,7 @@ cargo build --quiet --release --bin pd
 echo "Generating testnet config..."
 EPOCH_DURATION="${EPOCH_DURATION:-50}"
 UNBONDING_DELAY="${UNBONDING_DELAY:-50}"
-cargo run --quiet --release --bin pd -- testnet generate --unbonding-delay "$UNBONDING_DELAY" --epoch-duration "$EPOCH_DURATION" --timeout-commit 500ms
+cargo run --quiet --release --bin pd -- testnet generate --unbonding-delay "$UNBONDING_DELAY" --epoch-duration "$EPOCH_DURATION" --timeout-commit 500ms --gas-price-simple 5
 
 echo "Starting CometBFT..."
 cometbft start --log_level=error --home "${HOME}/.penumbra/testnet_data/node0/cometbft" > "${SMOKE_LOG_DIR}/comet.log" &


### PR DESCRIPTION
## Describe your changes

Adds a new CLI flag for `pd testnet generate`, to opt in to non-zero gas
prices. It's a bit of a shortcut to reuse the same numeric value across
all of them, but we can always add more CLI flags later to finetune.

Closes https://github.com/penumbra-zone/penumbra/issues/4154.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Adds opt-in behavior, and modifies CI runs, but does not touch application code.
  
## Testing/review

The simplest way to validate the new behavior here is:

0. check out this feature branch
1. `cargo run --bin pd -- testnet generate --gas-price-simple 5`
2. start cometbft/pd to serve the local devnet
3. configure pcli to use http://locahost:8080 as grpc_addr
4. run `pcli --home <path> view balance` and confirm you have multiple denoms
5. run `pcli --home <path> tx send --to <different_addr_in_same_wallet> 1test_usd`
6. run `pcli --home <path> view balance` and confirm that 1) the sent denom moved; and 2) a wee bit of penumbra was burned to pay the fee. 