### PR TITLE
staking: 🥞 `get_validator_info()` uses consensus set

### DIFF
--- a/crates/core/app/tests/app_can_define_and_delegate_to_a_validator.rs
+++ b/crates/core/app/tests/app_can_define_and_delegate_to_a_validator.rs
@@ -1,5 +1,5 @@
 use {
-    self::common::{BuilderExt, TestNodeExt},
+    self::common::{BuilderExt, TestNodeExt, ValidatorDataReadExt},
     anyhow::anyhow,
     cnidarium::TempStorage,
     decaf377_rdsa::{SigningKey, SpendAuth, VerificationKey},

--- a/crates/core/app/tests/app_can_disable_community_pool_spends.rs
+++ b/crates/core/app/tests/app_can_disable_community_pool_spends.rs
@@ -1,4 +1,5 @@
 use {
+    self::common::ValidatorDataReadExt,
     anyhow::anyhow,
     cnidarium::TempStorage,
     decaf377_rdsa::VerificationKey,
@@ -26,7 +27,7 @@ use {
         DomainType,
     },
     penumbra_shielded_pool::{genesis::Allocation, OutputPlan, SpendPlan},
-    penumbra_stake::{component::validator_handler::ValidatorDataRead, DelegationToken},
+    penumbra_stake::DelegationToken,
     penumbra_transaction::{
         memo::MemoPlaintext, plan::MemoPlan, ActionPlan, TransactionParameters, TransactionPlan,
     },

--- a/crates/core/app/tests/app_can_propose_community_pool_spends.rs
+++ b/crates/core/app/tests/app_can_propose_community_pool_spends.rs
@@ -1,4 +1,5 @@
 use {
+    self::common::ValidatorDataReadExt,
     anyhow::anyhow,
     cnidarium::TempStorage,
     decaf377_rdsa::VerificationKey,
@@ -26,7 +27,7 @@ use {
         DomainType,
     },
     penumbra_shielded_pool::{genesis::Allocation, OutputPlan, SpendPlan},
-    penumbra_stake::{component::validator_handler::ValidatorDataRead, DelegationToken},
+    penumbra_stake::DelegationToken,
     penumbra_transaction::{
         memo::MemoPlaintext, plan::MemoPlan, ActionPlan, TransactionParameters, TransactionPlan,
     },

--- a/crates/core/app/tests/app_can_undelegate_from_a_validator.rs
+++ b/crates/core/app/tests/app_can_undelegate_from_a_validator.rs
@@ -1,5 +1,5 @@
 use {
-    self::common::{BuilderExt, TestNodeExt},
+    self::common::{BuilderExt, TestNodeExt, ValidatorDataReadExt},
     anyhow::anyhow,
     ark_ff::UniformRand,
     cnidarium::TempStorage,

--- a/crates/core/app/tests/app_rejects_validator_definitions_with_invalid_auth_sigs.rs
+++ b/crates/core/app/tests/app_rejects_validator_definitions_with_invalid_auth_sigs.rs
@@ -1,5 +1,5 @@
 use {
-    self::common::BuilderExt,
+    self::common::{BuilderExt, ValidatorDataReadExt},
     cnidarium::TempStorage,
     decaf377_rdsa::{SigningKey, SpendAuth, VerificationKey},
     penumbra_app::{genesis::AppState, server::consensus::Consensus},
@@ -7,10 +7,7 @@ use {
     penumbra_mock_client::MockClient,
     penumbra_mock_consensus::TestNode,
     penumbra_proto::DomainType,
-    penumbra_stake::{
-        component::validator_handler::ValidatorDataRead as _, validator::Validator, FundingStreams,
-        GovernanceKey, IdentityKey,
-    },
+    penumbra_stake::{validator::Validator, FundingStreams, GovernanceKey, IdentityKey},
     rand_core::OsRng,
     tap::Tap,
     tracing::{error_span, info, Instrument},

--- a/crates/core/app/tests/app_tracks_uptime_for_genesis_validator_missing_blocks.rs
+++ b/crates/core/app/tests/app_tracks_uptime_for_genesis_validator_missing_blocks.rs
@@ -1,7 +1,5 @@
-mod common;
-
 use {
-    self::common::BuilderExt,
+    self::common::{BuilderExt, ValidatorDataReadExt},
     anyhow::Context,
     cnidarium::TempStorage,
     penumbra_app::{genesis::AppState, server::consensus::Consensus},
@@ -10,6 +8,8 @@ use {
     tap::Tap,
     tracing::{error_span, trace, Instrument},
 };
+
+mod common;
 
 #[tokio::test]
 async fn app_tracks_uptime_for_genesis_validator_missing_blocks() -> anyhow::Result<()> {

--- a/crates/core/app/tests/app_tracks_uptime_for_genesis_validator_signing_blocks.rs
+++ b/crates/core/app/tests/app_tracks_uptime_for_genesis_validator_signing_blocks.rs
@@ -1,5 +1,5 @@
 use {
-    self::common::BuilderExt,
+    self::common::{BuilderExt, ValidatorDataReadExt},
     anyhow::Context,
     cnidarium::TempStorage,
     penumbra_app::{genesis::AppState, server::consensus::Consensus},

--- a/crates/core/app/tests/app_tracks_uptime_for_validators_only_once_active.rs
+++ b/crates/core/app/tests/app_tracks_uptime_for_validators_only_once_active.rs
@@ -1,5 +1,5 @@
 use {
-    self::common::{BuilderExt, TestNodeExt},
+    self::common::{BuilderExt, TestNodeExt, ValidatorDataReadExt},
     cnidarium::TempStorage,
     decaf377_rdsa::{SigningKey, SpendAuth, VerificationKey},
     penumbra_app::{

--- a/crates/core/app/tests/common/mod.rs
+++ b/crates/core/app/tests/common/mod.rs
@@ -5,7 +5,7 @@
 pub use {
     self::{
         temp_storage_ext::TempStorageExt, test_node_builder_ext::BuilderExt,
-        test_node_ext::TestNodeExt,
+        test_node_ext::TestNodeExt, validator_read_ext::ValidatorDataReadExt,
     },
     penumbra_test_subscriber::set_tracing_subscriber,
 };
@@ -22,3 +22,9 @@ mod temp_storage_ext;
 ///
 /// See [`TestNodeExt`].
 mod test_node_ext;
+
+/// Helpful additions for reading validator information.
+///
+/// See [`ValidatorDataRead`][penumbra_stake::component::validator_handler::ValidatorDataRead],
+/// and [`ValidatorDataReadExt`].
+mod validator_read_ext;

--- a/crates/core/app/tests/common/validator_read_ext.rs
+++ b/crates/core/app/tests/common/validator_read_ext.rs
@@ -1,0 +1,39 @@
+use {
+    async_trait::async_trait,
+    futures::TryStreamExt,
+    penumbra_proto::StateReadProto,
+    penumbra_stake::{
+        component::validator_handler::ValidatorDataRead, state_key, validator::Validator,
+        IdentityKey,
+    },
+};
+
+/// All [`ValidatorDataRead`]s implement [`ValidatorDataReadExt`].
+impl<T: ValidatorDataRead + ?Sized> ValidatorDataReadExt for T {}
+
+/// Additional extensions to [`ValidatorDataRead`] for use in test cases.
+#[async_trait]
+pub trait ValidatorDataReadExt: ValidatorDataRead {
+    /// Returns a list of **all** known validators' metadata.
+    ///
+    /// This is not included in [`ValidatorDataRead`] because it is liable to become expensive
+    /// over time as more validators are defined. This should only be used in test cases.
+    async fn validator_definitions(&self) -> anyhow::Result<Vec<Validator>> {
+        self.prefix(state_key::validators::definitions::prefix())
+            .map_ok(|(_key, validator)| validator)
+            .try_collect()
+            .await
+    }
+
+    /// Returns a list of **all** known validators' identity keys.
+    ///
+    /// This is not included in [`ValidatorDataRead`] because it is liable to become expensive
+    /// over time as more validators are defined. This should only be used in test cases.
+    async fn validator_identity_keys(&self) -> anyhow::Result<Vec<IdentityKey>> {
+        self.prefix(state_key::validators::definitions::prefix())
+            .map_ok(|(_key, validator)| validator)
+            .map_ok(|validator: Validator| validator.identity_key)
+            .try_collect()
+            .await
+    }
+}

--- a/crates/core/app/tests/mock_consensus_can_define_a_genesis_validator.rs
+++ b/crates/core/app/tests/mock_consensus_can_define_a_genesis_validator.rs
@@ -1,5 +1,5 @@
 use {
-    self::common::BuilderExt,
+    self::common::{BuilderExt, ValidatorDataReadExt},
     anyhow::anyhow,
     cnidarium::TempStorage,
     penumbra_app::{genesis::AppState, server::consensus::Consensus},

--- a/crates/core/component/stake/src/component/rpc.rs
+++ b/crates/core/component/stake/src/component/rpc.rs
@@ -1,8 +1,7 @@
 use std::pin::Pin;
 
-use async_stream::try_stream;
 use cnidarium::Storage;
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use penumbra_proto::{
     core::component::stake::v1::{
         query_service_server::QueryService, CurrentValidatorRateRequest,
@@ -13,10 +12,10 @@ use penumbra_proto::{
     DomainType,
 };
 use tonic::Status;
-use tracing::instrument;
+use tracing::{error_span, instrument, Instrument, Span};
 
-use super::{validator_handler::ValidatorDataRead, SlashingData};
-use crate::validator;
+use super::{validator_handler::ValidatorDataRead, ConsensusIndexRead, SlashingData};
+use crate::validator::{Info, State};
 
 // TODO: Hide this and only expose a Router?
 pub struct Server {
@@ -39,38 +38,67 @@ impl QueryService for Server {
         &self,
         request: tonic::Request<ValidatorInfoRequest>,
     ) -> Result<tonic::Response<Self::ValidatorInfoStream>, Status> {
-        let state = self.storage.latest_snapshot();
+        use futures::TryStreamExt;
 
-        let validators = state
-            .validator_definitions() // TODO(erwan): think through a UX for defined validators. Then we can remove `validator_list` entirely.
-            .await
-            .map_err(|e| tonic::Status::unavailable(format!("error listing validators: {e}")))?;
+        // Get the latest snapshot from the backing storage, and determine whether or not the
+        // response should include inactive validator definitions.
+        let snapshot = self.storage.latest_snapshot();
+        let ValidatorInfoRequest { show_inactive } = request.into_inner();
 
-        let show_inactive = request.get_ref().show_inactive;
-        let s = try_stream! {
-            for v in validators {
-                let info = state.get_validator_info(&v.identity_key)
+        // Returns `true` if we should include a validator in the outbound response.
+        let filter_inactive = move |info: &Info| {
+            let should = match info.status.state {
+                State::Active => true,
+                _ if show_inactive => true, // Include other validators if the request asked us to.
+                _ => false,                 // Otherwise, skip this entry.
+            };
+            futures::future::ready(should)
+        };
+
+        // Converts information about a validator into a RPC response.
+        let to_resp = |info: Info| {
+            let validator_info = Some(info.to_proto());
+            ValidatorInfoResponse { validator_info }
+        };
+
+        // Creates a span that follows from the current tracing context.
+        let make_span = |identity_key| -> Span {
+            let span = error_span!("fetching validator information", %identity_key);
+            let current = Span::current();
+            span.follows_from(current);
+            span
+        };
+
+        // Get a stream of identity keys corresponding to validators in the consensus set.
+        let consensus_set = snapshot
+            .consensus_set_stream()
+            .map_err(|e| format!("error getting consensus set: {e}"))
+            .map_err(Status::unavailable)?;
+
+        // Adapt the stream of identity keys into a stream of validator information.
+        // Define a span indicating that the spawned future follows from the current context.
+        let validators = async_stream::try_stream! {
+            for await identity_key in consensus_set {
+                let identity_key = identity_key?;
+                let span = make_span(identity_key);
+                yield snapshot
+                    .get_validator_info(&identity_key)
+                    .instrument(span)
                     .await?
                     .expect("known validator must be present");
-                // Slashed and inactive validators are not shown by default.
-                if !show_inactive && info.status.state != validator::State::Active {
-                    continue;
-                }
-                yield info.to_proto();
             }
         };
 
-        Ok(tonic::Response::new(
-            s.map_ok(|info| ValidatorInfoResponse {
-                validator_info: Some(info),
-            })
-            .map_err(|e: anyhow::Error| {
-                tonic::Status::unavailable(format!("error getting validator info: {e}"))
-            })
-            // TODO: how do we instrument a Stream
-            //.instrument(Span::current())
-            .boxed(),
-        ))
+        // Construct the outbound response.
+        let stream = validators
+            .try_filter(filter_inactive)
+            .map_ok(to_resp)
+            .map_err(|e: anyhow::Error| format!("error getting validator info: {e}"))
+            .map_err(Status::unavailable)
+            .into_stream()
+            .boxed();
+
+        Ok(tonic::Response::new(stream))
     }
 
     #[instrument(skip(self, request))]

--- a/crates/core/component/stake/src/component/validator_handler/validator_store.rs
+++ b/crates/core/component/stake/src/component/validator_handler/validator_store.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::Result;
 use async_trait::async_trait;
 use cnidarium::{StateRead, StateWrite};
-use futures::{Future, FutureExt, TryStreamExt};
+use futures::{Future, FutureExt};
 use penumbra_num::Amount;
 use penumbra_proto::{state::future::DomainFuture, DomainType, StateReadProto, StateWriteProto};
 use std::pin::Pin;
@@ -226,23 +226,6 @@ pub trait ValidatorDataRead: StateRead {
         self.get(&state_key::validators::definitions::by_id(identity_key))
             .map_ok(|opt: Option<Validator>| opt.map(|v: Validator| v.consensus_key))
             .boxed()
-    }
-
-    /// Returns a list of **all** known validators metadata.
-    async fn validator_definitions(&self) -> Result<Vec<Validator>> {
-        self.prefix(state_key::validators::definitions::prefix())
-            .map_ok(|(_key, validator)| validator)
-            .try_collect()
-            .await
-    }
-
-    /// Returns a list of **all** known validators identity keys.
-    async fn validator_identity_keys(&self) -> Result<Vec<IdentityKey>> {
-        self.prefix(state_key::validators::definitions::prefix())
-            .map_ok(|(_key, validator)| validator)
-            .map_ok(|validator: Validator| validator.identity_key)
-            .try_collect()
-            .await
     }
 }
 


### PR DESCRIPTION
see #3846.

## :mag: changes

**NB:** this branch performs a refactor away from `validator_definitions()` and subsequently moves the definition of that method. this is done in distinct commits, which reviewers are encouraged to examine independently.

### staking: 🥞 `get_validator_info()` uses consensus set

> The staking component query service provides a ValidatorInfo RPC that returns
> the list of registered validators, optionally filtering Inactive validators.
>
> The way this method is implemented is by using an internal
> ValidatorDataRead::validator_definitions methods which returns every single
> definition ever submitted to the chain. This is problematic because this list
> will inevitably grow quite large, turning usage of a benign-looking method
> into an onerous source of I/O and expensive rendering.

this refactors the `validator_definitions()` method to only return validators
included within the consensus set. this will prevent the list returned from
becoming too large over time.

### app: 🧙 `ValidatorDataReadExt::validator_definitions()`

these methods are tremendously useful for tests, because they save us the
trouble of repeatedly hassling with a `Stream`. to discourage future use of
them in production code however, we can define these in a test-specific
extension.

this commit introduces `ValidatorDataReadExt`. `validator_identity_keys()` is
also moved, as it is subject to the same performance considerations.

#### checklist before requesting a review

- [x] if this code contains consensus-breaking changes, i have added the "consensus-breaking" label. otherwise, i declare my belief that there are not consensus-breaking changes, for the following reason:

  > this only changes the behavior of an RPC endpoint
