### PR TITLE
docs: update archive url for joining testnet

### DIFF
--- a/docs/guide/src/node/pd/join-testnet.md
+++ b/docs/guide/src/node/pd/join-testnet.md
@@ -41,7 +41,7 @@ docs to switch to the archive-url version:
 
 ```shell
 pd testnet join --external-address IP_ADDRESS:26656 --moniker MY_NODE_NAME \
-    --archive-url "https://snapshots.penumbra.zone/testnet/pd-migrated-state-70-71.tar.gz"
+    --archive-url "https://snapshots.penumbra.zone/testnet/pd-migrated-state-71-72.tar.gz"
 ```
 
 where `IP_ADDRESS` (like `1.2.3.4`) is the public IP address of the node you're running,


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

Refs #4239, #4271.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > docs-only

## Testing

Try to join the network by running the testnet join command in the docs. You must use `v0.72.0` in order for it to work, otherwise your local copy of pd won't be compatible. Then verify you can actually join the network and grab blocks.