### PR TITLE
ci: update cargo-dist 0.5.0 -> 0.13.3

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,0 @@
-[build]
-# Enable Tokio's `tracing` support for `tokio-console`
-# rustflags = ["--cfg", "tokio_unstable"]
-# Note(erwan): We decided to disable it for the time being,
-# I'm keeping this around to be able to reactivate it on a whim.

--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -54,9 +54,6 @@ jobs:
         with:
           lfs: true
 
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - uses: bufbuild/buf-setup-action@v1
         with:
           buf_api_token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -13,9 +13,9 @@ jobs:
         with:
           lfs: false
 
-      - name: Install rust toolchain
+      - name: Install nightly rust toolchain
         # The script for rustdoc build requires nightly toolchain.
-        uses: dtolnay/rust-toolchain@nightly
+        run: rustup toolchain install nightly
 
       # Loading cache takes ~15s, but saves us minutes of build.
       - name: Load rust cache
@@ -35,9 +35,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: false
-
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
 
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1

--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -17,8 +17,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        run: rustup toolchain install nightly
+
       - name: Load Rust caching
         uses: astriaorg/buildjet-rust-cache@v2.5.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2023, axodotdev
+# Copyright 2022-2024, axodotdev
 # SPDX-License-Identifier: MIT or Apache-2.0
 #
 # CI that:
@@ -6,10 +6,11 @@
 # * checks for a Git Tag that looks like a release
 # * builds artifacts with cargo-dist (archives, installers, hashes)
 # * uploads those artifacts to temporary workflow zip
-# * on success, uploads the artifacts to a Github Release™
+# * on success, uploads the artifacts to a GitHub Release
 #
-# Note that the Github Release™ will be created with a generated
+# Note that the GitHub Release will be created with a generated
 # title/body based on your changelogs.
+
 name: Release
 
 permissions:
@@ -21,28 +22,29 @@ permissions:
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
 # must be a Cargo-style SemVer Version (must have at least major.minor.patch).
 #
-# If PACKAGE_NAME is specified, then the release will be for that
+# If PACKAGE_NAME is specified, then the announcement will be for that
 # package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
 #
-# If PACKAGE_NAME isn't specified, then the release will be for all
+# If PACKAGE_NAME isn't specified, then the announcement will be for all
 # (cargo-dist-able) packages in the workspace with that version (this mode is
 # intended for workspaces with only one dist-able package, or with all dist-able
 # packages versioned/released in lockstep).
 #
 # If you push multiple tags at once, separate instances of this workflow will
-# spin up, creating an independent Github Release™ for each one. However Github
+# spin up, creating an independent announcement for each one. However, GitHub
 # will hard limit this to 3 tags per commit, as it will assume more tags is a
 # mistake.
 #
-# If there's a prerelease-style suffix to the version, then the Github Release™
+# If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
+  pull_request:
 
 jobs:
-  # Run 'cargo dist plan' to determine what tasks we need to do
+  # Run 'cargo dist plan' (or host) to determine what tasks we need to do
   plan:
     runs-on: ubuntu-latest
     outputs:
@@ -56,65 +58,72 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Install Rust
-        run: rustup update "1.75" --no-self-update && rustup default "1.75"
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.5.0/cargo-dist-installer.sh | sh"
+        # we specify bash to get pipefail; it guards against the `curl` command
+        # failing. otherwise `sh` won't catch that `curl` returned non-0
+        shell: bash
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.13.3/cargo-dist-installer.sh | sh"
+      # sure would be cool if github gave us proper conditionals...
+      # so here's a doubly-nested ternary-via-truthiness to try to provide the best possible
+      # functionality based on whether this is a pull_request, and whether it's from a fork.
+      # (PRs run on the *source* but secrets are usually on the *target* -- that's *good*
+      # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist plan ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }} --output-format=json > dist-manifest.json
-          echo "cargo dist plan ran successfully"
-          cat dist-manifest.json
-          echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          echo "cargo dist ran successfully"
+          cat plan-dist-manifest.json
+          echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
-          path: dist-manifest.json
+          name: artifacts-plan-dist-manifest
+          path: plan-dist-manifest.json
 
   # Build and packages all the platform-specific things
-  upload-local-artifacts:
+  build-local-artifacts:
+    name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
     # Let the initial task tell us to not run (currently very blunt)
-    needs: plan
-    if: ${{ fromJson(needs.plan.outputs.val).releases != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
+    needs:
+      - plan
+    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
     strategy:
       fail-fast: false
-      # We override the generated `matrix` so we can specify custom runners,
-      # for faster build times. This works for Linux & macOS. To generate the base template, run:
-      # `cargo dist plan --output-format json`. That JSON content has been adapted to YAML below.
-      # matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
-      matrix:
-        include:
-        - runner: buildjet-16vcpu-ubuntu-2204
-          dist_args: --artifacts=local --target=x86_64-unknown-linux-gnu
-          install_dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.5.0/cargo-dist-installer.sh | sh
-          targets:
-            - x86_64-unknown-linux-gnu
-        - runner: macos-12-xl
-          dist_args: --artifacts=local --target=aarch64-apple-darwin
-          install_dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.5.0/cargo-dist-installer.sh | sh
-          targets:
-            - aarch64-apple-darwin
-        - runner: macos-12-xl
-          dist_args: --artifacts=local --target=x86_64-apple-darwin
-          install_dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.5.0/cargo-dist-installer.sh | sh
-          targets:
-            - x86_64-apple-darwin
-
+      # Target platforms/runners are computed by cargo-dist in create-release.
+      # Each member of the matrix has the following arguments:
+      #
+      # - runner: the github runner
+      # - dist-args: cli flags to pass to cargo dist
+      # - install-dist: expression to run to install cargo-dist on the runner
+      #
+      # Typically there will be:
+      # - 1 "global" task that builds universal installers
+      # - N "local" tasks that build each platform's binaries and platform-specific installers
+      matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
-      RUSTFLAGS: "--cfg tokio_unstable"
     steps:
+      - name: enable windows longpaths
+        run: |
+          git config --global core.longpaths true
       - uses: actions/checkout@v4
         with:
+          submodules: recursive
           lfs: true
-      - name: Install Rust
-        run: rustup update "1.75" --no-self-update && rustup default "1.75"
       - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ join(matrix.targets, '-') }}
       - name: Install cargo-dist
         run: ${{ matrix.install_dist }}
+      # Get the dist-manifest
+      - name: Fetch local artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
       - name: Install dependencies
         run: |
           ${{ matrix.packages_install }}
@@ -130,54 +139,135 @@ jobs:
         # inconsistent syntax between shell and powershell.
         shell: bash
         run: |
-          # Parse out what we just built and upload it to the Github Release™
+          # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json >> "$GITHUB_OUTPUT"
+          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
 
-  should-publish:
+  # Build and package all the platform-agnostic(ish) things
+  build-global-artifacts:
     needs:
       - plan
-      - upload-local-artifacts
-    if: ${{ needs.plan.outputs.publishing == 'true' }}
-    runs-on: ubuntu-latest
+      - build-local-artifacts
+    runs-on: "ubuntu-20.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - name: print tag
-        run: echo "ok we're publishing!"
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          lfs: true
+      - name: Install cargo-dist
+        shell: bash
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.13.3/cargo-dist-installer.sh | sh"
+      # Get all the local artifacts for the global tasks to use (for e.g. checksums)
+      - name: Fetch local artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      - id: cargo-dist
+        shell: bash
+        run: |
+          cargo dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
+          echo "cargo dist ran successfully"
 
-  # Create a Github Release with all the results once everything is done
-  publish-release:
-    needs: [plan, should-publish]
-    runs-on: ubuntu-latest
+          # Parse out what we just built and upload it to scratch storage
+          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
+          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-build-global
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
+  # Determines if we should publish/announce
+  host:
+    needs:
+      - plan
+      - build-local-artifacts
+      - build-global-artifacts
+    # Only run if we're "publishing", and only if local and global didn't fail (skipped is fine)
+    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: "ubuntu-20.04"
+    outputs:
+      val: ${{ steps.host.outputs.manifest }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install cargo-dist
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.13.3/cargo-dist-installer.sh | sh"
+      # Fetch artifacts from scratch-storage
+      - name: Fetch artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      # This is a harmless no-op for GitHub Releases, hosting for that happens in "announce"
+      - id: host
+        shell: bash
+        run: |
+          cargo dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
+          echo "artifacts uploaded and released successfully"
+          cat dist-manifest.json
+          echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
+      - name: "Upload dist-manifest.json"
+        uses: actions/upload-artifact@v4
+        with:
+          # Overwrite the previous copy
+          name: artifacts-dist-manifest
+          path: dist-manifest.json
+
+  # Create a GitHub Release while uploading all files to it
+  announce:
+    needs:
+      - plan
+      - host
+    # use "always() && ..." to allow us to wait for all publish jobs while
+    # still allowing individual publish jobs to skip themselves (for prereleases).
+    # "host" however must run to completion, no skipping allowed!
+    if: ${{ always() && needs.host.result == 'success' }}
+    runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: "Download artifacts"
-        uses: actions/download-artifact@v3
+      - name: "Download GitHub Artifacts"
+        uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          pattern: artifacts-*
           path: artifacts
+          merge-multiple: true
       - name: Cleanup
         run: |
           # Remove the granular manifests
-          rm artifacts/*-dist-manifest.json
-      - name: Create Release
+          rm -f artifacts/*-dist-manifest.json
+      - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ needs.plan.outputs.tag }}
-          name: ${{ fromJson(needs.plan.outputs.val).announcement_title }}
-          body: ${{ fromJson(needs.plan.outputs.val).announcement_github_body }}
-          prerelease: ${{ fromJson(needs.plan.outputs.val).announcement_is_prerelease }}
+          name: ${{ fromJson(needs.host.outputs.val).announcement_title }}
+          body: ${{ fromJson(needs.host.outputs.val).announcement_github_body }}
+          prerelease: ${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}
           artifacts: "artifacts/*"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,10 +10,9 @@ jobs:
         with:
           lfs: true
 
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
+      # The `rust-toolchain.toml` file dictates which version of rust to setup.
+      - name: check rust version
+        run: rustc --version
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
@@ -24,9 +23,8 @@ jobs:
       - name: Run cargo check, failing on warnings
         run: cargo check --release --all-targets
         env:
-          # The `-D warnings` option causes an error on warnings;
-          # we must duplicate the rustflags from `.cargo/config.toml`.
-          RUSTFLAGS: "-D warnings --cfg tokio_unstable"
+          # The `-D warnings` option causes an error on warnings.
+          RUSTFLAGS: "-D warnings"
 
       - name: Check wasm compatibility
         run: ./deployments/scripts/check-wasm-compat.sh
@@ -55,10 +53,6 @@ jobs:
     runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
       - run: cargo fmt --all -- --check
@@ -68,8 +62,6 @@ jobs:
     runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
       - name: install cargo-hack

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           lfs: true
 
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
 

--- a/.github/workflows/summoner_smoke.yml
+++ b/.github/workflows/summoner_smoke.yml
@@ -20,9 +20,6 @@ jobs:
         with:
           lfs: true
 
-      - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,23 +58,26 @@ members = [
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.5.0"
-# The preferred Rust toolchain to use in CI (rustup toolchain syntax)
-rust-toolchain-version = "1.75"
+cargo-dist-version = "0.13.3"
 # CI backends to support
 ci = ["github"]
+# The archive format to use for non-windows builds (defaults .tar.xz)
+unix-archive = ".tar.gz"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = [
-  "x86_64-unknown-linux-gnu",
-  "aarch64-apple-darwin",
-  "x86_64-apple-darwin",
-]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
 # The installers to generate for each app
-installers = []
+installers = ["shell"]
 # Publish jobs to run in CI
-pr-run-mode = "skip"
-# We override RUSTFLAGS, so we must permit changes from the default template.
+pr-run-mode = "plan"
+# Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci"]
+# Whether to install an updater program
+install-updater = false
+
+[workspace.metadata.dist.github-custom-runners]
+aarch64-apple-darwin = "macos-13-large"
+x86_64-apple-darwin = "macos-13-large"
+x86_64-unknown-linux-gnu = "buildjet-32vcpu-ubuntu-2204"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/deployments/containerfiles/Dockerfile
+++ b/deployments/containerfiles/Dockerfile
@@ -1,6 +1,6 @@
-# N.B. the RUST_VERSION should match MSRV in crates/bin/pd/Cargo.toml
-ARG RUST_VERSION=1.75.0
-FROM docker.io/rust:${RUST_VERSION}-slim-bookworm AS build-env
+# We use the latest stable version of the official Rust container,
+# delegating to the `rust-toolchain.toml` file to pick a specific Rust toolchain.
+FROM docker.io/rust:1-slim-bookworm AS build-env
 
 # Install build dependencies. These packages should match what's recommended on
 # https://guide.penumbra.zone/main/pcli/install.html
@@ -13,7 +13,8 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /usr/src/penumbra
 # Add rust dependency lockfiles first, to cache downloads.
-COPY Cargo.lock Cargo.toml .
+COPY Cargo.lock Cargo.toml rust-toolchain.toml .
+
 # If any rust code changed, the cache will break on copying `crates/`.
 # Ideally we'd copy in all Cargo.toml files first, fetch, then copy crates.
 COPY crates ./crates
@@ -21,9 +22,10 @@ COPY crates ./crates
 COPY assets ./assets
 # Copy in summonerd contribution orchestrator.
 COPY tools ./tools
+# Download all workspace dependencies specified in Cargo.toml
 RUN cargo fetch
-COPY . .
 # Build Penumbra binaries
+COPY . .
 RUN cargo build --release
 
 # Runtime image.

--- a/docs/guide/src/dev/build.md
+++ b/docs/guide/src/dev/build.md
@@ -13,6 +13,8 @@ of the Rust compiler, installation instructions for which you can find
 `cargo` is available in your `$PATH`!
 
 You can verify the rust compiler version by running `rustc --version` which should indicate version 1.75 or later.
+The project uses a `rust-toolchain.toml` file, which will ensure that your version of rust stays current enough
+to build the project from source.
 
 ### Installing build prerequisites
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,8 @@
 [toolchain]
-channel = "stable"
+# We set a specific version of rust so that CI workflows use the same
+# version development environments do.
+channel = "1.75"
+components = [ "rustfmt" ]
+# Include wasm toolchain, for CI tests to check wasm32 build targets still work,
+# to avoid downstream breakage in `penumbra-wasm` crate, in the web repo.
+targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
## Describe your changes

Bumps the cargo-dist dependency, and regenerates the relevant CI files. Tested these changes in a private fork, so we can be confident they won't break builds.

Motivated by deprecation warnings in cargo-dist declaring that pinning rust versions should use `rust-toolchain.toml`, updated ours to pin 1.75. Standardizing on the toolchain file lets us remove repeated versions from a few different places, such as the containerbuild. Removed custom action helpers from Rust CI workflows, because GHA runners already come with rustup, and will honor the toolchain file. This change ensures that our dev, build, and test environments all use the same version of rust, which should minimize surprises like we saw in #4231.

Included in the release artifacts now is a complete source tarball with associated checksum, as requested in #4195. We're also distributing binaries compressed as .tar.gz, rather than .tar.xz, to satisfy #4256, and opting into a custom install script to satisfy #4255. Therefore:

* closes #4195
* closes #4255
* closes #4256

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > docs and ci only, no code changes