### PR TITLE
ci: fix rust-toolchain.toml in container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 !Cargo.toml
 !Cargo.lock
 !.cargo/
+!rust-toolchain.toml
 
 # testnets for 'pd testnet generate' defaults
 !testnets/


### PR DESCRIPTION

## Describe your changes
Follow-up to #4282, ensuring that the rust-toolchain.toml makes it into the container image, otherwise it'll throw an error on image build. Observed this on the post-merge preview deploy.

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > ci/build only