### PR TITLE
dex: Extend arbitrage routing

### DIFF
--- a/crates/core/component/dex/src/component/action_handler/swap.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{ensure, Result};
 use async_trait::async_trait;
 use cnidarium::StateWrite;
@@ -68,8 +70,12 @@ impl ActionHandler for Swap {
             .await;
 
         // Mark the assets for the swap's trading pair as accessed during this block.
-        state.add_recently_accessed_asset(swap.body.trading_pair.asset_1());
-        state.add_recently_accessed_asset(swap.body.trading_pair.asset_2());
+        let fixed_candidates = Arc::new(dex_params.fixed_candidates.clone());
+        state.add_recently_accessed_asset(
+            swap.body.trading_pair.asset_1(),
+            fixed_candidates.clone(),
+        );
+        state.add_recently_accessed_asset(swap.body.trading_pair.asset_2(), fixed_candidates);
 
         metrics::histogram!(crate::component::metrics::DEX_SWAP_DURATION)
             .record(swap_start.elapsed());

--- a/crates/core/component/dex/src/component/dex.rs
+++ b/crates/core/component/dex/src/component/dex.rs
@@ -90,9 +90,9 @@ impl Component for Dex {
                 .fixed_candidates
                 .iter()
                 .cloned()
-                // Limit the inclusion of recently accessed assets to 10 to avoid
+                // The set of recently accessed assets is already limited to avoid
                 // potentially blowing up routing time.
-                .chain(state.recently_accessed_assets().iter().take(10).cloned())
+                .chain(state.recently_accessed_assets().iter().cloned())
                 .collect::<Vec<_>>(),
         );
 

--- a/crates/core/component/dex/src/component/router/tests.rs
+++ b/crates/core/component/dex/src/component/router/tests.rs
@@ -61,6 +61,7 @@ async fn path_search_basic() {
 async fn path_extension_basic() {
     let _ = tracing_subscriber::fmt::try_init();
     let mut state = StateDelta::new(());
+    state.put_dex_params(DexParameters::default());
 
     // Write some test positions with a mispriced gn:pusd pair.
     create_test_positions_basic(&mut state, true).await;
@@ -130,6 +131,8 @@ async fn path_extension_basic() {
 
     // Reset the state.
     let mut state = StateDelta::new(());
+
+    state.put_dex_params(DexParameters::default());
 
     // Write some test positions without the mispriced position.
     create_test_positions_basic(&mut state, false).await;

--- a/crates/core/component/dex/src/state_key.rs
+++ b/crates/core/component/dex/src/state_key.rs
@@ -67,6 +67,10 @@ pub fn pending_position_closures() -> &'static str {
     "dex/pending_position_closures"
 }
 
+pub fn recently_accessed_assets() -> &'static str {
+    "dex/recently_accessed_assets"
+}
+
 pub fn pending_payloads() -> &'static str {
     "dex/pending_payloads"
 }


### PR DESCRIPTION
## Describe your changes

This PR extends arbitrage routing to route against assets involved in swaps and positions opened during the current block.

## Issue ticket number and link

#4177 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label.