### PR TITLE
penumbra-proto: fix comments on `StateReadProto` nv methods

### DIFF
--- a/crates/proto/src/state/read.rs
+++ b/crates/proto/src/state/read.rs
@@ -80,7 +80,7 @@ pub trait StateReadProto: StateRead + Send + Sync {
         }))
     }
 
-    /// Retrieve all values for keys matching a prefix from consensus-critical state, as domain types.
+    /// Retrieve all values for keys matching a prefix from nonverifiable storage, as domain types.
     #[allow(clippy::type_complexity)]
     fn nonverifiable_prefix<'a, D>(
         &'a self,
@@ -119,7 +119,7 @@ pub trait StateReadProto: StateRead + Send + Sync {
         Box::pin(o)
     }
 
-    /// Retrieve all values for keys matching a prefix from the verifiable key-value store, as proto types.
+    /// Retrieve all values for keys matching a prefix from the nonverifiable key-value store, as proto types.
     #[allow(clippy::type_complexity)]
     fn nonverifiable_prefix_proto<'a, P>(
         &'a self,


### PR DESCRIPTION
## Describe your changes

This fix incorrect comments on `StateReadProto` nv methods.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Comments
