### PR TITLE
docs: add security email info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ For a high-level view of current work-in-progress and future items, check out ou
 [protobuf]: https://buf.build/penumbra-zone/penumbra
 [tm-install]: https://github.com/tendermint/tendermint/blob/master/docs/introduction/install.md#from-source
 
-# License
+
+## Security
+If you believe you've found a security-related issue with Penumbra,
+please disclose responsibly by contacting the Penumbra Labs team at
+security@penumbralabs.xyz.
+
+## License
 
 By contributing to penumbra you agree that your contributions will be licensed
 under the terms of both the [LICENSE-Apache-2.0](LICENSE-Apache-2.0) and the
@@ -50,4 +56,3 @@ under the terms of both the [LICENSE-Apache-2.0](LICENSE-Apache-2.0) and the
 If you're using penumbra you are free to choose one of the provided licenses:
 
 `SPDX-License-Identifier: MIT OR Apache-2.0`
-


### PR DESCRIPTION
## Describe your changes
We have an email alias set up for team leads, so that external parties have a single entrypoint to disclose security-related issues. Once we settle on language here, we can duplicate this notice in other Penumbra-related repositories.

## Issue ticket number and link


## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > docs-only
