### PR TITLE
app: fold ibc stateful/historical check into their AHs

### DIFF
--- a/crates/core/component/ibc/src/component/client.rs
+++ b/crates/core/component/ibc/src/component/client.rs
@@ -558,9 +558,11 @@ mod tests {
         );
 
         create_client_action.check_stateless(()).await?;
-        create_client_action.check_stateful(state.clone()).await?;
+        create_client_action.check_historical(state.clone()).await?;
         let mut state_tx = state.try_begin_transaction().unwrap();
-        create_client_action.execute(&mut state_tx).await?;
+        create_client_action
+            .check_and_execute(&mut state_tx)
+            .await?;
         state_tx.apply();
 
         // Check that state reflects +1 client apps registered.
@@ -568,9 +570,11 @@ mod tests {
 
         // Now we update the client and confirm that the update landed in state.
         update_client_action.check_stateless(()).await?;
-        update_client_action.check_stateful(state.clone()).await?;
+        update_client_action.check_historical(state.clone()).await?;
         let mut state_tx = state.try_begin_transaction().unwrap();
-        update_client_action.execute(&mut state_tx).await?;
+        update_client_action
+            .check_and_execute(&mut state_tx)
+            .await?;
         state_tx.apply();
 
         // We've had one client update, yes. What about second client update?
@@ -587,10 +591,12 @@ mod tests {
 
         second_update_client_action.check_stateless(()).await?;
         second_update_client_action
-            .check_stateful(state.clone())
+            .check_historical(state.clone())
             .await?;
         let mut state_tx = state.try_begin_transaction().unwrap();
-        second_update_client_action.execute(&mut state_tx).await?;
+        second_update_client_action
+            .check_and_execute(&mut state_tx)
+            .await?;
         state_tx.apply();
 
         Ok(())

--- a/crates/core/component/shielded-pool/src/component/action_handler/ics20_withdrawal.rs
+++ b/crates/core/component/shielded-pool/src/component/action_handler/ics20_withdrawal.rs
@@ -1,7 +1,10 @@
-use anyhow::Result;
+use std::sync::Arc;
+
+use anyhow::{ensure, Result};
 use async_trait::async_trait;
-use cnidarium::StateWrite;
+use cnidarium::{StateRead, StateWrite};
 use cnidarium_component::ActionHandler;
+use penumbra_ibc::StateReadExt as _;
 
 use crate::{
     component::transfer::{Ics20TransferReadExt as _, Ics20TransferWriteExt as _},
@@ -13,6 +16,17 @@ impl ActionHandler for Ics20Withdrawal {
     type CheckStatelessContext = ();
     async fn check_stateless(&self, _context: ()) -> Result<()> {
         self.validate()
+    }
+
+    async fn check_historical<S: StateRead + 'static>(&self, state: Arc<S>) -> Result<()> {
+        ensure!(
+            state
+                .get_ibc_params()
+                .await?
+                .outbound_ics20_transfers_enabled,
+            "transaction an ICS20 withdrawal, but outbound ICS20 withdrawals are not enabled"
+        );
+        Ok(())
     }
 
     async fn check_and_execute<S: StateWrite>(&self, mut state: S) -> Result<()> {


### PR DESCRIPTION
## Describe your changes

This is a mechanical refactor to fold the ibc/ics20 historical checks into a more visible place (their action handler implementations).


## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Mechanical refactor
