### PR TITLE
fix(metrics): validator missed blocks, inc -> set

### DIFF
--- a/crates/core/component/stake/src/component/validator_handler/uptime_tracker.rs
+++ b/crates/core/component/stake/src/component/validator_handler/uptime_tracker.rs
@@ -172,7 +172,7 @@ pub trait ValidatorUptimeTracker: StateWrite {
             "recorded vote info"
         );
         metrics::gauge!(metrics::MISSED_BLOCKS, "identity_key" => identity_key.to_string())
-            .increment(uptime.num_missed_blocks() as f64);
+            .set(uptime.num_missed_blocks() as f64);
 
         uptime.mark_height_as_signed(height, voted)?;
         if uptime.num_missed_blocks() as u64 >= params.missed_blocks_maximum {


### PR DESCRIPTION


## Describe your changes

We were inappropriately `increment`ing a gauge to track missed blocks, when instead we should have been clobbering the value via `set`, as we know the precise number from the state machine. This fixes a broken metric for missed blocks that was growing too fast, emitting wrong values.

Refs #3746.

_Not_ included in this small patch is a rework of the other validator-related metrics. As described in #3746, we should migrate those metrics to use Events instead. 

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > metrics-only, no logic changes
