### PR TITLE
pd(migrate): add auction parameters to chain state for `Testnet74`

### DIFF
--- a/crates/bin/pd/src/migrate.rs
+++ b/crates/bin/pd/src/migrate.rs
@@ -34,7 +34,10 @@ pub enum Migration {
     /// Testnet-72 migration:
     /// - Migrate `BatchSwapOutputData` to new protobuf, replacing epoch height with index.
     Testnet72,
-    /// Testnet-74 migration: change liquidity positions to be ordered in descending order rather than ascending.
+    /// Testnet-74 migration:
+    /// - Update the base liquidity index to order routable pairs by descending liquidity
+    /// - Update arb executions to include the amount of filled input in the output
+    /// - Add `AuctionParameters` to the consensus state
     Testnet74,
 }
 


### PR DESCRIPTION
## Describe your changes

@hdevalence noticed that we were missing a migration for the `AuctionParameters`. This PR adds a migration to write the parameters to the app state.

## Issue ticket number and link

This was a miss in #4259

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This is a migration
