### PR TITLE
fix(dex): migration for dex trait proto encodings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,8 @@ jobs:
     runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
       - name: install cargo-hack


### PR DESCRIPTION
## Describe your changes

Fixes a chain halt due to changes introduced in #4188.

Previously, aggregate liquidity lookups in non-verifiable storage (i.e. "how much liquidity is available for trading pair `(A, B)`?") were stored as raw big-endian encoded values. In #4188 the DEX state accessors were refactored and part of that was adjusting the accessors for aggregate liquidity lookups to use `nonverifiable_put`/`nonverifiable_get` instead of the `_raw` methods they were using previously.

## Testing

**Manually testing the values were changed appropriately is actually quite difficult currently as `pcli` doesn't support querying values from non-verifiable storage, and returned values need to be parsed correctly into the `Amount` data type.**

- Create a devnet on v0.73.1
- Watch for changes to the aggregate liquidity prefix: `cargo run --release --bin pcli -- query watch --nv-key-regex 'dex/ab/.*'`
- Submit some liquidity positions. Note down the aggregate liquidity data
- Perform migration to this branch: delegate, propose, vote, halt, migrate, restart network
- The chain will halt if the migration doesn't properly change the encoding of the values. The first test is simply to ensure that the chain can run post-migration.
- A further test is to verify that the aggregate liquidity values remain the same post-migration. Query again and compare

## Issue ticket number and link

Closes #4340 
