### PR TITLE
docs: update guide for validator custody

### DIFF
--- a/docs/guide/src/node/pd/requirements.md
+++ b/docs/guide/src/node/pd/requirements.md
@@ -31,7 +31,12 @@ The relevant network endpoints for running Penumbra are:
 You can opt in to HTTPS support for Penumbra's gRPC service by setting
 the `--grpc-auto-https <DOMAIN>` option. See `pd start --help` for more info.
 
-# Deployment strategies
+## Custody considerations
+
+Validators should review the [pcli key custody](../../pcli/wallet.md#validator-custody) recommendations
+for protecting the validator identity.
+
+## Deployment strategies
 
 We expect node operators to manage the lifecycle of their Penumbra deployments.
 Some example configs for systemd, docker compose, and kubernetes helm charts


### PR DESCRIPTION
## Describe your changes

Tweak the description of validator key management to clarify the roles of the different keys


## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > docs changes
