### PR TITLE
view: reorganize planner components

### DIFF
--- a/crates/core/transaction/src/lib.rs
+++ b/crates/core/transaction/src/lib.rs
@@ -26,23 +26,24 @@ mod transaction;
 mod witness_data;
 
 pub mod action;
+pub mod action_list;
 pub mod gas;
 pub mod memo;
 pub mod plan;
 pub mod view;
 
 pub use action::Action;
+pub use action_list::ActionList;
 pub use auth_data::AuthorizationData;
 pub use detection_data::DetectionData;
 pub use error::Error;
 pub use is_action::IsAction;
 pub use parameters::TransactionParameters;
+pub use penumbra_txhash as txhash;
 pub use plan::{ActionPlan, TransactionPlan};
 pub use transaction::{Transaction, TransactionBody};
 pub use view::{ActionView, MemoPlaintextView, MemoView, TransactionPerspective, TransactionView};
 pub use witness_data::WitnessData;
-
-pub use penumbra_txhash as txhash;
 
 /// A compatibility wrapper for trait implementations that are temporarily duplicated
 /// in multiple crates as an orphan rule work around until we finish splitting crates (#2288).

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -472,27 +472,16 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     /// instance, a user might prefer a note prioritization strategy that harvested
     /// capital losses when possible, using cost basis information retained by the
     /// view server.
-    pub fn prioritize_and_filter_spendable_notes(
-        &mut self,
+    fn prioritize_and_filter_spendable_notes(
         records: Vec<SpendableNoteRecord>,
     ) -> Vec<SpendableNoteRecord> {
+        // Filter out zero valued notes.
         let mut filtered = records
             .into_iter()
             .filter(|record| record.note.amount() > Amount::zero())
             .collect::<Vec<_>>();
 
-        filtered.sort_by(|a, b| {
-            // Sort by whether the note was sent to an ephemeral address...
-            match (
-                a.address_index.is_ephemeral(),
-                b.address_index.is_ephemeral(),
-            ) {
-                (true, false) => std::cmp::Ordering::Less,
-                (false, true) => std::cmp::Ordering::Greater,
-                // ... then by largest amount.
-                _ => b.note.amount().cmp(&a.note.amount()),
-            }
-        });
+        filtered.sort_by(|a, b| b.note.amount().cmp(&a.note.amount()));
 
         filtered
     }

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -471,18 +471,26 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     /// instance, a user might prefer a note prioritization strategy that harvested
     /// capital losses when possible, using cost basis information retained by the
     /// view server.
-    fn prioritize_and_filter_spendable_notes(
+    pub fn prioritize_and_filter_spendable_notes(
         &mut self,
         records: Vec<SpendableNoteRecord>,
     ) -> Vec<SpendableNoteRecord> {
-        // Filter out zero valued notes.
         let mut filtered = records
             .into_iter()
             .filter(|record| record.note.amount() > Amount::zero())
             .collect::<Vec<_>>();
-
-        filtered.sort_by(|a, b| b.note.amount().cmp(&a.note.amount()));
-
+        filtered.sort_by(|a, b| {
+            // Sort by whether the note was sent to an ephemeral address...
+            match (
+                a.address_index.is_ephemeral(),
+                b.address_index.is_ephemeral(),
+            ) {
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                // ... then by largest amount.
+                _ => b.note.amount().cmp(&a.note.amount()),
+            }
+        });
         filtered
     }
 

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -45,8 +45,7 @@ use penumbra_tct as tct;
 use penumbra_transaction::{
     memo::MemoPlaintext,
     plan::{ActionPlan, MemoPlan, TransactionPlan},
-    TransactionParameters,
-    ActionList
+    ActionList, TransactionParameters,
 };
 
 /// A planner for a [`TransactionPlan`] that can fill in the required spends and change outputs upon
@@ -473,6 +472,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     /// capital losses when possible, using cost basis information retained by the
     /// view server.
     fn prioritize_and_filter_spendable_notes(
+        &mut self,
         records: Vec<SpendableNoteRecord>,
     ) -> Vec<SpendableNoteRecord> {
         // Filter out zero valued notes.
@@ -536,8 +536,6 @@ impl<R: RngCore + CryptoRng> Planner<R> {
                 .await?;
             notes_by_asset_id.insert(
                 required.asset_id,
-                // TODO: reorganize later, the important thing here is that this
-                // is separate from the Planner logic (will never be commonized)
                 self.prioritize_and_filter_spendable_notes(records),
             );
         }


### PR DESCRIPTION
## Describe your changes
Reorganize the `ActionList` struct, enabling the web code to use the same structure when updating its rust dependencies. 
## Issue ticket number and link
References https://github.com/penumbra-zone/penumbra/issues/4332

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason: