### PR TITLE
auction(rpc): support `grpc-web` in the auction query service

### DIFF
--- a/crates/core/app/src/rpc.rs
+++ b/crates/core/app/src/rpc.rs
@@ -81,9 +81,9 @@ pub fn router(
         .add_service(we(StorageQueryServiceServer::new(StorageServer::new(
             storage.clone(),
         ))))
-        .add_service(AuctionQueryServiceServer::new(AuctionServer::new(
+        .add_service(we(AuctionQueryServiceServer::new(AuctionServer::new(
             storage.clone(),
-        )))
+        ))))
         .add_service(we(AppQueryServiceServer::new(AppQueryServer::new(
             storage.clone(),
         ))))


### PR DESCRIPTION
## Describe your changes

This adds missing middleware to the auction query service

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > query server change
