### PR TITLE
docs: refine migrate steps

### DIFF
--- a/docs/guide/src/node/pd/chain-upgrade.md
+++ b/docs/guide/src/node/pd/chain-upgrade.md
@@ -13,9 +13,9 @@ At a high level, the upgrade process consists of the following steps:
 2. Governance proposal passes.
 3. Chain reaches specified height `n-1`, nodes stop generating blocks.
 4. Manual upgrade is performed on each validator and fullnode:
-  1. Install the new version of pd.
-  2. Apply changes to `pd` and `cometbft` state via `pd migrate`.
-  3. Restart node.
+    1. Install the new version of pd.
+    2. Apply changes to `pd` and `cometbft` state via `pd migrate`.
+    3. Restart node.
 
 After the node is restarted on the new version, it should be able to talk to the network again.
 Once enough validators with sufficient stake weight have upgraded, the network
@@ -23,11 +23,13 @@ will resume generating blocks.
 
 ## Performing a chain upgrade
 
+Consider performing a backup as a preliminary step during the downtime,
+so that your node state is recoverable.
+
 1. Stop both `pd` and `cometbft`. Depending on how you run Penumbra, this could mean `sudo systemctl stop penumbra cometbft`.
 2. Download the latest version of `pd` and install it. Run `pd --version` and confirm you see `{{ #include ../../penumbra_version.md }}` before proceeding.
 3. Optionally, use `pd export` to create a snapshot of the `pd` state.
 4. Apply the migration with `pd migrate --home PD_HOME --comet-home COMETBFT_HOME`.  If using the default home locations (from `pd testnet join`), you can omit the paths and just run `pd migrate`.
-5. Optionally, use `pd export` to create a snapshot of the post-migration state.
 
 Finally, restart the node, e.g. `sudo systemctl restart penumbra cometbft`. Check the logs, and you should see the chain progressing
 past the halt height `n`.


### PR DESCRIPTION
## Describe your changes
Fixed indented list. Explicitly mention backup. Remove recommendation, even optionally, to use `pd export` on post-migration state, because `pd export` won't generate an archive that's suitable for use with `pd testnet join`. We'll do that manually as part of post-release follow-up.
## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > docs-only!
