### PR TITLE
fix: reset TOTAL_HALT_COUNT

### DIFF
--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -558,7 +558,7 @@ impl App {
 ///
 /// Increment this manually after fixing the root cause for a chain halt: updated nodes will then be
 /// able to proceed past the block height of the halt.
-const TOTAL_HALT_COUNT: u64 = 2;
+const TOTAL_HALT_COUNT: u64 = 0;
 
 #[async_trait]
 pub trait StateReadExt: StateRead {


### PR DESCRIPTION


## Describe your changes

Follow-up to 0f349704c7af88f997d2a23bf2e939a1f5ca18f0, which claimed to reset this value, but did not actually.

## Issue ticket number and link

Refs: 

* https://github.com/penumbra-zone/penumbra/pull/4375
* https://github.com/penumbra-zone/penumbra/issues/4374

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Very relevant to shipping migrations.
