### PR TITLE
pcli: auction end-all, withdraw-all

### DIFF
--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -244,7 +244,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
 
         let plan = ActionDutchAuctionWithdrawPlan {
             auction_id,
-            seq: 2,
+            seq: 2, // 1 (closed) -> 2 (withdrawn)
             reserves_input,
             reserves_output,
         };

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -13,8 +13,8 @@ use tracing::instrument;
 use crate::{SpendableNoteRecord, ViewClient};
 use anyhow::anyhow;
 use penumbra_asset::{asset, Value};
-use penumbra_auction::auction::dutch::actions::ActionDutchAuctionWithdrawPlan;
 use penumbra_auction::auction::dutch::DutchAuctionDescription;
+use penumbra_auction::auction::dutch::{actions::ActionDutchAuctionWithdrawPlan, DutchAuction};
 use penumbra_auction::auction::{
     dutch::actions::{ActionDutchAuctionEnd, ActionDutchAuctionSchedule},
     AuctionId,
@@ -222,9 +222,33 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     }
 
     /// Withdraws the reserves of the Dutch auction.
-    // TODO: nicer api? what do we get by passing fields individually rather than the plan?
+    ///
+    /// Uses the provided auction state to automatically end the auction
+    /// if necessary.
     #[instrument(skip(self))]
-    pub fn dutch_auction_withdraw(&mut self, plan: ActionDutchAuctionWithdrawPlan) -> &mut Self {
+    pub fn dutch_auction_withdraw(&mut self, auction: &DutchAuction) -> &mut Self {
+        let auction_id = auction.description.id();
+        // Check if the auction needs to be ended
+        if auction.state.sequence == 0 {
+            self.dutch_auction_end(auction_id);
+        }
+
+        let reserves_input = Value {
+            amount: auction.state.input_reserves,
+            asset_id: auction.description.input.asset_id,
+        };
+        let reserves_output = Value {
+            amount: auction.state.output_reserves,
+            asset_id: auction.description.output_id,
+        };
+
+        let plan = ActionDutchAuctionWithdrawPlan {
+            auction_id,
+            seq: 2,
+            reserves_input,
+            reserves_output,
+        };
+
         self.action_list.push(plan);
         self
     }

--- a/crates/view/src/service.rs
+++ b/crates/view/src/service.rs
@@ -436,8 +436,8 @@ impl ViewService for ViewServer {
             None
         };
 
-        let responses =
-            futures::future::join_all(all_auctions.into_iter().map(|(auction_id, note_record)| {
+        let responses = futures::future::join_all(all_auctions.into_iter().map(
+            |(auction_id, note_record, local_seq)| {
                 let maybe_client = client.clone();
                 async move {
                     let (any_state, positions) = if let Some(mut client2) = maybe_client {
@@ -458,11 +458,12 @@ impl ViewService for ViewServer {
                         note_record: Some(note_record.into()),
                         auction: any_state,
                         positions,
-                        local_seq: 0, // TODO: implement with real values
+                        local_seq,
                     })
                 }
-            }))
-            .await;
+            },
+        ))
+        .await;
 
         let stream = stream::iter(responses)
             .map_err(|e| tonic::Status::internal(format!("error getting auction: {e}")))


### PR DESCRIPTION
## Describe your changes

Changes the `pcli tx auction` commands to support "end all", "withdraw all" rather than requiring specific auction IDs


## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Only client-side changes