### PR TITLE
ci: add `penumbra-mock-*` to rustdoc build list

### DIFF
--- a/deployments/scripts/rust-docs
+++ b/deployments/scripts/rust-docs
@@ -57,6 +57,8 @@ cargo +nightly doc --no-deps \
   -p penumbra-wallet \
   -p poseidon-paramgen \
   -p poseidon-permutation \
+  -p penumbra-mock-consensus \
+  -p penumbra-mock-client \
   -p poseidon377 \
   -p tendermint \
   -p tendermint-config \

--- a/deployments/scripts/rust-docs
+++ b/deployments/scripts/rust-docs
@@ -43,6 +43,7 @@ cargo +nightly doc --no-deps \
   -p penumbra-keys \
   -p penumbra-measure \
   -p penumbra-mock-consensus \
+  -p penumbra-mock-client \
   -p penumbra-num \
   -p penumbra-proof-params \
   -p penumbra-proof-setup \
@@ -57,8 +58,6 @@ cargo +nightly doc --no-deps \
   -p penumbra-wallet \
   -p poseidon-paramgen \
   -p poseidon-permutation \
-  -p penumbra-mock-consensus \
-  -p penumbra-mock-client \
   -p poseidon377 \
   -p tendermint \
   -p tendermint-config \


### PR DESCRIPTION
## Describe your changes

This will let us browse them on `rustdoc.penumbra.zone`

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > ci change to doc build
