### PR TITLE
staking: Make `Uptime::missed_blocks` yield a `DoubleEndedIterator`

### DIFF
--- a/crates/core/component/stake/src/uptime.rs
+++ b/crates/core/component/stake/src/uptime.rs
@@ -79,7 +79,7 @@ impl Uptime {
     }
 
     /// Enumerates the missed blocks over the window in terms of absolute block height.
-    pub fn missed_blocks(&self) -> impl Iterator<Item = u64> + '_ {
+    pub fn missed_blocks(&self) -> impl Iterator<Item = u64> + DoubleEndedIterator + '_ {
         // The height of the next block to be recorded (not yet recorded):
         let current_height = self.as_of_block_height;
         // The length of the window of blocks being recorded:


### PR DESCRIPTION
## Describe your changes

This adds a `DoubleEndedIterator` impl for `Uptime::missed_blocks`'s resultant iterator , which is useful if you want the most recent missed blocks first.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [X] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This is a purely additive change that does not affect consensus.
