### PR TITLE
feat: add method to `asset::Id` that gives the base64 encoding of the inner bytes

### DIFF
--- a/crates/core/asset/src/asset/id.rs
+++ b/crates/core/asset/src/asset/id.rs
@@ -1,12 +1,12 @@
+use crate::Value;
 use ark_ff::{fields::PrimeField, ToConstraintField};
 use ark_serialize::CanonicalDeserialize;
+use base64::Engine;
 use decaf377::{FieldExt, Fq};
 use once_cell::sync::Lazy;
 use penumbra_num::Amount;
 use penumbra_proto::{penumbra::core::asset::v1 as pb, serializers::bech32str, DomainType};
 use serde::{Deserialize, Serialize};
-
-use crate::Value;
 
 /// An identifier for an IBC asset type.
 ///
@@ -162,12 +162,16 @@ impl Id {
                 .as_bytes(),
         ))
     }
+
+    /// Returns the base64 encoded string of the inner bytes.
+    pub fn to_base64(&self) -> String {
+        base64::engine::general_purpose::STANDARD.encode(self.to_bytes())
+    }
 }
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn asset_id_encoding() {


### PR DESCRIPTION
## Describe your changes
add method to `asset::Id` that gives the base64 encoding of the inner bytes

## Issue ticket number and link

Closes #4192

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > It's just a helper method
