### PR TITLE
app: switch halt counter with halt bit

### DIFF
--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -135,6 +135,9 @@ pub enum RootCommand {
         // get explicit consent to muck around in another daemon's state.
         #[clap(long, display_order = 200)]
         comet_home: Option<PathBuf>,
+        /// If set, force a migration to occur even if the chain is not halted.
+        #[clap(long, display_order = 1000)]
+        force: bool,
     },
 }
 

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -440,16 +440,10 @@ async fn main() -> anyhow::Result<()> {
             pd_migrate_span
                 .in_scope(|| tracing::info!("migrating pd state in {}", pd_home.display()));
             ReadyToStart
-                .migrate(pd_home.clone(), Some(genesis_start), force)
+                .migrate(pd_home.clone(), comet_home, Some(genesis_start), force)
                 .instrument(pd_migrate_span)
                 .await
                 .context("failed to upgrade state")?;
-
-            if let Some(comet_home) = comet_home {
-                // TODO avoid this when refactoring to clean up migrations
-                let genesis_path = pd_home.join("genesis.json");
-                pd::migrate::migrate_comet_data(comet_home, genesis_path).await?;
-            }
         }
     }
     Ok(())

--- a/crates/bin/pd/src/migrate.rs
+++ b/crates/bin/pd/src/migrate.rs
@@ -4,21 +4,19 @@
 //! node operators must coordinate to perform a chain upgrade.
 //! This module declares how local `pd` state should be altered, if at all,
 //! in order to be compatible with the network post-chain-upgrade.
+mod reset_halt_bit;
+mod simple;
 mod testnet72;
 mod testnet74;
 
 use anyhow::{ensure, Context};
-use futures::StreamExt as _;
-use penumbra_governance::{StateReadExt, StateWriteExt};
+use penumbra_governance::StateReadExt;
+use penumbra_sct::component::clock::EpochRead;
 use std::path::{Path, PathBuf};
 use tracing::instrument;
 
-use cnidarium::{StateDelta, StateRead, StateWrite, Storage};
-use jmt::RootHash;
-use penumbra_app::{app::StateReadExt as _, SUBSTORE_PREFIXES};
-use penumbra_sct::component::clock::{EpochManager, EpochRead};
-
-use crate::testnet::generate::TestnetConfig;
+use cnidarium::Storage;
+use penumbra_app::SUBSTORE_PREFIXES;
 
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -32,8 +30,6 @@ pub enum Migration {
     /// A simple migration: adds a key to the consensus state.
     /// This is useful for testing upgrade mechanisms, including in production.
     SimpleMigration,
-    /// Testnet-70 migration: move swap executions from the jmt to nv-storage.
-    Testnet70,
     /// Testnet-72 migration:
     /// - Migrate `BatchSwapOutputData` to new protobuf, replacing epoch height with index.
     Testnet72,
@@ -45,30 +41,30 @@ pub enum Migration {
 }
 
 impl Migration {
-    #[instrument(skip(path_to_export, genesis_start, force))]
+    #[instrument(skip(pd_home, genesis_start, force))]
     pub async fn migrate(
         &self,
-        path_to_export: PathBuf,
+        pd_home: PathBuf,
+        comet_home: Option<PathBuf>,
         genesis_start: Option<tendermint::time::Time>,
         force: bool,
     ) -> anyhow::Result<()> {
         tracing::debug!(
-            ?path_to_export,
+            ?pd_home,
             ?genesis_start,
             ?force,
             "preparing to run migration!"
         );
-        let rocksdb_dir = path_to_export.join("rocksdb");
+        let rocksdb_dir = pd_home.join("rocksdb");
         let storage = Storage::load(rocksdb_dir, SUBSTORE_PREFIXES.to_vec()).await?;
         let export_state = storage.latest_snapshot();
         let root_hash = export_state.root_hash().await.expect("can get root hash");
-        let app_hash_pre_migration: RootHash = root_hash.into();
         let height = export_state
             .get_block_height()
             .await
             .expect("can get block height");
 
-        tracing::debug!(?app_hash_pre_migration, current_height = ?height, ?force,
+        tracing::debug!(pre_migration_root_hash = ?root_hash, current_height = ?height, ?force,
             "determining if the chain is halted and the migration is allowed to run");
 
         ensure!(
@@ -76,167 +72,30 @@ impl Migration {
             "to run a migration, the chain halt bit must be set to `true` or use the `--force` cli flag"
         );
 
-        tracing::info!(?app_hash_pre_migration, pre_upgrade_height = ?height, ?self, "started migration");
+        tracing::info!(pre_migration_root_hash = ?root_hash, pre_upgrade_height = ?height, ?self, "started migration");
         match self {
             Migration::ReadyToStart => {
-                let mut delta = StateDelta::new(export_state);
-                delta.ready_to_start();
-                let _ = storage.commit_in_place(delta).await?;
-                tracing::info!(
-                    "migration completed: halt bit is turned off, chain is ready to start"
-                );
-                Ok(())
+                reset_halt_bit::migrate(storage, pd_home, genesis_start).await?;
+                return Ok(());
             }
             Migration::SimpleMigration => {
-                let post_ugprade_height = height.wrapping_add(1);
-
-                /* --------- writing to the jmt  ------------ */
-                tracing::info!(?app_hash_pre_migration, "app hash pre-upgrade");
-                let mut delta = StateDelta::new(export_state);
-                delta.put_raw(
-                    "banana".to_string(),
-                    "a good fruit (and migration works!)".into(),
-                );
-                delta.put_block_height(0u64);
-                let root_hash = storage.commit_in_place(delta).await?;
-                let app_hash_post_migration: RootHash = root_hash.into();
-                tracing::info!(?app_hash_post_migration, "app hash post upgrade");
-
-                /* --------- collecting genesis data -------- */
-                tracing::info!("generating genesis");
-                let migrated_state = storage.latest_snapshot();
-                let root_hash = migrated_state.root_hash().await.expect("can get root hash");
-                let app_hash: RootHash = root_hash.into();
-                tracing::info!(?root_hash, "root hash from snapshot (post-upgrade)");
-
-                /* ---------- generate genesis ------------  */
-                let chain_id = migrated_state.get_chain_id().await?;
-                let app_state = penumbra_app::genesis::Content {
-                    chain_id,
-                    ..Default::default()
-                };
-                let mut genesis =
-                    TestnetConfig::make_genesis(app_state.clone()).expect("can make genesis");
-                genesis.app_hash = app_hash
-                    .0
-                    .to_vec()
-                    .try_into()
-                    .expect("infaillible conversion");
-                genesis.initial_height = post_ugprade_height as i64;
-                genesis.genesis_time = genesis_start.unwrap_or_else(|| {
-                    let now = tendermint::time::Time::now();
-                    tracing::info!(%now, "no genesis time provided, detecting a testing setup");
-                    now
-                });
-                let checkpoint = app_hash.0.to_vec();
-                let genesis = TestnetConfig::make_checkpoint(genesis, Some(checkpoint));
-
-                let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");
-                tracing::info!("genesis: {}", genesis_json);
-                let genesis_path = path_to_export.join("genesis.json");
-                std::fs::write(genesis_path, genesis_json).expect("can write genesis");
-
-                let validator_state_path = path_to_export.join("priv_validator_state.json");
-                let fresh_validator_state =
-                    crate::testnet::generate::TestnetValidator::initial_state();
-                std::fs::write(validator_state_path, fresh_validator_state)
-                    .expect("can write validator state");
-                Ok(())
+                simple::migrate(storage, pd_home.clone(), genesis_start).await?
             }
-            Migration::Testnet70 => {
-                // Our goal is to fetch all swap executions from the jmt and store them in nv-storage.
-                // In particular, we want to make sure that client lookups for (height, trading pair)
-                // resolve to the same value as before.
-
-                // Setup:
-                let start_time = std::time::SystemTime::now();
-                let rocksdb_dir = path_to_export.join("rocksdb");
-                let storage =
-                    Storage::load(rocksdb_dir.clone(), SUBSTORE_PREFIXES.to_vec()).await?;
-                let export_state = storage.latest_snapshot();
-                let root_hash = export_state.root_hash().await.expect("can get root hash");
-                let pre_upgrade_root_hash: RootHash = root_hash.into();
-                let pre_upgrade_height = export_state
-                    .get_block_height()
-                    .await
-                    .expect("can get block height");
-                let post_upgrade_height = pre_upgrade_height.wrapping_add(1);
-
-                // We initialize a `StateDelta` and start by reaching into the JMT for all entries matching the
-                // swap execution prefix. Then, we write each entry to the nv-storage.
-                let mut delta = StateDelta::new(export_state);
-
-                let prefix_key = "dex/swap_execution/";
-                let mut swap_execution_stream = delta.prefix_raw(prefix_key);
-
-                while let Some(r) = swap_execution_stream.next().await {
-                    let (key, swap_execution) = r?;
-                    tracing::info!("migrating swap execution: {}", key);
-                    delta.nonverifiable_put_raw(key.into_bytes(), swap_execution);
-                }
-
-                delta.put_block_height(0u64);
-
-                let post_upgrade_root_hash = storage.commit_in_place(delta).await?;
-                tracing::info!(?post_upgrade_root_hash, "post-upgrade root hash");
-
-                let migration_duration = start_time.elapsed().expect("start time not set");
-
-                // Reload storage so we can make reads against its migrated state:
-                storage.release().await;
-                let storage = Storage::load(rocksdb_dir, SUBSTORE_PREFIXES.to_vec()).await?;
-                let migrated_state = storage.latest_snapshot();
-                storage.release().await;
-
-                // The migration is complete, now we need to generate a genesis file. To do this, we need
-                // to lookup a validator view from the chain, and specify the post-upgrade app hash and
-                // initial height.
-                let chain_id = migrated_state.get_chain_id().await?;
-                let app_state = penumbra_app::genesis::Content {
-                    chain_id,
-                    ..Default::default()
-                };
-                let mut genesis =
-                    TestnetConfig::make_genesis(app_state.clone()).expect("can make genesis");
-                genesis.app_hash = post_upgrade_root_hash
-                    .0
-                    .to_vec()
-                    .try_into()
-                    .expect("infaillible conversion");
-                genesis.initial_height = post_upgrade_height as i64;
-                genesis.genesis_time = genesis_start.unwrap_or_else(|| {
-                    let now = tendermint::time::Time::now();
-                    tracing::info!(%now, "no genesis time provided, detecting a testing setup");
-                    now
-                });
-                let checkpoint = post_upgrade_root_hash.0.to_vec();
-                let genesis = TestnetConfig::make_checkpoint(genesis, Some(checkpoint));
-
-                let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");
-                tracing::info!("genesis: {}", genesis_json);
-                let genesis_path = path_to_export.join("genesis.json");
-                std::fs::write(genesis_path, genesis_json).expect("can write genesis");
-
-                let validator_state_path = path_to_export.join("priv_validator_state.json");
-                let fresh_validator_state =
-                    crate::testnet::generate::TestnetValidator::initial_state();
-                std::fs::write(validator_state_path, fresh_validator_state)
-                    .expect("can write validator state");
-
-                tracing::info!(
-                    pre_upgrade_height,
-                    post_upgrade_height,
-                    ?pre_upgrade_root_hash,
-                    ?post_upgrade_root_hash,
-                    duration = migration_duration.as_secs(),
-                    "successful migration!"
-                );
-
-                Ok(())
+            Migration::Testnet72 => {
+                testnet72::migrate(storage, pd_home.clone(), genesis_start).await?
             }
-            Migration::Testnet72 => testnet72::migrate(path_to_export, genesis_start).await,
-            Migration::Testnet74 => testnet74::migrate(path_to_export, genesis_start).await,
+            Migration::Testnet74 => {
+                testnet74::migrate(storage, pd_home.clone(), genesis_start).await?
+            }
+        };
+
+        if let Some(comet_home) = comet_home {
+            // TODO avoid this when refactoring to clean up migrations
+            let genesis_path = pd_home.join("genesis.json");
+            migrate_comet_data(comet_home, genesis_path).await?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/bin/pd/src/migrate.rs
+++ b/crates/bin/pd/src/migrate.rs
@@ -80,7 +80,7 @@ impl Migration {
         match self {
             Migration::ReadyToStart => {
                 let mut delta = StateDelta::new(export_state);
-                delta.signal_halt();
+                delta.ready_to_start();
                 let _ = storage.commit_in_place(delta).await?;
                 tracing::info!(
                     "migration completed: halt bit is turned off, chain is ready to start"

--- a/crates/bin/pd/src/migrate/reset_halt_bit.rs
+++ b/crates/bin/pd/src/migrate/reset_halt_bit.rs
@@ -1,0 +1,19 @@
+//! Contains functions related to the migration script of Testnet74
+
+use anyhow;
+use cnidarium::{StateDelta, Storage};
+use penumbra_governance::StateWriteExt as _;
+use std::path::PathBuf;
+
+pub async fn migrate(
+    storage: Storage,
+    _path_to_export: PathBuf,
+    _genesis_start: Option<tendermint::time::Time>,
+) -> anyhow::Result<()> {
+    let export_state = storage.latest_snapshot();
+    let mut delta = StateDelta::new(export_state);
+    delta.ready_to_start();
+    let _ = storage.commit_in_place(delta).await?;
+    tracing::info!("migration completed: halt bit is turned off, chain is ready to start");
+    Ok(())
+}

--- a/crates/bin/pd/src/migrate/reset_halt_bit.rs
+++ b/crates/bin/pd/src/migrate/reset_halt_bit.rs
@@ -1,4 +1,4 @@
-//! Contains functions related to the migration script of Testnet74
+//! A migration script to reset the chain's halt bit.
 
 use anyhow;
 use cnidarium::{StateDelta, Storage};

--- a/crates/bin/pd/src/migrate/simple.rs
+++ b/crates/bin/pd/src/migrate/simple.rs
@@ -1,0 +1,74 @@
+//! An example migration script.
+
+use anyhow;
+use cnidarium::{StateDelta, StateWrite, Storage};
+use jmt::RootHash;
+use penumbra_app::app::StateReadExt as _;
+use penumbra_sct::component::clock::{EpochManager, EpochRead};
+use std::path::PathBuf;
+
+use crate::testnet::generate::TestnetConfig;
+pub async fn migrate(
+    storage: Storage,
+    path_to_export: PathBuf,
+    genesis_start: Option<tendermint::time::Time>,
+) -> anyhow::Result<()> {
+    let export_state = storage.latest_snapshot();
+    let root_hash = export_state.root_hash().await.expect("can get root hash");
+    let height = export_state
+        .get_block_height()
+        .await
+        .expect("can get block height");
+    let app_hash_pre_migration: RootHash = root_hash.into();
+    let post_ugprade_height = height.wrapping_add(1);
+
+    /* --------- writing to the jmt  ------------ */
+    tracing::info!(?app_hash_pre_migration, "app hash pre-upgrade");
+    let mut delta = StateDelta::new(export_state);
+    delta.put_raw(
+        "banana".to_string(),
+        "a good fruit (and migration works!)".into(),
+    );
+    delta.put_block_height(0u64);
+    let root_hash = storage.commit_in_place(delta).await?;
+    let app_hash_post_migration: RootHash = root_hash.into();
+    tracing::info!(?app_hash_post_migration, "app hash post upgrade");
+
+    /* --------- collecting genesis data -------- */
+    tracing::info!("generating genesis");
+    let migrated_state = storage.latest_snapshot();
+    let root_hash = migrated_state.root_hash().await.expect("can get root hash");
+    let app_hash: RootHash = root_hash.into();
+    tracing::info!(?root_hash, "root hash from snapshot (post-upgrade)");
+
+    /* ---------- generate genesis ------------  */
+    let chain_id = migrated_state.get_chain_id().await?;
+    let app_state = penumbra_app::genesis::Content {
+        chain_id,
+        ..Default::default()
+    };
+    let mut genesis = TestnetConfig::make_genesis(app_state.clone()).expect("can make genesis");
+    genesis.app_hash = app_hash
+        .0
+        .to_vec()
+        .try_into()
+        .expect("infaillible conversion");
+    genesis.initial_height = post_ugprade_height as i64;
+    genesis.genesis_time = genesis_start.unwrap_or_else(|| {
+        let now = tendermint::time::Time::now();
+        tracing::info!(%now, "no genesis time provided, detecting a testing setup");
+        now
+    });
+    let checkpoint = app_hash.0.to_vec();
+    let genesis = TestnetConfig::make_checkpoint(genesis, Some(checkpoint));
+
+    let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");
+    tracing::info!("genesis: {}", genesis_json);
+    let genesis_path = path_to_export.join("genesis.json");
+    std::fs::write(genesis_path, genesis_json).expect("can write genesis");
+
+    let validator_state_path = path_to_export.join("priv_validator_state.json");
+    let fresh_validator_state = crate::testnet::generate::TestnetValidator::initial_state();
+    std::fs::write(validator_state_path, fresh_validator_state).expect("can write validator state");
+    Ok(())
+}

--- a/crates/bin/pd/src/migrate/testnet72.rs
+++ b/crates/bin/pd/src/migrate/testnet72.rs
@@ -126,11 +126,10 @@ async fn translate_compact_block_storage(
 
 /// Run the full migration, given an export path and a start time for genesis.
 pub async fn migrate(
+    storage: Storage,
     path_to_export: PathBuf,
     genesis_start: Option<tendermint::time::Time>,
 ) -> anyhow::Result<()> {
-    let rocksdb_dir = path_to_export.join("rocksdb");
-    let storage = Storage::load(rocksdb_dir.clone(), SUBSTORE_PREFIXES.to_vec()).await?;
     let export_state = storage.latest_snapshot();
     let root_hash = export_state.root_hash().await.expect("can get root hash");
     let pre_upgrade_root_hash: RootHash = root_hash.into();
@@ -161,6 +160,8 @@ pub async fn migrate(
     };
 
     storage.release().await;
+
+    let rocksdb_dir = path_to_export.join("rocksdb");
     let storage = Storage::load(rocksdb_dir, SUBSTORE_PREFIXES.to_vec()).await?;
     let migrated_state = storage.latest_snapshot();
 

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -35,7 +35,7 @@ use tendermint::abci::{self, Event};
 
 use tendermint::v0_37::abci::{request, response};
 use tendermint::validator::Update;
-use tracing::Instrument;
+use tracing::{instrument, Instrument};
 
 use crate::action_handler::AppActionHandler;
 use crate::genesis::AppState;
@@ -59,6 +59,7 @@ pub struct App {
 
 impl App {
     /// Constructs a new application, using the provided [`Snapshot`].
+    #[instrument(err, skip_all)]
     pub async fn new(snapshot: Snapshot) -> Result<Self> {
         tracing::debug!("initializing App instance");
 
@@ -69,8 +70,7 @@ impl App {
         // If the state says that the chain is halted, we should not proceed. This is a safety check
         // to ensure that automatic restarts by software like systemd do not cause the chain to come
         // back up again after a halt.
-        if state.is_chain_halted(TOTAL_HALT_COUNT).await? {
-            tracing::error!("chain is halted, refusing to restart!");
+        if state.is_chain_halted().await {
             anyhow::bail!("chain is halted, refusing to restart");
         }
 
@@ -500,10 +500,7 @@ impl App {
             .expect("we have exclusive ownership of the State at commit()");
 
         // Check if an emergency halt has been signaled.
-        let should_halt = state
-            .is_chain_halted(TOTAL_HALT_COUNT)
-            .await
-            .expect("must be able to read halt flag");
+        let should_halt = state.is_chain_halted().await;
 
         let is_upgrade_height = state
             .is_upgrade_height()
@@ -553,12 +550,6 @@ impl App {
             .unwrap_or_default()
     }
 }
-
-/// The total number of times the chain has been halted.
-///
-/// Increment this manually after fixing the root cause for a chain halt: updated nodes will then be
-/// able to proceed past the block height of the halt.
-const TOTAL_HALT_COUNT: u64 = 0;
 
 #[async_trait]
 pub trait StateReadExt: StateRead {

--- a/crates/core/app/src/app/state_key.rs
+++ b/crates/core/app/src/app/state_key.rs
@@ -20,9 +20,3 @@ pub mod cometbft_data {
         )
     }
 }
-
-pub mod counters {
-    pub fn halt_count() -> &'static str {
-        "application/counters/halt_count"
-    }
-}

--- a/crates/core/component/governance/src/component/view.rs
+++ b/crates/core/component/governance/src/component/view.rs
@@ -33,6 +33,7 @@ use crate::{
     params::GovernanceParameters,
     proposal::{Proposal, ProposalPayload},
     proposal_state::State as ProposalState,
+    state_key::persistent_flags,
     validator_vote::action::ValidatorVoteReason,
     vote::Vote,
 };
@@ -561,19 +562,11 @@ pub trait StateReadExt: StateRead + penumbra_stake::StateReadExt {
             .is_some()
     }
 
-    async fn is_chain_halted(&self, total_halt_count: u64) -> Result<bool> {
-        Ok(total_halt_count
-            < self
-                .get_proto(state_key::halt::halt_count())
-                .await?
-                .unwrap_or_default())
-    }
-
-    async fn halt_count(&self) -> Result<u64> {
-        Ok(self
-            .get_proto(state_key::halt::halt_count())
-            .await?
-            .unwrap_or_default())
+    async fn is_chain_halted(&self) -> bool {
+        self.nonverifiable_get_proto(state_key::persistent_flags::halt_bit().as_bytes())
+            .await
+            .expect("no deserialization errors")
+            .unwrap_or_default()
     }
 }
 
@@ -875,7 +868,7 @@ pub trait StateWriteExt: StateWrite + penumbra_ibc::component::ConnectionStateWr
                     // Print an informational message and signal to the consensus worker to halt the
                     // process after the state is committed
                     tracing::info!("emergency proposal passed calling for immediate chain halt");
-                    self.signal_halt().await?;
+                    self.signal_halt();
                 }
             }
             ProposalPayload::ParameterChange(change) => {
@@ -955,12 +948,17 @@ pub trait StateWriteExt: StateWrite + penumbra_ibc::component::ConnectionStateWr
         Ok(())
     }
 
-    /// Signals to the consensus worker to halt after the next commit.
-    async fn signal_halt(&mut self) -> Result<()> {
-        let halt_count = self.halt_count().await?;
+    /// Sets the application `halt_bit` to `true`, signaling that
+    /// the chain should be halted, and preventing restarts until
+    /// a migration is ran.
+    fn signal_halt(&mut self) {
+        self.nonverifiable_put_proto(persistent_flags::halt_bit().as_bytes().to_vec(), true);
+    }
 
-        self.put_proto(state_key::halt::halt_count().to_string(), halt_count + 1);
-        Ok(())
+    /// Sets the application `halt_bit` to `false`, signaling that
+    /// the chain can resume, and the application is ready to start.
+    fn ready_to_start(&mut self) {
+        self.nonverifiable_put_proto(persistent_flags::halt_bit().as_bytes().to_vec(), false);
     }
 }
 

--- a/crates/core/component/governance/src/component/view.rs
+++ b/crates/core/component/governance/src/component/view.rs
@@ -44,7 +44,7 @@ pub trait StateReadExt: StateRead + penumbra_stake::StateReadExt {
     /// Returns true if the next height is an upgrade height.
     /// We look-ahead to the next height because we want to halt the chain immediately after
     /// committing the block.
-    async fn is_upgrade_height(&self) -> Result<bool> {
+    async fn is_pre_upgrade_height(&self) -> Result<bool> {
         let Some(next_upgrade_height) = self
             .nonverifiable_get_raw(state_key::upgrades::next_upgrade().as_bytes())
             .await?

--- a/crates/core/component/governance/src/state_key.rs
+++ b/crates/core/component/governance/src/state_key.rs
@@ -124,8 +124,6 @@ pub fn param_changes_for_height(block_height: u64) -> String {
     format!("governance/param_changes/{block_height}/")
 }
 
-// Used for object store:
-
 pub fn proposal_started() -> &'static str {
     "governance/proposal_started"
 }
@@ -136,8 +134,8 @@ pub mod upgrades {
     }
 }
 
-pub mod halt {
-    pub fn halt_count() -> &'static str {
-        "governance/counters/halt_count"
+pub mod persistent_flags {
+    pub fn halt_bit() -> &'static str {
+        "governance/persistent_flags/halt_bit"
     }
 }

--- a/crates/proto/src/state/read.rs
+++ b/crates/proto/src/state/read.rs
@@ -61,6 +61,23 @@ pub trait StateReadProto: StateRead + Send + Sync {
         }
     }
 
+    /// Gets a value from the nonverifiable key-value store as a proto type.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(v))` if the value is present and parseable as a proto type `P`;
+    /// * `Ok(None)` if the value is missing;
+    /// * `Err(_)` if the value is present but not parseable as a proto type `P`, or if an underlying storage error occurred.
+    fn nonverifiable_get_proto<P>(&self, key: &[u8]) -> ProtoFuture<P, Self::GetRawFut>
+    where
+        P: Message + Default + Debug,
+    {
+        ProtoFuture {
+            inner: self.nonverifiable_get_raw(key),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
     /// Retrieve all values for keys matching a prefix from consensus-critical state, as domain types.
     #[allow(clippy::type_complexity)]
     fn prefix<'a, D>(

--- a/crates/proto/src/state/write.rs
+++ b/crates/proto/src/state/write.rs
@@ -31,6 +31,14 @@ pub trait StateWriteProto: StateWrite + Send + Sync {
         self.nonverifiable_put_raw(key, value.encode_to_vec());
     }
 
+    /// Puts a proto type into the verifiable key-value store with the given key.
+    fn nonverifiable_put_proto<P>(&mut self, key: Vec<u8>, value: P)
+    where
+        P: Message + Default + Debug,
+    {
+        self.nonverifiable_put_raw(key, value.encode_to_vec());
+    }
+
     /// Records a Protobuf message as a typed ABCI event.
     fn record_proto<E>(&mut self, proto_event: E)
     where


### PR DESCRIPTION
## Describe your changes

This PR implements #4373 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This is consensus breaking because it deprecates the application halt counter stored within the verifiable chain state. However, it does not require a state migration because the switch starts in the "off" (i.e. `false`) position. As a result, everything else being equal, using a new upgraded binary should be sufficient.