### PR TITLE
chore: bump version to 0.76.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "cnidarium"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-frost"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "ark-ff",
  "decaf377 0.5.0",
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "pcli"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "pclientd"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "pd"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-app"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4782,7 +4782,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-auction"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-auto-https"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "axum-server",
@@ -4849,7 +4849,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-bench"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-custody"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -4995,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5072,7 +5072,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-eddy"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-funding"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5137,7 +5137,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "aes 0.8.4",
  "anyhow",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-measure"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-mock-client"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "cnidarium",
@@ -5307,7 +5307,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-mock-consensus"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5322,7 +5322,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-setup"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5445,7 +5445,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5478,7 +5478,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5581,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct-property-test"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -5624,7 +5624,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct-visualize"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tendermint-proxy"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-test-subscriber"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -5693,7 +5693,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tower-trace"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "futures",
  "hex",
@@ -5714,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-view"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-wallet"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -7655,7 +7655,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "summonerd"
-version = "0.75.0"
+version = "0.76.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-groth16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ push = false
 [workspace.package]
 authors    = ["Penumbra Labs <team@penumbra.zone>"]
 edition    = "2021"
-version    = "0.75.0"
+version    = "0.76.0-alpha.1"
 repository = "https://github.com/penumbra-zone/penumbra"
 homepage   = "https://penumbra.zone"
 license    = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Describe your changes
No tag associated with this increment. Making the change to the local Cargo.toml files specifically to differentiate versions explicitly while testing upgrades and migrations from the previous stable tag of v0.75.0.

Refs #4402.

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > no code changes, version bump only.