### PR TITLE
tonic: 🍸 patch tonic dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8277,8 +8277,7 @@ dependencies = [
 [[package]]
 name = "tonic"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+source = "git+https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7029d1404ffa21639f596da58024364f0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8308,8 +8307,7 @@ dependencies = [
 [[package]]
 name = "tonic-reflection"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa37c513df1339d197f4ba21d28c918b9ef1ac1768265f11ecb6b7f1cba1b76"
+source = "git+https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7029d1404ffa21639f596da58024364f0"
 dependencies = [
  "prost",
  "prost-types",
@@ -8321,8 +8319,7 @@ dependencies = [
 [[package]]
 name = "tonic-web"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fddb2a37b247e6adcb9f239f4e5cefdcc5ed526141a416b943929f13aea2cce"
+source = "git+https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7029d1404ffa21639f596da58024364f0"
 dependencies = [
  "base64 0.21.7",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,3 +232,11 @@ tower-service                    = { version = "0.3.2" }
 tracing                          = { version = "0.1" }
 tracing-subscriber               = { version = "0.3.17", features = ["env-filter"] }
 url                              = { version = "2.2" }
+
+# TODO(kate):
+# temporarily point these dependencies to a tag in the penumbra-zone fork.
+# see #4392, #4400, and hyperium/tonic#1701 for more information.
+[patch.crates-io]
+tonic                            = { git = "https://github.com/penumbra-zone/tonic.git", tag = "v0.10.3-penumbra" }
+tonic-reflection                 = { git = "https://github.com/penumbra-zone/tonic.git", tag = "v0.10.3-penumbra" }
+tonic-web                        = { git = "https://github.com/penumbra-zone/tonic.git", tag = "v0.10.3-penumbra" }


### PR DESCRIPTION
fixes #4392.

in #4392, we found an issue with gRPC reflection when recent versions of `grpcurl` were used to list supported endpoints.

this was tracked down and fixed in #hyperium/tonic#1701, in collaboration with @conorsch. that pr targets the more recent 0.11 tonic release however, which we are not yet using.

eventually we should upgrade to tonic 0.11 (see #4400). as a short-term measure, but we want to unblock engineers from Skip working on an integration with Penumbra. this commit patches the `tonic` dependencies used to point to a temporary fork of the `tonic` repo, where i have backported that patch (and some ci-related fixes) to the 0.10 release.

see also:
* https://github.com/hyperium/tonic/pull/1701
* https://github.com/penumbra-zone/tonic/pull/1
* https://github.com/penumbra-zone/tonic/pull/2
* #4392
* #4400

---

checking that all transitive dependencies point to the patched version:

```
; cargo tree | grep tonic
│   └── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7)
├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   │   │   │   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   │   │   │   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   │   │   │   │   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   │   │   │   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   │   │   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   │   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   │   │   │   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   │   │   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   │   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   │   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   │   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   ├── tonic-reflection v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7)
│   │   └── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   ├── tonic-web v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7)
│   │   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
│   ├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
├── tonic-reflection v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
├── tonic-web v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
├── tonic-reflection v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
├── tonic-web v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
├── tonic v0.10.2 (https://github.com/penumbra-zone/tonic.git?tag=v0.10.3-penumbra#db355dd7) (*)
```

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > REPLACE THIS TEXT WITH RATIONALE (CAN BE BRIEF)
