### PR TITLE
ci: faster cargo check features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
 
   check:
     name: Check all crate features
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION

## Describe your changes
Bumping up the size of the runner, since we added more compute-intensive logic back in [0]. The logic is still serialized, but now it should complete faster. I've noticed the cache getting evicted faster lately, due to multiple large PRs, so the extra compute will help offset the delay caused by cache busting.

[0] f7234c0299b3732a6a7119c13a2eafaa6196bc7a

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > ci-only
