### PR TITLE
pd: refuse to bootstrap services if the app is not ready

### DIFF
--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -93,6 +93,10 @@ pub enum RootCommand {
         /// But, it is a potential DoS vector, so it is disabled by default.
         #[clap(short, long, display_order = 500)]
         enable_expensive_rpc: bool,
+
+        /// Force the node to start even if the application's halt flag is set.
+        #[clap(long, display_order = 1000)]
+        force: bool,
     },
     /// Generate, join, or reset a testnet.
     Testnet {

--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -93,10 +93,6 @@ pub enum RootCommand {
         /// But, it is a potential DoS vector, so it is disabled by default.
         #[clap(short, long, display_order = 500)]
         enable_expensive_rpc: bool,
-
-        /// Force the node to start even if the application's halt flag is set.
-        #[clap(long, display_order = 1000)]
-        force: bool,
     },
     /// Generate, join, or reset a testnet.
     Testnet {

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -61,7 +61,6 @@ async fn main() -> anyhow::Result<()> {
             metrics_bind,
             cometbft_addr,
             enable_expensive_rpc,
-            force,
         } => {
             // Use the given `grpc_bind` address if one was specified. If not, we will choose a
             // default depending on whether or not `grpc_auto_https` was set. See the
@@ -115,7 +114,7 @@ async fn main() -> anyhow::Result<()> {
                 "starting pd"
             );
 
-            if penumbra_app::app::App::is_ready(storage.latest_snapshot()).await || force {
+            if penumbra_app::app::App::is_ready(storage.latest_snapshot()).await {
                 tracing::info!("application ready to start");
             } else {
                 tracing::warn!("application is halted, refusing to start");

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -67,14 +67,15 @@ impl App {
         // there should be no unexpected copies elsewhere.
         let state = Arc::new(StateDelta::new(snapshot));
 
-        // If the state says that the chain is halted, we should not proceed. This is a safety check
-        // to ensure that automatic restarts by software like systemd do not cause the chain to come
-        // back up again after a halt.
-        if state.is_chain_halted().await {
-            anyhow::bail!("chain is halted, refusing to restart");
-        }
-
         Ok(Self { state })
+    }
+
+    #[instrument(skip_all, ret)]
+    pub async fn is_ready(snapshot: Snapshot) -> bool {
+        // If the chain is halted, we are not ready to start the application.
+        // This is a safety mechanism to prevent the chain from starting if it
+        // is in a halted state.
+        !state.is_chain_halted().await
     }
 
     // StateDelta::apply only works when the StateDelta wraps an underlying

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -1,4 +1,6 @@
+use std::process;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -35,6 +37,7 @@ use tendermint::abci::{self, Event};
 
 use tendermint::v0_37::abci::{request, response};
 use tendermint::validator::Update;
+use tokio::time::sleep;
 use tracing::{instrument, Instrument};
 
 use crate::action_handler::AppActionHandler;

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -59,19 +59,21 @@ pub struct App {
 
 impl App {
     /// Constructs a new application, using the provided [`Snapshot`].
-    #[instrument(err, skip_all)]
-    pub async fn new(snapshot: Snapshot) -> Result<Self> {
+    /// Callers should ensure that [`App::is_ready`]) returns `true`, but this is not enforced.
+    #[instrument(skip_all)]
+    pub fn new(snapshot: Snapshot) -> Self {
         tracing::debug!("initializing App instance");
 
         // We perform the `Arc` wrapping of `State` here to ensure
         // there should be no unexpected copies elsewhere.
         let state = Arc::new(StateDelta::new(snapshot));
 
-        Ok(Self { state })
+        Self { state }
     }
 
+    /// Returns whether the application is ready to start.
     #[instrument(skip_all, ret)]
-    pub async fn is_ready(snapshot: Snapshot) -> bool {
+    pub async fn is_ready(state: Snapshot) -> bool {
         // If the chain is halted, we are not ready to start the application.
         // This is a safety mechanism to prevent the chain from starting if it
         // is in a halted state.

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -155,6 +155,13 @@ impl App {
         &mut self,
         proposal: request::PrepareProposal,
     ) -> response::PrepareProposal {
+        if self.state.is_chain_halted().await {
+            // If we find ourselves preparing a proposal for a halted chain
+            // we stop abruptly to prevent any progress.
+            // The persistent halt mechanism will prevent restarts until we are ready.
+            process::exit(0);
+        }
+
         let mut included_txs = Vec::new();
         let num_candidate_txs = proposal.txs.len();
         tracing::debug!(

--- a/crates/core/app/src/server.rs
+++ b/crates/core/app/src/server.rs
@@ -57,8 +57,7 @@ pub fn new(
             req.create_span()
         }))
         .service(tower_actor::Actor::new(10, |queue: _| {
-            let storage = storage.clone();
-            async move { Mempool::new(storage.clone(), queue).await?.run().await }
+            Mempool::new(storage.clone(), queue).run()
         }));
     let info = Info::new(storage.clone());
     let snapshot = Snapshot {};

--- a/crates/core/app/src/server/consensus.rs
+++ b/crates/core/app/src/server/consensus.rs
@@ -36,27 +36,21 @@ impl Consensus {
 
     pub fn new(storage: Storage) -> ConsensusService {
         tower_actor::Actor::new(Self::QUEUE_SIZE, |queue: _| {
-            let storage = storage.clone();
-            async move {
-                Consensus::new_inner(storage.clone(), queue)
-                    .await?
-                    .run()
-                    .await
-            }
+            Consensus::new_inner(storage, queue).run()
         })
     }
 
-    async fn new_inner(
+    fn new_inner(
         storage: Storage,
         queue: mpsc::Receiver<Message<Request, Response, tower::BoxError>>,
-    ) -> Result<Self> {
-        let app = App::new(storage.latest_snapshot()).await?;
+    ) -> Self {
+        let app = App::new(storage.latest_snapshot());
 
-        Ok(Self {
+        Self {
             queue,
             storage,
             app,
-        })
+        }
     }
 
     async fn run(mut self) -> Result<(), tower::BoxError> {

--- a/crates/core/app/src/server/mempool.rs
+++ b/crates/core/app/src/server/mempool.rs
@@ -31,18 +31,18 @@ pub struct Mempool {
 }
 
 impl Mempool {
-    pub async fn new(
+    pub fn new(
         storage: Storage,
         queue: mpsc::Receiver<Message<Request, Response, tower::BoxError>>,
-    ) -> Result<Self> {
+    ) -> Self {
         let app = App::new(storage.latest_snapshot());
         let snapshot_rx = storage.subscribe();
 
-        Ok(Self {
+        Self {
             queue,
             app,
             rx_snapshot: snapshot_rx,
-        })
+        }
     }
 
     pub async fn check_tx(&mut self, req: Request) -> Result<Response, tower::BoxError> {

--- a/crates/core/app/src/server/mempool.rs
+++ b/crates/core/app/src/server/mempool.rs
@@ -35,7 +35,7 @@ impl Mempool {
         storage: Storage,
         queue: mpsc::Receiver<Message<Request, Response, tower::BoxError>>,
     ) -> Result<Self> {
-        let app = App::new(storage.latest_snapshot()).await?;
+        let app = App::new(storage.latest_snapshot());
         let snapshot_rx = storage.subscribe();
 
         Ok(Self {
@@ -91,7 +91,7 @@ impl Mempool {
                     if let Ok(()) = change {
                         let snapshot = self.rx_snapshot.borrow().clone();
                         tracing::debug!(height = ?snapshot.version(), "resetting ephemeral mempool state");
-                        self.app = App::new(snapshot).await?;
+                        self.app = App::new(snapshot);
                     } else {
                         // TODO: what triggers this, now that the channel is owned by the
                         // shared Storage instance, rather than the consensus worker?

--- a/crates/core/app/tests/common/temp_storage_ext.rs
+++ b/crates/core/app/tests/common/temp_storage_ext.rs
@@ -20,7 +20,7 @@ impl TempStorageExt for TempStorage {
         }
 
         // Apply the genesis state to the storage
-        let mut app = App::new(self.latest_snapshot()).await?;
+        let mut app = App::new(self.latest_snapshot());
         app.init_chain(&genesis).await;
         app.commit(self.deref().clone()).await;
 


### PR DESCRIPTION
## Describe your changes

Previously, the halting logic was structured such that full nodes would partially crash two of their four ABCI services (`Consensus` and `Mempool`); relying on future CometBFT consensus requests to crash the node.

This PR adds an `App::is_ready` method that callers (pd) SHOULD call in order to make sure that the application is ready, so that they can avoid to spin up any services unless an override flag (`--force`) is specified.

## Issue ticket number and link

Fix #4432 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Full node mechanical refactor
