### PR TITLE
Correct display of downtime in `pcli validator query uptime`

### DIFF
--- a/crates/bin/pcli/src/command/query/validator.rs
+++ b/crates/bin/pcli/src/command/query/validator.rs
@@ -286,8 +286,9 @@ impl ValidatorCmd {
                     100.0 * params.stake_params.missed_blocks_maximum as f64 / window_len as f64;
                 let percent_downtime = 100.0 * missed_blocks as f64 / window_len as f64;
                 let percent_downtime_penalty =
-                    // Converting from basis points squared to percentage
-                    params.stake_params.slashing_penalty_downtime as f64 / 100.0 / 100.0;
+                    // Converting from basis points squared to percentage: bais point ^ 2  %-age
+                    //                                                    /--------------\/-----\
+                    params.stake_params.slashing_penalty_downtime as f64 / 100.0 / 100.0 / 100.0;
                 let min_remaining_downtime_blocks = (window_len as u64)
                     .saturating_sub(missed_blocks as u64)
                     .saturating_sub(min_uptime_blocks);

--- a/crates/bin/pcli/src/command/query/validator.rs
+++ b/crates/bin/pcli/src/command/query/validator.rs
@@ -286,7 +286,7 @@ impl ValidatorCmd {
                     100.0 * params.stake_params.missed_blocks_maximum as f64 / window_len as f64;
                 let percent_downtime = 100.0 * missed_blocks as f64 / window_len as f64;
                 let percent_downtime_penalty =
-                    // Converting from basis points squared to percentage: bais point ^ 2  %-age
+                    // Converting from basis points squared to percentage: basis point ^ 2  %-age
                     //                                                    /--------------\/-----\
                     params.stake_params.slashing_penalty_downtime as f64 / 100.0 / 100.0 / 100.0;
                 let min_remaining_downtime_blocks = (window_len as u64)


### PR DESCRIPTION
The downtime penalty is 0.01%, not 1% as previously displayed. This corrects the erroneous calculation which previously displayed an incorrect figure by a 100x factor.

## Describe your changes

This adds a `/ 100.0` to correct the missing factor, and an explanatory comment.

## Checklist before requesting a review

- [X] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This is a display fix for `pcli`.
