### PR TITLE
view: don't record invalid and corrupted Metadata

### DIFF
--- a/crates/view/src/storage.rs
+++ b/crates/view/src/storage.rs
@@ -1147,25 +1147,6 @@ impl Storage {
         .await?
     }
 
-    pub async fn record_unknown_asset(&self, id: asset::Id) -> anyhow::Result<()> {
-        let asset_id = id.to_bytes().to_vec();
-        let denom = "Unknown".to_string();
-
-        let pool = self.pool.clone();
-
-        spawn_blocking(move || {
-            pool.get()?
-                .execute(
-                    "INSERT OR IGNORE INTO assets (asset_id, denom) VALUES (?1, ?2)",
-                    (asset_id, denom),
-                )
-                .map_err(anyhow::Error::from)
-        })
-        .await??;
-
-        Ok(())
-    }
-
     pub async fn record_position(&self, position: Position) -> anyhow::Result<()> {
         let position_id = position.id().0.to_vec();
 

--- a/crates/view/src/worker.rs
+++ b/crates/view/src/worker.rs
@@ -399,12 +399,7 @@ impl Worker {
                                 .record_asset(denom_metadata.try_into()?)
                                 .await?;
                         } else {
-                            // Otherwise we are dealing with an unknown/novel asset ID, but we don't have the original raw denom field naming the asset.
-                            // For now, we can just record the asset ID with the denom value as "Unknown".
-
-                            self.storage
-                                .record_unknown_asset(note_record.note.asset_id())
-                                .await?;
+                            tracing::warn!(asset_id = ?note_record.note.asset_id(), "received unknown asset ID with no available metadata");
                         }
                     }
                 }


### PR DESCRIPTION
This doesn't solve the problem that the metadata will be missing, but it does at least avoid corrupting the database.

Closes #4452

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > only changes client code