### PR TITLE
dex: add duration metric for SimulateTrade RPC

### DIFF
--- a/crates/core/component/dex/src/component/action_handler/swap.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap.rs
@@ -7,7 +7,7 @@ use penumbra_proto::StateWriteProto;
 use penumbra_sct::component::source::SourceContext;
 
 use crate::{
-    component::{metrics, StateReadExt, StateWriteExt, SwapManager},
+    component::{StateReadExt, StateWriteExt, SwapManager},
     event,
     swap::{proof::SwapProofPublic, Swap},
 };
@@ -42,7 +42,6 @@ impl ActionHandler for Swap {
             "Dex MUST be enabled to process swap actions."
         );
 
-        let swap_start = std::time::Instant::now();
         let swap = self;
 
         // All swaps will be tallied for the block so the
@@ -65,8 +64,6 @@ impl ActionHandler for Swap {
             .add_swap_payload(self.body.payload.clone(), source)
             .await;
 
-        metrics::histogram!(crate::component::metrics::DEX_SWAP_DURATION)
-            .record(swap_start.elapsed());
         state.record_proto(event::swap(self));
 
         Ok(())

--- a/crates/core/component/dex/src/component/metrics.rs
+++ b/crates/core/component/dex/src/component/metrics.rs
@@ -36,9 +36,9 @@ pub fn register_metrics() {
         "The time spent filling routes while executing trades within the DEX"
     );
     describe_histogram!(
-        DEX_SWAP_DURATION,
+        DEX_RPC_SIMULATE_TRADE_DURATION,
         Unit::Seconds,
-        "The time spent processing swaps within the DEX"
+        "The time spent processing a SimulateTrade RPC request"
     );
 }
 
@@ -52,4 +52,5 @@ pub const DEX_PATH_SEARCH_DURATION: &str = "penumbra_dex_path_search_duration_se
 pub const DEX_ROUTE_FILL_DURATION: &str = "penumbra_dex_route_fill_duration_seconds";
 pub const DEX_ARB_DURATION: &str = "penumbra_dex_arb_duration_seconds";
 pub const DEX_BATCH_DURATION: &str = "penumbra_dex_batch_duration_seconds";
-pub const DEX_SWAP_DURATION: &str = "penumbra_dex_swap_duration_seconds";
+pub const DEX_RPC_SIMULATE_TRADE_DURATION: &str =
+    "penumbra_dex_rpc_simulate_trade_duration_seconds";

--- a/crates/core/component/dex/src/component/rpc.rs
+++ b/crates/core/component/dex/src/component/rpc.rs
@@ -25,6 +25,7 @@ use penumbra_proto::{
 
 use super::ExecutionCircuitBreaker;
 use crate::{
+    component::metrics,
     lp::position::{self, Position},
     state_key, DirectedTradingPair, SwapExecution, TradingPair,
 };
@@ -522,6 +523,7 @@ impl SimulationService for Server {
                 tonic::Status::invalid_argument(format!("error parsing output id: {:#}", e))
             })?;
 
+        let start_time = std::time::Instant::now();
         let state = self.storage.latest_snapshot();
 
         let mut routing_params = state.routing_params().await.unwrap();
@@ -560,9 +562,15 @@ impl SimulationService for Server {
             asset_id: input.asset_id,
         };
 
-        Ok(tonic::Response::new(SimulateTradeResponse {
+        let rsp = tonic::Response::new(SimulateTradeResponse {
             unfilled: Some(unfilled.into()),
             output: Some(swap_execution.into()),
-        }))
+        });
+
+        let duration = start_time.elapsed();
+
+        metrics::histogram!(metrics::DEX_RPC_SIMULATE_TRADE_DURATION).record(duration);
+
+        Ok(rsp)
     }
 }


### PR DESCRIPTION
This removes the "swap" RPC, which was not useful (processing swaps is ~free)

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > metrics changes