### PR TITLE
app: 👐 `rpc::router(..)` accepts a `TendermintProxyService`

### DIFF
--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -118,8 +118,8 @@ async fn main() -> anyhow::Result<()> {
                 penumbra_app::server::new(storage.clone()).listen_tcp(abci_bind),
             );
 
-            let grpc_server =
-                penumbra_app::rpc::router(&storage, cometbft_addr, enable_expensive_rpc)?;
+            let tm_proxy = penumbra_tendermint_proxy::TendermintProxy::new(cometbft_addr);
+            let grpc_server = penumbra_app::rpc::router(&storage, tm_proxy, enable_expensive_rpc)?;
 
             // Create Axum routes for the frontend app.
             let frontend = pd::zipserve::router("/app/", pd::MINIFRONT_ARCHIVE_BYTES);


### PR DESCRIPTION
#### 💭 describe your changes

instead of accepting a `url::Url` and constructing specifically the "real" `TendermintProxy`, tweak the signature of the router function so that it accepts a `T: TendermintProxyService`.

in the future, this will allow mock consensus test cases to run an rpc endpoint for the view server, without running a Tendermint/CometBFT process.

#### 🔖 issue ticket number and link

see #3913.

#### ✅ checklist before requesting a review

- [x] if this code contains consensus-breaking changes, i have added the "consensus-breaking" label. otherwise, i declare my belief that there are not consensus-breaking changes, for the following reason:

    > this is a like-for-like refactoring, changing a function
    > signature.
