### PR TITLE
pd: bump app_version 4 -> 5

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,3 +4,4 @@
 | 2 (Testnet 73)            | v0.73.x                | v0.37.5  |   v1     |
 | 3 (Testnet 74)            | v0.74.x                | v0.37.5  |   v1     |
 | 4 (Testnet 75)            | v0.75.x                | v0.37.5  |   v1     |
+| 5 (Testnet 76)            | v0.76.x                | v0.37.5  |   v1     |

--- a/crates/core/app/src/lib.rs
+++ b/crates/core/app/src/lib.rs
@@ -22,7 +22,7 @@ use once_cell::sync::Lazy;
 
 /// Representation of the Penumbra application version. Notably, this is distinct
 /// from the crate version(s). This number should only ever be incremented.
-pub const APP_VERSION: u64 = 4;
+pub const APP_VERSION: u64 = 5;
 
 pub static SUBSTORE_PREFIXES: Lazy<Vec<String>> = Lazy::new(|| {
     vec![


### PR DESCRIPTION

## Describe your changes
We're not actually using this value in storage yet (#4365), but we still update it for clarity about compatibility.

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > docs and logging-only app version, does not affect how node comes to consensus