### PR TITLE
dex: add duration metric for SimulateTrade RPC (#4454)

### DIFF
--- a/crates/core/component/dex/src/component/action_handler/swap.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap.rs
@@ -9,9 +9,7 @@ use penumbra_proto::StateWriteProto;
 use penumbra_sct::component::source::SourceContext;
 
 use crate::{
-    component::{
-        metrics, position_manager::PositionManager as _, StateReadExt, StateWriteExt, SwapManager,
-    },
+    component::{position_manager::PositionManager as _, StateReadExt, StateWriteExt, SwapManager},
     event,
     swap::{proof::SwapProofPublic, Swap},
 };
@@ -46,7 +44,6 @@ impl ActionHandler for Swap {
             "Dex MUST be enabled to process swap actions."
         );
 
-        let swap_start = std::time::Instant::now();
         let swap = self;
 
         // All swaps will be tallied for the block so the
@@ -77,8 +74,6 @@ impl ActionHandler for Swap {
         );
         state.add_recently_accessed_asset(swap.body.trading_pair.asset_2(), fixed_candidates);
 
-        metrics::histogram!(crate::component::metrics::DEX_SWAP_DURATION)
-            .record(swap_start.elapsed());
         state.record_proto(event::swap(self));
 
         Ok(())

--- a/crates/core/component/dex/src/component/metrics.rs
+++ b/crates/core/component/dex/src/component/metrics.rs
@@ -36,9 +36,9 @@ pub fn register_metrics() {
         "The time spent filling routes while executing trades within the DEX"
     );
     describe_histogram!(
-        DEX_SWAP_DURATION,
+        DEX_RPC_SIMULATE_TRADE_DURATION,
         Unit::Seconds,
-        "The time spent processing swaps within the DEX"
+        "The time spent processing a SimulateTrade RPC request"
     );
 }
 
@@ -52,4 +52,5 @@ pub const DEX_PATH_SEARCH_DURATION: &str = "penumbra_dex_path_search_duration_se
 pub const DEX_ROUTE_FILL_DURATION: &str = "penumbra_dex_route_fill_duration_seconds";
 pub const DEX_ARB_DURATION: &str = "penumbra_dex_arb_duration_seconds";
 pub const DEX_BATCH_DURATION: &str = "penumbra_dex_batch_duration_seconds";
-pub const DEX_SWAP_DURATION: &str = "penumbra_dex_swap_duration_seconds";
+pub const DEX_RPC_SIMULATE_TRADE_DURATION: &str =
+    "penumbra_dex_rpc_simulate_trade_duration_seconds";


### PR DESCRIPTION
## Describe your changes
Backports #4454 for inclusion in v0.76.0. Refs #4402. Closes #4457. (cherry picked from commit e1d8b2c60b984942d310dcd32698919a2817638c)

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > metrics emission, no changes to consensus logic