### PR TITLE
app: demote ABCI event tracing

### DIFF
--- a/crates/core/app/src/server/consensus.rs
+++ b/crates/core/app/src/server/consensus.rs
@@ -22,10 +22,10 @@ pub type ConsensusService = tower_actor::Actor<Request, Response, BoxError>;
 
 fn trace_events(events: &[Event]) {
     for event in events {
-        let span = tracing::info_span!("event", kind = ?event.kind);
+        let span = tracing::debug_span!("event", kind = ?event.kind);
         span.in_scope(|| {
             for attr in &event.attributes {
-                tracing::info!(k = ?attr.key, v=?attr.value);
+                tracing::debug!(k = ?attr.key, v=?attr.value);
             }
         })
     }


### PR DESCRIPTION
## Describe your changes

We have a lot more ABCI events now and we have indexers that consume them.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > logging changes