### PR TITLE
view: 🔎 add tracing telemetry to view server

### DIFF
--- a/crates/bin/pcli/src/network.rs
+++ b/crates/bin/pcli/src/network.rs
@@ -102,7 +102,7 @@ impl App {
         println!("broadcasting transaction and awaiting confirmation...");
         let mut rsp = self.view().broadcast_transaction(transaction, true).await?;
 
-        let id = (async move {
+        let id = async move {
             while let Some(rsp) = rsp.try_next().await? {
                 match rsp.status {
                     Some(status) => match status {
@@ -140,7 +140,7 @@ impl App {
                 "should have received BroadcastTransaction status or error"
             ))
         }
-        .boxed())
+        .boxed()
         .await
         .context("error broadcasting transaction")?;
 

--- a/crates/view/src/service.rs
+++ b/crates/view/src/service.rs
@@ -1225,8 +1225,16 @@ impl ViewService for ViewServer {
     ) -> Result<tonic::Response<Self::StatusStreamStream>, tonic::Status> {
         self.check_worker().await?;
 
-        let (latest_known_block_height, _) =
-            self.latest_known_block_height().await.map_err(|e| {
+        let (latest_known_block_height, _) = self
+            .latest_known_block_height()
+            .await
+            .tap_err(|error| {
+                tracing::debug!(
+                    ?error,
+                    "unable to fetch latest known block height from fullnode"
+                )
+            })
+            .map_err(|e| {
                 tonic::Status::unknown(format!(
                     "unable to fetch latest known block height from fullnode: {e}"
                 ))


### PR DESCRIPTION
#### 💭 describe your changes

while debugging my work integrating mock consensus tests with the view server,
it was helpful to add additional instrumentation to some relevant parts of the
`penumbra-view` crate. this branch adds some useful spans and events.

#### 🔖 issue ticket number and link

this branch contains preliminary changes related to #3913. see also, #4447.

#### ✅ checklist before requesting a review

- [x] if this code contains consensus-breaking changes, i have added the
  "consensus-breaking" label. otherwise, i declare my belief that there are not
  consensus-breaking changes, for the following reason:

  > this only makes changes to tracing events, and makes a small syntactic
  > change. no behavior changes here should affect consensus.
