### PR TITLE
transaction: 🧁 `TransactionPlan::with_populated_detection_data()`

### DIFF
--- a/crates/core/app/tests/app_can_define_and_delegate_to_a_validator.rs
+++ b/crates/core/app/tests/app_can_define_and_delegate_to_a_validator.rs
@@ -2,7 +2,6 @@ use {
     self::common::{BuilderExt, TestNodeExt, ValidatorDataReadExt},
     anyhow::anyhow,
     cnidarium::TempStorage,
-    decaf377_fmd::Precision,
     decaf377_rdsa::{SigningKey, SpendAuth, VerificationKey},
     penumbra_app::{
         genesis::{self, AppState},
@@ -148,7 +147,7 @@ async fn app_can_define_and_delegate_to_a_validator() -> anyhow::Result<()> {
             validator: new_validator.clone(),
             auth_sig,
         });
-        let mut plan = TransactionPlan {
+        TransactionPlan {
             actions: vec![action.into()],
             // Now fill out the remaining parts of the transaction needed for verification:
             memo: None,
@@ -157,9 +156,8 @@ async fn app_can_define_and_delegate_to_a_validator() -> anyhow::Result<()> {
                 chain_id: TestNode::<()>::CHAIN_ID.to_string(),
                 ..Default::default()
             },
-        };
-        plan.populate_detection_data(rand_core::OsRng, Precision::default());
-        plan
+        }
+        .with_populated_detection_data(OsRng, Default::default())
     };
     let tx = client.witness_auth_build(&plan).await?;
 
@@ -258,7 +256,7 @@ async fn app_can_define_and_delegate_to_a_validator() -> anyhow::Result<()> {
             delegate.delegation_value(),
             test_keys::ADDRESS_1.deref().clone(),
         );
-        let mut plan = TransactionPlan {
+        TransactionPlan {
             actions: vec![spend.into(), output.into(), delegate.into()],
             // Now fill out the remaining parts of the transaction needed for verification:
             memo: Some(MemoPlan::new(
@@ -270,9 +268,8 @@ async fn app_can_define_and_delegate_to_a_validator() -> anyhow::Result<()> {
                 chain_id: TestNode::<()>::CHAIN_ID.to_string(),
                 ..Default::default()
             },
-        };
-        plan.populate_detection_data(rand_core::OsRng, Precision::default());
-        plan
+        }
+        .with_populated_detection_data(OsRng, Default::default())
     };
     let tx = client.witness_auth_build(&plan).await?;
 
@@ -419,8 +416,7 @@ async fn app_can_define_and_delegate_to_a_validator() -> anyhow::Result<()> {
             undelegate.unbonded_value(),
             test_keys::ADDRESS_1.deref().clone(),
         );
-
-        let mut plan = TransactionPlan {
+        TransactionPlan {
             actions: vec![spend.into(), output.into(), undelegate.into()],
             // Now fill out the remaining parts of the transaction needed for verification:
             memo: Some(MemoPlan::new(
@@ -432,9 +428,8 @@ async fn app_can_define_and_delegate_to_a_validator() -> anyhow::Result<()> {
                 chain_id: TestNode::<()>::CHAIN_ID.to_string(),
                 ..Default::default()
             },
-        };
-        plan.populate_detection_data(rand_core::OsRng, Precision::default());
-        plan
+        }
+        .with_populated_detection_data(OsRng, Default::default())
     };
     let tx = client.witness_auth_build(&plan).await?;
 

--- a/crates/core/app/tests/app_can_disable_community_pool_spends.rs
+++ b/crates/core/app/tests/app_can_disable_community_pool_spends.rs
@@ -162,7 +162,7 @@ async fn app_can_disable_community_pool_spends() -> anyhow::Result<()> {
         .ok_or_else(|| anyhow!("mock client had no note"))?;
 
     // Create a community pool transaction.
-    let mut plan = {
+    let plan = {
         let value = note.value();
         let spend = SpendPlan::new(
             &mut OsRng,
@@ -183,8 +183,8 @@ async fn app_can_disable_community_pool_spends() -> anyhow::Result<()> {
                 ..Default::default()
             },
         }
+        .with_populated_detection_data(OsRng, Default::default())
     };
-    plan.populate_detection_data(OsRng, Default::default());
     let tx = client.witness_auth_build(&plan).await?;
 
     // Execute the transaction, applying it to the chain state.
@@ -198,7 +198,7 @@ async fn app_can_disable_community_pool_spends() -> anyhow::Result<()> {
 
     // Now, make a governance proposal that we should spend community pool funds, to return
     // the note back to the test wallet.
-    let mut plan = {
+    let plan = {
         let value = note.value();
         let proposed_tx_plan = TransactionPlan {
             actions: vec![
@@ -252,8 +252,8 @@ async fn app_can_disable_community_pool_spends() -> anyhow::Result<()> {
                 ..Default::default()
             },
         }
+        .with_populated_detection_data(OsRng, Default::default())
     };
-    plan.populate_detection_data(OsRng, Default::default());
     let tx = client.witness_auth_build(&plan).await?;
 
     // Execute the transaction, applying it to the chain state.
@@ -268,7 +268,7 @@ async fn app_can_disable_community_pool_spends() -> anyhow::Result<()> {
     let post_proposal_state = storage.latest_snapshot().proposal_state(0).await?;
 
     // Now make another transaction that will contain a validator vote upon our transaction.
-    let mut plan = {
+    let plan = {
         let body = ValidatorVoteBody {
             proposal: 0_u64,
             vote: penumbra_governance::Vote::Yes,
@@ -287,8 +287,8 @@ async fn app_can_disable_community_pool_spends() -> anyhow::Result<()> {
                 ..Default::default()
             },
         }
+        .with_populated_detection_data(OsRng, Default::default())
     };
-    plan.populate_detection_data(OsRng, Default::default());
     let tx = client.witness_auth_build(&plan).await?;
 
     // Execute the transaction, applying it to the chain state.

--- a/crates/core/app/tests/app_can_spend_notes_and_detect_outputs.rs
+++ b/crates/core/app/tests/app_can_spend_notes_and_detect_outputs.rs
@@ -2,7 +2,6 @@ use {
     self::common::BuilderExt,
     anyhow::anyhow,
     cnidarium::TempStorage,
-    decaf377_fmd::Precision,
     penumbra_app::{
         genesis::{self, AppState},
         server::consensus::Consensus,
@@ -57,7 +56,7 @@ async fn app_can_spend_notes_and_detect_outputs() -> anyhow::Result<()> {
         .ok_or_else(|| anyhow!("mock client had no note"))?;
 
     // Write down a transaction plan with exactly one spend and one output.
-    let mut plan = TransactionPlan {
+    let plan = TransactionPlan {
         actions: vec![
             // First, spend the selected input note.
             SpendPlan::new(
@@ -87,8 +86,8 @@ async fn app_can_spend_notes_and_detect_outputs() -> anyhow::Result<()> {
             chain_id: TestNode::<()>::CHAIN_ID.to_string(),
             ..Default::default()
         },
-    };
-    plan.populate_detection_data(OsRng, Precision::default());
+    }
+    .with_populated_detection_data(OsRng, Default::default());
 
     let tx = client.witness_auth_build(&plan).await?;
 

--- a/crates/core/app/tests/app_can_undelegate_from_a_validator.rs
+++ b/crates/core/app/tests/app_can_undelegate_from_a_validator.rs
@@ -137,7 +137,7 @@ async fn app_can_undelegate_from_a_validator() -> anyhow::Result<()> {
             delegate.delegation_value(),
             test_keys::ADDRESS_1.deref().clone(),
         );
-        let mut plan = TransactionPlan {
+        let plan = TransactionPlan {
             actions: vec![spend.into(), output.into(), delegate.into()],
             // Now fill out the remaining parts of the transaction needed for verification:
             memo: Some(MemoPlan::new(
@@ -149,8 +149,8 @@ async fn app_can_undelegate_from_a_validator() -> anyhow::Result<()> {
                 chain_id: TestNode::<()>::CHAIN_ID.to_string(),
                 ..Default::default()
             },
-        };
-        plan.populate_detection_data(rand_core::OsRng, Precision::default());
+        }
+        .with_populated_detection_data(rand_core::OsRng, Precision::default());
         (plan, note, staking_note_nullifier)
     };
     let tx = client.witness_auth_build(&plan).await?;
@@ -237,7 +237,7 @@ async fn app_can_undelegate_from_a_validator() -> anyhow::Result<()> {
             undelegate.unbonded_value(),
             test_keys::ADDRESS_1.deref().clone(),
         );
-        let mut plan = TransactionPlan {
+        let plan = TransactionPlan {
             actions: vec![spend.into(), output.into(), undelegate.into()],
             // Now fill out the remaining parts of the transaction needed for verification:
             memo: Some(MemoPlan::new(
@@ -249,8 +249,8 @@ async fn app_can_undelegate_from_a_validator() -> anyhow::Result<()> {
                 chain_id: TestNode::<()>::CHAIN_ID.to_string(),
                 ..Default::default()
             },
-        };
-        plan.populate_detection_data(rand_core::OsRng, Precision::default());
+        }
+        .with_populated_detection_data(rand_core::OsRng, Precision::default());
         (plan, undelegate_token_id)
     };
     let tx = client.witness_auth_build(&plan).await?;
@@ -321,7 +321,7 @@ async fn app_can_undelegate_from_a_validator() -> anyhow::Result<()> {
             proof_blinding_r: decaf377::Fq::rand(&mut OsRng),
             proof_blinding_s: decaf377::Fq::rand(&mut OsRng),
         };
-        let mut plan = TransactionPlan {
+        let plan = TransactionPlan {
             actions: vec![claim.into()],
             // Now fill out the remaining parts of the transaction needed for verification:
             memo: Some(MemoPlan::new(
@@ -333,8 +333,8 @@ async fn app_can_undelegate_from_a_validator() -> anyhow::Result<()> {
                 chain_id: TestNode::<()>::CHAIN_ID.to_string(),
                 ..Default::default()
             },
-        };
-        plan.populate_detection_data(rand_core::OsRng, Precision::default());
+        }
+        .with_populated_detection_data(rand_core::OsRng, Precision::default());
         plan
     };
     let tx = client.witness_auth_build(&plan).await?;

--- a/crates/core/app/tests/app_reproduce_testnet_75_vcb_close.rs
+++ b/crates/core/app/tests/app_reproduce_testnet_75_vcb_close.rs
@@ -1,6 +1,3 @@
-use decaf377_fmd::Precision;
-use penumbra_auction::StateReadExt as _;
-use tracing_subscriber::filter::EnvFilter;
 use {
     self::common::BuilderExt,
     anyhow::anyhow,
@@ -10,6 +7,7 @@ use {
         server::consensus::Consensus,
     },
     penumbra_asset::{Value, STAKING_TOKEN_ASSET_ID},
+    penumbra_auction::StateReadExt as _,
     penumbra_auction::{
         auction::{
             dutch::{ActionDutchAuctionEnd, ActionDutchAuctionSchedule, DutchAuctionDescription},
@@ -29,7 +27,9 @@ use {
     std::{ops::Deref, str::FromStr},
     tap::Tap,
     tracing::{error_span, info, Instrument},
+    tracing_subscriber::filter::EnvFilter,
 };
+
 mod common;
 
 #[tokio::test]
@@ -150,7 +150,7 @@ async fn app_can_reproduce_tesnet_75_vcb_close() -> anyhow::Result<()> {
         nft_open_output_note.clone().into(),
     ];
 
-    let mut plan = TransactionPlan {
+    let plan = TransactionPlan {
         memo: Some(MemoPlan::new(
             &mut OsRng,
             MemoPlaintext::blank_memo(test_keys::ADDRESS_0.deref().clone()),
@@ -161,10 +161,10 @@ async fn app_can_reproduce_tesnet_75_vcb_close() -> anyhow::Result<()> {
             chain_id: TestNode::<()>::CHAIN_ID.to_string(),
             ..Default::default()
         },
-    };
-    plan.populate_detection_data(&mut OsRng, Precision::default());
+    }
+    .with_populated_detection_data(OsRng, Default::default());
 
-    let tx = client.witness_auth_build(&mut plan).await?;
+    let tx = client.witness_auth_build(&plan).await?;
     node.block()
         .add_tx(tx.encode_to_vec())
         .execute()
@@ -221,7 +221,7 @@ async fn app_can_reproduce_tesnet_75_vcb_close() -> anyhow::Result<()> {
         nft_closed_output_note,
     ];
 
-    let mut plan = TransactionPlan {
+    let plan = TransactionPlan {
         memo: Some(MemoPlan::new(
             &mut OsRng,
             MemoPlaintext::blank_memo(test_keys::ADDRESS_0.deref().clone()),
@@ -232,10 +232,10 @@ async fn app_can_reproduce_tesnet_75_vcb_close() -> anyhow::Result<()> {
             chain_id: TestNode::<()>::CHAIN_ID.to_string(),
             ..Default::default()
         },
-    };
-    plan.populate_detection_data(&mut OsRng, Precision::default());
+    }
+    .with_populated_detection_data(OsRng, Default::default());
 
-    let tx = client.witness_auth_build(&mut plan).await?;
+    let tx = client.witness_auth_build(&plan).await?;
     tracing::info!("closing the auction");
     node.block()
         .add_tx(tx.encode_to_vec())

--- a/crates/core/app/tests/app_tracks_uptime_for_validators_only_once_active.rs
+++ b/crates/core/app/tests/app_tracks_uptime_for_validators_only_once_active.rs
@@ -1,7 +1,6 @@
 use {
     self::common::{BuilderExt, TestNodeExt, ValidatorDataReadExt},
     cnidarium::TempStorage,
-    decaf377_fmd::Precision,
     decaf377_rdsa::{SigningKey, SpendAuth, VerificationKey},
     penumbra_app::{
         genesis::{self, AppState},
@@ -124,7 +123,7 @@ async fn app_tracks_uptime_for_validators_only_once_active() -> anyhow::Result<(
             validator: new_validator.clone(),
             auth_sig,
         });
-        let mut plan = TransactionPlan {
+        TransactionPlan {
             actions: vec![action.into()],
             // Now fill out the remaining parts of the transaction needed for verification:
             memo: None,
@@ -133,9 +132,8 @@ async fn app_tracks_uptime_for_validators_only_once_active() -> anyhow::Result<(
                 chain_id: TestNode::<()>::CHAIN_ID.to_string(),
                 ..Default::default()
             },
-        };
-        plan.populate_detection_data(rand_core::OsRng, Precision::default());
-        plan
+        }
+        .with_populated_detection_data(OsRng, Default::default())
     };
 
     // Execute the transaction, applying it to the chain state.
@@ -198,7 +196,7 @@ async fn app_tracks_uptime_for_validators_only_once_active() -> anyhow::Result<(
             delegate.delegation_value(),
             test_keys::ADDRESS_1.deref().clone(),
         );
-        let mut plan = TransactionPlan {
+        TransactionPlan {
             actions: vec![spend.into(), output.into(), delegate.into()],
             // Now fill out the remaining parts of the transaction needed for verification:
             memo: Some(MemoPlan::new(
@@ -210,9 +208,8 @@ async fn app_tracks_uptime_for_validators_only_once_active() -> anyhow::Result<(
                 chain_id: TestNode::<()>::CHAIN_ID.to_string(),
                 ..Default::default()
             },
-        };
-        plan.populate_detection_data(rand_core::OsRng, Precision::default());
-        plan
+        }
+        .with_populated_detection_data(OsRng, Default::default())
     };
     let tx = client.witness_auth_build(&plan).await?;
 
@@ -322,7 +319,7 @@ async fn app_tracks_uptime_for_validators_only_once_active() -> anyhow::Result<(
             test_keys::ADDRESS_1.deref().clone(),
         );
 
-        let mut plan = TransactionPlan {
+        TransactionPlan {
             actions: vec![spend.into(), output.into(), undelegate.into()],
             // Now fill out the remaining parts of the transaction needed for verification:
             memo: Some(MemoPlan::new(
@@ -334,9 +331,8 @@ async fn app_tracks_uptime_for_validators_only_once_active() -> anyhow::Result<(
                 chain_id: TestNode::<()>::CHAIN_ID.to_string(),
                 ..Default::default()
             },
-        };
-        plan.populate_detection_data(rand_core::OsRng, Precision::default());
-        plan
+        }
+        .with_populated_detection_data(OsRng, Default::default())
     };
     let tx = client.witness_auth_build(&plan).await?;
 

--- a/crates/core/transaction/src/plan.rs
+++ b/crates/core/transaction/src/plan.rs
@@ -382,6 +382,18 @@ impl TransactionPlan {
         }
     }
 
+    /// A builder-style version of [`TransactionPlan::populate_detection_data()`].
+    ///
+    /// Populates the detection data for this transaction plan.
+    pub fn with_populated_detection_data<R: CryptoRng + Rng>(
+        mut self,
+        rng: R,
+        precision_bits: Precision,
+    ) -> Self {
+        self.populate_detection_data(rng, precision_bits);
+        self
+    }
+
     /// Convenience method to grab the `MemoKey` from the plan.
     pub fn memo_key(&self) -> Option<PayloadKey> {
         self.memo.as_ref().map(|memo_plan| memo_plan.key.clone())


### PR DESCRIPTION
#### 💭 describe your changes

this would be helpful in many mock consensus tests. to avoid short-lived `plan` bindings, and mutable plans, add a builder-style method to call `populate_detection_data()` on a `TransactionPlan`.

#### ✅ checklist before requesting a review

- [x] if this code contains consensus-breaking changes, i have added the
  "consensus-breaking" label. otherwise, i declare my belief that there are not
  consensus-breaking changes, for the following reason:

  > this only makes changes to test code.
