### PR TITLE
mock-consensus: ⭐ assert that `TestNode<C>` is `Send + Sync`

### DIFF
--- a/crates/test/mock-consensus/src/lib.rs
+++ b/crates/test/mock-consensus/src/lib.rs
@@ -153,3 +153,14 @@ where
         Ok(()).tap(|_| info!("finished fast forward"))
     }
 }
+
+/// Assert that a [`TestNode`] is both [`Send`] and [`Sync`].
+#[allow(dead_code)]
+mod assert_address_is_send_and_sync {
+    fn is_send<T: Send>() {}
+    fn is_sync<T: Sync>() {}
+    fn f() {
+        is_send::<super::TestNode<()>>();
+        is_sync::<super::TestNode<()>>();
+    }
+}


### PR DESCRIPTION
while refactoring the test node, i found that this is an assumption that isn't explicitly upheld, but is often expected by test code.

to prevent future changes/additions from breaking these properties, add some compile-time assertions that a `TestNode<()>` is both `Send` and `Sync`.

#### ✅ checklist before requesting a review

- [x] if this code contains consensus-breaking changes, i have added the
  "consensus-breaking" label. otherwise, i declare my belief that there are not
  consensus-breaking changes, for the following reason:

  > this only makes compile-time assertions on test code.