### PR TITLE
cnidarium(watch): always check that the channel is open

### DIFF
--- a/crates/cnidarium/src/rpc.rs
+++ b/crates/cnidarium/src/rpc.rs
@@ -205,7 +205,7 @@ async fn watch_changes(
     tx: tokio::sync::mpsc::Sender<Result<WatchResponse, tonic::Status>>,
 ) -> anyhow::Result<()> {
     let mut changes_rx = storage.subscribe_changes();
-    loop {
+    while !tx.is_closed() {
         // Wait for a new set of changes, reporting an error if we don't get one.
         if let Err(e) = changes_rx.changed().await {
             tx.send(Err(tonic::Status::internal(e.to_string()))).await?;
@@ -252,4 +252,5 @@ async fn watch_changes(
             }
         }
     }
+    return Ok(());
 }


### PR DESCRIPTION
## Describe your changes

We need to bind server resource usage to the lifetime of a connection. Currently, the way client connection termination is percolated to the state watcher task is that sending over the channel would fail as soon as the receive handler is dropped. However, this is insufficient because we only send over the channel in specific cases. Instead, we should be checking unconditionally.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Mechanical change