### PR TITLE
docs: archive url for testnet 76

### DIFF
--- a/docs/guide/src/node/pd/join-testnet.md
+++ b/docs/guide/src/node/pd/join-testnet.md
@@ -37,10 +37,11 @@ The following section describes how to join a testnet chain *which has never upg
 Once a chain upgrade occurs, a new-joining node must have access to an archive
 of historical, migrated state. When we upgrade the chain, we should update these
 docs to switch to the archive-url version:
+-->
 
 ```shell
 pd testnet join --external-address IP_ADDRESS:26656 --moniker MY_NODE_NAME \
-    --archive-url "https://snapshots.penumbra.zone/testnet/pd-migrated-state-71-72.tar.gz"
+    --archive-url "https://snapshots.penumbra.zone/testnet/pd-migrated-state-75-76.tar.gz"
 ```
 
 where `IP_ADDRESS` (like `1.2.3.4`) is the public IP address of the node you're running,
@@ -48,8 +49,8 @@ and `MY_NODE_NAME` is a moniker identifying your node. Other peers will try to c
 to your node over port `26656/TCP`. Finally, the `--archive-url` flag will fetch
 a tarball of historical blocks, so that your newly joining node can understand transactions
 that occurred prior to the most recent chain upgrade.
--->
 
+<!--
 ```shell
 pd testnet join --external-address IP_ADDRESS:26656 --moniker MY_NODE_NAME
 ```
@@ -57,7 +58,6 @@ pd testnet join --external-address IP_ADDRESS:26656 --moniker MY_NODE_NAME
 where `IP_ADDRESS` (like `1.2.3.4`) is the public IP address of the node you're running,
 and `MY_NODE_NAME` is a moniker identifying your node. Other peers will try to connect
 to your node over port `26656/TCP`.
-<!--
 ### End join customization
 -->
 


### PR DESCRIPTION


## Describe your changes
Refs #4402. Documents new archive url for testnet 76, which is required for any nodes joining the network after the upgrade boundary. Already confirmed I could join, peer, and stream blocks from this via localhost.

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > docs-only
