### PR TITLE
Fix alignment for validator uptime printout

### DIFF
--- a/crates/bin/pcli/src/command/query/validator.rs
+++ b/crates/bin/pcli/src/command/query/validator.rs
@@ -302,7 +302,7 @@ impl ValidatorCmd {
                 let window_len_len = window_len.to_string().len();
 
                 println!("{state} validator: as of block {as_of_height}");
-                println!("Successful signing: {percent_uptime:>6.2}% = {signed_blocks:width$}/{window_len} most-recent blocks", width = window_len_len);
+                println!("Achieved signing: {percent_uptime:>6.2}% = {signed_blocks:width$}/{window_len} most-recent blocks", width = window_len_len);
                 if active {
                     println!("Required signing: {percent_min_uptime:>6.2}% = {min_uptime_blocks:width$}/{window_len} most-recent blocks", width = window_len_len);
                 }


### PR DESCRIPTION
## Describe your changes

The alignment for the CLI output was broken by #4461. This changes the wording to "Achieved signing" which is still slightly incorrect (a new validator has signed nothing but has a 100% uptime) but aligns correctly.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [X] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Tiny tweak to CLI output