### PR TITLE
dex: 🪣 add two larger dex buckets

### DIFF
--- a/crates/core/component/dex/src/component/metrics.rs
+++ b/crates/core/component/dex/src/component/metrics.rs
@@ -46,7 +46,7 @@ pub fn register_metrics() {
 // Prometheus metrics are structured as a Histogram, rather than as a Summary.
 // These values are loosely based on the initial Summary output, and may need to be
 // updated over time.
-pub const DEX_BUCKETS: &[f64; 5] = &[0.00001, 0.0001, 0.001, 0.01, 0.1];
+pub const DEX_BUCKETS: &[f64] = &[0.00001, 0.0001, 0.001, 0.01, 0.1, 1_f64, 10_f64];
 
 pub const DEX_PATH_SEARCH_DURATION: &str = "penumbra_dex_path_search_duration_seconds";
 pub const DEX_ROUTE_FILL_DURATION: &str = "penumbra_dex_route_fill_duration_seconds";


### PR DESCRIPTION
fixes #4464.

this adds two larger buckets to the dex component's histograms.

when our dashboards calculate quantiles, we observed signals that some operations were taking longer than 100ms. to help obtain more accurate performance data, we add a 1 second and 10 second bucket.

#### :heavy_check_mark: checklist before requesting a review

- [x] if this code contains consensus-breaking changes, i have added the "consensus-breaking" label. otherwise, i declare my belief that there are not consensus-breaking changes, for the following reason:

  > this only changes telemetry
