### PR TITLE
chore: 📌 pin `rocksdb` crate dependency specifically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,6 @@ rand                             = { version = "0.8.5" }
 rand_chacha                      = { version = "0.3.1" }
 rand_core                        = { version = "0.6.4" }
 regex                            = { version = "1.8.1" }
-rocksdb                          = { version = "0.21.0" }
 serde                            = { version = "1.0.186" }
 serde_json                       = { version = "1.0.96" }
 serde_unit_struct                = { version = "0.1" }
@@ -233,6 +232,15 @@ tower-service                    = { version = "0.3.2" }
 tracing                          = { version = "0.1" }
 tracing-subscriber               = { version = "0.3.17", features = ["env-filter"] }
 url                              = { version = "2.2" }
+
+# NB: RocksDB is used as consensus-critical storage for cnidarium. Be careful
+# to inspect updates to these bindings (which statically link to RocksDB)
+# with care. So, this is pinned specifically to `0.21.0`.
+#
+# This release builds and links against commit `6a43615` of rocksdb, v8.1.1:
+# https://github.com/facebook/rocksdb/tree/6a436150417120a3f9732d65a2a5c2b8d19b60fc
+[workspace.dependencies.rocksdb]
+version = "=0.21.0"
 
 # TODO(kate):
 # temporarily point these dependencies to a tag in the penumbra-zone fork.


### PR DESCRIPTION
#### 💭 describe your changes

RocksDB is used for the consensus-critical storage layer in cnidarium.

the `rocksdb` crate uses a dependency called `librocksdb-sys`, containing FFI
bindings to RocksDB's headers. that crate internally clones a git submodule of
the RocksDB repository, builds the project, and statically links against it.

to avoid regular maintenance upgrading crates in the future from introducing
unexpected consensus-breaking changes, explicitly pin this crate to a specific
major, minor, and patch version.

this will also help clear the way for operators and engineers maintaining the
protocol to improve build times by building RocksDB out-of-band, and then
statically linking against that local copy of `librocksdb.a`.

#### 🔍 checking my work:

to confirm how i found this commit hash, for posterity:

from the `Cargo.lock`:

```toml
[[package]]
name = "librocksdb-sys"
version = "0.11.0+8.1.1"
```

..and confirming the rocksdb commit manually:

```sh
; pwd
/path/to/rust-rocksdb
; git show --oneline --quiet
b539412 (HEAD, tag: v0.21.0) Release 0.21.0 (#777)
; git submodule status
6a436150417120a3f9732d65a2a5c2b8d19b60fc librocksdb-sys/rocksdb (v8.1.1)
2b63814b15a2aaae54b7943f0cd935892fae628f librocksdb-sys/snappy (1.1.9)
```

#### ✅ checklist before requesting a review

- [x] if this code contains consensus-breaking changes, i have added the
  "consensus-breaking" label. otherwise, i declare my belief that there are not
  consensus-breaking changes, for the following reason:

> this does not change the version of `rocksdb` being used (note the lack of
> any changes to the Cargo.lock); this only changes the semantic version
> constraints applied to that package, adding some comments flagging relevant
> commit hashes & version numbers.
