### PR TITLE
chore: 🪨 improve incremental builds by linking to rocksdb

### DIFF
--- a/docs/guide/src/dev/build.md
+++ b/docs/guide/src/dev/build.md
@@ -80,7 +80,7 @@ Then, build all the project binaries using `cargo`:
 cargo build --release
 ```
 
-### Linking Against RocksDB
+### Linking Against RocksDB (Optional)
 
 Development builds can avoid the cost of recompiling RocksDB for storage libraries in the Cargo
 workspace. This manifests as a `librocksdb-sys(build)` message when building or testing crates

--- a/docs/guide/src/dev/build.md
+++ b/docs/guide/src/dev/build.md
@@ -80,5 +80,58 @@ Then, build all the project binaries using `cargo`:
 cargo build --release
 ```
 
+### Linking Against RocksDB
+
+Development builds can avoid the cost of recompiling RocksDB for storage libraries in the Cargo
+workspace. This manifests as a `librocksdb-sys(build)` message when building or testing crates
+in the monorepo.
+
+#### Building `librocksdb.a` from source
+
+First, clone the rocksdb repository:
+
+```sh
+# Clone the repository, and enter that directory.
+git clone git@github.com:facebook/rocksdb.git && cd rocksdb
+
+# Checkout the version of rocksdb used in `librocksdb-sys`.
+git checkout 6a43615
+
+# Add an environment variable pointing to this repository:
+ROCKSDB_LIB_DIR=`pwd`
+
+# Compile the static `librocksdb.a` library to link against:
+make static_lib
+```
+
+#### Building `libsnappy.a` from source
+
+next, clone the snappy repository and follow the
+[instructions][snappy-build] to build it:
+
+```
+# Clone the repository, and enter that directory.
+git clone git@github.com:google/snappy.git && cd snappy
+
+# Checkout the version of snappy used in `librocksdb-sys`.
+git checkout 2b63814
+
+# Initialize the submodules.
+git submodule update --init
+
+# Build snappy using cmake.
+mkdir build
+cd build && cmake .. && make
+
+# Add an environment variable pointing to the build/ directory.
+SNAPPY_LIB_DIR=`pwd`
+```
+
+### Building Penumbra
+
+Once you've built rocksdb and set the environment variable, the `librocksdb-sys` crate will search
+in that directory for the compiled `librocksdb.a` static library when it is rebuilt.
+
+[snappy-build]: https://github.com/google/snappy?tab=readme-ov-file#building
 [protoc-install]: https://grpc.io/docs/protoc-installation/
 [WSL]: https://learn.microsoft.com/en-us/windows/wsl/install

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,7 @@
           # Important environment variables so that the build can find the necessary libraries
           PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig";
           LIBCLANG_PATH="${pkgs.libclang.lib}/lib";
+          ROCKSDB_LIB_DIR="${pkgs.rocksdb.out}/lib";
         in with pkgs; with pkgs.lib; let
           # All the Penumbra binaries
           penumbra = (craneLib.buildPackage {
@@ -56,8 +57,8 @@
                 (craneLib.filterCargoSources path type);
             };
             nativeBuildInputs = [ pkg-config ];
-            buildInputs = [ clang openssl ];
-            inherit system PKG_CONFIG_PATH LIBCLANG_PATH;
+            buildInputs = [ clang openssl rocksdb ];
+            inherit system PKG_CONFIG_PATH LIBCLANG_PATH ROCKSDB_LIB_DIR;
             cargoExtraArgs = "-p pd -p pcli -p pclientd";
             meta = {
               description = "A fully private proof-of-stake network and decentralized exchange for the Cosmos ecosystem";
@@ -101,12 +102,13 @@
             paths = [ penumbra cometbft ];
           };
           devShells.default = craneLib.devShell {
-            inherit LIBCLANG_PATH;
+            inherit LIBCLANG_PATH ROCKSDB_LIB_DIR;
             inputsFrom = [ penumbra ];
-            packages = [ cargo-watch cargo-nextest protobuf cometbft ];
+            packages = [ cargo-watch cargo-nextest protobuf cometbft rocksdb ];
             shellHook = ''
               export LIBCLANG_PATH=${LIBCLANG_PATH}
               export RUST_SRC_PATH=${pkgs.rustPlatform.rustLibSrc} # Required for rust-analyzer
+              export ROCKSDB_LIB_DIR=${ROCKSDB_LIB_DIR}
             '';
           };
         }


### PR DESCRIPTION
first, the cool part: here are incremental build timings for `cargo build -p cnidarium` filtering for compilation units that took > 1.5 seconds to compile.

on my machine, this improved incremental build times by 72.92% :heart: 

**before** :weary: 

![warm-build-timing-without-rocksdb-linking](https://github.com/penumbra-zone/penumbra/assets/57912822/20e60b9b-8f0c-4834-9cde-de492a52c65e)

**after** :heart_eyes: 

![warm-build-timing-with-rocksdb-linking](https://github.com/penumbra-zone/penumbra/assets/57912822/bf1a72b3-ed6c-47ec-9588-84d484aa1c1a)

## :heavy_plus_sign: changes
### docs: 🪨 add notes on linking to prebuilt rocksdb

#### 💭 background

`librocksdb-sys(build)` is a somewhat infamous source of lengthy build
times when engineers are working in the monorepo. this is a crate whose
build script, clones and builds the rocksdb database from source,
statically linking against the generated `librocksdb.a` file.

this interacts poorly with a Cargo workspace like ours, which contains a
number of different features. because features are additive, running
commands like `cargo build --workspace` and `cargo build --package penumbra-app`
can result in different feature sets being enabled for leaf
dependencies, mandating that the library be rebuilt (_which means
rebuilding librocksdb.a once more_).

### flake: 🔗 link against a precompiled rocksdb

this adds a `ROCKSDB_LIB_DIR` environment variable to the nix
development shell.

this environment variable points to the directory that
contains the `librocksdb.a` file, to be statically linked against the
`librocksdb-sys` crate.

a `nixpkgs.rocksdb` build input is added.

#### 📐 build timing methodology

this shell script was used to generate build timings. in order to see
how this behaved on an incremental build, the script will clear the
cache, build the workspace, and _then_ build a crate that depends on
`librocksdb-sys`.

```sh
 #!/usr/bin/env bash
 #
 # see https://doc.rust-lang.org/cargo/reference/timings.html for more info.
 set -euox pipefail

 # clean out any preëxisting build artifacts.
 cargo clean;

 # build once before we generate our report.
 cargo build --workspace

 # build a particular crate, recording the build timings.
 cargo build --package cnidarium --timings

 # hang on to the report generated.
 cp target/cargo-timings/cargo-timing.html .
```
