### PR TITLE
feat(pd): add --ready-to-start flag to pd migrate

### DIFF
--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -138,6 +138,12 @@ pub enum RootCommand {
         /// If set, force a migration to occur even if the chain is not halted.
         #[clap(long, display_order = 1000)]
         force: bool,
+        /// If set, edit local state to to permit the node to start, despite
+        /// a pre-existing halt order, e.g. via governance. This option
+        /// can be useful for relayer operators, to run a temporary archive node
+        /// across upgrade boundaries.
+        #[clap(long, display_order = 1000)]
+        ready_to_start: bool,
     },
 }
 


### PR DESCRIPTION

## Describe your changes

Adds a new flag to `pd migrate --ready-to-start` that makes an in-place edit to local state, setting an enabled halt bit to false.

Refs #4494.

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This code directly munges local state, via a migration, and therefore deserves careful scrutiny.