### PR TITLE
dex: evict excess of liquidity positions

### DIFF
--- a/crates/core/component/compact-block/src/component/manager.rs
+++ b/crates/core/component/compact-block/src/component/manager.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use cnidarium::StateWrite;
 #[cfg(feature = "component")]
-use penumbra_dex::component::{StateReadExt, SwapManager as _};
+use penumbra_dex::component::SwapDataRead;
 use penumbra_fee::component::StateReadExt as _;
 use penumbra_governance::StateReadExt as _;
 use penumbra_proto::DomainType;

--- a/crates/core/component/dex/src/component/action_handler/swap.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap.rs
@@ -9,7 +9,7 @@ use penumbra_proto::StateWriteProto;
 use penumbra_sct::component::source::SourceContext;
 
 use crate::{
-    component::{position_manager::PositionManager as _, StateReadExt, StateWriteExt, SwapManager},
+    component::{InternalDexWrite, StateReadExt, SwapDataRead, SwapDataWrite, SwapManager},
     event,
     swap::{proof::SwapProofPublic, Swap},
 };

--- a/crates/core/component/dex/src/component/arb.rs
+++ b/crates/core/component/dex/src/component/arb.rs
@@ -10,14 +10,11 @@ use penumbra_sct::component::clock::EpochRead;
 use tracing::instrument;
 
 use crate::{
-    component::{ExecutionCircuitBreaker, ValueCircuitBreaker},
+    component::{ExecutionCircuitBreaker, InternalDexWrite, ValueCircuitBreaker},
     event, SwapExecution,
 };
 
-use super::{
-    router::{RouteAndFill, RoutingParams},
-    StateWriteExt,
-};
+use super::router::{RouteAndFill, RoutingParams};
 
 #[async_trait]
 pub trait Arbitrage: StateWrite + Sized {

--- a/crates/core/component/dex/src/component/chandelier.rs
+++ b/crates/core/component/dex/src/component/chandelier.rs
@@ -271,7 +271,7 @@ mod tests {
     use crate::{
         component::{
             router::create_buy, tests::TempStorageExt as _, Dex, PositionManager as _,
-            StateReadExt as _, StateWriteExt as _,
+            SwapDataRead, SwapDataWrite,
         },
         DirectedUnitPair,
     };

--- a/crates/core/component/dex/src/component/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/component/circuit_breaker/value.rs
@@ -64,7 +64,7 @@ mod tests {
 
     use crate::component::position_manager::price_index::PositionByPriceIndex;
     use crate::component::router::HandleBatchSwaps as _;
-    use crate::component::{StateReadExt as _, StateWriteExt as _};
+    use crate::component::{InternalDexWrite, StateReadExt as _, SwapDataRead, SwapDataWrite};
     use crate::lp::plan::PositionWithdrawPlan;
     use crate::{
         component::{router::create_buy, tests::TempStorageExt},

--- a/crates/core/component/dex/src/component/dex.rs
+++ b/crates/core/component/dex/src/component/dex.rs
@@ -1,17 +1,18 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
 use cnidarium::{StateRead, StateWrite};
 use cnidarium_component::Component;
+use penumbra_asset::asset;
 use penumbra_asset::{Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_proto::{StateReadProto, StateWriteProto};
 use tendermint::v0_37::abci;
 use tracing::instrument;
 
 use crate::{
-    component::flow::SwapFlow, event, genesis, state_key, BatchSwapOutputData, DexParameters,
-    DirectedTradingPair, SwapExecution, TradingPair,
+    component::SwapDataRead, component::SwapDataWrite, event, genesis, state_key,
+    BatchSwapOutputData, DexParameters, DirectedTradingPair, SwapExecution, TradingPair,
 };
 
 use super::{
@@ -54,7 +55,6 @@ impl Component for Dex {
         // This has already happened in the action handlers for each `PositionOpen` action.
 
         // 2. For each batch swap during the block, calculate clearing prices and set in the JMT.
-
         let routing_params = state.routing_params().await.expect("dex params are set");
 
         for (trading_pair, swap_flows) in state.swap_flows() {
@@ -135,9 +135,26 @@ impl Component for Dex {
     }
 }
 
-/// Extension trait providing read access to dex data.
+/// Provides public read access to DEX data.
 #[async_trait]
 pub trait StateReadExt: StateRead {
+    /// Gets the DEX parameters from the state.
+    async fn get_dex_params(&self) -> Result<DexParameters> {
+        self.get(state_key::config::dex_params())
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Missing DexParameters"))
+    }
+
+    /// Uses the DEX parameters to construct a `RoutingParams` for use in execution or simulation.
+    async fn routing_params(&self) -> Result<RoutingParams> {
+        let dex_params = self.get_dex_params().await?;
+        Ok(RoutingParams {
+            max_hops: dex_params.max_hops as usize,
+            fixed_candidates: Arc::new(dex_params.fixed_candidates),
+            price_limit: None,
+        })
+    }
+
     async fn output_data(
         &self,
         height: u64,
@@ -159,47 +176,49 @@ pub trait StateReadExt: StateRead {
     async fn arb_execution(&self, height: u64) -> Result<Option<SwapExecution>> {
         self.get(&state_key::arb_execution(height)).await
     }
-
-    /// Get the swap flow for the given trading pair accumulated in this block so far.
-    fn swap_flow(&self, pair: &TradingPair) -> SwapFlow {
-        self.swap_flows().get(pair).cloned().unwrap_or_default()
-    }
-
-    fn swap_flows(&self) -> BTreeMap<TradingPair, SwapFlow> {
-        self.object_get::<BTreeMap<TradingPair, SwapFlow>>(state_key::swap_flows())
-            .unwrap_or_default()
-    }
-
-    fn pending_batch_swap_outputs(&self) -> im::OrdMap<TradingPair, BatchSwapOutputData> {
-        self.object_get(state_key::pending_outputs())
-            .unwrap_or_default()
-    }
-
-    /// Gets the DEX parameters from the state.
-    async fn get_dex_params(&self) -> Result<DexParameters> {
-        self.get(state_key::config::dex_params())
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Missing DexParameters"))
-    }
-
-    /// Uses the DEX parameters to construct a `RoutingParams` for use in execution or simulation.
-    async fn routing_params(&self) -> Result<RoutingParams> {
-        let dex_params = self.get_dex_params().await?;
-        Ok(RoutingParams {
-            max_hops: dex_params.max_hops as usize,
-            fixed_candidates: Arc::new(dex_params.fixed_candidates),
-            price_limit: None,
-        })
-    }
 }
 
 impl<T: StateRead + ?Sized> StateReadExt for T {}
 
 /// Extension trait providing write access to dex data.
 #[async_trait]
-pub trait StateWriteExt: StateWrite + StateReadExt {
+pub trait StateWriteExt: StateWrite {
     fn put_dex_params(&mut self, params: DexParameters) {
         self.put(state_key::config::dex_params().to_string(), params);
+    }
+}
+
+impl<T: StateWrite + ?Sized> StateWriteExt for T {}
+
+/// The maximum number of "hot" asset identifiers to track for this block.
+const RECENTLY_ACCESSED_ASSET_LIMIT: usize = 10;
+pub(crate) trait InternalDexWrite: StateWrite {
+    /// Adds an asset ID to the list of recently accessed assets,
+    /// making it a candidate for the current block's arbitrage routing.
+    ///
+    /// This ensures that assets associated with recently active positions
+    /// will be eligible for arbitrage if mispriced positions are opened.
+    #[tracing::instrument(level = "debug", skip_all)]
+    fn add_recently_accessed_asset(
+        &mut self,
+        asset_id: asset::Id,
+        fixed_candidates: Arc<Vec<asset::Id>>,
+    ) {
+        let mut assets = self.recently_accessed_assets();
+
+        // Limit the number of recently accessed assets to prevent blowing
+        // up routing time.
+        if assets.len() >= RECENTLY_ACCESSED_ASSET_LIMIT {
+            return;
+        }
+
+        // If the asset is already in the fixed candidate list, don't insert it.
+        if fixed_candidates.contains(&asset_id) {
+            return;
+        }
+
+        assets.insert(asset_id);
+        self.object_put(state_key::recently_accessed_assets(), assets);
     }
 
     async fn set_output_data(
@@ -258,44 +277,6 @@ pub trait StateWriteExt: StateWrite + StateReadExt {
     fn set_arb_execution(&mut self, height: u64, execution: SwapExecution) {
         self.put(state_key::arb_execution(height), execution);
     }
-
-    async fn put_swap_flow(
-        &mut self,
-        trading_pair: &TradingPair,
-        swap_flow: SwapFlow,
-    ) -> Result<()> {
-        // Credit the DEX for the swap inflows.
-        //
-        // Note that we credit the DEX for _all_ inflows, since we don't know
-        // how much will eventually be filled.
-        self.dex_vcb_credit(Value {
-            amount: swap_flow.0,
-            asset_id: trading_pair.asset_1,
-        })
-        .await?;
-        self.dex_vcb_credit(Value {
-            amount: swap_flow.1,
-            asset_id: trading_pair.asset_2,
-        })
-        .await?;
-
-        // TODO: replace with IM struct later
-        let mut swap_flows = self.swap_flows();
-        swap_flows.insert(*trading_pair, swap_flow);
-        self.object_put(state_key::swap_flows(), swap_flows);
-
-        Ok(())
-    }
-
-    fn put_swap_execution_at_height(
-        &mut self,
-        height: u64,
-        pair: DirectedTradingPair,
-        swap_execution: SwapExecution,
-    ) {
-        let path = state_key::swap_execution(height, pair);
-        self.nonverifiable_put(path.as_bytes().to_vec(), swap_execution);
-    }
 }
 
-impl<T: StateWrite + ?Sized> StateWriteExt for T {}
+impl<T: StateWrite + ?Sized> InternalDexWrite for T {}

--- a/crates/core/component/dex/src/component/dex.rs
+++ b/crates/core/component/dex/src/component/dex.rs
@@ -116,11 +116,11 @@ impl Component for Dex {
 
         // 4. Inspect trading pairs that saw new position opened during this block, and
         // evict their excess LPs if any are found.
-        Arc::get_mut(state)
+        let _ = Arc::get_mut(state)
             .expect("state should be uniquely referenced after batch swaps complete")
             .evict_positions()
             .await
-            .expect("MERGEBLOCK(erwan): remove this");
+            .map_err(|e| tracing::error!(?e, "error evicting positions, skipping"));
 
         // 5. Close all positions queued for closure at the end of the block.
         // It's important to do this after execution, to allow block-scoped JIT liquidity.

--- a/crates/core/component/dex/src/component/dex.rs
+++ b/crates/core/component/dex/src/component/dex.rs
@@ -156,12 +156,7 @@ pub trait StateReadExt: StateRead {
 
     /// Uses the DEX parameters to construct a `RoutingParams` for use in execution or simulation.
     async fn routing_params(&self) -> Result<RoutingParams> {
-        let dex_params = self.get_dex_params().await?;
-        Ok(RoutingParams {
-            max_hops: dex_params.max_hops as usize,
-            fixed_candidates: Arc::new(dex_params.fixed_candidates),
-            price_limit: None,
-        })
+        self.get_dex_params().await.map(RoutingParams::from)
     }
 
     async fn output_data(

--- a/crates/core/component/dex/src/component/eviction_manager.rs
+++ b/crates/core/component/dex/src/component/eviction_manager.rs
@@ -21,7 +21,7 @@ pub(crate) trait EvictionManager: StateWrite {
     /// # Mechanism
     ///
     /// The eviction mechanism functions by inspecting every trading pair which
-    /// had LP opened during the block. For each of them, it compute the "excess"
+    /// had LP opened during the block. For each of them, it computes the "excess"
     /// amount of positions `M`, defined as follow:
     /// `M = N - N_max` where N is the number of positions,
     ///                   and N_max is a chain parameter.

--- a/crates/core/component/dex/src/component/eviction_manager.rs
+++ b/crates/core/component/dex/src/component/eviction_manager.rs
@@ -1,0 +1,108 @@
+use crate::component::StateReadExt;
+use crate::{component::position_manager::counter::PositionCounterRead, lp::position};
+use futures::{StreamExt as _, TryStreamExt};
+use std::collections::BTreeSet;
+use tokio::task::JoinSet;
+
+use crate::state_key::eviction_queue;
+use anyhow::Result;
+use cnidarium::StateWrite;
+use penumbra_proto::DomainType;
+use tracing::instrument;
+
+use crate::{component::PositionManager, DirectedTradingPair, TradingPair};
+
+pub(crate) trait EvictionManager: StateWrite {
+    /// Evict liquidity positions that are in excess of the trading pair limit.
+    ///
+    /// # Overview
+    /// This method enforce the approximate limit on the number of
+    /// positions that can be active for a given trading pair, as defined
+    /// by [`max_positions_per_pair`](DexParameters#max_positions_per_pair).
+    ///
+    /// # Mechanism
+    ///
+    /// The eviction mechanism functions by inspecting every trading pair which
+    /// had LP opened during the block. For each of them, it compute the "excess"
+    /// amount of positions `M`, defined as follow:
+    /// `M = N - N_max` where N is the number of positions,
+    ///                   and N_max is a chain parameter.
+    ///
+    /// Since a [`TradingPair`] defines two possible directed pairs, we need
+    /// to ensure that we don't evict LPs if they provide important liquidity
+    /// to at least one direction of the pair.
+    ///
+    /// To do this effectively, we maintain a liquidity index which orders LPs
+    /// by ascending liquidity for each direction of a trading pair. This allow
+    /// us to easily fetch the worse M positions for each index, and only evict
+    /// overlapping LPs.
+    ///
+    /// This approach sidestep the problem of adjudicating which position deserve
+    /// to be preserved depending on the trading direction, and limit the number
+    /// of reads to 2*M. On the other hand, it means that the actual maximum number
+    /// of positions per pair is 2*N_max.
+    ///
+    /// ## Diagram
+    ///
+    ///                                                      Q_1: A -> B
+    ///    ╔════════════╦━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ///    ║  Bottom M  ┃  M+1  │  M+2  │    . . .       │  N-1  │   N   ┃
+    ///    ╚════════════╩━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+    ///     ▽▼▼▼▼▼▼▼▽▽▼▽
+    /// ┌─▶ find overlap
+    /// │   ▲▲▲▲△△△▲▲▲▲▲                                     Q_2: B -> A
+    /// │  ╔════════════╦━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    /// │  ║  Bottom M  ┃  M+1  │  M+2  │    . . .       │  N-1  │   N   ┃
+    /// │  ╚════════════╩━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+    /// │    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━▶
+    /// │                                                         Ordered by inventory
+    /// │
+    /// │         ▽▼▼▼▼▼▼▼▽▽▼▽
+    /// └───────▶      ∩       Across both indices, the
+    ///           ▲▲▲▲△△△▲▲▲▲▲ bottom M positions overlap
+    ///                        k times where 0 <= k <= M
+    ///                        for N < 2*N_max
+    ///
+    #[instrument(skip_all, err, level = "trace")]
+    async fn evict_positions(&mut self) -> Result<()> {
+        let hot_pairs: Vec<TradingPair> = todo!();
+        let max_positions_per_pair = self.get_dex_params().await?.max_positions_per_pair;
+
+        for pair in hot_pairs.iter() {
+            let total_positions = self.get_position_count(pair).await;
+            let overhead_size = total_positions.saturating_sub(max_positions_per_pair);
+            if overhead_size == 0 {
+                continue;
+            }
+
+            let pair_ab = DirectedTradingPair::new(pair.asset_1(), pair.asset_2());
+            let pair_ba = pair_ab.flip();
+            let key_ab = eviction_queue::inventory_index::by_trading_pair(&pair_ab);
+            let key_ba = eviction_queue::inventory_index::by_trading_pair(&pair_ba);
+
+            let mut stream_ab = self.nonverifiable_prefix_raw(&key_ab).boxed();
+            let mut stream_ba = self.nonverifiable_prefix_raw(&key_ba).boxed();
+
+            let overhead_ab = stream_ab
+                .take(overhead_size as usize)
+                .and_then(|(_, raw_id)| async move { position::Id::decode(&*raw_id) })
+                .try_collect::<BTreeSet<position::Id>>()
+                .await?;
+
+            let overhead_ba = stream_ba
+                .take(overhead_size as usize)
+                .and_then(|(_, raw_id)| async move { position::Id::decode(&*raw_id) })
+                .try_collect::<BTreeSet<position::Id>>()
+                .await?;
+
+            let overlap = overhead_ab.intersection(&overhead_ba);
+
+            for id in overlap {
+                self.close_position_by_id(id).await?;
+            }
+        }
+        todo!()
+    }
+}
+
+impl<T: StateWrite + ?Sized> EvictionManager for T {}

--- a/crates/core/component/dex/src/component/eviction_manager.rs
+++ b/crates/core/component/dex/src/component/eviction_manager.rs
@@ -32,7 +32,7 @@ pub(crate) trait EvictionManager: StateWrite {
     ///
     /// To do this effectively, we maintain a liquidity index which orders LPs
     /// by ascending liquidity for each direction of a trading pair. This allow
-    /// us to easily fetch the worse M positions for each index, and only evict
+    /// us to easily fetch the worst M positions for each index, and only evict
     /// overlapping LPs.
     ///
     /// This approach sidestep the problem of adjudicating which position deserve

--- a/crates/core/component/dex/src/component/eviction_manager.rs
+++ b/crates/core/component/dex/src/component/eviction_manager.rs
@@ -6,7 +6,6 @@ use std::collections::BTreeSet;
 use crate::state_key::eviction_queue;
 use anyhow::Result;
 use cnidarium::StateWrite;
-use penumbra_proto::DomainType;
 use tracing::instrument;
 
 use crate::{component::PositionManager, DirectedTradingPair, TradingPair};
@@ -84,13 +83,19 @@ pub(crate) trait EvictionManager: StateWrite {
 
             let overhead_ab = stream_ab
                 .take(overhead_size as usize)
-                .and_then(|(_, raw_id)| async move { position::Id::decode(&*raw_id) })
+                .and_then(|(k, _)| async move {
+                    let raw_id = eviction_queue::inventory_index::parse_id_from_key(k)?;
+                    Ok(position::Id(raw_id))
+                })
                 .try_collect::<BTreeSet<position::Id>>()
                 .await?;
 
             let overhead_ba = stream_ba
                 .take(overhead_size as usize)
-                .and_then(|(_, raw_id)| async move { position::Id::decode(&*raw_id) })
+                .and_then(|(k, _)| async move {
+                    let raw_id = eviction_queue::inventory_index::parse_id_from_key(k)?;
+                    Ok(position::Id(raw_id))
+                })
                 .try_collect::<BTreeSet<position::Id>>()
                 .await?;
 

--- a/crates/core/component/dex/src/component/mod.rs
+++ b/crates/core/component/dex/src/component/mod.rs
@@ -16,18 +16,21 @@ mod flow;
 mod position_manager;
 mod swap_manager;
 
-pub use self::metrics::register_metrics;
-pub(crate) use arb::Arbitrage;
-pub(crate) use circuit_breaker::ExecutionCircuitBreaker;
-pub(crate) use circuit_breaker::ValueCircuitBreaker;
-pub(crate) use dex::InternalDexWrite;
 pub use dex::{Dex, StateReadExt, StateWriteExt};
 pub use position_manager::PositionManager;
-pub(crate) use swap_manager::SwapDataWrite;
-pub(crate) use swap_manager::SwapManager;
 
 // Read data from the Dex component;
 pub use position_manager::PositionRead;
 pub use swap_manager::SwapDataRead;
+
+pub(crate) use arb::Arbitrage;
+pub(crate) use circuit_breaker::ExecutionCircuitBreaker;
+pub(crate) use circuit_breaker::ValueCircuitBreaker;
+pub(crate) use dex::InternalDexWrite;
+pub(crate) use swap_manager::SwapDataWrite;
+pub(crate) use swap_manager::SwapManager;
+
 #[cfg(test)]
 pub(crate) mod tests;
+
+pub use self::metrics::register_metrics;

--- a/crates/core/component/dex/src/component/mod.rs
+++ b/crates/core/component/dex/src/component/mod.rs
@@ -19,8 +19,14 @@ pub use self::metrics::register_metrics;
 pub(crate) use arb::Arbitrage;
 pub(crate) use circuit_breaker::ExecutionCircuitBreaker;
 pub(crate) use circuit_breaker::ValueCircuitBreaker;
+pub(crate) use dex::InternalDexWrite;
 pub use dex::{Dex, StateReadExt, StateWriteExt};
-pub use position_manager::{PositionManager, PositionRead};
-pub use swap_manager::SwapManager;
+pub use position_manager::PositionManager;
+pub(crate) use swap_manager::SwapDataWrite;
+pub(crate) use swap_manager::SwapManager;
+
+// Read data from the Dex component;
+pub use position_manager::PositionRead;
+pub use swap_manager::SwapDataRead;
 #[cfg(test)]
 pub(crate) mod tests;

--- a/crates/core/component/dex/src/component/mod.rs
+++ b/crates/core/component/dex/src/component/mod.rs
@@ -11,6 +11,7 @@ mod arb;
 mod chandelier;
 pub(crate) mod circuit_breaker;
 mod dex;
+mod eviction_manager;
 mod flow;
 mod position_manager;
 mod swap_manager;

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -274,6 +274,9 @@ pub trait PositionManager: StateWrite + PositionRead {
             position.phi.pair.asset_2(),
             routing_params.fixed_candidates,
         );
+        // Mark the trading pair as active so that we can inspect it
+        // at the end of the block and garbage collect excess LPs.
+        self.mark_trading_pair_as_active(position.phi.pair);
 
         // Finally, record the new position state.
         self.record_proto(event::position_open(&position));

--- a/crates/core/component/dex/src/component/position_manager/counter.rs
+++ b/crates/core/component/dex/src/component/position_manager/counter.rs
@@ -8,7 +8,7 @@ use crate::TradingPair;
 use anyhow::Result;
 
 #[async_trait]
-pub(super) trait PositionCounterRead: StateRead {
+pub(crate) trait PositionCounterRead: StateRead {
     /// Returns the number of position for a [`TradingPair`].
     /// If there were no counter initialized for a given pair, this default to zero.
     async fn get_position_count(&self, trading_pair: &TradingPair) -> u32 {

--- a/crates/core/component/dex/src/component/router/params.rs
+++ b/crates/core/component/dex/src/component/router/params.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use penumbra_asset::asset;
 use penumbra_num::fixpoint::U128x128;
 
+use crate::DexParameters;
+
 #[derive(Debug, Clone)]
 pub struct RoutingParams {
     pub price_limit: Option<U128x128>,
@@ -34,6 +36,22 @@ impl RoutingParams {
             (Some(spill_price), None) => (Some(spill_price), false),
             (None, Some(price_limit)) => (Some(price_limit), true),
             (None, None) => (None, false),
+        }
+    }
+}
+
+impl From<DexParameters> for RoutingParams {
+    fn from(
+        DexParameters {
+            fixed_candidates,
+            max_hops,
+            ..
+        }: DexParameters,
+    ) -> Self {
+        Self {
+            fixed_candidates: Arc::new(fixed_candidates),
+            max_hops: max_hops as usize,
+            price_limit: None,
         }
     }
 }

--- a/crates/core/component/dex/src/component/router/route_and_fill.rs
+++ b/crates/core/component/dex/src/component/router/route_and_fill.rs
@@ -13,7 +13,7 @@ use crate::{
         chandelier::Chandelier,
         flow::SwapFlow,
         router::{FillRoute, PathSearch, RoutingParams},
-        ExecutionCircuitBreaker, PositionManager, StateWriteExt,
+        ExecutionCircuitBreaker, InternalDexWrite, PositionManager,
     },
     lp::position::MAX_RESERVE_AMOUNT,
     BatchSwapOutputData, SwapExecution, TradingPair,

--- a/crates/core/component/dex/src/component/router/tests.rs
+++ b/crates/core/component/dex/src/component/router/tests.rs
@@ -8,6 +8,8 @@ use penumbra_num::{fixpoint::U128x128, Amount};
 use rand_core::OsRng;
 use std::sync::Arc;
 
+use crate::component::SwapDataRead;
+use crate::component::SwapDataWrite;
 use crate::lp::SellOrder;
 use crate::DexParameters;
 use crate::{

--- a/crates/core/component/dex/src/component/tests.rs
+++ b/crates/core/component/dex/src/component/tests.rs
@@ -8,6 +8,7 @@ use penumbra_asset::{asset, Value};
 use penumbra_num::Amount;
 use rand_core::OsRng;
 
+use crate::component::{SwapDataRead, SwapDataWrite};
 use crate::lp::action::PositionOpen;
 use crate::lp::{position, SellOrder};
 use crate::DexParameters;

--- a/crates/core/component/dex/src/state_key.rs
+++ b/crates/core/component/dex/src/state_key.rs
@@ -60,6 +60,14 @@ pub mod candlesticks {
     }
 }
 
+pub mod block_scoped {
+    pub mod active {
+        pub fn trading_pairs() -> &'static str {
+            "dex/block_scoped/active/trading_pairs"
+        }
+    }
+}
+
 pub fn output_data(height: u64, trading_pair: TradingPair) -> String {
     format!(
         "dex/output/{:020}/{}/{}",

--- a/crates/core/component/dex/src/state_key.rs
+++ b/crates/core/component/dex/src/state_key.rs
@@ -222,6 +222,7 @@ pub(crate) mod eviction_queue {
     pub(crate) mod inventory_index {
         use crate::lp::position;
         use crate::DirectedTradingPair;
+        use anyhow::ensure;
         use penumbra_num::Amount;
 
         pub(crate) fn by_trading_pair(pair: &DirectedTradingPair) -> [u8; 107] {
@@ -244,6 +245,12 @@ pub(crate) mod eviction_queue {
             full_key[123..155].copy_from_slice(&id.0);
 
             full_key
+        }
+
+        pub(crate) fn parse_id_from_key(key: Vec<u8>) -> anyhow::Result<[u8; 32]> {
+            ensure!(key.len() == 155, "key must be 155 bytes");
+            let k = &key[123..155];
+            Ok(k.try_into()?)
         }
     }
 }

--- a/repro.sh
+++ b/repro.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+cargo run --release --bin pcli -- --home localnet_config tx lp order sell 183.070325gn@1.000501gm
+cargo run --release --bin pcli -- --home localnet_config tx lp order sell 200gn@1.000501gm
+cargo run --release --bin pcli -- --home localnet_config tx lp order sell 2.013014gn@1.00502gm
+cargo run --release --bin pcli -- --home localnet_config tx lp order sell 2.013014gn@3.19999penumbra
+cargo run --release --bin pcli -- --home localnet_config tx lp order buy 2.013014gn@3.19999penumbra

--- a/repro.sh
+++ b/repro.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-cargo run --release --bin pcli -- --home localnet_config tx lp order sell 183.070325gn@1.000501gm
-cargo run --release --bin pcli -- --home localnet_config tx lp order sell 200gn@1.000501gm
-cargo run --release --bin pcli -- --home localnet_config tx lp order sell 2.013014gn@1.00502gm
-cargo run --release --bin pcli -- --home localnet_config tx lp order sell 2.013014gn@3.19999penumbra
-cargo run --release --bin pcli -- --home localnet_config tx lp order buy 2.013014gn@3.19999penumbra


### PR DESCRIPTION
## Description

This PR:
- [x] break out `StateWriteExt` and trim the dex component's public interface
- [x] block-based tracking of "active" trading pairs (= has had an LP opened)
- [x] implement the end block eviction logic

## Issue ticket number and link

Final step to implement #4077 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Consensus breaking
