### PR TITLE
Exclude IBC assets from TotalSupply if their denom metadata is nonexistent

### DIFF
--- a/crates/core/component/shielded-pool/src/component/rpc/bank_query.rs
+++ b/crates/core/component/shielded-pool/src/component/rpc/bank_query.rs
@@ -101,9 +101,9 @@ impl BankQuery for Server {
         for (asset_id, amount) in ibc_amounts {
             let denom_metadata = snapshot.denom_metadata_by_asset(&asset_id).await;
             if denom_metadata.is_none() {
-                return Err(tonic::Status::internal(
-                    "bad IBC ics20 value balance key in state".to_string(),
-                ));
+                // This is likely an NFT asset that is intentionally
+                // not registered, so it is fine to exclude from the output.
+                continue;
             }
             let denom_metadata = denom_metadata.expect("should not be an error");
 


### PR DESCRIPTION
## Describe your changes

This changes the `TotalSupply` query to skip including assets when there is no denom metadata available, for example liquidity position NFTs. This is okay since these are mostly of interest to a single user rather than the market as a whole.

I validated that the error when querying on the current v0.77.0 testnet goes away.


```
$ grpcurl -plaintext -vv localhost:8080 cosmos.bank.v1beta1.Query/TotalSupply
```

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Changes RPC output only