### PR TITLE
misc: 🟢 address warnings from galileo build

### DIFF
--- a/crates/core/component/auction/src/component/dutch_auction.rs
+++ b/crates/core/component/auction/src/component/dutch_auction.rs
@@ -458,13 +458,6 @@ pub(crate) trait DutchAuctionData: StateRead {
             })
             .boxed()
     }
-
-    async fn stream_dutch_state_by_trigger(
-        &self,
-        _trigger_height: u64,
-    ) -> Pin<Box<dyn futures::Stream<Item = DutchAuction> + Send + 'static>> {
-        todo!()
-    }
 }
 
 impl<T: StateRead + ?Sized> DutchAuctionData for T {}

--- a/crates/core/component/shielded-pool/src/component/fmd.rs
+++ b/crates/core/component/shielded-pool/src/component/fmd.rs
@@ -76,11 +76,6 @@ impl<T: StateRead + StateWrite> ClueManager for T {}
 
 #[async_trait]
 pub(crate) trait ClueManagerInternal: ClueManager {
-    fn init(&mut self) {
-        self.put_current_clue_count(0);
-        self.put_previous_clue_count(0);
-    }
-
     /// Flush the clue counts, returning the previous and current counts
     async fn flush_clue_count(&mut self) -> Result<(u64, u64)> {
         let previous = self.get_previous_clue_count().await?;


### PR DESCRIPTION
#### 💭 describe your changes

when [galileo](https://github.com/penumbra-zone/galileo) is built against the current contents of `main`, these warnings appear:

```
warning: method `init` is never used
  --> /penumbra/crates/core/component/shielded-pool/src/component/fmd.rs:79:8
   |
78 | pub(crate) trait ClueManagerInternal: ClueManager {
   |                  ------------------- method in this trait
79 |     fn init(&mut self) {
   |        ^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `penumbra-shielded-pool` (lib) generated 1 warning
warning: method `get_position_count` is never used
  --> /penumbra/crates/core/component/dex/src/component/position_manager/counter.rs:14:14
   |
11 | pub(super) trait PositionCounterRead: StateRead {
   |                  ------------------- method in this trait
...
14 |     async fn get_position_count(&self, trading_pair: &TradingPair) -> u32 {
   |              ^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `penumbra-dex` (lib) generated 1 warning
warning: method `stream_dutch_state_by_trigger` is never used
   --> /penumbra/crates/core/component/auction/src/component/dutch_auction.rs:462:14
    |
444 | pub(crate) trait DutchAuctionData: StateRead {
    |                  ---------------- method in this trait
...
462 |     async fn stream_dutch_state_by_trigger(
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: `penumbra-auction` (lib) generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.12s
[Finished running. Exit status: 0]
```

this addresses those warnings.

#### ✅ checklist before requesting a review

- [x] if this code contains consensus-breaking changes, i have added the
  "consensus-breaking" label. otherwise, i declare my belief that there are not
  consensus-breaking changes, for the following reason:

  > this only removes dead code.
