### PR TITLE
dex: less awkward logging if no arbs are found

### DIFF
--- a/crates/core/component/dex/src/component/dex.rs
+++ b/crates/core/component/dex/src/component/dex.rs
@@ -107,8 +107,11 @@ impl Component for Dex {
             .arbitrage(*STAKING_TOKEN_ASSET_ID, arb_routing_params)
             .await
         {
-            // The arb search completed, it may or may not have found surplus.
-            Ok(v) => tracing::info!(surplus = ?v, "arbitrage successful!"),
+            // The arb search completed successfully, and surfaced some surplus.
+            Ok(Some(v)) => tracing::info!(surplus = ?v, "arbitrage successful!"),
+            // The arb completed without errors, but resulted in no surplus, so
+            // the state fork was discarded.
+            Ok(None) => tracing::debug!("no arbitrage found"),
             // The arbitrage search should not error, but if it does, we should
             // simply not perform arbitrage, rather than halting the entire chain.
             Err(e) => tracing::warn!(?e, "error processing arb, this is a bug"),

--- a/crates/core/component/dex/src/component/tests.rs
+++ b/crates/core/component/dex/src/component/tests.rs
@@ -953,9 +953,9 @@ async fn reproduce_arbitrage_loop_testnet_53() -> anyhow::Result<()> {
     .await??;
 
     tracing::info!(profit = ?arb_profit, "the arbitrage logic has concluded!");
-    // we should have made a profit of 0.01penumbra, with accuracy loss of 0.000002penumbra.
+    // we should have made a profit of 0.01penumbra, with precision loss of 0.000002penumbra.
     let profit: Value = "0.099998penumbra".parse().unwrap();
-    assert_eq!(arb_profit, profit);
+    assert_eq!(arb_profit, Some(profit));
 
     tracing::info!("fetching the `ArbExecution`");
     let arb_execution = state.arb_execution(0).await?.expect("arb was performed");


### PR DESCRIPTION
## Describe your changes

Fix #4513, this change the arbitrage method signature to return `Result<Option<Value>>`, and avoid logging that an arbitrage run is "successful" if the state fork gets discarded. 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Mechanical refactor
