### PR TITLE
dex: 🌱 add a `SimulationsDisabled` stub for dex queries

### DIFF
--- a/crates/core/app/src/rpc.rs
+++ b/crates/core/app/src/rpc.rs
@@ -23,7 +23,7 @@ use {
     },
     penumbra_auction::component::rpc::Server as AuctionServer,
     penumbra_compact_block::component::rpc::Server as CompactBlockServer,
-    penumbra_dex::component::rpc::Server as DexServer,
+    penumbra_dex::component::rpc::{stub::SimulationsDisabled, Server as DexServer},
     penumbra_fee::component::rpc::Server as FeeServer,
     penumbra_governance::component::rpc::Server as GovernanceServer,
     penumbra_proto::{
@@ -129,6 +129,9 @@ pub fn router(
         grpc_server = grpc_server.add_service(we(SimulationServiceServer::new(DexServer::new(
             storage.clone(),
         ))));
+    } else {
+        grpc_server =
+            grpc_server.add_service(we(SimulationServiceServer::new(SimulationsDisabled)));
     }
 
     Ok(grpc_server)

--- a/crates/core/component/dex/src/component/rpc.rs
+++ b/crates/core/component/dex/src/component/rpc.rs
@@ -38,6 +38,8 @@ use crate::{
 
 use super::{chandelier::CandlestickRead, router::RouteAndFill, PositionRead, StateReadExt};
 
+pub mod stub;
+
 // TODO: Hide this and only expose a Router?
 pub struct Server {
     storage: Storage,

--- a/crates/core/component/dex/src/component/rpc/stub.rs
+++ b/crates/core/component/dex/src/component/rpc/stub.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+/// A [`SimulationService`] that always returns an error.
+///
+/// This is useful for improving error messages if `pd` is not running with expensive RPCs
+/// enabled.
+pub struct SimulationsDisabled;
+
+#[tonic::async_trait]
+impl SimulationService for SimulationsDisabled {
+    async fn simulate_trade(
+        &self,
+        _: tonic::Request<SimulateTradeRequest>,
+    ) -> Result<tonic::Response<SimulateTradeResponse>, Status> {
+        Err(Status::unimplemented(
+            "SimulationService::simulate_trade() is not enabled on this node.\
+             Run pd with `--enable-expensive-rpc` to use this RPC.",
+        ))
+    }
+}


### PR DESCRIPTION
if the `--enable-expensive-rpc` is not given, cryptic errors can be found on the client side. this adds a stub service that can be used in lieu of the expensive service, returning a helpful error message.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > only changes rpc services.