### PR TITLE
backport: exclude IBC assets from TotalSupply

### DIFF
--- a/crates/core/component/shielded-pool/src/component/rpc/bank_query.rs
+++ b/crates/core/component/shielded-pool/src/component/rpc/bank_query.rs
@@ -101,9 +101,9 @@ impl BankQuery for Server {
         for (asset_id, amount) in ibc_amounts {
             let denom_metadata = snapshot.denom_metadata_by_asset(&asset_id).await;
             if denom_metadata.is_none() {
-                return Err(tonic::Status::internal(
-                    "bad IBC ics20 value balance key in state".to_string(),
-                ));
+                // This is likely an NFT asset that is intentionally
+                // not registered, so it is fine to exclude from the output.
+                continue;
             }
             let denom_metadata = denom_metadata.expect("should not be an error");
 


### PR DESCRIPTION
## Describe your changes

This PR backports https://github.com/penumbra-zone/penumbra/pull/4518 for prep as `0.77.1` point release, to unblock the Skip team, working on IBC integrations.

(cherry picked from commit 785ac6adaba475db66ef128fcaa792537b0eec0e)

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Changes RPC output only
