### PR TITLE
dex: backport arb execution metric fix to `v0.77.x`

### DIFF
--- a/crates/core/component/dex/src/component/arb.rs
+++ b/crates/core/component/dex/src/component/arb.rs
@@ -63,6 +63,11 @@ pub trait Arbitrage: StateWrite + Sized {
             .checked_sub(&filled_input)
             .expect("filled input should always be <= flash loan amount");
 
+        // Record the duration of the arb execution now, since we've computed it
+        // and we might return early if it's zero-valued, but in that case we still
+        // want to record how long we spent looking for it.
+        metrics::histogram!(metrics::DEX_ARB_DURATION).record(arb_start.elapsed());
+
         // Because we're trading the arb token to itself, the total output is the
         // output from the route-and-fill, plus the unfilled input.
         let total_output = output + unfilled_input;
@@ -134,7 +139,6 @@ pub trait Arbitrage: StateWrite + Sized {
 
         // Emit an ABCI event detailing the arb execution.
         self_mut.record_proto(event::arb_execution(height, se));
-        metrics::histogram!(metrics::DEX_ARB_DURATION).record(arb_start.elapsed());
         return Ok(Value {
             amount: arb_profit,
             asset_id: arb_token,


### PR DESCRIPTION
## Describe your changes
This backport #4535 into the v0.77.x feature branch so that we can release into `v0.77.2`

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Change to metrics emission
