### PR TITLE
Change Planner to use optional gas prices field and error if unset

### DIFF
--- a/crates/bin/pcli/src/command/validator.rs
+++ b/crates/bin/pcli/src/command/validator.rs
@@ -22,7 +22,7 @@ use penumbra_stake::{
 
 use crate::App;
 
-use super::tx::FeeTier;
+use penumbra_fee::FeeTier;
 
 #[derive(Debug, clap::Subcommand)]
 pub enum ValidatorCmd {
@@ -73,7 +73,7 @@ pub enum VoteCmd {
         #[clap(long, global = true, display_order = 600)]
         validator: Option<IdentityKey>,
         /// The selected fee tier to multiply the fee amount by.
-        #[clap(short, long, value_enum, default_value_t)]
+        #[clap(short, long, default_value_t)]
         fee_tier: FeeTier,
     },
     /// Sign a vote on a proposal in your capacity as a validator, for submission elsewhere.
@@ -113,7 +113,7 @@ pub enum DefinitionCmd {
         #[clap(long)]
         signature: Option<String>,
         /// The selected fee tier to multiply the fee amount by.
-        #[clap(short, long, value_enum, default_value_t)]
+        #[clap(short, long, default_value_t)]
         fee_tier: FeeTier,
     },
     /// Sign a validator definition offline for submission elsewhere.

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -56,7 +56,7 @@ pub struct Planner<R: RngCore + CryptoRng> {
     /// The fee tier to apply to this transaction.
     fee_tier: FeeTier,
     /// The set of prices used for gas estimation.
-    gas_prices: GasPrices,
+    gas_prices: Option<GasPrices>,
     /// The transaction parameters to use for the transaction.
     transaction_parameters: TransactionParameters,
     /// A user-specified change address, if any.
@@ -105,7 +105,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     /// Set the current gas prices for fee prediction.
     #[instrument(skip(self))]
     pub fn set_gas_prices(&mut self, gas_prices: GasPrices) -> &mut Self {
-        self.gas_prices = gas_prices;
+        self.gas_prices = Some(gas_prices);
         self
     }
 
@@ -544,7 +544,9 @@ impl<R: RngCore + CryptoRng> Planner<R> {
         // Compute an initial fee estimate based on the actions we have so far.
         self.action_list.refresh_fee_and_change(
             &mut self.rng,
-            &self.gas_prices,
+            &self
+                .gas_prices
+                .context("planner instances must call set_gas_prices prior to planning")?,
             &self.fee_tier,
             &change_address,
         );
@@ -597,7 +599,9 @@ impl<R: RngCore + CryptoRng> Planner<R> {
             // Refresh the fee estimate and change outputs.
             self.action_list.refresh_fee_and_change(
                 &mut self.rng,
-                &self.gas_prices,
+                &self
+                    .gas_prices
+                    .context("planner instances must call set_gas_prices prior to planning")?,
                 &self.fee_tier,
                 &change_address,
             );

--- a/crates/wallet/src/plan.rs
+++ b/crates/wallet/src/plan.rs
@@ -91,6 +91,8 @@ where
 {
     const SWEEP_COUNT: usize = 8;
 
+    let gas_prices = view.gas_prices().await?;
+
     let all_notes = view
         .notes(NotesRequest {
             ..Default::default()
@@ -123,6 +125,7 @@ where
             // chunks, ignoring the biggest notes in the remainder.
             for group in records.chunks_exact(SWEEP_COUNT) {
                 let mut planner = Planner::new(&mut rng);
+                planner.set_gas_prices(gas_prices);
 
                 for record in group {
                     planner.spend(record.note.clone(), record.position);


### PR DESCRIPTION
Closes #4555 and fixes fee inclusion in validator definition upload, validator vote casting, and tx sweep.

This also introduces some protection for future planner invocations. The `Planner`'s `gas_prices` field has been changed to an `Option` type and if it's not set it will return an error during planning:

```
$ cargo run --bin pcli --release -- --home ~/.local/share/pcli-preview/ validator definition upload --file validator.toml
...
Error: planner instances must call set_gas_prices prior to planning
```

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > should be limited to addressing client-side failures on tx submission, so shouldn't change consensus on which 
