### PR TITLE
backport fixes to planner gas prices & validator voting

### DIFF
--- a/crates/bin/pcli/src/command/validator.rs
+++ b/crates/bin/pcli/src/command/validator.rs
@@ -64,6 +64,12 @@ pub enum VoteCmd {
         /// vote may be generated using the `pcli validator vote sign` command.
         #[clap(long, global = true, display_order = 500)]
         signature: Option<String>,
+        /// Vote on behalf of a particular validator.
+        ///
+        /// This must be specified when the custody backend does not match the validator identity
+        /// key, i.e. when using a separate governance key on another wallet.
+        #[clap(long, global = true, display_order = 600)]
+        validator: Option<IdentityKey>,
     },
     /// Sign a vote on a proposal in your capacity as a validator, for submission elsewhere.
     Sign {
@@ -76,6 +82,12 @@ pub enum VoteCmd {
         /// The file to write the signature to [default: stdout].
         #[clap(long, global = true, display_order = 500)]
         signature_file: Option<String>,
+        /// Vote on behalf of a particular validator.
+        ///
+        /// This must be specified when the custody backend does not match the validator identity
+        /// key, i.e. when using a separate governance key on another wallet.
+        #[clap(long, global = true, display_order = 600)]
+        validator: Option<IdentityKey>,
     },
 }
 
@@ -260,8 +272,10 @@ impl ValidatorCmd {
                 vote,
                 reason,
                 signature_file,
+                validator,
             }) => {
-                let identity_key = IdentityKey(fvk.spend_verification_key().clone().into());
+                let identity_key = validator
+                    .unwrap_or_else(|| IdentityKey(fvk.spend_verification_key().clone().into()));
                 let governance_key = app.config.governance_key();
 
                 let (proposal, vote): (u64, Vote) = (*vote).into();
@@ -306,8 +320,10 @@ impl ValidatorCmd {
                 vote,
                 reason,
                 signature,
+                validator,
             }) => {
-                let identity_key = IdentityKey(fvk.spend_verification_key().clone().into());
+                let identity_key = validator
+                    .unwrap_or_else(|| IdentityKey(fvk.spend_verification_key().clone().into()));
                 let governance_key = app.config.governance_key();
 
                 let (proposal, vote): (u64, Vote) = (*vote).into();

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -56,7 +56,7 @@ pub struct Planner<R: RngCore + CryptoRng> {
     /// The fee tier to apply to this transaction.
     fee_tier: FeeTier,
     /// The set of prices used for gas estimation.
-    gas_prices: GasPrices,
+    gas_prices: Option<GasPrices>,
     /// The transaction parameters to use for the transaction.
     transaction_parameters: TransactionParameters,
     /// A user-specified change address, if any.
@@ -105,7 +105,7 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     /// Set the current gas prices for fee prediction.
     #[instrument(skip(self))]
     pub fn set_gas_prices(&mut self, gas_prices: GasPrices) -> &mut Self {
-        self.gas_prices = gas_prices;
+        self.gas_prices = Some(gas_prices);
         self
     }
 
@@ -544,7 +544,9 @@ impl<R: RngCore + CryptoRng> Planner<R> {
         // Compute an initial fee estimate based on the actions we have so far.
         self.action_list.refresh_fee_and_change(
             &mut self.rng,
-            &self.gas_prices,
+            &self
+                .gas_prices
+                .context("planner instances must call set_gas_prices prior to planning")?,
             &self.fee_tier,
             &change_address,
         );
@@ -597,7 +599,9 @@ impl<R: RngCore + CryptoRng> Planner<R> {
             // Refresh the fee estimate and change outputs.
             self.action_list.refresh_fee_and_change(
                 &mut self.rng,
-                &self.gas_prices,
+                &self
+                    .gas_prices
+                    .context("planner instances must call set_gas_prices prior to planning")?,
                 &self.fee_tier,
                 &change_address,
             );

--- a/crates/wallet/src/plan.rs
+++ b/crates/wallet/src/plan.rs
@@ -91,6 +91,8 @@ where
 {
     const SWEEP_COUNT: usize = 8;
 
+    let gas_prices = view.gas_prices().await?;
+
     let all_notes = view
         .notes(NotesRequest {
             ..Default::default()
@@ -123,6 +125,7 @@ where
             // chunks, ignoring the biggest notes in the remainder.
             for group in records.chunks_exact(SWEEP_COUNT) {
                 let mut planner = Planner::new(&mut rng);
+                planner.set_gas_prices(gas_prices);
 
                 for record in group {
                     planner.spend(record.note.clone(), record.position);


### PR DESCRIPTION
## Describe your changes
Backports two PRs for 0.77.2 (#4545):

* https://github.com/penumbra-zone/penumbra/pull/4510
* https://github.com/penumbra-zone/penumbra/pull/4554

The planner changes in the latter are crucial to point-release. The former less so, but including those changes reduced conflicts on the cherry-pick, and the client-side improvement is a nice-to-have as we focus on resolving #4540.

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > client-side changes only, no changes to consensus logic
