### PR TITLE
ci: don't run long tests on docs-only PRs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,9 @@
 name: Rust CI
-on: pull_request
+on:
+  pull_request:
+    # Don't run Rust tests if only docs changed.
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   test:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,9 +1,9 @@
 name: Smoke Test
 on:
   pull_request:
-  push:
-    branches:
-      - main
+    # Don't run Rust tests if only docs changed.
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   smoke_test:

--- a/.github/workflows/summoner_smoke.yml
+++ b/.github/workflows/summoner_smoke.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   smoke_test:


### PR DESCRIPTION

## Describe your changes
I want to keep the docs up to date, and sometimes that requires fussy management of version numbers, particularly as we invest in multi-branch workflows to support point releases (e.g. #4545). If *only* the docs changed, skip the long-running rust tests, because we don't need to validate rust functionality on docs changes.

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > ci-only