### PR TITLE
dex: fold `Position`s into the price indexes

### DIFF
--- a/crates/bin/pd/src/migrate.rs
+++ b/crates/bin/pd/src/migrate.rs
@@ -50,6 +50,7 @@ pub enum Migration {
     Testnet77,
     /// Testnet-78 migration:
     /// - Truncate various user-supplied `String` fields to a maximum length.
+    /// - Populate the DEX NV price idnexes with position data
     Testnet78,
 }
 
@@ -90,11 +91,12 @@ impl Migration {
             Migration::Testnet78 => {
                 testnet78::migrate(storage, pd_home.clone(), genesis_start).await?
             }
-            _ => unreachable!(),
+            // We keep historical migrations around for now, this will help inform an abstracted
+            // design. Feel free to remove it if it's causing you trouble.
+            _ => unimplemented!("the specified migration is unimplemented"),
         }
 
         if let Some(comet_home) = comet_home {
-            // TODO avoid this when refactoring to clean up migrations
             let genesis_path = pd_home.join("genesis.json");
             migrate_comet_data(comet_home, genesis_path).await?;
         }

--- a/crates/bin/pd/src/migrate/testnet78.rs
+++ b/crates/bin/pd/src/migrate/testnet78.rs
@@ -1,17 +1,20 @@
 //! Contains functions related to the migration script of Testnet78.
-use anyhow::Context;
-use cnidarium::{Snapshot, StateDelta, Storage};
+use cnidarium::{Snapshot, StateDelta, StateWrite, Storage};
 use futures::TryStreamExt as _;
+use futures::{pin_mut, StreamExt};
 use jmt::RootHash;
 use penumbra_app::app::StateReadExt as _;
+use penumbra_dex::component::PositionManager;
+use penumbra_dex::lp::position;
+use penumbra_dex::lp::position::Position;
 use penumbra_governance::proposal_state::State as ProposalState;
 use penumbra_governance::Proposal;
 use penumbra_governance::StateReadExt as _;
-use penumbra_governance::StateWriteExt;
+use penumbra_governance::StateWriteExt as _;
 use penumbra_proto::core::component::governance::v1 as pb_governance;
-use penumbra_proto::{StateReadProto as _, StateWriteProto as _};
+use penumbra_proto::{StateReadProto, StateWriteProto};
 use penumbra_sct::component::clock::EpochManager;
-use penumbra_sct::component::clock::EpochRead as _;
+use penumbra_sct::component::clock::EpochRead;
 use penumbra_stake::validator::Validator;
 use std::path::PathBuf;
 use tracing::instrument;
@@ -41,32 +44,36 @@ use crate::testnet::generate::TestnetConfig;
 ///    - `client_id` (128 bytes)
 ///   * Governance Signaling Proposals:
 ///    - `commit hash` (255 bytes)
+/// - Close and re-open all *open* positions so that they are re-indexed.
 #[instrument]
 pub async fn migrate(
     storage: Storage,
     pd_home: PathBuf,
     genesis_start: Option<tendermint::time::Time>,
 ) -> anyhow::Result<()> {
-    // Setup:
+    /* `Migration::prepare`: collect basic migration data, logging, initialize alt-storage if needed */
     let initial_state = storage.latest_snapshot();
+
     let chain_id = initial_state.get_chain_id().await?;
     let root_hash = initial_state
         .root_hash()
         .await
         .expect("chain state has a root hash");
-    let pre_upgrade_root_hash: RootHash = root_hash.into();
+
     let pre_upgrade_height = initial_state
         .get_block_height()
         .await
         .expect("chain state has a block height");
     let post_upgrade_height = pre_upgrade_height.wrapping_add(1);
 
-    // We initialize a `StateDelta` and start by reaching into the JMT for all entries matching the
-    // swap execution prefix. Then, we write each entry to the nv-storage.
+    let pre_upgrade_root_hash: RootHash = root_hash.into();
+
+    /* `Migration::migrate`: reach into the chain state and perform an offline state transition */
     let mut delta = StateDelta::new(initial_state);
-    tracing::info!("beginning migration steps");
+
     let (migration_duration, post_upgrade_root_hash) = {
         let start_time = std::time::SystemTime::now();
+
         // Adjust the length of `Validator` fields.
         truncate_validator_fields(&mut delta).await?;
 
@@ -76,30 +83,26 @@ pub async fn migrate(
         // Adjust the length of governance proposal outcome fields.
         truncate_proposal_outcome_fields(&mut delta).await?;
 
+        // Re-index all open positions.
+        reindex_dex_positions(&mut delta).await?;
+
+        // Reset the application height and halt flag.
+        delta.ready_to_start();
+        delta.put_block_height(0u64);
+
+        // Finally, commit the changes to the chain state.
         let post_upgrade_root_hash = storage.commit_in_place(delta).await?;
         tracing::info!(?post_upgrade_root_hash, "post-migration root hash");
 
         (
-            start_time.elapsed().expect("start time not set"),
+            start_time.elapsed().expect("start is set"),
             post_upgrade_root_hash,
         )
     };
-    tracing::info!("completed migration steps");
 
-    // Set halt bit to 0, so chain can start again.
-    let migrated_state = storage.latest_snapshot();
-    let mut delta = StateDelta::new(migrated_state);
-    delta.ready_to_start();
-    delta.put_block_height(0u64);
-    let _ = storage
-        .commit_in_place(delta)
-        .await
-        .context("failed to reset halt bit")?;
-    storage.release().await;
+    tracing::info!("migration completed, generating genesis and signing state...");
 
-    // The migration is complete, now we need to generate a genesis file. To do this, we need
-    // to lookup a validator view from the chain, and specify the post-upgrade app hash and
-    // initial height.
+    /* `Migration::complete`: the state transition has been performed, we prepare the checkpointed genesis and signing state */
     let app_state = penumbra_app::genesis::Content {
         chain_id,
         ..Default::default()
@@ -110,22 +113,26 @@ pub async fn migrate(
         .to_vec()
         .try_into()
         .expect("infaillible conversion");
+
     genesis.initial_height = post_upgrade_height as i64;
     genesis.genesis_time = genesis_start.unwrap_or_else(|| {
         let now = tendermint::time::Time::now();
         tracing::info!(%now, "no genesis time provided, detecting a testing setup");
         now
     });
+
+    tracing::info!("generating checkpointed genesis");
     let checkpoint = post_upgrade_root_hash.0.to_vec();
     let genesis = TestnetConfig::make_checkpoint(genesis, Some(checkpoint));
 
+    tracing::info!("writing genesis to disk");
     let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");
     tracing::info!("genesis: {}", genesis_json);
     let genesis_path = pd_home.join("genesis.json");
     std::fs::write(genesis_path, genesis_json).expect("can write genesis");
 
+    tracing::info!("updating signing state");
     let validator_state_path = pd_home.join("priv_validator_state.json");
-
     let fresh_validator_state = crate::testnet::generate::TestnetValidator::initial_state();
     std::fs::write(validator_state_path, fresh_validator_state).expect("can write validator state");
 
@@ -135,9 +142,35 @@ pub async fn migrate(
         ?pre_upgrade_root_hash,
         ?post_upgrade_root_hash,
         duration = migration_duration.as_secs(),
-        "successful migration!"
+        "migration fully complete"
     );
 
+    Ok(())
+}
+
+async fn reindex_dex_positions(delta: &mut StateDelta<Snapshot>) -> anyhow::Result<()> {
+    tracing::info!("running dex re-indexing migration");
+    let prefix_key_lp = penumbra_dex::state_key::all_positions();
+    let stream_all_lp = delta.prefix::<Position>(&prefix_key_lp);
+    let stream_open_lp = stream_all_lp.filter_map(|entry| async {
+        match entry {
+            Ok((_, lp)) if lp.state == position::State::Opened => Some(lp),
+            _ => None,
+        }
+    });
+    pin_mut!(stream_open_lp);
+
+    while let Some(lp) = stream_open_lp.next().await {
+        // Re-hash the position, since the key is a bech32 string.
+        let id = lp.id();
+        // Close the position, adjusting all its index entries.
+        delta.close_position_by_id(&id).await?;
+        // Erase the position from the state, so that we circumvent the `update_position` guard.
+        delta.delete(penumbra_dex::state_key::position_by_id(&id));
+        // Open a position with the adjusted indexing logic.
+        delta.open_position(lp).await?;
+    }
+    tracing::info!("completed dex migration");
     Ok(())
 }
 

--- a/crates/core/component/dex/src/component/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/component/circuit_breaker/value.rs
@@ -241,7 +241,7 @@ mod tests {
 
         let position = buy_1;
         state_tx
-            .update_position_by_price_index(&None, &position, &position.id())
+            .update_position_by_price_index(&position.id(), &None, &position)
             .expect("can update price index");
         state_tx.put(state_key::position_by_id(&id), position);
 

--- a/crates/core/component/dex/src/component/position_manager/base_liquidity_index.rs
+++ b/crates/core/component/dex/src/component/position_manager/base_liquidity_index.rs
@@ -76,9 +76,9 @@ pub(crate) trait AssetByLiquidityIndex: StateWrite {
     ///     │     └──┘                                                      
     async fn update_asset_by_base_liquidity_index(
         &mut self,
+        id: &position::Id,
         prev_state: &Option<Position>,
         new_state: &Position,
-        id: &position::Id,
     ) -> Result<()> {
         // We need to reconstruct the position's previous contribution and compute
         // its new contribution to the index. We do this for each asset in the pair

--- a/crates/core/component/dex/src/component/position_manager/counter.rs
+++ b/crates/core/component/dex/src/component/position_manager/counter.rs
@@ -41,7 +41,6 @@ pub(crate) trait PositionCounter: StateWrite {
         &mut self,
         prev_state: &Option<Position>,
         new_state: &Position,
-        _id: &position::Id,
     ) -> Result<()> {
         use position::State::*;
         let trading_pair = new_state.phi.pair;

--- a/crates/core/component/dex/src/component/position_manager/inventory_index.rs
+++ b/crates/core/component/dex/src/component/position_manager/inventory_index.rs
@@ -13,9 +13,9 @@ use position::State::*;
 pub(super) trait PositionByInventoryIndex: StateWrite {
     fn update_position_by_inventory_index(
         &mut self,
+        position_id: &position::Id,
         prev_state: &Option<Position>,
         new_state: &Position,
-        position_id: &position::Id,
     ) -> Result<()> {
         // Clear an existing record of the position, since changes to the
         // reserves or the position state might have invalidated it.

--- a/crates/core/component/dex/src/component/position_manager/price_index.rs
+++ b/crates/core/component/dex/src/component/position_manager/price_index.rs
@@ -1,4 +1,5 @@
 use cnidarium::StateWrite;
+use penumbra_proto::StateWriteProto;
 
 use crate::{
     lp::position::{self, Position},
@@ -12,9 +13,9 @@ use position::State::*;
 pub(crate) trait PositionByPriceIndex: StateWrite {
     fn update_position_by_price_index(
         &mut self,
+        position_id: &position::Id,
         prev_state: &Option<Position>,
         new_state: &Position,
-        position_id: &position::Id,
     ) -> Result<()> {
         // Clear an existing record for the position, since changes to the
         // reserves or the position state might have invalidated it.
@@ -57,7 +58,10 @@ trait Inner: StateWrite {
                 end: pair.asset_2(),
             };
             let phi12 = phi.component.clone();
-            self.nonverifiable_put_raw(engine::price_index::key(&pair12, &phi12, &id), vec![]);
+            self.nonverifiable_put(
+                engine::price_index::key(&pair12, &phi12, &id),
+                position.clone(),
+            );
             tracing::debug!("indexing position for 1=>2 trades");
         }
 
@@ -68,7 +72,10 @@ trait Inner: StateWrite {
                 end: pair.asset_1(),
             };
             let phi21 = phi.component.flip();
-            self.nonverifiable_put_raw(engine::price_index::key(&pair21, &phi21, &id), vec![]);
+            self.nonverifiable_put(
+                engine::price_index::key(&pair21, &phi21, &id),
+                position.clone(),
+            );
             tracing::debug!("indexing position for 2=>1 trades");
         }
     }

--- a/crates/core/component/dex/src/component/router/tests.rs
+++ b/crates/core/component/dex/src/component/router/tests.rs
@@ -446,8 +446,8 @@ async fn position_get_best_price() -> anyhow::Result<()> {
     let positions = state_tx
         .positions_by_price(&pair)
         .then(|result| async {
-            let id = result.unwrap();
-            state_tx.position_by_id(&id).await.unwrap().unwrap()
+            let (_, lp) = result.unwrap();
+            lp
         })
         .collect::<Vec<position::Position>>()
         .await;
@@ -463,8 +463,8 @@ async fn position_get_best_price() -> anyhow::Result<()> {
     let positions = state_tx
         .positions_by_price(&pair)
         .then(|result| async {
-            let id = result.unwrap();
-            state_tx.position_by_id(&id).await.unwrap().unwrap()
+            let (_, lp) = result.unwrap();
+            lp
         })
         .collect::<Vec<position::Position>>()
         .await;
@@ -505,7 +505,7 @@ async fn test_multiple_similar_position() -> anyhow::Result<()> {
     // that we make up a context here.
     let context = pair_1.into_directed_trading_pair();
 
-    let mut p_1 = state_tx
+    let (_, mut p_1) = state_tx
         .best_position(&pair_1.into_directed_trading_pair())
         .await
         .unwrap()
@@ -514,7 +514,7 @@ async fn test_multiple_similar_position() -> anyhow::Result<()> {
     p_1.reserves = p_1.reserves.flip();
     state_tx.position_execution(p_1, context).await.unwrap();
 
-    let mut p_2 = state_tx
+    let (_, mut p_2) = state_tx
         .best_position(&pair_1.into_directed_trading_pair())
         .await
         .unwrap()

--- a/crates/core/component/dex/src/state_key.rs
+++ b/crates/core/component/dex/src/state_key.rs
@@ -19,6 +19,7 @@ pub fn positions(trading_pair: &TradingPair, position_id: &str) -> String {
 }
 
 /// Looks up a `Position` by its ID
+// This should only ever be called by `position_manager::Inner::update_position`.
 pub fn position_by_id(id: &position::Id) -> String {
     format!("dex/position/{id}")
 }


### PR DESCRIPTION
## Describe your changes

This PR:
- fold `Position` records into the DEX price indexes
- remove extra hashing of positions (to compute `Id`s)
- adds a migration script to population the nonconsensus idx

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This is consensus breaking, AND requires a migration. 
