### PR TITLE
Enforce string limits for deserialization

### DIFF
--- a/crates/bin/pd/src/migrate.rs
+++ b/crates/bin/pd/src/migrate.rs
@@ -10,19 +10,24 @@ mod testnet72;
 mod testnet74;
 mod testnet76;
 mod testnet77;
+mod testnet78;
 
 use anyhow::{ensure, Context};
-use penumbra_governance::StateReadExt;
-use penumbra_sct::component::clock::EpochRead;
+use jmt::RootHash;
+use penumbra_app::app::StateReadExt as _;
+use penumbra_governance::{StateReadExt, StateWriteExt as _};
+use penumbra_sct::component::clock::{EpochManager as _, EpochRead};
 use std::path::{Path, PathBuf};
 use tracing::instrument;
 
-use cnidarium::Storage;
+use cnidarium::{StateDelta, Storage};
 use penumbra_app::SUBSTORE_PREFIXES;
 
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use std::fs::File;
+
+use crate::testnet::generate::TestnetConfig;
 
 /// The kind of migration that should be performed.
 #[derive(Debug)]
@@ -47,6 +52,9 @@ pub enum Migration {
     /// Testnet-77 migration:
     /// - Reset the halt bit
     Testnet77,
+    /// Testnet-78 migration:
+    /// - Truncate various user-supplied `String` fields to a maximum length.
+    Testnet78,
 }
 
 impl Migration {
@@ -72,36 +80,95 @@ impl Migration {
         );
         tracing::info!("started migration");
 
-        match self {
-            Migration::ReadyToStart => {
-                reset_halt_bit::migrate(storage, pd_home, genesis_start).await?;
-                return Ok(());
-            }
-            Migration::SimpleMigration => {
-                simple::migrate(storage, pd_home.clone(), genesis_start).await?
-            }
+        // If this is `ReadyToStart`, we need to reset the halt bit and return early.
+        if let Migration::ReadyToStart = self {
+            reset_halt_bit::migrate(storage, pd_home, genesis_start).await?;
+            return Ok(());
+        }
 
-            Migration::Testnet72 => {
-                testnet72::migrate(storage, pd_home.clone(), genesis_start).await?
-            }
+        // Collect various pieces of state pre-migration:
+        let initial_state = storage.latest_snapshot();
+        let root_hash = initial_state
+            .root_hash()
+            .await
+            .expect("chain state has a root hash");
+        let pre_upgrade_root_hash: RootHash = root_hash.into();
+        let pre_upgrade_height = initial_state
+            .get_block_height()
+            .await
+            .expect("chain state has a block height");
+        let post_upgrade_height = pre_upgrade_height.wrapping_add(1);
 
-            Migration::Testnet74 => {
-                testnet74::migrate(storage, pd_home.clone(), genesis_start).await?
-            }
+        let migration_duration = match self {
+            Migration::SimpleMigration => simple::migrate(storage.clone()).await?,
 
-            Migration::Testnet76 => {
-                testnet76::migrate(storage, pd_home.clone(), genesis_start).await?
-            }
-            Migration::Testnet77 => {
-                testnet77::migrate(storage, pd_home.clone(), genesis_start).await?
-            }
+            Migration::Testnet78 => testnet78::migrate(storage.clone()).await?,
+            _ => unreachable!(),
         };
+
+        // There are some common operations that need to take place post-migration.
+        // Get a new `StateDelta` post-migration:
+        let post_upgrade_state = storage.latest_snapshot();
+        let mut delta = StateDelta::new(post_upgrade_state);
+
+        // Set halt bit to 0, so chain can start again.
+        delta.ready_to_start();
+
+        // Set the block height to 0, as upgrades should start at block 0.
+        delta.put_block_height(0u64);
+        let chain_id = delta.get_chain_id().await?;
+        let post_upgrade_root_hash = storage
+            .commit_in_place(delta)
+            .await
+            .context("failed to reset halt bit")?;
+
+        storage.release().await;
+
+        // The migration is complete, now we need to generate a genesis file. To do this, we need
+        // to lookup a validator view from the chain, and specify the post-upgrade app hash and
+        // initial height.
+        let app_state = penumbra_app::genesis::Content {
+            chain_id,
+            ..Default::default()
+        };
+        let mut genesis = TestnetConfig::make_genesis(app_state.clone()).expect("can make genesis");
+        genesis.app_hash = post_upgrade_root_hash
+            .0
+            .to_vec()
+            .try_into()
+            .expect("infallible conversion");
+        genesis.initial_height = post_upgrade_height as i64;
+        genesis.genesis_time = genesis_start.unwrap_or_else(|| {
+            let now = tendermint::time::Time::now();
+            tracing::info!(%now, "no genesis time provided, detecting a testing setup");
+            now
+        });
+        let checkpoint = post_upgrade_root_hash.0.to_vec();
+        let genesis = TestnetConfig::make_checkpoint(genesis, Some(checkpoint));
+        let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");
+        tracing::info!("genesis: {}", genesis_json);
+        let genesis_path = pd_home.join("genesis.json");
+        std::fs::write(genesis_path, genesis_json).expect("can write genesis");
+
+        let validator_state_path = pd_home.join("priv_validator_state.json");
+        let fresh_validator_state = crate::testnet::generate::TestnetValidator::initial_state();
+        std::fs::write(validator_state_path, fresh_validator_state)
+            .expect("can write validator state");
 
         if let Some(comet_home) = comet_home {
             // TODO avoid this when refactoring to clean up migrations
             let genesis_path = pd_home.join("genesis.json");
             migrate_comet_data(comet_home, genesis_path).await?;
         }
+
+        tracing::info!(
+            pre_upgrade_height,
+            post_upgrade_height,
+            ?pre_upgrade_root_hash,
+            ?post_upgrade_root_hash,
+            duration = migration_duration.as_secs(),
+            "successful migration!"
+        );
 
         Ok(())
     }

--- a/crates/bin/pd/src/migrate/reset_halt_bit.rs
+++ b/crates/bin/pd/src/migrate/reset_halt_bit.rs
@@ -16,5 +16,6 @@ pub async fn migrate(
     let _ = storage.commit_in_place(delta).await?;
     storage.release().await;
     tracing::info!("migration completed: halt bit is turned off, chain is ready to start");
+
     Ok(())
 }

--- a/crates/bin/pd/src/migrate/simple.rs
+++ b/crates/bin/pd/src/migrate/simple.rs
@@ -3,72 +3,25 @@
 use anyhow;
 use cnidarium::{StateDelta, StateWrite, Storage};
 use jmt::RootHash;
-use penumbra_app::app::StateReadExt as _;
-use penumbra_sct::component::clock::{EpochManager, EpochRead};
-use std::path::PathBuf;
+use penumbra_sct::component::clock::EpochManager;
+use std::time::Duration;
 
-use crate::testnet::generate::TestnetConfig;
-pub async fn migrate(
-    storage: Storage,
-    path_to_export: PathBuf,
-    genesis_start: Option<tendermint::time::Time>,
-) -> anyhow::Result<()> {
+pub async fn migrate(storage: Storage) -> anyhow::Result<Duration> {
     let export_state = storage.latest_snapshot();
     let root_hash = export_state.root_hash().await.expect("can get root hash");
-    let height = export_state
-        .get_block_height()
-        .await
-        .expect("can get block height");
     let app_hash_pre_migration: RootHash = root_hash.into();
-    let post_ugprade_height = height.wrapping_add(1);
 
     /* --------- writing to the jmt  ------------ */
     tracing::info!(?app_hash_pre_migration, "app hash pre-upgrade");
     let mut delta = StateDelta::new(export_state);
+    let start_time = std::time::SystemTime::now();
     delta.put_raw(
         "banana".to_string(),
         "a good fruit (and migration works!)".into(),
     );
     delta.put_block_height(0u64);
-    let root_hash = storage.commit_in_place(delta).await?;
-    let app_hash_post_migration: RootHash = root_hash.into();
-    tracing::info!(?app_hash_post_migration, "app hash post upgrade");
 
-    /* --------- collecting genesis data -------- */
-    tracing::info!("generating genesis");
-    let migrated_state = storage.latest_snapshot();
-    let root_hash = migrated_state.root_hash().await.expect("can get root hash");
-    let app_hash: RootHash = root_hash.into();
-    tracing::info!(?root_hash, "root hash from snapshot (post-upgrade)");
+    storage.commit_in_place(delta).await?;
 
-    /* ---------- generate genesis ------------  */
-    let chain_id = migrated_state.get_chain_id().await?;
-    let app_state = penumbra_app::genesis::Content {
-        chain_id,
-        ..Default::default()
-    };
-    let mut genesis = TestnetConfig::make_genesis(app_state.clone()).expect("can make genesis");
-    genesis.app_hash = app_hash
-        .0
-        .to_vec()
-        .try_into()
-        .expect("infaillible conversion");
-    genesis.initial_height = post_ugprade_height as i64;
-    genesis.genesis_time = genesis_start.unwrap_or_else(|| {
-        let now = tendermint::time::Time::now();
-        tracing::info!(%now, "no genesis time provided, detecting a testing setup");
-        now
-    });
-    let checkpoint = app_hash.0.to_vec();
-    let genesis = TestnetConfig::make_checkpoint(genesis, Some(checkpoint));
-
-    let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");
-    tracing::info!("genesis: {}", genesis_json);
-    let genesis_path = path_to_export.join("genesis.json");
-    std::fs::write(genesis_path, genesis_json).expect("can write genesis");
-
-    let validator_state_path = path_to_export.join("priv_validator_state.json");
-    let fresh_validator_state = crate::testnet::generate::TestnetValidator::initial_state();
-    std::fs::write(validator_state_path, fresh_validator_state).expect("can write validator state");
-    Ok(())
+    Ok(start_time.elapsed().expect("start time not set"))
 }

--- a/crates/bin/pd/src/migrate/simple.rs
+++ b/crates/bin/pd/src/migrate/simple.rs
@@ -3,25 +3,72 @@
 use anyhow;
 use cnidarium::{StateDelta, StateWrite, Storage};
 use jmt::RootHash;
-use penumbra_sct::component::clock::EpochManager;
-use std::time::Duration;
+use penumbra_app::app::StateReadExt as _;
+use penumbra_sct::component::clock::{EpochManager, EpochRead};
+use std::path::PathBuf;
 
-pub async fn migrate(storage: Storage) -> anyhow::Result<Duration> {
+use crate::testnet::generate::TestnetConfig;
+pub async fn migrate(
+    storage: Storage,
+    path_to_export: PathBuf,
+    genesis_start: Option<tendermint::time::Time>,
+) -> anyhow::Result<()> {
     let export_state = storage.latest_snapshot();
     let root_hash = export_state.root_hash().await.expect("can get root hash");
+    let height = export_state
+        .get_block_height()
+        .await
+        .expect("can get block height");
     let app_hash_pre_migration: RootHash = root_hash.into();
+    let post_ugprade_height = height.wrapping_add(1);
 
     /* --------- writing to the jmt  ------------ */
     tracing::info!(?app_hash_pre_migration, "app hash pre-upgrade");
     let mut delta = StateDelta::new(export_state);
-    let start_time = std::time::SystemTime::now();
     delta.put_raw(
         "banana".to_string(),
         "a good fruit (and migration works!)".into(),
     );
     delta.put_block_height(0u64);
+    let root_hash = storage.commit_in_place(delta).await?;
+    let app_hash_post_migration: RootHash = root_hash.into();
+    tracing::info!(?app_hash_post_migration, "app hash post upgrade");
 
-    storage.commit_in_place(delta).await?;
+    /* --------- collecting genesis data -------- */
+    tracing::info!("generating genesis");
+    let migrated_state = storage.latest_snapshot();
+    let root_hash = migrated_state.root_hash().await.expect("can get root hash");
+    let app_hash: RootHash = root_hash.into();
+    tracing::info!(?root_hash, "root hash from snapshot (post-upgrade)");
 
-    Ok(start_time.elapsed().expect("start time not set"))
+    /* ---------- generate genesis ------------  */
+    let chain_id = migrated_state.get_chain_id().await?;
+    let app_state = penumbra_app::genesis::Content {
+        chain_id,
+        ..Default::default()
+    };
+    let mut genesis = TestnetConfig::make_genesis(app_state.clone()).expect("can make genesis");
+    genesis.app_hash = app_hash
+        .0
+        .to_vec()
+        .try_into()
+        .expect("infaillible conversion");
+    genesis.initial_height = post_ugprade_height as i64;
+    genesis.genesis_time = genesis_start.unwrap_or_else(|| {
+        let now = tendermint::time::Time::now();
+        tracing::info!(%now, "no genesis time provided, detecting a testing setup");
+        now
+    });
+    let checkpoint = app_hash.0.to_vec();
+    let genesis = TestnetConfig::make_checkpoint(genesis, Some(checkpoint));
+
+    let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");
+    tracing::info!("genesis: {}", genesis_json);
+    let genesis_path = path_to_export.join("genesis.json");
+    std::fs::write(genesis_path, genesis_json).expect("can write genesis");
+
+    let validator_state_path = path_to_export.join("priv_validator_state.json");
+    let fresh_validator_state = crate::testnet::generate::TestnetValidator::initial_state();
+    std::fs::write(validator_state_path, fresh_validator_state).expect("can write validator state");
+    Ok(())
 }

--- a/crates/bin/pd/src/migrate/testnet72.rs
+++ b/crates/bin/pd/src/migrate/testnet72.rs
@@ -1,5 +1,5 @@
 //! Contains functions related to the migration script of Testnet72
-
+#![allow(dead_code)]
 use anyhow;
 use cnidarium::{Snapshot, StateDelta, StateRead, StateWrite, Storage};
 use futures::StreamExt as _;

--- a/crates/bin/pd/src/migrate/testnet74.rs
+++ b/crates/bin/pd/src/migrate/testnet74.rs
@@ -1,4 +1,5 @@
 //! Contains functions related to the migration script of Testnet74
+#![allow(dead_code)]
 
 use anyhow;
 use cnidarium::{EscapedByteSlice, Snapshot, StateDelta, StateRead, StateWrite, Storage};

--- a/crates/bin/pd/src/migrate/testnet76.rs
+++ b/crates/bin/pd/src/migrate/testnet76.rs
@@ -1,4 +1,5 @@
 //! Contains functions related to the migration script of Testnet74
+#![allow(dead_code)]
 
 use anyhow;
 use cnidarium::{Snapshot, StateDelta, Storage};

--- a/crates/bin/pd/src/migrate/testnet78.rs
+++ b/crates/bin/pd/src/migrate/testnet78.rs
@@ -1,0 +1,43 @@
+//! Contains functions related to the migration script of Testnet78.
+use cnidarium::{StateDelta, Storage};
+use std::time::Duration;
+use tracing::instrument;
+
+/// Run the full migration, given an export path and a start time for genesis.
+///
+/// Menu:
+/// - Truncate various user-supplied `String` fields to a maximum length.
+///   * Validator Definitions:
+///    - `name` (140 characters)
+///    - `website` (70 characters)
+///    - `description` (280 characters)
+///   * Governance Parameter Changes:
+///    - `key` (64 characters)
+///    - `value` (2048 characters)
+///    - `component` (64 characters)
+///   * Governance Proposals:
+///    - `title` (80 characters)
+///    - `description` (10,000 characters)
+///   * Governance Proposal Withdrawals:
+///    - `reason` (1024 characters)
+///   * Governance IBC Client Freeze Proposals:
+///    - `client_id` (128 characters)
+///   * Signaling Proposals:
+///    - `commit hash` (64 characters)
+#[instrument]
+pub async fn migrate(storage: Storage) -> anyhow::Result<Duration> {
+    // Setup:
+    let initial_state = storage.latest_snapshot();
+
+    // We initialize a `StateDelta` and start by reaching into the JMT for all entries matching the
+    // swap execution prefix. Then, we write each entry to the nv-storage.
+    let mut delta = StateDelta::new(initial_state);
+    let start_time = std::time::SystemTime::now();
+
+    // TODO: adjust data lengths here
+
+    let post_upgrade_root_hash = storage.commit_in_place(delta).await?;
+    tracing::info!(?post_upgrade_root_hash, "post-migration root hash");
+
+    Ok(start_time.elapsed().expect("start time not set"))
+}

--- a/crates/bin/pd/src/migrate/testnet78.rs
+++ b/crates/bin/pd/src/migrate/testnet78.rs
@@ -354,7 +354,7 @@ pub fn floor_char_boundary(s: &str, index: usize) -> usize {
             .rposition(|b| is_utf8_char_boundary(*b));
 
         // SAFETY: we know that the character boundary will be within four bytes
-        unsafe { lower_bound + new_index.unwrap_unchecked() }
+        lower_bound + new_index.unwrap()
     }
 }
 

--- a/crates/bin/pd/src/migrate/testnet78.rs
+++ b/crates/bin/pd/src/migrate/testnet78.rs
@@ -1,13 +1,22 @@
 //! Contains functions related to the migration script of Testnet78.
-use cnidarium::{StateDelta, Storage};
-use std::time::Duration;
+use cnidarium::{Snapshot, StateDelta, Storage};
+use futures::TryStreamExt as _;
+use jmt::RootHash;
+use pbjson_types::Any;
+use penumbra_app::app::StateReadExt as _;
+use penumbra_proto::{DomainType as _, StateReadProto as _, StateWriteProto as _};
+use penumbra_sct::component::clock::EpochRead as _;
+use penumbra_stake::validator::Validator;
+use std::{path::PathBuf, time::Duration};
 use tracing::instrument;
+
+use crate::testnet::generate::TestnetConfig;
 
 /// Run the full migration, given an export path and a start time for genesis.
 ///
 /// Menu:
 /// - Truncate various user-supplied `String` fields to a maximum length.
-///   * Validator Definitions:
+///   * Validators:
 ///    - `name` (140 characters)
 ///    - `website` (70 characters)
 ///    - `description` (280 characters)
@@ -25,19 +34,154 @@ use tracing::instrument;
 ///   * Signaling Proposals:
 ///    - `commit hash` (64 characters)
 #[instrument]
-pub async fn migrate(storage: Storage) -> anyhow::Result<Duration> {
+pub async fn migrate(
+    storage: Storage,
+    pd_home: PathBuf,
+    genesis_start: Option<tendermint::time::Time>,
+) -> anyhow::Result<()> {
     // Setup:
     let initial_state = storage.latest_snapshot();
+    let chain_id = initial_state.get_chain_id().await?;
+    let root_hash = initial_state
+        .root_hash()
+        .await
+        .expect("chain state has a root hash");
+    let pre_upgrade_root_hash: RootHash = root_hash.into();
+    let pre_upgrade_height = initial_state
+        .get_block_height()
+        .await
+        .expect("chain state has a block height");
+    let post_upgrade_height = pre_upgrade_height.wrapping_add(1);
 
     // We initialize a `StateDelta` and start by reaching into the JMT for all entries matching the
     // swap execution prefix. Then, we write each entry to the nv-storage.
     let mut delta = StateDelta::new(initial_state);
-    let start_time = std::time::SystemTime::now();
+    let (migration_duration, post_upgrade_root_hash) = {
+        let start_time = std::time::SystemTime::now();
+        // Adjust the length of `Validator` fields.
+        truncate_validator_fields(&mut delta).await?;
 
-    // TODO: adjust data lengths here
+        let post_upgrade_root_hash = storage.commit_in_place(delta).await?;
+        tracing::info!(?post_upgrade_root_hash, "post-migration root hash");
 
-    let post_upgrade_root_hash = storage.commit_in_place(delta).await?;
-    tracing::info!(?post_upgrade_root_hash, "post-migration root hash");
+        (
+            start_time.elapsed().expect("start time not set"),
+            post_upgrade_root_hash,
+        )
+    };
+    storage.release().await;
 
-    Ok(start_time.elapsed().expect("start time not set"))
+    // The migration is complete, now we need to generate a genesis file. To do this, we need
+    // to lookup a validator view from the chain, and specify the post-upgrade app hash and
+    // initial height.
+    let app_state = penumbra_app::genesis::Content {
+        chain_id,
+        ..Default::default()
+    };
+    let mut genesis = TestnetConfig::make_genesis(app_state.clone()).expect("can make genesis");
+    genesis.app_hash = post_upgrade_root_hash
+        .0
+        .to_vec()
+        .try_into()
+        .expect("infaillible conversion");
+    genesis.initial_height = post_upgrade_height as i64;
+    genesis.genesis_time = genesis_start.unwrap_or_else(|| {
+        let now = tendermint::time::Time::now();
+        tracing::info!(%now, "no genesis time provided, detecting a testing setup");
+        now
+    });
+    let checkpoint = post_upgrade_root_hash.0.to_vec();
+    let genesis = TestnetConfig::make_checkpoint(genesis, Some(checkpoint));
+
+    let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");
+    tracing::info!("genesis: {}", genesis_json);
+    let genesis_path = pd_home.join("genesis.json");
+    std::fs::write(genesis_path, genesis_json).expect("can write genesis");
+
+    let validator_state_path = pd_home.join("priv_validator_state.json");
+
+    let fresh_validator_state = crate::testnet::generate::TestnetValidator::initial_state();
+    std::fs::write(validator_state_path, fresh_validator_state).expect("can write validator state");
+
+    tracing::info!(
+        pre_upgrade_height,
+        post_upgrade_height,
+        ?pre_upgrade_root_hash,
+        ?post_upgrade_root_hash,
+        duration = migration_duration.as_secs(),
+        "successful migration!"
+    );
+
+    Ok(())
+}
+
+async fn truncate_validator_fields(delta: &mut StateDelta<Snapshot>) -> anyhow::Result<()> {
+    let key_prefix_validators = penumbra_stake::state_key::validators::definitions::prefix();
+    let all_validators = delta
+        .prefix_proto::<Any>(&key_prefix_validators)
+        .map_ok(|(k, v)| (k, Validator::decode(v.value).expect("only validators")))
+        .try_collect::<Vec<(String, Validator)>>()
+        .await?;
+
+    for (key, mut validator) in all_validators {
+        validator.name = truncate(&validator.name, 140).to_string();
+
+        delta.put(key, validator);
+    }
+
+    Ok(())
+}
+
+// Since the limits are based on `String::len`, which returns
+// the number of bytes, we need to truncate the UTF-8 strings at the
+// correct byte boundaries.
+//
+// This can be simplified once https://github.com/rust-lang/rust/issues/93743
+// is stabilized.
+#[inline]
+pub fn floor_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        s.len()
+    } else {
+        let lower_bound = index.saturating_sub(3);
+        let new_index = s.as_bytes()[lower_bound..=index]
+            .iter()
+            .rposition(|b| is_utf8_char_boundary(*b));
+
+        // SAFETY: we know that the character boundary will be within four bytes
+        unsafe { lower_bound + new_index.unwrap_unchecked() }
+    }
+}
+
+#[inline]
+pub(crate) const fn is_utf8_char_boundary(b: u8) -> bool {
+    // This is bit magic equivalent to: b < 128 || b >= 192
+    (b as i8) >= -0x40
+}
+
+// Truncates a utf-8 string to the nearest character boundary,
+// not exceeding max_bytes
+fn truncate(s: &str, max_bytes: usize) -> &str {
+    let closest = floor_char_boundary(s, max_bytes);
+
+    &s[..closest]
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncation() {
+        let s = "Hello, world!";
+
+        assert_eq!(truncate(s, 5), "Hello");
+
+        let s = "❤️🧡💛💚💙💜";
+        assert_eq!(s.len(), 26);
+        assert_eq!("❤".len(), 3);
+
+        assert_eq!(truncate(s, 2), "");
+        assert_eq!(truncate(s, 3), "❤");
+        assert_eq!(truncate(s, 4), "❤");
+    }
 }

--- a/crates/bin/pd/src/testnet/generate.rs
+++ b/crates/bin/pd/src/testnet/generate.rs
@@ -572,6 +572,22 @@ impl Default for TestnetValidator {
 impl TryFrom<&TestnetValidator> for Validator {
     type Error = anyhow::Error;
     fn try_from(tv: &TestnetValidator) -> anyhow::Result<Validator> {
+        // Validation:
+        // - Website has a max length of 70 chars
+        if tv.website.len() > 70 {
+            anyhow::bail!("validator website field must be less than 70 characters");
+        }
+
+        // - Name has a max length of 140 chars
+        if tv.name.len() > 140 {
+            anyhow::bail!("validator name must be less than 140 characters");
+        }
+
+        // - Description has a max length of 280 chars
+        if tv.description.len() > 280 {
+            anyhow::bail!("validator description must be less than 280 characters");
+        }
+
         Ok(Validator {
             // Currently there's no way to set validator keys beyond
             // manually editing the genesis.json. Otherwise they

--- a/crates/bin/pd/src/testnet/generate.rs
+++ b/crates/bin/pd/src/testnet/generate.rs
@@ -573,19 +573,19 @@ impl TryFrom<&TestnetValidator> for Validator {
     type Error = anyhow::Error;
     fn try_from(tv: &TestnetValidator) -> anyhow::Result<Validator> {
         // Validation:
-        // - Website has a max length of 70 chars
+        // - Website has a max length of 70 bytes
         if tv.website.len() > 70 {
-            anyhow::bail!("validator website field must be less than 70 characters");
+            anyhow::bail!("validator website field must be less than 70 bytes");
         }
 
-        // - Name has a max length of 140 chars
+        // - Name has a max length of 140 bytes
         if tv.name.len() > 140 {
-            anyhow::bail!("validator name must be less than 140 characters");
+            anyhow::bail!("validator name must be less than 140 bytes");
         }
 
-        // - Description has a max length of 280 chars
+        // - Description has a max length of 280 bytes
         if tv.description.len() > 280 {
-            anyhow::bail!("validator description must be less than 280 characters");
+            anyhow::bail!("validator description must be less than 280 bytes");
         }
 
         Ok(Validator {

--- a/crates/core/component/governance/src/change.rs
+++ b/crates/core/component/governance/src/change.rs
@@ -20,6 +20,18 @@ impl DomainType for EncodedParameter {
 impl TryFrom<pb::EncodedParameter> for EncodedParameter {
     type Error = anyhow::Error;
     fn try_from(value: pb::EncodedParameter) -> Result<Self, Self::Error> {
+        // TODO: what are max key/value lengths here?
+        // Validation:
+        // - Key has max length of 64 chars
+        if value.key.len() > 64 {
+            anyhow::bail!("key length must be less than or equal to 64 characters");
+        }
+
+        // - Value has max length of 2048 chars
+        if value.value.len() > 2048 {
+            anyhow::bail!("value length must be less than or equal to 2048 characters");
+        }
+
         Ok(EncodedParameter {
             component: value.component,
             key: value.key,

--- a/crates/core/component/governance/src/change.rs
+++ b/crates/core/component/governance/src/change.rs
@@ -32,6 +32,11 @@ impl TryFrom<pb::EncodedParameter> for EncodedParameter {
             anyhow::bail!("value length must be less than or equal to 2048 characters");
         }
 
+        // - Component has max length of 64 chars
+        if value.component.len() > 64 {
+            anyhow::bail!("component length must be less than or equal to 64 characters");
+        }
+
         Ok(EncodedParameter {
             component: value.component,
             key: value.key,

--- a/crates/core/component/governance/src/proposal.rs
+++ b/crates/core/component/governance/src/proposal.rs
@@ -82,6 +82,17 @@ impl TryFrom<pb::Proposal> for Proposal {
     type Error = anyhow::Error;
 
     fn try_from(inner: pb::Proposal) -> Result<Proposal, Self::Error> {
+        // Validation:
+        // - Title has a max length of 70 chars
+        if inner.title.len() > 70 {
+            anyhow::bail!("proposal title field must be less than 70 characters");
+        }
+
+        // - Description has a max length of 280 chars
+        if inner.description.len() > 280 {
+            anyhow::bail!("proposal description must be less than 280 characters");
+        }
+
         use pb::proposal::Payload;
         Ok(Proposal {
             id: inner.id,
@@ -95,6 +106,11 @@ impl TryFrom<pb::Proposal> for Proposal {
                     commit: if signaling.commit.is_empty() {
                         None
                     } else {
+                        // Commit hash has max length of 64 chars:
+                        if signaling.commit.len() > 64 {
+                            anyhow::bail!("proposal commit hash must be less than 64 characters");
+                        }
+
                         Some(signaling.commit)
                     },
                 },

--- a/crates/core/component/governance/src/proposal.rs
+++ b/crates/core/component/governance/src/proposal.rs
@@ -82,15 +82,15 @@ impl TryFrom<pb::Proposal> for Proposal {
     type Error = anyhow::Error;
 
     fn try_from(inner: pb::Proposal) -> Result<Proposal, Self::Error> {
-        // Validation:
-        // - Title has a max length of 70 chars
-        if inner.title.len() > 70 {
-            anyhow::bail!("proposal title field must be less than 70 characters");
+        // Validation (matches limits from `impl AppActionHandler for ProposalSubmit`):
+        // - Title has a max length of 80 chars
+        if inner.title.len() > 80 {
+            anyhow::bail!("proposal title field must be less than 80 characters");
         }
 
-        // - Description has a max length of 280 chars
-        if inner.description.len() > 280 {
-            anyhow::bail!("proposal description must be less than 280 characters");
+        // - Description has a max length of 10_000 chars
+        if inner.description.len() > 10_000 {
+            anyhow::bail!("proposal description must be less than 10,000 characters");
         }
 
         use pb::proposal::Payload;

--- a/crates/core/component/governance/src/proposal.rs
+++ b/crates/core/component/governance/src/proposal.rs
@@ -139,9 +139,15 @@ impl TryFrom<pb::Proposal> for Proposal {
                 Payload::UpgradePlan(upgrade_plan) => ProposalPayload::UpgradePlan {
                     height: upgrade_plan.height,
                 },
-                Payload::FreezeIbcClient(freeze_ibc_client) => ProposalPayload::FreezeIbcClient {
-                    client_id: freeze_ibc_client.client_id,
-                },
+                Payload::FreezeIbcClient(freeze_ibc_client) => {
+                    // Validation: client ID has a max length of 128 chars
+                    if freeze_ibc_client.client_id.len() > 128 {
+                        anyhow::bail!("client ID must be less than 128 characters");
+                    }
+                    ProposalPayload::FreezeIbcClient {
+                        client_id: freeze_ibc_client.client_id,
+                    }
+                }
                 Payload::UnfreezeIbcClient(unfreeze_ibc_client) => {
                     ProposalPayload::UnfreezeIbcClient {
                         client_id: unfreeze_ibc_client.client_id,

--- a/crates/core/component/governance/src/proposal.rs
+++ b/crates/core/component/governance/src/proposal.rs
@@ -106,9 +106,9 @@ impl TryFrom<pb::Proposal> for Proposal {
                     commit: if signaling.commit.is_empty() {
                         None
                     } else {
-                        // Commit hash has max length of 64 chars:
-                        if signaling.commit.len() > 64 {
-                            anyhow::bail!("proposal commit hash must be less than 64 characters");
+                        // Commit hash has max length of 255 bytes:
+                        if signaling.commit.len() > 255 {
+                            anyhow::bail!("proposal commit hash must be less than 255 bytes");
                         }
 
                         Some(signaling.commit)
@@ -140,15 +140,19 @@ impl TryFrom<pb::Proposal> for Proposal {
                     height: upgrade_plan.height,
                 },
                 Payload::FreezeIbcClient(freeze_ibc_client) => {
-                    // Validation: client ID has a max length of 128 chars
+                    // Validation: client ID has a max length of 128 bytes
                     if freeze_ibc_client.client_id.len() > 128 {
-                        anyhow::bail!("client ID must be less than 128 characters");
+                        anyhow::bail!("client ID must be less than 128 bytes");
                     }
                     ProposalPayload::FreezeIbcClient {
                         client_id: freeze_ibc_client.client_id,
                     }
                 }
                 Payload::UnfreezeIbcClient(unfreeze_ibc_client) => {
+                    // Validation: client ID has a max length of 128 bytes
+                    if unfreeze_ibc_client.client_id.len() > 128 {
+                        anyhow::bail!("client ID must be less than 128 bytes");
+                    }
                     ProposalPayload::UnfreezeIbcClient {
                         client_id: unfreeze_ibc_client.client_id,
                     }

--- a/crates/core/component/governance/src/proposal_state.rs
+++ b/crates/core/component/governance/src/proposal_state.rs
@@ -294,7 +294,7 @@ impl TryFrom<pb::ProposalOutcome> for Outcome<String> {
                     withdrawn: if let Some(pb::proposal_outcome::Withdrawn { reason }) = withdrawn {
                         // Max reason length is 1kb
                         if reason.len() > 1024 {
-                            anyhow::bail!("withdrawn reason is too long")
+                            anyhow::bail!("withdrawn reason must be smaller than 1kb")
                         }
 
                         Withdrawn::WithReason { reason }
@@ -308,7 +308,7 @@ impl TryFrom<pb::ProposalOutcome> for Outcome<String> {
                     withdrawn: if let Some(pb::proposal_outcome::Withdrawn { reason }) = withdrawn {
                         // Max reason length is 1kb
                         if reason.len() > 1024 {
-                            anyhow::bail!("withdrawn reason is too long")
+                            anyhow::bail!("withdrawn reason must be smaller than 1kb")
                         }
                         Withdrawn::WithReason { reason }
                     } else {
@@ -374,7 +374,7 @@ impl TryFrom<pb::ProposalOutcome> for Outcome<()> {
                     if withdrawn.is_some() {
                         let reason = &withdrawn.as_ref().expect("reason is some").reason;
                         if reason.len() > 1024 {
-                            anyhow::bail!("withdrawn reason is too long");
+                            anyhow::bail!("withdrawn reason must be smaller than 1kb");
                         }
                     }
                     Outcome::Failed {
@@ -389,7 +389,7 @@ impl TryFrom<pb::ProposalOutcome> for Outcome<()> {
                     if withdrawn.is_some() {
                         let reason = &withdrawn.as_ref().expect("reason is some").reason;
                         if reason.len() > 1024 {
-                            anyhow::bail!("withdrawn reason is too long");
+                            anyhow::bail!("withdrawn reason must be smaller than 1kb");
                         }
                     }
 

--- a/crates/core/component/governance/src/proposal_state.rs
+++ b/crates/core/component/governance/src/proposal_state.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use penumbra_proto::{penumbra::core::component::governance::v1 as pb, DomainType};
 
+use crate::MAX_VALIDATOR_VOTE_REASON_LENGTH;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(try_from = "pb::ProposalState", into = "pb::ProposalState")]
 pub enum State {
@@ -293,7 +295,7 @@ impl TryFrom<pb::ProposalOutcome> for Outcome<String> {
                 }) => Outcome::Failed {
                     withdrawn: if let Some(pb::proposal_outcome::Withdrawn { reason }) = withdrawn {
                         // Max reason length is 1kb
-                        if reason.len() > 1024 {
+                        if reason.len() > MAX_VALIDATOR_VOTE_REASON_LENGTH {
                             anyhow::bail!("withdrawn reason must be smaller than 1kb")
                         }
 
@@ -307,7 +309,7 @@ impl TryFrom<pb::ProposalOutcome> for Outcome<String> {
                 }) => Outcome::Slashed {
                     withdrawn: if let Some(pb::proposal_outcome::Withdrawn { reason }) = withdrawn {
                         // Max reason length is 1kb
-                        if reason.len() > 1024 {
+                        if reason.len() > MAX_VALIDATOR_VOTE_REASON_LENGTH {
                             anyhow::bail!("withdrawn reason must be smaller than 1kb")
                         }
                         Withdrawn::WithReason { reason }
@@ -373,7 +375,7 @@ impl TryFrom<pb::ProposalOutcome> for Outcome<()> {
                     // Max reason length is 1kb
                     if withdrawn.is_some() {
                         let reason = &withdrawn.as_ref().expect("reason is some").reason;
-                        if reason.len() > 1024 {
+                        if reason.len() > MAX_VALIDATOR_VOTE_REASON_LENGTH {
                             anyhow::bail!("withdrawn reason must be smaller than 1kb");
                         }
                     }
@@ -388,7 +390,7 @@ impl TryFrom<pb::ProposalOutcome> for Outcome<()> {
                     // Max reason length is 1kb
                     if withdrawn.is_some() {
                         let reason = &withdrawn.as_ref().expect("reason is some").reason;
-                        if reason.len() > 1024 {
+                        if reason.len() > MAX_VALIDATOR_VOTE_REASON_LENGTH {
                             anyhow::bail!("withdrawn reason must be smaller than 1kb");
                         }
                     }

--- a/crates/core/component/governance/src/validator_vote/action.rs
+++ b/crates/core/component/governance/src/validator_vote/action.rs
@@ -4,7 +4,7 @@ use penumbra_stake::{GovernanceKey, IdentityKey};
 use penumbra_txhash::{EffectHash, EffectingData};
 use serde::{Deserialize, Serialize};
 
-use crate::vote::Vote;
+use crate::{vote::Vote, MAX_VALIDATOR_VOTE_REASON_LENGTH};
 
 /// A vote by a validator.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -138,6 +138,11 @@ impl TryFrom<pb::ValidatorVoteReason> for ValidatorVoteReason {
     type Error = anyhow::Error;
 
     fn try_from(msg: pb::ValidatorVoteReason) -> Result<Self, Self::Error> {
+        // Check the length of the validator reason field.
+        if msg.reason.len() > MAX_VALIDATOR_VOTE_REASON_LENGTH {
+            anyhow::bail!("validator vote reason is too long");
+        }
+
         Ok(ValidatorVoteReason(msg.reason))
     }
 }

--- a/crates/core/component/stake/src/validator.rs
+++ b/crates/core/component/stake/src/validator.rs
@@ -133,6 +133,22 @@ impl TryFrom<ValidatorToml> for Validator {
     type Error = anyhow::Error;
 
     fn try_from(v: ValidatorToml) -> anyhow::Result<Self> {
+        // Validation:
+        // - Website has a max length of 70 chars
+        if v.website.len() > 70 {
+            anyhow::bail!("validator website field must be less than 70 characters");
+        }
+
+        // - Name has a max length of 140 chars
+        if v.name.len() > 140 {
+            anyhow::bail!("validator name must be less than 140 characters");
+        }
+
+        // - Description has a max length of 280 chars
+        if v.description.len() > 280 {
+            anyhow::bail!("validator description must be less than 280 characters");
+        }
+
         Ok(Validator {
             identity_key: v.identity_key,
             governance_key: v.governance_key,
@@ -224,6 +240,22 @@ impl From<Validator> for pb::Validator {
 impl TryFrom<pb::Validator> for Validator {
     type Error = anyhow::Error;
     fn try_from(v: pb::Validator) -> Result<Self, Self::Error> {
+        // Validation:
+        // - Website has a max length of 70 chars
+        if v.website.len() > 70 {
+            anyhow::bail!("validator website field must be less than 70 characters");
+        }
+
+        // - Name has a max length of 140 chars
+        if v.name.len() > 140 {
+            anyhow::bail!("validator name must be less than 140 characters");
+        }
+
+        // - Description has a max length of 280 chars
+        if v.description.len() > 280 {
+            anyhow::bail!("validator description must be less than 280 characters");
+        }
+
         Ok(Validator {
             identity_key: v
                 .identity_key

--- a/crates/core/component/stake/src/validator.rs
+++ b/crates/core/component/stake/src/validator.rs
@@ -134,19 +134,19 @@ impl TryFrom<ValidatorToml> for Validator {
 
     fn try_from(v: ValidatorToml) -> anyhow::Result<Self> {
         // Validation:
-        // - Website has a max length of 70 chars
+        // - Website has a max length of 70 bytes
         if v.website.len() > 70 {
-            anyhow::bail!("validator website field must be less than 70 characters");
+            anyhow::bail!("validator website field must be less than 70 bytes");
         }
 
-        // - Name has a max length of 140 chars
+        // - Name has a max length of 140 bytes
         if v.name.len() > 140 {
-            anyhow::bail!("validator name must be less than 140 characters");
+            anyhow::bail!("validator name must be less than 140 bytes");
         }
 
-        // - Description has a max length of 280 chars
+        // - Description has a max length of 280 bytes
         if v.description.len() > 280 {
-            anyhow::bail!("validator description must be less than 280 characters");
+            anyhow::bail!("validator description must be less than 280 bytes");
         }
 
         Ok(Validator {
@@ -241,19 +241,19 @@ impl TryFrom<pb::Validator> for Validator {
     type Error = anyhow::Error;
     fn try_from(v: pb::Validator) -> Result<Self, Self::Error> {
         // Validation:
-        // - Website has a max length of 70 chars
+        // - Website has a max length of 70 bytes
         if v.website.len() > 70 {
-            anyhow::bail!("validator website field must be less than 70 characters");
+            anyhow::bail!("validator website field must be less than 70 bytes");
         }
 
-        // - Name has a max length of 140 chars
+        // - Name has a max length of 140 bytes
         if v.name.len() > 140 {
-            anyhow::bail!("validator name must be less than 140 characters");
+            anyhow::bail!("validator name must be less than 140 bytes");
         }
 
-        // - Description has a max length of 280 chars
+        // - Description has a max length of 280 bytes
         if v.description.len() > 280 {
-            anyhow::bail!("validator description must be less than 280 characters");
+            anyhow::bail!("validator description must be less than 280 bytes");
         }
 
         Ok(Validator {

--- a/crates/core/component/stake/src/validator/definition.rs
+++ b/crates/core/component/stake/src/validator/definition.rs
@@ -29,11 +29,27 @@ impl From<Definition> for pb::ValidatorDefinition {
 impl TryFrom<pb::ValidatorDefinition> for Definition {
     type Error = anyhow::Error;
     fn try_from(v: pb::ValidatorDefinition) -> Result<Self, Self::Error> {
+        let validator = v
+            .validator
+            .ok_or_else(|| anyhow::anyhow!("missing validator field in proto"))?;
+        // Validation:
+        // - Website has a max length of 70 chars
+        if validator.website.len() > 70 {
+            anyhow::bail!("validator website field must be less than 70 characters");
+        }
+
+        // - Name has a max length of 140 chars
+        if validator.name.len() > 140 {
+            anyhow::bail!("validator name must be less than 140 characters");
+        }
+
+        // - Description has a max length of 280 chars
+        if validator.description.len() > 280 {
+            anyhow::bail!("validator description must be less than 280 characters");
+        }
+
         Ok(Definition {
-            validator: v
-                .validator
-                .ok_or_else(|| anyhow::anyhow!("missing validator field in proto"))?
-                .try_into()?,
+            validator: validator.try_into()?,
             auth_sig: v.auth_sig.as_slice().try_into()?,
         })
     }

--- a/crates/core/component/stake/src/validator/definition.rs
+++ b/crates/core/component/stake/src/validator/definition.rs
@@ -33,21 +33,7 @@ impl TryFrom<pb::ValidatorDefinition> for Definition {
             .validator
             .ok_or_else(|| anyhow::anyhow!("missing validator field in proto"))?;
         // Validation:
-        // - Website has a max length of 70 chars
-        if validator.website.len() > 70 {
-            anyhow::bail!("validator website field must be less than 70 characters");
-        }
-
-        // - Name has a max length of 140 chars
-        if validator.name.len() > 140 {
-            anyhow::bail!("validator name must be less than 140 characters");
-        }
-
-        // - Description has a max length of 280 chars
-        if validator.description.len() > 280 {
-            anyhow::bail!("validator description must be less than 280 characters");
-        }
-
+        // The validator fields are validated by the `try_into` call below:
         Ok(Definition {
             validator: validator.try_into()?,
             auth_sig: v.auth_sig.as_slice().try_into()?,


### PR DESCRIPTION
## Describe your changes

This follows the suggestion from @hdevalence in https://github.com/penumbra-zone/penumbra/issues/3620#issuecomment-2141013858 to add validation of user-supplied `String` lengths to the various `TryFrom` protobuf deserialization implementations.

The user-supplied `String` values concerned are found within the governance and staking crates, concerning governance proposals and validator definitions.

**This is consensus breaking** as historic data **may not comply with the new limitations**. Thus there may be unexpected panics when trying to retrieve and deserialize data from storage.

An additional migration has been included to truncate any existing data that does not adhere to the new limits.

The strings are configured to use **byte length limits** rather than **character length limits**. This seems favorable because values will be guaranteed to fit into fixed-size buffers of the byte length limit for the field. Code based on https://github.com/rust-lang/rust/issues/93743 was pulled in to perform the truncation at UTF-8 character boundaries.

## Issue ticket number and link

Closes https://github.com/penumbra-zone/penumbra/issues/3620

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:
