### PR TITLE
dex: 🔖 instrument search path relaxation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5029,6 +5029,7 @@ dependencies = [
  "im",
  "itertools 0.11.0",
  "metrics",
+ "metrics-exporter-prometheus",
  "once_cell",
  "parking_lot",
  "pbjson-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ im                               = { version = "^15.1.0" }
 indicatif                        = { version = "0.16" }
 jmt                              = { version = "0.10", features = ["migration"] }
 metrics                          = { version = "0.22" }
+metrics-exporter-prometheus      = { version = "0.13", features = ["http-listener"] }
 metrics-tracing-context          = { version = "0.15" }
 num-bigint                       = { version = "0.4" }
 num-traits                       = { default-features = false, version = "0.2.15" }

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -59,7 +59,7 @@ ibc-types                        = { workspace = true, default-features = true }
 ics23                            = { workspace = true }
 jmt                              = { workspace = true }
 metrics                          = { workspace = true }
-metrics-exporter-prometheus      = { version = "0.13", features = ["http-listener"] }
+metrics-exporter-prometheus      = { workspace = true }
 metrics-tracing-context          = { workspace = true }
 metrics-util                     = "0.16.2"
 mime_guess                       = "2"

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -166,14 +166,12 @@ async fn main() -> anyhow::Result<()> {
             };
 
             // Configure a Prometheus recorder and exporter.
+            use penumbra_dex::component::metrics::PrometheusBuilderExt;
             let (recorder, exporter) = PrometheusBuilder::new()
                 .with_http_listener(metrics_bind)
                 // Set explicit buckets so that Prometheus endpoint emits true histograms, rather
                 // than the default distribution type summaries, for time-series data.
-                .set_buckets_for_metric(
-                    metrics_exporter_prometheus::Matcher::Prefix("penumbra_dex_".to_string()),
-                    penumbra_dex::component::metrics::DEX_BUCKETS,
-                )?
+                .set_buckets_for_dex_metrics()?
                 .build()
                 .map_err(|e| {
                     let msg = format!(

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -7,6 +7,7 @@ edition = {workspace = true}
 component = [
     "cnidarium-component",
     "cnidarium",
+    "metrics-exporter-prometheus",
     "penumbra-proto/cnidarium",
     "penumbra-shielded-pool/component",
     "penumbra-fee/component",
@@ -49,6 +50,7 @@ futures = {workspace = true}
 hex = {workspace = true}
 im = {workspace = true}
 metrics = {workspace = true}
+metrics-exporter-prometheus = {workspace = true, optional = true}
 once_cell = {workspace = true}
 parking_lot = {workspace = true}
 pbjson-types = {workspace = true}

--- a/crates/core/component/dex/src/component/metrics.rs
+++ b/crates/core/component/dex/src/component/metrics.rs
@@ -71,3 +71,23 @@ pub const DEX_ARB_DURATION: &str = "penumbra_dex_arb_duration_seconds";
 pub const DEX_BATCH_DURATION: &str = "penumbra_dex_batch_duration_seconds";
 pub const DEX_RPC_SIMULATE_TRADE_DURATION: &str =
     "penumbra_dex_rpc_simulate_trade_duration_seconds";
+
+/// An extension trait providing DEX-related interfaces for [`PrometheusBuilder`].
+///
+/// [builder]: metrics_exporter_prometheus::PrometheusBuilder
+pub trait PrometheusBuilderExt
+where
+    Self: Sized,
+{
+    /// Configure buckets for histogram metrics.
+    fn set_buckets_for_dex_metrics(self) -> Result<Self, metrics_exporter_prometheus::BuildError>;
+}
+
+impl PrometheusBuilderExt for metrics_exporter_prometheus::PrometheusBuilder {
+    fn set_buckets_for_dex_metrics(self) -> Result<Self, metrics_exporter_prometheus::BuildError> {
+        self.set_buckets_for_metric(
+            metrics_exporter_prometheus::Matcher::Prefix("penumbra_dex_".to_string()),
+            DEX_BUCKETS,
+        )
+    }
+}

--- a/crates/core/component/dex/src/component/metrics.rs
+++ b/crates/core/component/dex/src/component/metrics.rs
@@ -46,7 +46,7 @@ pub fn register_metrics() {
 // Prometheus metrics are structured as a Histogram, rather than as a Summary.
 // These values may need to be updated over time.
 // These values are logarithmically spaced from 5ms to 250ms.
-pub const DEX_BUCKETS: &[f64; 16] = &[
+const GENERIC_DEX_BUCKETS: &[f64; 16] = &[
     0.005,
     0.00648985018,
     0.00842363108,
@@ -86,13 +86,19 @@ where
 impl PrometheusBuilderExt for metrics_exporter_prometheus::PrometheusBuilder {
     fn set_buckets_for_dex_metrics(self) -> Result<Self, metrics_exporter_prometheus::BuildError> {
         use metrics_exporter_prometheus::Matcher::Full;
-        self.set_buckets_for_metric(Full(DEX_PATH_SEARCH_DURATION.to_owned()), DEX_BUCKETS)?
-            .set_buckets_for_metric(Full(DEX_ROUTE_FILL_DURATION.to_owned()), DEX_BUCKETS)?
-            .set_buckets_for_metric(Full(DEX_ARB_DURATION.to_owned()), DEX_BUCKETS)?
-            .set_buckets_for_metric(Full(DEX_BATCH_DURATION.to_owned()), DEX_BUCKETS)?
-            .set_buckets_for_metric(
-                Full(DEX_RPC_SIMULATE_TRADE_DURATION.to_owned()),
-                DEX_BUCKETS,
-            )
+        self.set_buckets_for_metric(
+            Full(DEX_PATH_SEARCH_DURATION.to_owned()),
+            GENERIC_DEX_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Full(DEX_ROUTE_FILL_DURATION.to_owned()),
+            GENERIC_DEX_BUCKETS,
+        )?
+        .set_buckets_for_metric(Full(DEX_ARB_DURATION.to_owned()), GENERIC_DEX_BUCKETS)?
+        .set_buckets_for_metric(Full(DEX_BATCH_DURATION.to_owned()), GENERIC_DEX_BUCKETS)?
+        .set_buckets_for_metric(
+            Full(DEX_RPC_SIMULATE_TRADE_DURATION.to_owned()),
+            GENERIC_DEX_BUCKETS,
+        )
     }
 }

--- a/crates/core/component/dex/src/component/metrics.rs
+++ b/crates/core/component/dex/src/component/metrics.rs
@@ -30,6 +30,11 @@ pub fn register_metrics() {
         Unit::Seconds,
         "The time spent searching for paths while executing trades within the DEX"
     );
+    describe_counter!(
+        DEX_PATH_SEARCH_RELAX_PATH_DURATION,
+        Unit::Seconds,
+        "The time spent relaxing a path while routing trades within the DEX"
+    );
     describe_histogram!(
         DEX_ROUTE_FILL_DURATION,
         Unit::Seconds,
@@ -66,6 +71,8 @@ const GENERIC_DEX_BUCKETS: &[f64; 16] = &[
 ];
 
 pub const DEX_PATH_SEARCH_DURATION: &str = "penumbra_dex_path_search_duration_seconds";
+pub const DEX_PATH_SEARCH_RELAX_PATH_DURATION: &str =
+    "penumbra_dex_path_search_relax_path_duration_seconds";
 pub const DEX_ROUTE_FILL_DURATION: &str = "penumbra_dex_route_fill_duration_seconds";
 pub const DEX_ARB_DURATION: &str = "penumbra_dex_arb_duration_seconds";
 pub const DEX_BATCH_DURATION: &str = "penumbra_dex_batch_duration_seconds";
@@ -88,6 +95,10 @@ impl PrometheusBuilderExt for metrics_exporter_prometheus::PrometheusBuilder {
         use metrics_exporter_prometheus::Matcher::Full;
         self.set_buckets_for_metric(
             Full(DEX_PATH_SEARCH_DURATION.to_owned()),
+            GENERIC_DEX_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Full(DEX_PATH_SEARCH_RELAX_PATH_DURATION.to_owned()),
             GENERIC_DEX_BUCKETS,
         )?
         .set_buckets_for_metric(

--- a/crates/core/component/dex/src/component/metrics.rs
+++ b/crates/core/component/dex/src/component/metrics.rs
@@ -85,9 +85,14 @@ where
 
 impl PrometheusBuilderExt for metrics_exporter_prometheus::PrometheusBuilder {
     fn set_buckets_for_dex_metrics(self) -> Result<Self, metrics_exporter_prometheus::BuildError> {
-        self.set_buckets_for_metric(
-            metrics_exporter_prometheus::Matcher::Prefix("penumbra_dex_".to_string()),
-            DEX_BUCKETS,
-        )
+        use metrics_exporter_prometheus::Matcher::Full;
+        self.set_buckets_for_metric(Full(DEX_PATH_SEARCH_DURATION.to_owned()), DEX_BUCKETS)?
+            .set_buckets_for_metric(Full(DEX_ROUTE_FILL_DURATION.to_owned()), DEX_BUCKETS)?
+            .set_buckets_for_metric(Full(DEX_ARB_DURATION.to_owned()), DEX_BUCKETS)?
+            .set_buckets_for_metric(Full(DEX_BATCH_DURATION.to_owned()), DEX_BUCKETS)?
+            .set_buckets_for_metric(
+                Full(DEX_RPC_SIMULATE_TRADE_DURATION.to_owned()),
+                DEX_BUCKETS,
+            )
     }
 }


### PR DESCRIPTION
#### 💭 describe your changes

this makes a few changes to the dex component's prometheus metrics.

see #4464 for previous context.

importantly, this adds a new metric that tracks the time spent processing a
distinct, individual path. this specific metric is configured to use a larger
set of buckets on the upper end, so that we can capture and observe latencies
observed running pd on a testnet while positions are being routed.

this is a sibling metric to the existing path search metric, which records the
time spent finding the final output path. as a part of this branch, we also
fix a small bug, which is that the duration is still recorded if a dead-end
is reached, and no path could be found.

finally, the configuration of the prometheus metrics builder is tweaked so that
we can add counters to this component in the future. additional counters tracking
things like: (1) paths that were ruled out for being too expensive, (2) dead-ends
reached, (3) errors encountered, etc. i would love for reviewers to offer insight
about other conditions worth counting.

#### 🔖 issue ticket number and link

* #4464

#### ✅ checklist before requesting a review

- [x] if this code contains consensus-breaking changes, i have added the
  "consensus-breaking" label. otherwise, i declare my belief that there are not
  consensus-breaking changes, for the following reason:

  > this only affects metrics emission.
