### PR TITLE
Pretty print transaction plan in threshold custody using view

### DIFF
--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -73,6 +73,7 @@ penumbra-ibc = {workspace = true, default-features = false}
 penumbra-keys = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}
 penumbra-proof-setup = {workspace = true}
+penumbra-proof-params = { workspace = true, default-features = true }
 penumbra-proto = {workspace = true, features = ["rpc", "box-grpc"], default-features = true}
 penumbra-sct = {workspace = true, default-features = false}
 penumbra-shielded-pool = {workspace = true, default-features = false}

--- a/crates/bin/pcli/src/command/init.rs
+++ b/crates/bin/pcli/src/command/init.rs
@@ -297,7 +297,7 @@ impl InitCmd {
                 (
                     spend_key.full_viewing_key().clone(),
                     if self.encrypted {
-                        let password = ActualTerminal.get_confirmed_password().await?;
+                        let password = ActualTerminal::get_confirmed_password().await?;
                         CustodyConfig::Encrypted(penumbra_custody::encrypted::Config::create(
                             &password,
                             penumbra_custody::encrypted::InnerConfig::SoftKms(spend_key.into()),
@@ -315,10 +315,12 @@ impl InitCmd {
                 }),
                 false,
             ) => {
-                let config = threshold::dkg(*threshold, *num_participants, &ActualTerminal).await?;
+                let config =
+                    threshold::dkg(*threshold, *num_participants, &ActualTerminal::default())
+                        .await?;
                 let fvk = config.fvk().clone();
                 let custody_config = if self.encrypted {
-                    let password = ActualTerminal.get_confirmed_password().await?;
+                    let password = ActualTerminal::get_confirmed_password().await?;
                     CustodyConfig::Encrypted(penumbra_custody::encrypted::Config::create(
                         &password,
                         penumbra_custody::encrypted::InnerConfig::Threshold(config),
@@ -358,14 +360,14 @@ impl InitCmd {
                     x @ CustodyConfig::ViewOnly => x,
                     x @ CustodyConfig::Encrypted(_) => x,
                     CustodyConfig::SoftKms(spend_key) => {
-                        let password = ActualTerminal.get_confirmed_password().await?;
+                        let password = ActualTerminal::get_confirmed_password().await?;
                         CustodyConfig::Encrypted(penumbra_custody::encrypted::Config::create(
                             &password,
                             penumbra_custody::encrypted::InnerConfig::SoftKms(spend_key),
                         )?)
                     }
                     CustodyConfig::Threshold(c) => {
-                        let password = ActualTerminal.get_confirmed_password().await?;
+                        let password = ActualTerminal::get_confirmed_password().await?;
                         CustodyConfig::Encrypted(penumbra_custody::encrypted::Config::create(
                             &password,
                             penumbra_custody::encrypted::InnerConfig::Threshold(c),

--- a/crates/bin/pcli/src/command/threshold.rs
+++ b/crates/bin/pcli/src/command/threshold.rs
@@ -25,7 +25,7 @@ impl ThresholdCmd {
         let config = match app.config.custody.clone() {
             CustodyConfig::Threshold(config) => Some(config),
             CustodyConfig::Encrypted(config) => {
-                let password = ActualTerminal.get_password().await?;
+                let password = ActualTerminal::default().get_password().await?;
                 config.convert_to_threshold(&password)?
             }
             _ => None, // If not threshold, we can't sign using threshold config
@@ -42,7 +42,7 @@ impl ThresholdCmd {
                 penumbra_custody::threshold::follow(
                     config.as_ref(),
                     governance_config.as_ref(),
-                    &ActualTerminal,
+                    &ActualTerminal::default(),
                 )
                 .await
             }


### PR DESCRIPTION
This converts the plan into a view, using dummy values, so that we can reuse the existing formatting.

This only handles outputs and spends, but that should be enough for 90% of use cases, the rest of which can look at the JSON.

Closes #3444.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Just changes how pcli prints stuff to stdout
