### PR TITLE
View Service: Don't sync the same block twice

### DIFF
--- a/crates/view/src/worker.rs
+++ b/crates/view/src/worker.rs
@@ -217,10 +217,17 @@ impl Worker {
             }
         });
 
+        let mut expected_height = start_height;
+
         while let Some(block) = buffered_stream.recv().await {
             let block: CompactBlock = block?.try_into()?;
 
             let height = block.height;
+            if height < expected_height {
+                tracing::warn!("repeated block detected");
+                continue;
+            }
+            expected_height += 1;
 
             // Lock the SCT only while processing this block.
             let mut sct_guard = self.sct.write().await;

--- a/crates/view/src/worker.rs
+++ b/crates/view/src/worker.rs
@@ -223,8 +223,8 @@ impl Worker {
             let block: CompactBlock = block?.try_into()?;
 
             let height = block.height;
-            if height < expected_height {
-                tracing::warn!("repeated block detected");
+            if height != expected_height {
+                tracing::warn!("out of order block detected");
                 continue;
             }
             expected_height += 1;


### PR DESCRIPTION
This should fix an issue wherein a load balanced RPC can cause data corruption by delivering the same block twice in the stream.

## Issue ticket number and link

This should close #4577.


## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Just a client change
