### PR TITLE
pcli(gda): apply web fixes to pcli recipes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4445,7 +4445,6 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "rand_distr",
  "regex",
  "rpassword",
  "serde",

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -85,7 +85,6 @@ pin-project = {workspace = true}
 rand = {workspace = true}
 rand_chacha = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}
-rand_distr = "0.4.3"
 regex = {workspace = true}
 rpassword = "7"
 serde = {workspace = true, features = ["derive"]}

--- a/crates/bin/pcli/src/command/tx/auction/dutch/gda.rs
+++ b/crates/bin/pcli/src/command/tx/auction/dutch/gda.rs
@@ -40,22 +40,19 @@ impl GdaRecipe {
         }
     }
 
-    pub fn poisson_intensity_per_block(&self) -> f64 {
+    pub fn poisson_intensity(&self) -> f64 {
         match &self {
-            GdaRecipe::TenMinutes => 0.064614,
-            GdaRecipe::ThirtyMinutes => 0.050577,
-            GdaRecipe::OneHour => 0.042122,
-            GdaRecipe::TwoHours => 0.022629,
-            GdaRecipe::SixHours => 0.010741,
-            GdaRecipe::TwelveHours => 0.00537,
-            GdaRecipe::OneDay => 0.03469,
-            GdaRecipe::TwoDays => 0.00735,
+            GdaRecipe::TenMinutes => 0.0645833333333,
+            GdaRecipe::ThirtyMinutes => 0.05058333333,
+            GdaRecipe::OneHour => 0.02525,
+            GdaRecipe::TwoHours => 0.02266666666,
+            GdaRecipe::SixHours => 0.01075,
+            GdaRecipe::TwelveHours => 0.0053333333,
+            GdaRecipe::OneDay => 0.035,
+            GdaRecipe::TwoDays => 0.00175,
         }
     }
 
-    pub fn poisson_intensity(&self) -> f64 {
-        self.poisson_intensity_per_block() * self.as_blocks() as f64
-    }
 
     pub fn num_auctions(&self) -> u64 {
         match self {


### PR DESCRIPTION
## Describe your changes

This aligns the pcli gda sampling method on the one used by minifront. First, the current parameters are incorrect for 48h, and second, this means we don't have two codepaths to maintain in sync.

## Issue ticket number and link
fix mistakes in recipe parameters by erwanor · Pull Request #1207 · penumbra-zon…

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Client changes
