### PR TITLE
pd: 💤 a sleep worker, tracking scheduler latency

### DIFF
--- a/crates/bin/pd/src/lib.rs
+++ b/crates/bin/pd/src/lib.rs
@@ -5,7 +5,7 @@
 // Requires nightly.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-mod metrics;
+pub mod metrics;
 
 pub mod cli;
 pub mod migrate;

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -195,6 +195,7 @@ async fn main() -> anyhow::Result<()> {
             // register pd's metrics with the exporter.
             tokio::spawn(exporter);
             pd::register_metrics();
+            tokio::spawn(pd::metrics::sleep_worker::run());
 
             // We error out if a service errors, rather than keep running.
             // A special attempt is made to detect whether binding to target socket failed;

--- a/crates/bin/pd/src/metrics.rs
+++ b/crates/bin/pd/src/metrics.rs
@@ -14,6 +14,8 @@
 #[allow(unused_imports)] // It is okay if this reëxport isn't used, see above.
 pub use metrics::*;
 
+pub mod sleep_worker;
+
 /// Registers all metrics used by this crate.
 ///
 /// For this implementation, in the `pd` crate, we also call the `register_metrics()`
@@ -21,4 +23,5 @@ pub use metrics::*;
 pub fn register_metrics() {
     // This will register metrics for all components.
     penumbra_app::register_metrics();
+    self::sleep_worker::register_metrics();
 }

--- a/crates/bin/pd/src/metrics/sleep_worker.rs
+++ b/crates/bin/pd/src/metrics/sleep_worker.rs
@@ -1,0 +1,65 @@
+//! A sleep worker.
+//!
+//! ### Overview
+//!
+//! This submodule defines a metric, and an accompanying worker task, for use in measuring
+//! scheduler latency in the tokio runtime. This worker will repeatedly sleep for one second, and
+//! then observe the amount of time it *actually* spent waiting to be woken up. This is useful for
+//! detecting when the asynchronous runtime is being disrupted by blocking I/O, or other expensive
+//! non-coöperative computation.
+//!
+//! Use [`register_metrics()`] to register the [`SLEEP_DRIFT`] metric with an exporter, and spawn
+//! the worker onto a runtime by calling [`run()`].
+
+use {
+    super::*,
+    std::time::{Duration, Instant},
+    tokio::time::sleep,
+};
+
+pub const SLEEP_DRIFT: &str = "pd_async_sleep_drift_microseconds";
+
+const ONE_SECOND: Duration = Duration::from_secs(1);
+const ONE_SECOND_US: u128 = ONE_SECOND.as_micros();
+
+pub fn register_metrics() {
+    describe_counter!(
+        SLEEP_DRIFT,
+        Unit::Microseconds,
+        "Tracks drift in the async runtime's timer, in microseconds."
+    );
+}
+
+/// Run the sleep worker.
+///
+/// This function will never return.
+pub async fn run() -> std::convert::Infallible {
+    let counter = counter!(SLEEP_DRIFT);
+
+    loop {
+        // Ask the async runtime to pause this task for one second, and then observe the amount of
+        // microseconds we were actually suspended.
+        let start = Instant::now();
+        sleep(ONE_SECOND).await;
+        let end = Instant::now();
+        let actual = end.duration_since(start).as_micros();
+
+        // Find the difference between the observed sleep duration and our expected duration.
+        let drift: u64 = actual
+            .saturating_sub(ONE_SECOND_US)
+            .try_into()
+            .unwrap_or_else(|error| {
+                // In the unlikely event that the number of microseconds we waited can't fit into
+                // a u64, round down to u64::MAX. This is lossy, but will still indicate that
+                // there is a severe issue with the runtime.
+                tracing::error!(?error, %actual, "failed to convert timer drift into a u64");
+                u64::MAX
+            });
+
+        // If there was scheduler drift, increment the counter.
+        match drift {
+            0 => continue,
+            n => counter.increment(n),
+        }
+    }
+}


### PR DESCRIPTION
this introduces a submodule to `pd::metrics`, which observes tokio scheduler latency and records it for the Prometheus exporter.

the core idea in this worker is that it will invoke `tokio::time::sleep(..)` to put the task to sleep for one second. upon being woken up by the scheduler, it will check the *new* wall-clock time and calculate the actual amount of time it spent waiting. if this took longer than expected, it increments the `pd_async_sleep_drift_milliseconds` counter by the observed latency, measured in milliseconds.

as the module-level docs note, this is a very useful tool to identify when the runtime is being disrupted by blocking I/O or other expensive computation.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > metrics emission
