### PR TITLE
Fix crash in positions --include-closed and display multi-sided LPs consistently

### DIFF
--- a/crates/bin/pcli/src/command/utils.rs
+++ b/crates/bin/pcli/src/command/utils.rs
@@ -85,7 +85,8 @@ pub(crate) fn render_positions(asset_cache: &asset::Cache, positions: &[Position
                     .format(asset_cache),
                 ]);
                 table.add_row(vec![
-                    String::new(),
+                    // Add a mark indicating this row is associated with the same position.
+                    "└──────────────────────────────────────────────────────────────▶".to_string(),
                     String::new(),
                     format!("{}bps", position.phi.component.fee),
                     format!("Unknown asset"),

--- a/crates/core/component/dex/src/lp/order.rs
+++ b/crates/core/component/dex/src/lp/order.rs
@@ -200,6 +200,10 @@ impl SellOrder {
         let desired_amount = U128x128::from(self.desired.amount);
         let offered_unit_amount = U128x128::from(offered_unit.unit_amount());
 
+        if offered_amount == 0u64.into() {
+            return Ok("∞".to_string());
+        }
+
         let price_amount: Amount = ((desired_amount * offered_unit_amount) / offered_amount)?
             // TODO: Is this the correct rounding behavior? Should we expect this to round-trip exactly?
             .round_up()?


### PR DESCRIPTION
## Describe your changes

This PR fixes a crash currently occurring when viewing withdrawn LPs in `pcli`. It also makes the display of positions involving unknown assets more consistent.

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > only pcli display changes