### PR TITLE
pcli: 🌷 add a top-level `--grpc-url` override

### DIFF
--- a/crates/bin/pcli/src/command/init.rs
+++ b/crates/bin/pcli/src/command/init.rs
@@ -22,15 +22,15 @@ pub struct InitCmd {
     pub subcmd: InitTopSubCmd,
     /// The GRPC URL that will be used in the generated config.
     #[clap(
-            long,
-            default_value = "https://grpc.testnet.penumbra.zone",
-            // Note: reading from the environment here means that running
-            // pcli init inside of the test harness (where we override that)
-            // will correctly set the URL, even though we don't subsequently
-            // read it from the environment.
-            env = "PENUMBRA_NODE_PD_URL",
-            parse(try_from_str = Url::parse),
-        )]
+        long,
+        default_value = "https://grpc.testnet.penumbra.zone",
+        // Note: reading from the environment here means that running
+        // pcli init inside of the test harness (where we override that)
+        // will correctly set the URL, even though we don't subsequently
+        // read it from the environment.
+        env = "PENUMBRA_NODE_PD_URL",
+        parse(try_from_str = Url::parse),
+    )]
     grpc_url: Url,
     /// For configs with spend authority, this will enable password encryption.
     ///


### PR DESCRIPTION
when a pcli user initializes their configuration, they provide the `init` command with the grpc url of a fullnode, which is stored in pcli's configuration file. by default, this is found at `~/.local/share/pcli/config.toml`.

if that fullnode is later encountering issues, this can render many pcli commands unusable, without a clear workaround. this is a small patch, providing a top-level `--grpc-url` option that will override the config file's GRPC url.

this can help users temporarily send requests to a different fullnode, until their preferred default comes back online.


## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > only client-side changes
