### PR TITLE
Add output to pcli to display transaction fees paid

### DIFF
--- a/crates/bin/pcli/src/network.rs
+++ b/crates/bin/pcli/src/network.rs
@@ -22,6 +22,12 @@ impl App {
         &mut self,
         plan: TransactionPlan,
     ) -> anyhow::Result<TransactionId> {
+        let asset_cache = self.view().assets().await?;
+        println!(
+            "including transaction fee of {}...",
+            plan.transaction_parameters.fee.0.format(&asset_cache)
+        );
+
         let transaction = self.build_transaction(plan).await?;
         self.submit_transaction(transaction).await
     }


### PR DESCRIPTION
## Describe your changes

This adds a line to transactions displaying fees paid:

```
including transaction fee of 13.001mpenumbra...
building transaction [5 actions, 5 proofs]...
finished proving in 1.109 seconds [5 actions, 5 proofs, 3431 bytes]
broadcasting transaction and awaiting confirmation...
transaction broadcast successfully: d1f6b182f04fc34f9437475df841dff8329a938e5949849f50033e5d73c980f5
transaction confirmed and detected: d1f6b182f04fc34f9437475df841dff8329a938e5949849f50033e5d73c980f5 @ height 501989
Swap submitted and batch confirmed!
You will receive outputs of 100test_usd and 0test_atom. Claiming now...
including transaction fee of 1.715mpenumbra...
building transaction [1 actions, 1 proofs]...
finished proving in 0.622 seconds [1 actions, 1 proofs, 591 bytes]
broadcasting transaction and awaiting confirmation...
transaction broadcast successfully: 565c203e3f42223a7989e5d0c3098b60373bd16bcedb99e1127181bb58244553
transaction confirmed and detected: 565c203e3f42223a7989e5d0c3098b60373bd16bcedb99e1127181bb58244553
```

We might want to call out pre-paid swap claim fees separately.

## Issue ticket number and link

Closes #4589

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > pcli only
