### PR TITLE
pd: use 10MB as mempool limit in comet config template

### DIFF
--- a/testnets/cometbft_config_template.toml
+++ b/testnets/cometbft_config_template.toml
@@ -294,7 +294,7 @@ size = 5000
 # This is the raw, total transaction size. For example, given 1MB
 # transactions and a 5MB maximum mempool byte size, the mempool will
 # only accept five transactions.
-max_txs_bytes = 5242880
+max_txs_bytes = 10485760
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
 cache_size = 10000

--- a/testnets/cometbft_config_template.toml
+++ b/testnets/cometbft_config_template.toml
@@ -290,10 +290,11 @@ wal_dir = ""
 # Maximum number of transactions in the mempool
 size = 5000
 
-# Limit the total size of all txs in the mempool.
-# This only accounts for raw transactions (e.g. given 1MB transactions and
-# max_txs_bytes=5MB, mempool will only accept 5 transactions).
-max_txs_bytes = 1073741824
+# The maximum size in bytes of all transactions stored in the mempool.
+# This is the raw, total transaction size. For example, given 1MB
+# transactions and a 5MB maximum mempool byte size, the mempool will
+# only accept five transactions.
+max_txs_bytes = 67108864
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
 cache_size = 10000

--- a/testnets/cometbft_config_template.toml
+++ b/testnets/cometbft_config_template.toml
@@ -294,7 +294,7 @@ size = 5000
 # This is the raw, total transaction size. For example, given 1MB
 # transactions and a 5MB maximum mempool byte size, the mempool will
 # only accept five transactions.
-max_txs_bytes = 67108864
+max_txs_bytes = 5242880
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
 cache_size = 10000


### PR DESCRIPTION
## Describe your changes

Lower the default value for `max_txs_bytes` from 1GiB to 10MiB. Upstream also substantially lowered this default recently. 
https://github.com/cometbft/cometbft/pull/2767

See also the [new `nop` mempool type](https://github.com/cometbft/cometbft/pull/1643) they added to deal with the mempool being a potential DoS vector a la [p2p-storms](https://github.com/notional-labs/placid).

## Issue ticket number and link

## Checklist before requesting a review

- [X] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

The mempool and its configuration are outside consensus.