### PR TITLE
pd: configure cometbft with `max_bytes` to 1MiB

### DIFF
--- a/crates/bin/pd/src/testnet/generate.rs
+++ b/crates/bin/pd/src/testnet/generate.rs
@@ -287,7 +287,7 @@ impl TestnetConfig {
             consensus_params: tendermint::consensus::Params {
                 abci: AbciParams::default(),
                 block: tendermint::block::Size {
-                    max_bytes: 22020096,
+                    max_bytes: 4194304,
                     max_gas: -1,
                     // minimum time increment between consecutive blocks
                     time_iota_ms: 500,

--- a/crates/bin/pd/src/testnet/generate.rs
+++ b/crates/bin/pd/src/testnet/generate.rs
@@ -287,7 +287,7 @@ impl TestnetConfig {
             consensus_params: tendermint::consensus::Params {
                 abci: AbciParams::default(),
                 block: tendermint::block::Size {
-                    max_bytes: 4194304,
+                    max_bytes: 1048576,
                     max_gas: -1,
                     // minimum time increment between consecutive blocks
                     time_iota_ms: 500,


### PR DESCRIPTION
## Describe your changes

Reduce `tendermint::block::Size::max_bytes` from 21MiB to 1MiB.

## Issue ticket number and link
Closes #4595

## Checklist before requesting a review

- [X] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

Consensus parameters are not part of consensus but could affect network liveness. 