### PR TITLE
dex(metrics): set buckets around expected latency region

### DIFF
--- a/crates/core/component/dex/src/component/metrics.rs
+++ b/crates/core/component/dex/src/component/metrics.rs
@@ -50,8 +50,13 @@ pub fn register_metrics() {
 // We configure buckets for the DEX routing times manually, in order to ensure
 // Prometheus metrics are structured as a Histogram, rather than as a Summary.
 // These values may need to be updated over time.
-// These values are logarithmically spaced from 5ms to 250ms.
+// These values are logarithmically spaced from 5us to 67ms.
 const GENERIC_DEX_BUCKETS: &[f64; 16] = &[
+    0.0005,
+    0.000792,
+    0.001256,
+    0.001991,
+    0.003155,
     0.005,
     0.00648985018,
     0.00842363108,
@@ -63,11 +68,6 @@ const GENERIC_DEX_BUCKETS: &[f64; 16] = &[
     0.0402798032,
     0.05228197763,
     0.06786044041,
-    0.08808081833,
-    0.11432626298,
-    0.14839206374,
-    0.1926084524,
-    0.250,
 ];
 
 pub const DEX_PATH_SEARCH_DURATION: &str = "penumbra_dex_path_search_duration_seconds";

--- a/deployments/compose/metrics.yml
+++ b/deployments/compose/metrics.yml
@@ -19,5 +19,4 @@ services:
     image: "docker.io/prom/prometheus"
     network_mode: host
     volumes:
-      # TODO: this path is not accurate
-      - /home/conor/src/penumbra/deployments/config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - "${PWD:?}/../config/prometheus.yml:/etc/prometheus/prometheus.yml:ro"


### PR DESCRIPTION
## Describe your changes
This re-centers the DEX buckets around the expected latency region

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

