### PR TITLE
Add `leave-archive` flag to `pd join`

### DIFF
--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -221,7 +221,8 @@ pub enum TestnetCommand {
 
         /// Optional URL of archived node state in .tar.gz format. The archive will be
         /// downloaded and extracted locally, allowing the node to join a network at a block height
-        /// higher than 0.
+        /// higher than 0. Supports loading the archive from a local file, if set with file scheme
+        /// explicitly, e.g. `file:///path/to/archive.tar.gz`.
         #[clap(long, env = "PENUMBRA_PD_ARCHIVE_URL")]
         archive_url: Option<Url>,
 

--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -240,6 +240,9 @@ pub enum TestnetCommand {
         /// When generating Tendermint config, use this socket to bind the Tendermint P2P service.
         #[clap(long, env = "PENUMBRA_PD_TM_P2P_BIND", default_value = "0.0.0.0:26656")]
         tendermint_p2p_bind: SocketAddr,
+        /// Leave the downloaded archive file on disk after extraction.
+        #[clap(long, env = "PENUMBRA_PD_LEAVE_ARCHIVE", action)]
+        leave_archive: bool,
     },
 
     /// Reset all `pd` testnet state.

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -255,6 +255,7 @@ async fn main() -> anyhow::Result<()> {
                     external_address,
                     tendermint_rpc_bind,
                     tendermint_p2p_bind,
+                    leave_archive,
                 },
             testnet_dir,
         } => {
@@ -297,7 +298,8 @@ async fn main() -> anyhow::Result<()> {
 
             // Download and extract archive URL, if set.
             if let Some(archive_url) = archive_url {
-                pd::testnet::join::unpack_state_archive(archive_url, output_dir).await?;
+                pd::testnet::join::unpack_state_archive(archive_url, output_dir, leave_archive)
+                    .await?;
             }
         }
 

--- a/crates/bin/pd/src/testnet/join.rs
+++ b/crates/bin/pd/src/testnet/join.rs
@@ -244,7 +244,13 @@ pub async fn fetch_peers(tm_url: &Url) -> anyhow::Result<Vec<TendermintAddress>>
 ///
 /// The `output_dir` should be the same argument as passed to `pd testnet --testnet-dir <dir> join`;
 /// relative paths for pd and cometbft will be created from this base path.
-pub async fn unpack_state_archive(archive_url: Url, output_dir: PathBuf) -> anyhow::Result<()> {
+///
+/// The `leave_archive` argument allows you to keep the downloaded archive file after unpacking.
+pub async fn unpack_state_archive(
+    archive_url: Url,
+    output_dir: PathBuf,
+    leave_archive: bool,
+) -> anyhow::Result<()> {
     tracing::info!(%archive_url, "downloading compressed node state");
     // Download.
     // Here we inspect HEAD so we can infer filename.
@@ -304,8 +310,14 @@ pub async fn unpack_state_archive(archive_url: Url, output_dir: PathBuf) -> anyh
     }
 
     tracing::info!("archived node state unpacked to {}", pd_home.display());
-    // Post-extraction, clean up the downloaded tarball.
-    std::fs::remove_file(archive_filepath)?;
+
+    if !leave_archive {
+        // Post-extraction, clean up the downloaded tarball.
+        std::fs::remove_file(archive_filepath)?;
+    } else {
+        tracing::info!(path = ?archive_filepath, "leaving downloaded archive on disk");
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Describe your changes

Small change to add a `--leave-archive` flag to `pd join` (defaults to false) to optionally leave behind the  downloaded archive file.

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > local to `pd` nodes only