### PR TITLE
auction: dex-enabled check during LP allocation

### DIFF
--- a/crates/core/component/auction/src/component/action_handler/dutch/schedule.rs
+++ b/crates/core/component/auction/src/component/action_handler/dutch/schedule.rs
@@ -1,13 +1,10 @@
-use std::sync::Arc;
-
 use crate::auction::dutch::actions::schedule::MAX_AUCTION_AMOUNT_RESERVES;
 use crate::auction::dutch::DutchAuctionDescription;
 use crate::component::AuctionStoreRead;
 use anyhow::{ensure, Result};
 use async_trait::async_trait;
-use cnidarium::{StateRead, StateWrite};
+use cnidarium::StateWrite;
 use cnidarium_component::ActionHandler;
-use penumbra_dex::component::StateReadExt;
 use penumbra_num::Amount;
 use penumbra_sct::component::clock::EpochRead;
 
@@ -106,19 +103,6 @@ impl ActionHandler for ActionDutchAuctionSchedule {
             "the block window ({block_window}) MUST be a multiple of the step count ({step_count})"
         );
 
-        Ok(())
-    }
-
-    async fn check_historical<S: StateRead + 'static>(
-        &self,
-        historical_state: Arc<S>,
-    ) -> Result<()> {
-        // Safety: This is safe to do in a historical check because the chain state
-        // it inspects cannot be modified by other actions in the same transaction.
-        ensure!(
-            historical_state.get_dex_params().await?.is_enabled,
-            "Dex MUST be enabled to schedule auctions"
-        );
         Ok(())
     }
 

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -81,11 +81,11 @@ pub trait PositionRead: StateRead {
         self.get(&state_key::position_by_id(id)).await
     }
 
-    async fn check_position_by_id(&self, id: &position::Id) -> Result<bool> {
-        Ok(self
-            .get_raw(&state_key::position_by_id(id))
-            .await?
-            .is_some())
+    async fn check_position_by_id(&self, id: &position::Id) -> bool {
+        self.get_raw(&state_key::position_by_id(id))
+            .await
+            .expect("no deserialization errors")
+            .is_some()
     }
 
     async fn best_position(


### PR DESCRIPTION
## Describe your changes

Close #4599 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Consensus breaking, does not require a migration. 
