### PR TITLE
add mempool.type to cometbft config template

### DIFF
--- a/testnets/cometbft_config_template.toml
+++ b/testnets/cometbft_config_template.toml
@@ -283,6 +283,16 @@ dial_timeout = "3s"
 #   2) "v1" - prioritized mempool (deprecated; will be removed in the next release).
 version = "v0"
 
+# The type of mempool for this node to use.
+#
+#  Possible types:
+#  - "flood" : concurrent linked list mempool with flooding gossip protocol
+#  (default)
+#  - "nop"   : nop-mempool (short for no operation; the ABCI app is responsible
+#  for storing, disseminating and proposing txs). "create_empty_blocks=false" is
+#  not supported.
+type = "flood"
+
 recheck = true
 broadcast = true
 wal_dir = ""


### PR DESCRIPTION
## Describe your changes

`mempool.type` was [added](https://github.com/cometbft/cometbft/blob/v0.37.x/CHANGELOG.md#v0374) in v0.37.4 (penumbra updated to 0.37.5 in #4024). Set it to its default value explicitly.

## Issue ticket number and link

## Checklist before requesting a review

- [X] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > no functionality change