### PR TITLE
app: drop stateful mempool

### DIFF
--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -253,6 +253,9 @@ impl App {
         let mut bytes_tracker = 0usize;
 
         for evidence in proposal.misbehavior {
+            // This should be pretty cheap, we allow for `MAX_EVIDENCE_SIZE_BYTES` in total
+            // but a single evidence datum should be an order of magnitude smaller than that.
+            evidence_buffer.clear();
             let proto_evidence: tendermint_proto::v0_37::abci::Misbehavior = evidence.into();
             let evidence_size = match proto_evidence.encode(&mut evidence_buffer) {
                 Ok(_) => evidence_buffer.len(),

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -576,10 +576,10 @@ impl App {
         jmt_root
     }
 
-    pub fn tendermint_validator_updates(&self) -> Vec<Update> {
+    pub fn cometbft_validator_updates(&self) -> Vec<Update> {
         self.state
             .cometbft_validator_updates()
-            // If the tendermint validator updates are not set, we return an empty
+            // If the cometbft validator updates are not set, we return an empty
             // update set, signaling no change to Tendermint.
             .unwrap_or_default()
     }

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -185,7 +185,7 @@ impl App {
         );
 
         // This is a node controlled parameter that is different from the homonymous
-        // mempool's `max_tx_bytes`. Comet will send us raw proposals that exceed that
+        // mempool's `max_tx_bytes`. Comet will send us raw proposals that exceed this
         // limit, presuming that a subset of those transactions will be shed.
         // More context in https://github.com/cometbft/cometbft/blob/v0.37.5/spec/abci/abci%2B%2B_app_requirements.md
         let max_proposal_size_bytes = proposal.max_tx_bytes as u64;

--- a/crates/core/app/src/server/consensus.rs
+++ b/crates/core/app/src/server/consensus.rs
@@ -70,6 +70,18 @@ impl Consensus {
                         .await
                         .expect("init_chain must succeed"),
                 ),
+                Request::PrepareProposal(proposal) => Response::PrepareProposal(
+                    self.prepare_proposal(proposal)
+                        .instrument(span)
+                        .await
+                        .expect("prepare proposal must succeed"),
+                ),
+                Request::ProcessProposal(proposal) => Response::ProcessProposal(
+                    self.process_proposal(proposal)
+                        .instrument(span)
+                        .await
+                        .expect("process proposal must succeed"),
+                ),
                 Request::BeginBlock(begin_block) => Response::BeginBlock(
                     self.begin_block(begin_block)
                         .instrument(span)
@@ -87,18 +99,6 @@ impl Consensus {
                         .instrument(span)
                         .await
                         .expect("commit must succeed"),
-                ),
-                Request::PrepareProposal(proposal) => Response::PrepareProposal(
-                    self.prepare_proposal(proposal)
-                        .instrument(span)
-                        .await
-                        .expect("prepare proposal must succeed"),
-                ),
-                Request::ProcessProposal(proposal) => Response::ProcessProposal(
-                    self.process_proposal(proposal)
-                        .instrument(span)
-                        .await
-                        .expect("process proposal must succeed"),
                 ),
             }));
         }
@@ -123,7 +123,7 @@ impl Consensus {
         // to be provided inside the initial app genesis state (`GenesisAppState`). Returning those
         // validators in InitChain::Response tells Tendermint that they are the initial validator
         // set. See https://docs.tendermint.com/master/spec/abci/abci.html#initchain
-        let validators = self.app.tendermint_validator_updates();
+        let validators = self.app.cometbft_validator_updates();
 
         let app_hash = match &app_state {
             crate::genesis::AppState::Checkpoint(h) => {
@@ -162,7 +162,11 @@ impl Consensus {
         proposal: request::PrepareProposal,
     ) -> Result<response::PrepareProposal> {
         tracing::info!(height = ?proposal.height, proposer = ?proposal.proposer_address, "preparing proposal");
-        Ok(self.app.prepare_proposal(proposal).await)
+        // We prepare a proposal against an isolated fork of the application state.
+        let mut tmp_app = App::new(self.storage.latest_snapshot());
+        // Once we are done, we discard it so that the application state doesn't get corrupted
+        // if another round of consensus is required because the proposal fails to finalize.
+        Ok(tmp_app.prepare_proposal(proposal).await)
     }
 
     async fn process_proposal(
@@ -218,7 +222,7 @@ impl Consensus {
         // validators and voting power. This must be the last step performed,
         // after all voting power calculations and validator state transitions have
         // been completed.
-        let validator_updates = self.app.tendermint_validator_updates();
+        let validator_updates = self.app.cometbft_validator_updates();
 
         tracing::debug!(
             ?validator_updates,

--- a/crates/core/app/src/server/mempool.rs
+++ b/crates/core/app/src/server/mempool.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
 
-use cnidarium::{Snapshot, Storage};
+use cnidarium::Storage;
 
 use tendermint::v0_37::abci::{
     request::CheckTx as CheckTxReq, request::CheckTxKind, response::CheckTx as CheckTxRsp,
     MempoolRequest as Request, MempoolResponse as Response,
 };
-use tokio::sync::{mpsc, watch};
+use tokio::sync::mpsc;
 use tower_actor::Message;
 use tracing::Instrument;
 
@@ -15,8 +15,7 @@ use crate::{app::App, metrics};
 /// A mempool service that applies transaction checks against an isolated application fork.
 pub struct Mempool {
     queue: mpsc::Receiver<Message<Request, Response, tower::BoxError>>,
-    snapshot: Snapshot,
-    rx_snapshot: watch::Receiver<Snapshot>,
+    storage: Storage,
 }
 
 impl Mempool {
@@ -24,14 +23,7 @@ impl Mempool {
         storage: Storage,
         queue: mpsc::Receiver<Message<Request, Response, tower::BoxError>>,
     ) -> Self {
-        let snapshot = storage.latest_snapshot();
-        let snapshot_rx = storage.subscribe();
-
-        Self {
-            queue,
-            snapshot,
-            rx_snapshot: snapshot_rx,
-        }
+        Self { queue, storage }
     }
 
     pub async fn check_tx(&mut self, req: Request) -> Result<Response, tower::BoxError> {
@@ -45,7 +37,7 @@ impl Mempool {
             CheckTxKind::Recheck => "recheck",
         };
 
-        let mut app = App::new(self.snapshot.clone());
+        let mut app = App::new(self.storage.latest_snapshot());
 
         match app.deliver_tx_bytes(tx_bytes.as_ref()).await {
             Ok(events) => {
@@ -72,31 +64,20 @@ impl Mempool {
     }
 
     pub async fn run(mut self) -> Result<(), tower::BoxError> {
-        loop {
-            tokio::select! {
-                // Use a biased select to poll for height changes *before* polling for messages.
-                biased;
-                // Check whether the height has changed, which requires us to throw away our
-                // ephemeral mempool state, and create a new one based on the new state.
-                change = self.rx_snapshot.changed() => {
-                    if let Ok(()) = change {
-                        let snapshot = self.rx_snapshot.borrow().clone();
-                        tracing::debug!(height = ?snapshot.version(), "mempool has rewired to use the latest snapshot");
-                        self.snapshot = snapshot;
-                    } else {
-                        tracing::info!("state notification channel closed, shutting down");
-                        return Ok(());
-                    }
-                }
-                message = self.queue.recv() => {
-                    if let Some(Message {req, rsp_sender, span }) = message {
-                        let _ = rsp_sender.send(self.check_tx(req).instrument(span).await);
-                    } else {
-                        // The queue is closed, so we're done.
-                        return Ok(());
-                    }
-                }
-            }
+        tracing::info!("mempool service started");
+        while let Some(Message {
+            req,
+            rsp_sender,
+            span,
+            // We could perform `CheckTx` asynchronously, and poll many
+            // entries from the queue:
+            // See https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.Receiver.html#method.recv_many
+        }) = self.queue.recv().await
+        {
+            let result = self.check_tx(req).instrument(span).await;
+            let _ = rsp_sender.send(result);
         }
+        tracing::info!("mempool service stopped");
+        Ok(())
     }
 }


### PR DESCRIPTION
## Describe your changes

This is a draft PR that removes the stateful mempool from the application, replacing it with:
- a stateless mempool that gates inclusion on validity against the latest version of the app state
- a prepare proposal implementation that filters for valid transactions
- a process proposal implementation that validates block quality and lays the groundwork to do optimistic execution

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Consensus breaking
