### PR TITLE
fix(pd): adjust chain id randomizer for devnets

### DIFF
--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -329,7 +329,9 @@ async fn main() -> anyhow::Result<()> {
                     let randomizer = OsRng.gen::<u32>();
                     let chain_id =
                         chain_id.unwrap_or_else(|| env!("PD_LATEST_TESTNET_NAME").to_string());
-                    format!("{}-{}", chain_id, randomizer)
+                    // We insert an 'x' in the randomized hex string to ensure it's not parsed as a
+                    // revision id.
+                    format!("{}-x{}", chain_id, hex::encode(randomizer.to_le_bytes()))
                 }
             };
 


### PR DESCRIPTION


## Describe your changes
We automatically append a hex randomizer to devnet/preview chain ids, to avoid collisions. Client tooling may expect that suffix to be a revision number, a behavior we want to avoid. Let's stick an 'x' in the randomizer to prevent this behavior.

## Issue ticket number and link
Follow-up to #4558. Revisits and therefore closes #4552.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > no changes to app logic, only affects generation of new test chains
