### PR TITLE
stake: tighten downtime jail parameters to 6h40m

### DIFF
--- a/crates/core/component/stake/src/params.rs
+++ b/crates/core/component/stake/src/params.rs
@@ -71,9 +71,9 @@ impl Default for StakeParameters {
         Self {
             unbonding_delay: 719 * 3 + 1,
             active_validator_limit: 80,
-            // Copied from cosmos hub
-            signed_blocks_window_len: 10000,
-            missed_blocks_maximum: 9500,
+            // Adapted from Osmosis. Jail iff 6h40m downtime in the last 33 hours.
+            signed_blocks_window_len: 24000,
+            missed_blocks_maximum: 4800,
             // 1000 basis points = 10%
             slashing_penalty_misbehavior: 1000_0000,
             // 1 basis point = 0.01%


### PR DESCRIPTION
## Describe your changes

Allowing 9,500 out of 10,000 blocks to go unsigned is incredibly lax and lets a downed validator linger in the active set for over 13 hours.

Instead of using values from the Cosmos Hub, this PR adapts values from a DEX appchain, Osmosis. They're moving to 1.5-second blocks, and validators get jailed if less than 80% of blocks are signed in an 80,000 block window. Adapting from 1.5s to Penumbra's 5s blocks, equivalent parameters would be:

- `signed_blocks_window_len: 24000` (33h20m window)
- `missed_blocks_maximum: 4800` (6h40m downtime)

## Issue ticket number and link

## Checklist before requesting a review

- [X] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > changes the default value for two chain parameters, which can only be changed with a proposal vote on a live chain