### PR TITLE
template(comet): lower mempool.max_tx_bytes from 1MiB to 30KiB

### DIFF
--- a/testnets/cometbft_config_template.toml
+++ b/testnets/cometbft_config_template.toml
@@ -316,7 +316,7 @@ keep-invalid-txs-in-cache = false
 
 # Maximum size of a single transaction.
 # NOTE: the max size of a tx transmitted over the network is {max_tx_bytes}.
-max_tx_bytes = 1048576
+max_tx_bytes = 30720
 
 # Maximum size of a batch of transactions to send to a peer
 # Including space needed by encoding (one varint per transaction).


### PR DESCRIPTION
## Describe your changes

Set the individual transaction size limit to be smaller than the entire block size, but to a still lax, permissive value.

## Issue ticket number and link

#4629

## Checklist before requesting a review

- [X] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > the mempool is outside consensus; and this only edits a template file