### PR TITLE
ibc: fix timeouts: use client height and timestamp

### DIFF
--- a/crates/core/component/ibc/src/component/msg_handler/timeout.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/timeout.rs
@@ -66,12 +66,12 @@ impl MsgHandler for MsgTimeout {
             .get_verified_consensus_state(&client_state.latest_height(), &connection.client_id)
             .await?;
         let last_update_time = last_consensus_state.timestamp;
-        let last_update_height = client_state.latest_height();
+        let proof_update_height = self.proof_height_on_b;
 
         // check that timeout height or timeout timestamp has passed on the other end
         if !self
             .packet
-            .timed_out(&last_update_time.into(), last_update_height)
+            .timed_out(&last_update_time.into(), proof_update_height)
         {
             anyhow::bail!("packet has not timed out on the counterparty chain");
         }


### PR DESCRIPTION
Previously, when processing timeouts, we used the `client_processed_height` and `client_processed_timestamp` data to determine if a timeout duration had elapsed:

https://github.com/penumbra-zone/penumbra/blob/c9d778c0ad573b0aabfe4f3d7334eaa9778185e5/crates/core/component/ibc/src/component/msg_handler/timeout.rs#L70

However, those refer to a height and timestamp *on penumbra* when any client update for that client had last been processed:

https://github.com/penumbra-zone/penumbra/blob/c9d778c0ad573b0aabfe4f3d7334eaa9778185e5/crates/core/component/ibc/src/component/client.rs#L168

This comparison is invalid, we should instead be checking against the timestamp and height of the last consensus state from the counterparty client. This PR does that. This was verified to fix the interchain test failures in #4634 .

Closes #4634 