### PR TITLE
dex: avoid recording null `SwapExecution`s

### DIFF
--- a/crates/core/component/dex/src/component/arb.rs
+++ b/crates/core/component/dex/src/component/arb.rs
@@ -45,7 +45,7 @@ pub trait Arbitrage: StateWrite + Sized {
 
         let execution_budget = self.get_dex_params().await?.max_execution_budget;
         let execution_circuit_breaker = ExecutionCircuitBreaker::new(execution_budget);
-        let swap_execution = this
+        let Some(swap_execution) = this
             .route_and_fill(
                 arb_token,
                 arb_token,
@@ -53,7 +53,11 @@ pub trait Arbitrage: StateWrite + Sized {
                 routing_params,
                 execution_circuit_breaker,
             )
-            .await?;
+            .await?
+        else {
+            return Ok(None);
+        };
+
         let filled_input = swap_execution.input.amount;
         let output = swap_execution.output.amount;
         let unfilled_input = flash_loan


### PR DESCRIPTION
## Describe your changes

This PR:
- makes `route_and_fill` return a `Result<Option<SwapExecution>>`
- avoid recording ambiguous `SwapExecution`s with no input or output
- simplify the `handle_batch_swap` logic
- modify the simulate trade RPC to return a failed precondition error if it simulates a trade that doesn't result in any execution

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Not consensus breaking
