### PR TITLE
ibc: delete packet commitments instead of writing empty values

### DIFF
--- a/crates/core/component/ibc/src/component/channel.rs
+++ b/crates/core/component/ibc/src/component/channel.rs
@@ -81,11 +81,10 @@ pub trait StateWriteExt: StateWrite + StateReadExt {
         port_id: &PortId,
         sequence: u64,
     ) {
-        self.put_raw(
+        self.delete(
             IBC_COMMITMENT_PREFIX.apply_string(
                 CommitmentPath::new(port_id, channel_id, sequence.into()).to_string(),
             ),
-            vec![],
         );
     }
 


### PR DESCRIPTION
The IBC spec calls for deletion of packet commitments after a successful acknowledgement, in order to avoid double-acknowledgements.

Previously, our implementation accomplished this deletion by writing an empty byte slice vec![] to the commitment path.

However, this will cause nonexistence proofs by exclusion (the standard NX-proof type used in ics23) of adjacent keys to fail, since ics23 does not support existence proofs of empty values. We observed this when timeouts from osmosis testnet failed to verify the NX proofs from penumbra testnet.

This PR changes `delete_packet_commitment` to actually delete the commitment, and introduces a migration for testnet 78 that will delete all of the previously overwritten commitments.
