### PR TITLE
cnidarium: fix outdated docs for StateRead::object_get()

### DIFF
--- a/crates/cnidarium/src/read.rs
+++ b/crates/cnidarium/src/read.rs
@@ -33,7 +33,7 @@ pub trait StateRead: Send + Sync {
     /// # Returns
     ///
     /// - `Some(&T)` if a value of type `T` was present at `key`.
-    /// - `None` if `key` was not present, or if `key` was present but the value was not of type `T`.
+    /// - `None` if `key` was not present.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
The documentation was contradicting itself since #2563.
