### PR TITLE
chore: update summonerd docs to 0.77.3

### DIFF
--- a/tools/summonerd/templates/main.html
+++ b/tools/summonerd/templates/main.html
@@ -89,10 +89,10 @@
           to set up <span class="font-mono">pcli</span> and create a wallet.
           <br>
           If you already have <span class="font-mono">pcli</span> installed, make sure you're using
-          <span class="font-bold">v0.77.2</span>:
+          <span class="font-bold">v0.77.3</span>:
         <pre
           class="text-sm my-8 p-2 bg-charcoal rounded-lg"><span class="no-select">$ </span>pcli --version
-<span class="no-select">pcli v0.77.2</span></pre>
+<span class="no-select">pcli v0.77.3</span></pre>
         </p>
         <h3 class="font-bold text-xl pt-4 bg-text-linear bg-clip-text text-transparent">Receiving Faucet Funds</h3>
         <p>


### PR DESCRIPTION
## Describe your changes

Bumps the recommended pcli version on the summonerd help page. Notably the summonerd feature branch is still based on 0.77.0, so we're not actually including the changes shipped as 0.77.3, but that's ok: the coordinator is pointed at a solo node url, and that node will get the server-side 0.77.3 improvements.

After 0.77.3 is live, I'll get this branch on the coordinator box and restart the service.

## Issue ticket number and link
Refs #4648.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > docs specific to summonerd