### PR TITLE
pd: 🙏 propagate errors from ACME worker

### DIFF
--- a/crates/util/auto-https/src/lib.rs
+++ b/crates/util/auto-https/src/lib.rs
@@ -70,7 +70,10 @@ where
     loop {
         match state.next().await {
             Some(Ok(ok)) => tracing::debug!("received acme event: {:?}", ok),
-            Some(Err(err)) => tracing::error!("acme error: {:?}", err),
+            Some(Err(err)) => {
+                tracing::error!("acme error: {:?}", err);
+                anyhow::bail!("exiting due to acme error");
+            }
             None => {
                 debug_assert!(false, "acme worker unexpectedly reached end-of-stream");
                 tracing::error!("acme worker unexpectedly reached end-of-stream");


### PR DESCRIPTION
when auto-https is enabled, we spawn a task in the background to handle https certificate resolution, via `rustls_acme::AcmeState`.

if that task encounters errors, they should be propagated up to the daemon, so that `pd` does not rapidly retry lookups, potentially hitting rate-limits and causing service interruptions.

this changes the `pd` entrypoint, binding the [`JoinHandle`] to a variable and polling upon that future in the `tokio::select` block that represents the core steady-state event loop of the daemon.

## checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > while this does change node behavior, none of the components changed are consensus-critical.