### PR TITLE
cnidarium: prefix queries over substores are hazardous

### DIFF
--- a/crates/bin/pd/src/migrate/testnet78.rs
+++ b/crates/bin/pd/src/migrate/testnet78.rs
@@ -169,9 +169,9 @@ async fn delete_empty_deleted_packet_commitments(
     pin_mut!(stream);
 
     while let Some(entry) = stream.next().await {
-        let (substore_key, value) = entry?;
+        let (key, value) = entry?;
         if value.is_empty() {
-            delta.delete(format!("ibc-data/{substore_key}"));
+            delta.delete(key);
         }
     }
 

--- a/crates/cnidarium/src/snapshot.rs
+++ b/crates/cnidarium/src/snapshot.rs
@@ -424,10 +424,13 @@ impl StateRead for Snapshot {
                     // Costly to do on every iteration, but this should be dwarfed by the
                     // context switch to the tokio runtime.
                     let mut full_key: Vec<u8> = vec![];
-                    let prefix = substore_prefix.clone();
-                    full_key.extend(prefix);
-                    full_key.extend(iter::once(b'/'));
-                    full_key.extend(key);
+                    if substore_prefix.is_empty() {
+                        full_key.extend(key);
+                    } else {
+                        full_key.extend(substore_prefix.clone());
+                        full_key.extend(iter::once(b'/'));
+                        full_key.extend(key);
+                    }
 
                     tx_prefix_query.blocking_send(Ok((full_key, value)))?;
                 }

--- a/crates/cnidarium/tests/substore_tests.rs
+++ b/crates/cnidarium/tests/substore_tests.rs
@@ -738,6 +738,7 @@ async fn reproduction_bad_substore_cache_range() -> anyhow::Result<()> {
     let mut dirty_delta_prefix = delta.prefix_raw("zest/");
     let mut visited = vec![];
     // Cache interleaving logic will build a bad range and cause a panic.
+    // Check out `v0.77.3` or prior to see the panic.
     while let Some(entry) = dirty_delta_prefix.next().await {
         let (k, _) = entry?;
         visited.push(k);


### PR DESCRIPTION
## Describe your changes

This PR contains a minimal reproduction for a bug in cnidarium's prefix query handling. It also contains a sketch for a fix that we can workshop. The bug was introduced in the original substore implementation PR (#3131).

## Minimal reproduction of the prefix range cache bug.

**Context**
`cnidarium`, our storage layer, supports prefix storage.
This allows users to configure independent storage units, each with
their own merkle tree, nonverifiable sidecar, and separate namespace.
Routing is done transparently without the user having to worry about
the details.

**Overview**
Prefix queries return tuples of (key, value)s, but instead of
returning the full key, they return the substore key. This is a layering
violation, and indeed causes a bug in the cache interleaving logic.

**Terminology**
- a `full_key`:  a key that contains a substore prefix, a delimiter, and a substore key.
- a `substore_key`: a key with a stripped prefix.

**Walkthrough**
`StateDelta` index changes using full keys, as it is not aware of the
particular substore configuration that it is working against, by design.
As part of the cache interleaving logic, the `StateDetla` will try look for
new writes or covering deletions. However, since the base prefix implementation
returns substore keys, the cache will build an incoherence range and panic (or miss data).

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Consensus breaking in the sense that the chain won't halt if we hit this.