### PR TITLE
app: make prepare proposal more robust to comet misconfiguration

### DIFF
--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -204,6 +204,12 @@ impl App {
             // We compute the total proposal size if we were to include this transaction.
             let total_with_tx = proposal_size_bytes.saturating_add(transaction_size);
 
+            // This should never happen, unless Comet is misbehaving because of a bug
+            // or a misconfiguration. We handle it gracefully, to prioritize forward progress.
+            if transaction_size > MAX_TRANSACTION_SIZE_BYTES as u64 {
+                continue;
+            }
+
             // First, we filter proposals to fit within the block limit.
             if total_with_tx >= max_proposal_size_bytes {
                 break;


### PR DESCRIPTION
## Describe your changes

This PR adds a tx size check in the proposal preparation logic so that the application always build valid blocks even in the even of a cometbft misconfiguration.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This is not consensus breaking, but makes the prepare proposal logic more robust to misconfiguration.
