### PR TITLE
Add transaction saving and broadcasting feature

### DIFF
--- a/crates/bin/pcli/src/command.rs
+++ b/crates/bin/pcli/src/command.rs
@@ -6,7 +6,7 @@ pub use tx::TxCmd;
 pub use validator::ValidatorCmd;
 pub use view::ViewCmd;
 
-use self::ceremony::CeremonyCmd;
+use self::{ceremony::CeremonyCmd, tx::TxCmdWithOptions};
 
 mod ceremony;
 mod debug;
@@ -51,8 +51,8 @@ pub enum Command {
     #[clap(subcommand, display_order = 300, visible_alias = "v")]
     View(ViewCmd),
     /// Create and broadcast a transaction.
-    #[clap(subcommand, display_order = 400, visible_alias = "tx")]
-    Transaction(TxCmd),
+    #[clap(display_order = 400, visible_alias = "tx")]
+    Transaction(TxCmdWithOptions),
     /// Manage a validator.
     #[clap(subcommand, display_order = 900)]
     Validator(ValidatorCmd),

--- a/crates/bin/pcli/src/lib.rs
+++ b/crates/bin/pcli/src/lib.rs
@@ -10,6 +10,7 @@ use {
         view::v1::view_service_client::ViewServiceClient,
     },
     penumbra_view::ViewClient,
+    std::path::PathBuf,
 };
 
 pub mod command;
@@ -34,6 +35,8 @@ pub struct App {
     pub custody: CustodyServiceClient<BoxGrpcService>,
     pub governance_custody: CustodyServiceClient<BoxGrpcService>,
     pub config: PcliConfig,
+    /// If present, save the transaction here instead of broadcasting it.
+    pub save_transaction_here_instead: Option<PathBuf>,
 }
 
 impl App {

--- a/crates/bin/pcli/src/network.rs
+++ b/crates/bin/pcli/src/network.rs
@@ -11,7 +11,7 @@ use penumbra_proto::{
 use penumbra_stake::validator::Validator;
 use penumbra_transaction::{txhash::TransactionId, Transaction, TransactionPlan};
 use penumbra_view::ViewClient;
-use std::future::Future;
+use std::{fs, future::Future};
 use tonic::transport::{Channel, ClientTlsConfig};
 use tracing::instrument;
 
@@ -105,6 +105,15 @@ impl App {
         &mut self,
         transaction: Transaction,
     ) -> anyhow::Result<TransactionId> {
+        if let Some(file) = &self.save_transaction_here_instead {
+            println!(
+                "saving transaction to disk, path: {}",
+                file.to_string_lossy()
+            );
+            fs::write(file, &serde_json::to_vec(&transaction)?)?;
+            return Ok(transaction.id());
+        }
+
         println!("broadcasting transaction and awaiting confirmation...");
         let mut rsp = self.view().broadcast_transaction(transaction, true).await?;
 

--- a/crates/bin/pcli/src/opt.rs
+++ b/crates/bin/pcli/src/opt.rs
@@ -173,6 +173,7 @@ impl Opt {
             custody,
             governance_custody,
             config,
+            save_transaction_here_instead: None,
         };
         Ok((app, self.cmd))
     }


### PR DESCRIPTION
This adds:

  - `pcli tx --offline <FILE> <COMMAND>`
  - `pcli tx broadcast <FILE>`

The first will save the transaction to a file after signing, the second will broadcast the result of the first command.

Closes #4660.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Client side only
