### PR TITLE
docs: update archive url for testnet 78

### DIFF
--- a/docs/guide/src/node/pd/join-testnet.md
+++ b/docs/guide/src/node/pd/join-testnet.md
@@ -41,7 +41,7 @@ docs to switch to the archive-url version:
 
 ```shell
 pd testnet join --external-address IP_ADDRESS:26656 --moniker MY_NODE_NAME \
-    --archive-url "https://snapshots.penumbra.zone/testnet/pd-migrated-state-76-77.tar.gz"
+    --archive-url "https://snapshots.penumbra.zone/testnet/pd-migrated-state-77-78.tar.gz"
 ```
 
 where `IP_ADDRESS` (like `1.2.3.4`) is the public IP address of the node you're running,


### PR DESCRIPTION


## Describe your changes
Refs https://github.com/penumbra-zone/penumbra/issues/4582

Also relevant is #4525 which the archive referenced in this PR does _not_ account for; 4524 is still outstanding.

To test this, one should be able to join the post-upgrade Testnet 78 with v0.78.0 of pd and sync blocks.
## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > docs-only