### PR TITLE
chore(Cargo.toml): 🪄 remove explicit `default-features = true`

### DIFF
--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -62,12 +62,12 @@ ark-serialize = {workspace = true}
 ark-snark = {workspace = true}
 ark-std = {workspace = true, default-features = false}
 bech32 = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 num-bigint = {workspace = true}
 once_cell = {workspace = true}
-penumbra-asset = {workspace = true, default-features = true}
-penumbra-keys = {workspace = true, default-features = true}
-penumbra-num = {workspace = true, default-features = true}
+penumbra-asset = {workspace = true}
+penumbra-keys = {workspace = true}
+penumbra-num = {workspace = true}
 rand = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}
 serde = {workspace = true, features = ["derive"]}
@@ -79,17 +79,16 @@ criterion = {workspace = true, features = ["html_reports"]}
 decaf377-fmd = {workspace = true}
 decaf377-ka = {workspace = true}
 decaf377-rdsa = {workspace = true}
-penumbra-dex = {workspace = true, default-features = true}
-penumbra-fee = {workspace = true, default-features = true}
-penumbra-governance = {workspace = true, default-features = true}
-penumbra-sct = {workspace = true, default-features = true}
-penumbra-shielded-pool = {workspace = true, default-features = true}
-penumbra-stake = {workspace = true, default-features = true}
-penumbra-tct = {workspace = true, features = ["r1cs"], default-features = true}
+penumbra-dex = {workspace = true}
+penumbra-fee = {workspace = true}
+penumbra-governance = {workspace = true}
+penumbra-sct = {workspace = true}
+penumbra-shielded-pool = {workspace = true}
+penumbra-stake = {workspace = true}
+penumbra-tct = {workspace = true, features = ["r1cs"]}
 
 [dev-dependencies.penumbra-proof-params]
 workspace = true
-default-features = true
 features = [
     "bundled-proving-keys",
     "download-proving-keys",

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -44,7 +44,7 @@ clap = {workspace = true, features = ["derive", "env"]}
 colored = "2.1.0"
 colored_json = "4.1"
 comfy-table = "5"
-decaf377 = {workspace = true, default-features = true}
+decaf377 = {workspace = true}
 decaf377-rdsa = {workspace = true}
 dialoguer = "0.10.4"
 time = "0.3"
@@ -54,8 +54,8 @@ futures = {workspace = true}
 hex = {workspace = true}
 http-body = {workspace = true}
 humantime = {workspace = true}
-ibc-proto = {workspace = true, default-features = true}
-ibc-types = {workspace = true, features = ["std", "with_serde"], default-features = true}
+ibc-proto = {workspace = true}
+ibc-types = {workspace = true, features = ["std", "with_serde"]}
 indicatif = {workspace = true}
 jmt = {workspace = true}
 ndarray = "0.15.6"
@@ -73,13 +73,13 @@ penumbra-ibc = {workspace = true, default-features = false}
 penumbra-keys = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}
 penumbra-proof-setup = {workspace = true}
-penumbra-proof-params = { workspace = true, default-features = true }
-penumbra-proto = {workspace = true, features = ["rpc", "box-grpc"], default-features = true}
+penumbra-proof-params = { workspace = true }
+penumbra-proto = {workspace = true, features = ["rpc", "box-grpc"]}
 penumbra-sct = {workspace = true, default-features = false}
 penumbra-shielded-pool = {workspace = true, default-features = false}
 penumbra-stake = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-transaction = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true}
+penumbra-transaction = {workspace = true}
 penumbra-view = {workspace = true}
 penumbra-wallet = {workspace = true}
 pin-project = {workspace = true}
@@ -93,7 +93,7 @@ serde_json = {workspace = true}
 serde_with = {workspace = true, features = ["hex"]}
 sha2 = {workspace = true}
 simple-base64 = "0.23"
-tendermint = {workspace = true, features = ["rust-crypto"], default-features = true}
+tendermint = {workspace = true, features = ["rust-crypto"]}
 tokio = {workspace = true, features = ["full"]}
 tokio-stream = {workspace = true}
 tokio-util = {workspace = true}
@@ -113,7 +113,6 @@ regex = {workspace = true}
 tempfile = {workspace = true}
 
 [dev-dependencies.penumbra-proof-params]
-default-features = true
 workspace = true
 features = [
     "bundled-proving-keys",

--- a/crates/bin/pclientd/Cargo.toml
+++ b/crates/bin/pclientd/Cargo.toml
@@ -27,12 +27,12 @@ http-body = {workspace = true}
 metrics = {workspace = true}
 parking_lot = {workspace = true}
 penumbra-app = {workspace = true}
-penumbra-asset = {workspace = true, default-features = true}
+penumbra-asset = {workspace = true}
 penumbra-custody = {workspace = true}
-penumbra-keys = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-transaction = {workspace = true, default-features = true}
+penumbra-keys = {workspace = true}
+penumbra-proto = {workspace = true, features = ["rpc"]}
+penumbra-tct = {workspace = true}
+penumbra-transaction = {workspace = true}
 penumbra-view = {workspace = true}
 prost = {workspace = true}
 rand = {workspace = true}
@@ -57,9 +57,9 @@ url = {workspace = true, features = ["serde"]}
 assert_cmd = {workspace = true}
 base64 = {workspace = true}
 ibc-proto = {workspace = true, default-features = false, features = ["server"]}
-ibc-types = {workspace = true, default-features = true}
+ibc-types = {workspace = true}
 penumbra-proof-params = {workspace = true, features = [
     "bundled-proving-keys",
     "download-proving-keys",
-], default-features = true}
+]}
 tempfile = {workspace = true}

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1"
 
 [dependencies]
 anyhow                           = { workspace = true }
-ark-ff                           = { workspace = true, default-features = true }
+ark-ff                           = { workspace = true }
 async-stream                     = { workspace = true }
 async-trait                      = { workspace = true }
 axum                             = "0.6"
@@ -43,9 +43,9 @@ blake2b_simd                     = { workspace = true }
 bytes                            = { workspace = true }
 chrono                           = { workspace = true, default-features = false, features = ["serde"] }
 clap                             = { workspace = true, features = ["derive", "env"] }
-cnidarium                        = { workspace = true, features = ["migration", "rpc"], default-features = true }
+cnidarium                        = { workspace = true, features = ["migration", "rpc"] }
 csv                              = "1.1"
-decaf377                         = { workspace = true, features = ["parallel"], default-features = true }
+decaf377                         = { workspace = true, features = ["parallel"] }
 decaf377-rdsa                    = { workspace = true }
 directories                      = { workspace = true }
 ed25519-consensus                = { workspace = true }
@@ -55,7 +55,7 @@ futures                          = { workspace = true }
 hex                              = { workspace = true }
 http                             = { workspace = true }
 ibc-proto                        = { workspace = true, default-features = false, features = ["server"] }
-ibc-types                        = { workspace = true, default-features = true }
+ibc-types                        = { workspace = true }
 ics23                            = { workspace = true }
 jmt                              = { workspace = true }
 metrics                          = { workspace = true }
@@ -67,25 +67,25 @@ mime_guess                       = "2"
 once_cell                        = { workspace = true }
 pbjson-types                     = { workspace = true }
 penumbra-app                     = { workspace = true }
-penumbra-asset                   = { workspace = true, default-features = true }
+penumbra-asset                   = { workspace = true }
 penumbra-auto-https              = { path = "../../util/auto-https" }
-penumbra-compact-block           = { workspace = true, default-features = true }
+penumbra-compact-block           = { workspace = true }
 penumbra-custody                 = { workspace = true }
-penumbra-auction                 = { workspace = true, features = ["parallel"], default-features = true }
-penumbra-dex                     = { workspace = true, features = ["parallel"], default-features = true }
-penumbra-fee                     = { workspace = true, default-features = true }
-penumbra-governance              = { workspace = true, features = ["parallel"], default-features = true }
-penumbra-ibc                     = { workspace = true, features = ["rpc"], default-features = true }
-penumbra-keys                    = { workspace = true, default-features = true }
-penumbra-num                     = { workspace = true, default-features = true }
-penumbra-proto                   = { workspace = true, default-features = true }
-penumbra-sct                     = { workspace = true, default-features = true }
-penumbra-shielded-pool           = { workspace = true, features = ["parallel"], default-features = true }
-penumbra-stake                   = { workspace = true, features = ["parallel"], default-features = true }
-penumbra-tct                     = { workspace = true, default-features = true }
+penumbra-auction                 = { workspace = true, features = ["parallel"] }
+penumbra-dex                     = { workspace = true, features = ["parallel"] }
+penumbra-fee                     = { workspace = true }
+penumbra-governance              = { workspace = true, features = ["parallel"] }
+penumbra-ibc                     = { workspace = true, features = ["rpc"] }
+penumbra-keys                    = { workspace = true }
+penumbra-num                     = { workspace = true }
+penumbra-proto                   = { workspace = true }
+penumbra-sct                     = { workspace = true }
+penumbra-shielded-pool           = { workspace = true, features = ["parallel"] }
+penumbra-stake                   = { workspace = true, features = ["parallel"] }
+penumbra-tct                     = { workspace = true }
 penumbra-tendermint-proxy        = { path = "../../util/tendermint-proxy" }
 penumbra-tower-trace             = { path = "../../util/tower-trace" }
-penumbra-transaction             = { workspace = true, default-features = true }
+penumbra-transaction             = { workspace = true }
 pin-project                      = { workspace = true }
 pin-project-lite                 = { workspace = true }
 prost                            = { workspace = true }
@@ -128,7 +128,7 @@ zip = "0.6"
 penumbra-proof-params = { workspace = true, features = [
     "bundled-proving-keys",
     "download-proving-keys",
-], default-features = true }
+] }
 assert_cmd = { workspace = true }
 predicates = "2.1"
 prost-reflect = "0.13.1"

--- a/crates/core/app/Cargo.toml
+++ b/crates/core/app/Cargo.toml
@@ -21,9 +21,9 @@ bech32                           = { workspace = true }
 bincode                          = { workspace = true }
 bitvec                           = { workspace = true }
 blake2b_simd                     = { workspace = true }
-cnidarium                        = { workspace = true, features = ["migration", "rpc"], default-features = true }
-cnidarium-component              = { workspace = true, default-features = true }
-decaf377                         = { workspace = true, default-features = true }
+cnidarium                        = { workspace = true, features = ["migration", "rpc"] }
+cnidarium-component              = { workspace = true }
+decaf377                         = { workspace = true }
 decaf377-rdsa                    = { workspace = true }
 futures                          = { workspace = true }
 hex                              = { workspace = true }
@@ -35,29 +35,29 @@ jmt                              = { workspace = true }
 metrics                          = { workspace = true }
 once_cell                        = { workspace = true }
 parking_lot                      = { workspace = true }
-penumbra-asset                   = { workspace = true, default-features = true }
-penumbra-auction                 = { workspace = true, default-features = true }
-penumbra-community-pool          = { workspace = true, default-features = true }
-penumbra-compact-block           = { workspace = true, default-features = true }
-penumbra-dex                     = { workspace = true, default-features = true }
-penumbra-distributions           = { workspace = true, default-features = true }
-penumbra-fee                     = { workspace = true, default-features = true }
-penumbra-funding                 = { workspace = true, default-features = true }
-penumbra-governance              = { workspace = true, default-features = true }
-penumbra-ibc                     = { workspace = true, features = ["component", "rpc"], default-features = true }
-penumbra-keys                    = { workspace = true, default-features = true }
-penumbra-num                     = { workspace = true, default-features = true }
-penumbra-proof-params            = { workspace = true, default-features = true }
-penumbra-proto                   = { workspace = true, features = ["cnidarium"], default-features = true }
-penumbra-sct                     = { workspace = true, default-features = true }
-penumbra-shielded-pool           = { workspace = true, features = ["component"], default-features = true }
-penumbra-stake                   = { workspace = true, default-features = true }
-penumbra-tct                     = { workspace = true, default-features = true }
+penumbra-asset                   = { workspace = true }
+penumbra-auction                 = { workspace = true }
+penumbra-community-pool          = { workspace = true }
+penumbra-compact-block           = { workspace = true }
+penumbra-dex                     = { workspace = true }
+penumbra-distributions           = { workspace = true }
+penumbra-fee                     = { workspace = true }
+penumbra-funding                 = { workspace = true }
+penumbra-governance              = { workspace = true }
+penumbra-ibc                     = { workspace = true, features = ["component", "rpc"] }
+penumbra-keys                    = { workspace = true }
+penumbra-num                     = { workspace = true }
+penumbra-proof-params            = { workspace = true }
+penumbra-proto                   = { workspace = true, features = ["cnidarium"] }
+penumbra-sct                     = { workspace = true }
+penumbra-shielded-pool           = { workspace = true, features = ["component"] }
+penumbra-stake                   = { workspace = true }
+penumbra-tct                     = { workspace = true }
 penumbra-tendermint-proxy        = { path = "../../util/tendermint-proxy" }
 penumbra-test-subscriber         = { workspace = true }
 penumbra-tower-trace             = {  path = "../../util/tower-trace"  }
-penumbra-transaction             = { workspace = true, features = ["parallel"], default-features = true }
-penumbra-txhash                  = { workspace = true, default-features = true }
+penumbra-transaction             = { workspace = true, features = ["parallel"] }
+penumbra-txhash                  = { workspace = true }
 prost                            = { workspace = true }
 rand_chacha                      = { workspace = true }
 regex                            = { workspace = true }
@@ -85,7 +85,7 @@ url                              = { workspace = true }
 [dev-dependencies]
 axum-server                      = { workspace = true }
 camino                           = { workspace = true }
-decaf377-fmd                     = { workspace = true, default-features = true }
+decaf377-fmd                     = { workspace = true }
 ed25519-consensus                = { workspace = true }
 penumbra-mock-client             = { workspace = true }
 penumbra-mock-consensus          = { workspace = true }

--- a/crates/core/asset/Cargo.toml
+++ b/crates/core/asset/Cargo.toml
@@ -25,7 +25,7 @@ base64 = {workspace = true}
 bech32 = {workspace = true}
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 decaf377-fmd = {workspace = true}
 decaf377-rdsa = {workspace = true}
 derivative = {workspace = true}
@@ -34,8 +34,8 @@ hex = {workspace = true}
 ibig = {workspace = true}
 num-bigint = {workspace = true}
 once_cell = {workspace = true}
-penumbra-num = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, default-features = true}
+penumbra-num = {workspace = true}
+penumbra-proto = {workspace = true}
 poseidon377 = {workspace = true, features = ["r1cs"]}
 rand = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}

--- a/crates/core/component/auction/Cargo.toml
+++ b/crates/core/component/auction/Cargo.toml
@@ -48,7 +48,7 @@ bitvec = {workspace = true}
 cnidarium = {workspace = true, default-features = false, optional = true}
 cnidarium-component = {workspace = true, default-features = false, optional = true}
 blake2b_simd = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 decaf377-rdsa = {workspace = true}
 futures = {workspace = true, optional = true}
 hex = {workspace = true}
@@ -58,12 +58,12 @@ once_cell = {workspace = true}
 penumbra-asset = {workspace = true, default-features = false}
 penumbra-keys = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}
-penumbra-proof-params = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true}
+penumbra-proto = {workspace = true}
 penumbra-sct = {workspace = true, default-features = false}
 penumbra-dex = {workspace = true, default-features = false}
 penumbra-shielded-pool = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true}
 penumbra-txhash = {workspace = true, default-features = false}
 rand_chacha = {workspace = true}
 rand_core = {workspace = true}
@@ -72,7 +72,7 @@ serde = {workspace = true, features = ["derive"]}
 serde_with = {workspace = true}
 sha2 = {workspace = true}
 tap = {workspace = true}
-tendermint = {workspace = true, default-features = true}
+tendermint = {workspace = true}
 tokio = {workspace = true, features = ["full", "tracing"], optional = true}
 tonic = {workspace = true, optional = true}
 tracing = {workspace = true}

--- a/crates/core/component/community-pool/Cargo.toml
+++ b/crates/core/component/community-pool/Cargo.toml
@@ -19,8 +19,8 @@ ark-ff = {workspace = true, default-features = false}
 async-trait = {workspace = true}
 base64 = {workspace = true}
 blake2b_simd = {workspace = true}
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
+cnidarium = {workspace = true, optional = true}
+cnidarium-component = {workspace = true, optional = true}
 futures = {workspace = true}
 hex = {workspace = true}
 metrics = {workspace = true}

--- a/crates/core/component/compact-block/Cargo.toml
+++ b/crates/core/component/compact-block/Cargo.toml
@@ -25,8 +25,8 @@ ark-ff = {workspace = true, default-features = false}
 async-trait = {workspace = true}
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
+cnidarium = {workspace = true, optional = true}
+cnidarium-component = {workspace = true, optional = true}
 decaf377-rdsa = {workspace = true}
 futures = {workspace = true}
 im = {workspace = true}
@@ -40,7 +40,7 @@ penumbra-proto = {workspace = true, default-features = false}
 penumbra-sct = {workspace = true, default-features = false}
 penumbra-shielded-pool = {workspace = true, default-features = false}
 penumbra-stake = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true}
 rand = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}
 serde = {workspace = true, features = ["derive"]}

--- a/crates/core/component/dex/Cargo.toml
+++ b/crates/core/component/dex/Cargo.toml
@@ -40,9 +40,9 @@ async-trait = {workspace = true}
 base64 = {workspace = true}
 bincode = {workspace = true}
 blake2b_simd = {workspace = true}
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+cnidarium = {workspace = true, optional = true}
+cnidarium-component = {workspace = true, optional = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 decaf377-fmd = {workspace = true}
 decaf377-ka = {workspace = true}
 decaf377-rdsa = {workspace = true}
@@ -58,7 +58,7 @@ penumbra-asset = {workspace = true, default-features = false}
 penumbra-fee = {workspace = true, default-features = false}
 penumbra-keys = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}
-penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true}
 penumbra-proto = {workspace = true, default-features = false}
 penumbra-sct = {workspace = true, default-features = false}
 penumbra-shielded-pool = {workspace = true, default-features = false}

--- a/crates/core/component/distributions/Cargo.toml
+++ b/crates/core/component/distributions/Cargo.toml
@@ -16,8 +16,8 @@ docsrs = []
 [dependencies]
 anyhow = {workspace = true}
 async-trait = {workspace = true}
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
+cnidarium = {workspace = true, optional = true}
+cnidarium-component = {workspace = true, optional = true}
 penumbra-asset = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}
 penumbra-proto = {workspace = true, default-features = false}

--- a/crates/core/component/fee/Cargo.toml
+++ b/crates/core/component/fee/Cargo.toml
@@ -21,9 +21,9 @@ ark-ff = {workspace = true, default-features = false}
 async-trait = {workspace = true}
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
-decaf377 = {workspace = true, default-features = true}
+cnidarium = {workspace = true, optional = true}
+cnidarium-component = {workspace = true, optional = true}
+decaf377 = {workspace = true}
 decaf377-rdsa = {workspace = true}
 im = {workspace = true}
 metrics = {workspace = true}

--- a/crates/core/component/funding/Cargo.toml
+++ b/crates/core/component/funding/Cargo.toml
@@ -22,11 +22,11 @@ docsrs = []
 [dependencies]
 anyhow = {workspace = true}
 async-trait = {workspace = true}
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
+cnidarium = {workspace = true, optional = true}
+cnidarium-component = {workspace = true, optional = true}
 futures = {workspace = true, optional = true}
 metrics = {workspace = true, optional = true}
-penumbra-asset = {workspace = true, default-features = true}
+penumbra-asset = {workspace = true}
 penumbra-community-pool = {workspace = true, default-features = false}
 penumbra-distributions = {workspace = true, default-features = false}
 penumbra-proto = {workspace = true, default-features = false}

--- a/crates/core/component/governance/Cargo.toml
+++ b/crates/core/component/governance/Cargo.toml
@@ -39,9 +39,9 @@ async-trait = {workspace = true}
 base64 = {workspace = true}
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+cnidarium = {workspace = true, optional = true}
+cnidarium-component = {workspace = true, optional = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 decaf377-rdsa = {workspace = true}
 futures = {workspace = true}
 ibc-types = {workspace = true, default-features = false}
@@ -59,7 +59,7 @@ penumbra-proto = {workspace = true, default-features = false}
 penumbra-sct = {workspace = true, default-features = false}
 penumbra-shielded-pool = {workspace = true, default-features = false}
 penumbra-stake = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true}
 penumbra-txhash = {workspace = true, default-features = false}
 rand = {workspace = true}
 rand_chacha = {workspace = true}

--- a/crates/core/component/ibc/Cargo.toml
+++ b/crates/core/component/ibc/Cargo.toml
@@ -20,7 +20,7 @@ ark-ff = {workspace = true, default-features = false}
 async-trait = {workspace = true}
 base64 = {workspace = true}
 blake2b_simd = {workspace = true}
-cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium = {workspace = true, optional = true}
 futures = {workspace = true}
 hex = {workspace = true}
 ibc-proto = {workspace = true, default-features = false}

--- a/crates/core/component/sct/Cargo.toml
+++ b/crates/core/component/sct/Cargo.toml
@@ -25,9 +25,9 @@ async-trait = {workspace = true}
 bincode = {workspace = true}
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+cnidarium = {workspace = true, optional = true}
+cnidarium-component = {workspace = true, optional = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 decaf377-rdsa = {workspace = true}
 hex = {workspace = true}
 im = {workspace = true}
@@ -36,7 +36,7 @@ once_cell = {workspace = true}
 pbjson-types = {workspace = true}
 penumbra-keys = {workspace = true, default-features = false}
 penumbra-proto = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true}
 poseidon377 = {workspace = true, features = ["r1cs"]}
 rand = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}

--- a/crates/core/component/shielded-pool/Cargo.toml
+++ b/crates/core/component/shielded-pool/Cargo.toml
@@ -42,9 +42,9 @@ base64 = {workspace = true}
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
 chacha20poly1305 = {workspace = true}
-cnidarium = {workspace = true, optional = true, default-features = true}
-cnidarium-component = {workspace = true, optional = true, default-features = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+cnidarium = {workspace = true, optional = true}
+cnidarium-component = {workspace = true, optional = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 decaf377-fmd = {workspace = true}
 decaf377-ka = {workspace = true}
 decaf377-rdsa = {workspace = true}
@@ -62,7 +62,7 @@ penumbra-num = {workspace = true, default-features = false}
 penumbra-proof-params = {workspace = true, default-features = false}
 penumbra-proto = {workspace = true, default-features = false}
 penumbra-sct = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true}
 penumbra-txhash = {workspace = true, default-features = false}
 poseidon377 = {workspace = true, features = ["r1cs"]}
 prost = {workspace = true}

--- a/crates/core/component/stake/Cargo.toml
+++ b/crates/core/component/stake/Cargo.toml
@@ -47,7 +47,7 @@ bech32 = {workspace = true}
 bitvec = {workspace = true}
 cnidarium = {workspace = true, default-features = false, optional = true}
 cnidarium-component = {workspace = true, default-features = false, optional = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 decaf377-rdsa = {workspace = true}
 futures = {workspace = true, optional = true}
 hex = {workspace = true}
@@ -58,11 +58,11 @@ penumbra-asset = {workspace = true, default-features = false}
 penumbra-distributions = {workspace = true, default-features = false}
 penumbra-keys = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}
-penumbra-proof-params = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true}
+penumbra-proto = {workspace = true}
 penumbra-sct = {workspace = true, default-features = false}
 penumbra-shielded-pool = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true}
 penumbra-txhash = {workspace = true, default-features = false}
 rand_chacha = {workspace = true}
 rand_core = {workspace = true}
@@ -72,7 +72,7 @@ serde_unit_struct = {workspace = true}
 serde_with = {workspace = true}
 sha2 = {workspace = true}
 tap = {workspace = true}
-tendermint = {workspace = true, default-features = true}
+tendermint = {workspace = true}
 tokio = {workspace = true, features = ["full", "tracing"], optional = true}
 tonic = {workspace = true, optional = true}
 tracing = {workspace = true}

--- a/crates/core/keys/Cargo.toml
+++ b/crates/core/keys/Cargo.toml
@@ -21,7 +21,7 @@ bip32 = "0.5"
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
 chacha20poly1305 = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 decaf377-fmd = {workspace = true}
 decaf377-ka = {workspace = true}
 decaf377-rdsa = {workspace = true}
@@ -34,9 +34,9 @@ ibig = {workspace = true}
 num-bigint = {workspace = true}
 once_cell = {workspace = true}
 pbkdf2 = "0.12.0"
-penumbra-asset = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, default-features = true}
-penumbra-tct = {workspace = true, features = ["r1cs"], default-features = true}
+penumbra-asset = {workspace = true}
+penumbra-proto = {workspace = true}
+penumbra-tct = {workspace = true, features = ["r1cs"]}
 poseidon377 = {workspace = true, features = ["r1cs"]}
 rand = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}

--- a/crates/core/num/Cargo.toml
+++ b/crates/core/num/Cargo.toml
@@ -20,7 +20,7 @@ base64 = {workspace = true}
 bech32 = {workspace = true}
 blake2b_simd = {workspace = true}
 bytes = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 decaf377-fmd = {workspace = true}
 decaf377-rdsa = {workspace = true}
 derivative = {workspace = true}
@@ -29,7 +29,7 @@ hex = {workspace = true}
 ibig = {workspace = true}
 num-bigint = {workspace = true}
 once_cell = {workspace = true}
-penumbra-proto = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true}
 rand = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}
 regex = {workspace = true}

--- a/crates/core/transaction/Cargo.toml
+++ b/crates/core/transaction/Cargo.toml
@@ -45,12 +45,12 @@ penumbra-governance = {workspace = true, default-features = false}
 penumbra-ibc = {workspace = true, default-features = false}
 penumbra-keys = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}
-penumbra-proof-params = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, default-features = true}
+penumbra-proof-params = {workspace = true}
+penumbra-proto = {workspace = true}
 penumbra-sct = {workspace = true, default-features = false}
 penumbra-shielded-pool = {workspace = true, default-features = false}
 penumbra-stake = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true}
 penumbra-txhash = {workspace = true, default-features = false}
 poseidon377 = {workspace = true, features = ["r1cs"]}
 rand = {workspace = true}

--- a/crates/core/txhash/Cargo.toml
+++ b/crates/core/txhash/Cargo.toml
@@ -8,5 +8,5 @@ anyhow = {workspace = true}
 blake2b_simd = {workspace = true}
 hex = {workspace = true}
 penumbra-proto = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true}
 serde = {workspace = true}

--- a/crates/crypto/decaf377-frost/Cargo.toml
+++ b/crates/crypto/decaf377-frost/Cargo.toml
@@ -12,4 +12,4 @@ decaf377-rdsa = {workspace = true}
 frost-core = "0.7"
 frost-rerandomized = "0.7"
 rand_core = {workspace = true, features = ["getrandom"]}
-penumbra-proto = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true}

--- a/crates/crypto/proof-params/Cargo.toml
+++ b/crates/crypto/proof-params/Cargo.toml
@@ -43,7 +43,7 @@ ark-serialize = {workspace = true}
 ark-snark = {workspace = true}
 ark-std = {workspace = true, default-features = false}
 bech32 = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 lazy_static = "1.4.0"
 num-bigint = {workspace = true}
 once_cell = {workspace = true}

--- a/crates/crypto/proof-setup/Cargo.toml
+++ b/crates/crypto/proof-setup/Cargo.toml
@@ -29,12 +29,12 @@ ark-relations = {workspace = true}
 ark-serialize = {workspace = true}
 blake2b_simd = {workspace = true}
 decaf377 = {workspace = true, default-features = false}
-penumbra-dex = {workspace = true, default-features = true}
-penumbra-governance = {workspace = true, default-features = true}
-penumbra-proof-params = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, default-features = true}
-penumbra-shielded-pool = {workspace = true, default-features = true}
-penumbra-stake = {workspace = true, features = ["component"], default-features = true}
+penumbra-dex = {workspace = true}
+penumbra-governance = {workspace = true}
+penumbra-proof-params = {workspace = true}
+penumbra-proto = {workspace = true}
+penumbra-shielded-pool = {workspace = true}
+penumbra-stake = {workspace = true, features = ["component"]}
 rand_core = {workspace = true, features = ["getrandom"]}
 rayon = { version = "1.8.0", optional = true }
 
@@ -42,6 +42,6 @@ rayon = { version = "1.8.0", optional = true }
 ark-r1cs-std = {workspace = true}
 ark-snark = {workspace = true}
 criterion = {workspace = true, features = ["html_reports"]}
-penumbra-dex = {workspace = true, default-features = true}
-penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-dex = {workspace = true}
+penumbra-proof-params = {workspace = true}
 rand_chacha = {workspace = true}

--- a/crates/crypto/tct/Cargo.toml
+++ b/crates/crypto/tct/Cargo.toml
@@ -17,7 +17,7 @@ ark-relations = {workspace = true, optional = true}
 ark-serialize = {workspace = true}
 async-trait = {workspace = true}
 blake2b_simd = {workspace = true}
-decaf377 = {workspace = true, default-features = true}
+decaf377 = {workspace = true}
 derivative = {workspace = true}
 futures = {workspace = true}
 hash_hasher = "2"
@@ -25,7 +25,7 @@ hex = {workspace = true}
 im = {workspace = true, features = ["serde"]}
 once_cell = {workspace = true}
 parking_lot = {workspace = true}
-penumbra-proto = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true}
 poseidon377 = {workspace = true, features = ["r1cs"]}
 proptest = {workspace = true, optional = true}
 proptest-derive = {workspace = true, optional = true}

--- a/crates/custody/Cargo.toml
+++ b/crates/custody/Cargo.toml
@@ -20,11 +20,11 @@ ed25519-consensus = {workspace = true}
 futures = {workspace = true}
 hex = {workspace = true}
 penumbra-governance = {workspace = true, default-features = false}
-penumbra-keys = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+penumbra-keys = {workspace = true}
+penumbra-proto = {workspace = true, features = ["rpc"]}
 penumbra-stake = {workspace = true, default-features = false}
-penumbra-transaction = {workspace = true, default-features = true}
-penumbra-txhash = {workspace = true, default-features = true}
+penumbra-transaction = {workspace = true}
+penumbra-txhash = {workspace = true}
 prost = {workspace = true}
 rand_core = {workspace = true}
 serde = {workspace = true, features = ["derive"]}

--- a/crates/misc/measure/Cargo.toml
+++ b/crates/misc/measure/Cargo.toml
@@ -16,7 +16,7 @@ bytesize = "1.2"
 clap = {workspace = true, features = ["derive", "env"]}
 indicatif = {workspace = true}
 penumbra-compact-block = {workspace = true, default-features = false}
-penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+penumbra-proto = {workspace = true, features = ["rpc"]}
 serde_json = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
 tonic = {workspace = true, features = ["tls"]}

--- a/crates/misc/tct-visualize/Cargo.toml
+++ b/crates/misc/tct-visualize/Cargo.toml
@@ -14,7 +14,7 @@ name = "tct-live-edit"
 
 
 [dependencies]
-penumbra-tct = {workspace = true, features = ["arbitrary"], default-features = true}
+penumbra-tct = {workspace = true, features = ["arbitrary"]}
 decaf377 = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
 tokio-util = {workspace = true, features = ["full"]}

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -24,13 +24,13 @@ async-trait = {workspace = true}
 bech32 = {workspace = true}
 bytes = {workspace = true, features = ["serde"]}
 chrono = {workspace = true, optional = true, default-features = false, features = ["serde"]}
-cnidarium = {workspace = true, optional = true, default-features = true}
+cnidarium = {workspace = true, optional = true}
 decaf377-fmd = {workspace = true}
 decaf377-rdsa = {workspace = true}
 futures = {workspace = true}
 hex = {workspace = true}
 http-body = {workspace = true, optional = true}
-ibc-types = {workspace = true, features = ["std"], default-features = true}
+ibc-types = {workspace = true, features = ["std"]}
 ics23 = {workspace = true}
 pbjson = {workspace = true}
 pbjson-types = {workspace = true}

--- a/crates/test/mock-client/Cargo.toml
+++ b/crates/test/mock-client/Cargo.toml
@@ -9,16 +9,16 @@ license.workspace = true
 
 [dependencies]
 anyhow = {workspace = true}
-cnidarium = {workspace = true, default-features = true}
+cnidarium = {workspace = true}
 penumbra-asset = {workspace = true}
-penumbra-compact-block = {workspace = true, default-features = true}
-penumbra-dex = {workspace = true, default-features = true}
-penumbra-keys = {workspace = true, default-features = true}
-penumbra-sct = {workspace = true, default-features = true}
+penumbra-compact-block = {workspace = true}
+penumbra-dex = {workspace = true}
+penumbra-keys = {workspace = true}
+penumbra-sct = {workspace = true}
 penumbra-shielded-pool = {workspace = true, features = [
     "component",
-], default-features = true}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-transaction = {workspace = true, default-features = true}
+]}
+penumbra-tct = {workspace = true}
+penumbra-transaction = {workspace = true}
 rand_core = {workspace = true}
 

--- a/crates/test/mock-consensus/Cargo.toml
+++ b/crates/test/mock-consensus/Cargo.toml
@@ -18,6 +18,6 @@ ed25519-consensus = { workspace = true }
 rand_core = { workspace = true }
 sha2 = { workspace = true }
 tap = { workspace = true }
-tendermint = { workspace = true, default-features = true }
+tendermint = { workspace = true }
 tower = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/crates/test/tct-property-test/Cargo.toml
+++ b/crates/test/tct-property-test/Cargo.toml
@@ -6,7 +6,7 @@ edition = {workspace = true}
 [dev-dependencies]
 anyhow = {workspace = true}
 futures = {workspace = true}
-penumbra-tct = {workspace = true, features = ["arbitrary"], default-features = true}
+penumbra-tct = {workspace = true, features = ["arbitrary"]}
 proptest = {workspace = true}
 proptest-derive = {workspace = true}
 tokio = {workspace = true, features = ["full"]}

--- a/crates/view/Cargo.toml
+++ b/crates/view/Cargo.toml
@@ -23,7 +23,7 @@ async-stream = {workspace = true}
 async-trait = {workspace = true}
 bytes = {workspace = true, features = ["serde"]}
 camino = {workspace = true}
-decaf377 = {workspace = true, features = ["r1cs"], default-features = true}
+decaf377 = {workspace = true, features = ["r1cs"]}
 digest = "0.9"
 ed25519-consensus = {workspace = true}
 futures = {workspace = true}
@@ -34,7 +34,7 @@ metrics = {workspace = true}
 once_cell = {workspace = true}
 parking_lot = {workspace = true}
 penumbra-app = {workspace = true}
-penumbra-asset = {workspace = true, default-features = true}
+penumbra-asset = {workspace = true}
 penumbra-community-pool = {workspace = true, default-features = false}
 penumbra-compact-block = {workspace = true, default-features = false}
 penumbra-dex = {workspace = true, default-features = false}
@@ -43,15 +43,15 @@ penumbra-fee = {workspace = true, default-features = false}
 penumbra-funding = {workspace = true, default-features = false}
 penumbra-governance = {workspace = true, default-features = false}
 penumbra-ibc = {workspace = true, default-features = false}
-penumbra-keys = {workspace = true, default-features = true}
-penumbra-num = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, features = ["rpc"], default-features = true}
+penumbra-keys = {workspace = true}
+penumbra-num = {workspace = true}
+penumbra-proto = {workspace = true, features = ["rpc"]}
 penumbra-sct = {workspace = true, default-features = false}
 penumbra-shielded-pool = {workspace = true, default-features = false}
 penumbra-stake = {workspace = true, default-features = false}
-penumbra-tct = {workspace = true, default-features = true}
-penumbra-transaction = {workspace = true, default-features = true}
-penumbra-auction = {workspace = true, default-features = true}
+penumbra-tct = {workspace = true}
+penumbra-transaction = {workspace = true}
+penumbra-auction = {workspace = true}
 prost = {workspace = true}
 r2d2 = {workspace = true}
 r2d2_sqlite = {workspace = true, features = ["bundled"]}

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -18,21 +18,21 @@ anyhow = {workspace = true}
 ark-std = {workspace = true, default-features = false}
 bincode = {workspace = true}
 bytes = {workspace = true}
-decaf377 = {workspace = true, default-features = true}
+decaf377 = {workspace = true}
 hex = {workspace = true}
 penumbra-app = {workspace = true}
-penumbra-asset = {workspace = true, default-features = true}
+penumbra-asset = {workspace = true}
 penumbra-custody = {workspace = true}
-penumbra-dex = {workspace = true, default-features = true}
-penumbra-fee = {workspace = true, default-features = true}
-penumbra-governance = {workspace = true, default-features = true}
-penumbra-keys = {workspace = true, default-features = true}
-penumbra-num = {workspace = true, default-features = true}
-penumbra-proto = {workspace = true, default-features = true}
-penumbra-stake = {workspace = true, default-features = true}
-penumbra-tct = {workspace = true, default-features = true}
+penumbra-dex = {workspace = true}
+penumbra-fee = {workspace = true}
+penumbra-governance = {workspace = true}
+penumbra-keys = {workspace = true}
+penumbra-num = {workspace = true}
+penumbra-proto = {workspace = true}
+penumbra-stake = {workspace = true}
+penumbra-tct = {workspace = true}
 penumbra-sct = {workspace = true, default-features = false}
-penumbra-transaction = {workspace = true, default-features = true}
+penumbra-transaction = {workspace = true}
 penumbra-view = {workspace = true}
 pin-project = {workspace = true}
 rand = {workspace = true}

--- a/tools/summonerd/Cargo.toml
+++ b/tools/summonerd/Cargo.toml
@@ -26,12 +26,12 @@ futures = {workspace = true}
 hex = {workspace = true}
 http-body = {workspace = true}
 metrics-tracing-context = {workspace = true}
-penumbra-asset = {workspace = true, default-features = true}
-penumbra-keys = {workspace = true, default-features = true}
-penumbra-num = {workspace = true, default-features = true}
-penumbra-proof-params = {workspace = true, default-features = true}
+penumbra-asset = {workspace = true}
+penumbra-keys = {workspace = true}
+penumbra-num = {workspace = true}
+penumbra-proof-params = {workspace = true}
 penumbra-proof-setup = {workspace = true, features = ["parallel"]}
-penumbra-proto = {workspace = true, default-features = true}
+penumbra-proto = {workspace = true}
 penumbra-view = {workspace = true}
 r2d2 = {workspace = true}
 r2d2_sqlite = {workspace = true, features = ["bundled"]}


### PR DESCRIPTION
in #3748, we migrated to using cargo's workspace dependencies feature. this has been excellent, workspace dependencies rock. 🎸

one wrinkle in the [script] used to migrate all of our constituent crates' manifests over was that it provided an explicit `default-features` attribute, even when `True`.

default features are, by their nature, enabled by default. a dependency need only provide this attribute when _disabling_ default features, in order to e.g. explicitly provide a list of `#[cfg(..)]` features to conditionally compile into a library/binary.

via the magic of vim macros and the quickfix list, this commit mechanically removes any occurrences of `default-features = true` in our dependency tree.

[script]: https://github.com/penumbra-zone/penumbra/pull/3748#issuecomment-1930641300

## checklist before requesting a review

- [x] if this code contains consensus-breaking changes, i have added the "consensus-breaking" label. otherwise, i declare my belief that there are not consensus-breaking changes, for the following reason:

  > this is a noöp cosmetic change to the package manifests
