### PR TITLE
Use raw amount for staking issuance parameter

### DIFF
--- a/crates/core/component/distributions/src/component.rs
+++ b/crates/core/component/distributions/src/component.rs
@@ -9,7 +9,6 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use cnidarium::StateWrite;
 use cnidarium_component::Component;
-use penumbra_asset::STAKING_TOKEN_DENOM;
 use penumbra_num::Amount;
 use tendermint::v0_37::abci;
 use tracing::instrument;

--- a/crates/core/component/distributions/src/component.rs
+++ b/crates/core/component/distributions/src/component.rs
@@ -84,20 +84,8 @@ trait DistributionManager: StateWriteExt {
             .checked_mul(num_blocks as u128) /* Safe to cast a `u64` to `u128` */
             .expect("infaillible unless issuance is pathological");
 
-        tracing::debug!(
-            ?new_issuance_for_epoch,
-            "computed new issuance for epoch (pre-scaled)"
-        );
+        tracing::debug!(?new_issuance_for_epoch, "computed new issuance for epoch");
 
-        let new_issuance_for_epoch = STAKING_TOKEN_DENOM
-            .default_unit()
-            .value(new_issuance_for_epoch.into())
-            .amount;
-
-        tracing::debug!(
-            ?new_issuance_for_epoch,
-            "computed new issuance for epoch (scaled)"
-        );
         Ok(Amount::from(new_issuance_for_epoch))
     }
 

--- a/crates/core/component/distributions/src/params.rs
+++ b/crates/core/component/distributions/src/params.rs
@@ -36,7 +36,7 @@ impl From<DistributionsParameters> for pb::DistributionsParameters {
 impl Default for DistributionsParameters {
     fn default() -> Self {
         Self {
-            staking_issuance_per_block: 1,
+            staking_issuance_per_block: 1_000_000,
         }
     }
 }


### PR DESCRIPTION
We were scaling this before using the default metadata, which is more brittle, and less precise.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This will change how the parameter is interpreted.
