### PR TITLE
pd(generate): use constants from `penumbra_app`

### DIFF
--- a/crates/bin/pd/src/network/generate.rs
+++ b/crates/bin/pd/src/network/generate.rs
@@ -3,7 +3,10 @@
 //! for Penumbra.
 use crate::network::config::{get_network_dir, NetworkTendermintConfig, ValidatorKeys};
 use anyhow::{Context, Result};
-use penumbra_app::params::AppParameters;
+use penumbra_app::{
+    app::{MAX_BLOCK_TXS_PAYLOAD_BYTES, MAX_EVIDENCE_SIZE_BYTES},
+    params::AppParameters,
+};
 use penumbra_asset::{asset, STAKING_TOKEN_ASSET_ID};
 use penumbra_fee::genesis::Content as FeeContent;
 use penumbra_governance::genesis::Content as GovernanceContent;
@@ -288,7 +291,7 @@ impl NetworkConfig {
                 abci: AbciParams::default(),
                 block: tendermint::block::Size {
                     // 1MB
-                    max_bytes: 1048576,
+                    max_bytes: MAX_BLOCK_TXS_PAYLOAD_BYTES as u64,
                     // Set to infinity since a chain running Penumbra won't use
                     // cometbft's notion of gas.
                     max_gas: -1,
@@ -302,7 +305,7 @@ impl NetworkConfig {
                     // Similarly, we set the max age duration for evidence to be a little over a week.
                     max_age_duration: tendermint::evidence::Duration(Duration::from_secs(650000)),
                     // 30KB
-                    max_bytes: 30000,
+                    max_bytes: MAX_EVIDENCE_SIZE_BYTES as i64,
                 },
                 validator: tendermint::consensus::params::ValidatorParams {
                     pub_key_types: vec![Algorithm::Ed25519],

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -52,13 +52,13 @@ pub mod state_key;
 type InterBlockState = Arc<StateDelta<Snapshot>>;
 
 /// The maximum size of a CometBFT block payload (1MB)
-const MAX_BLOCK_TXS_PAYLOAD_BYTES: usize = 1024 * 1024;
+pub const MAX_BLOCK_TXS_PAYLOAD_BYTES: usize = 1024 * 1024;
 
 /// The maximum size of a single individual transaction (96KB).
-const MAX_TRANSACTION_SIZE_BYTES: usize = 96 * 1024;
+pub const MAX_TRANSACTION_SIZE_BYTES: usize = 96 * 1024;
 
 /// The maximum size of the evidence portion of a block (30KB).
-const MAX_EVIDENCE_SIZE_BYTES: usize = 30 * 1024;
+pub const MAX_EVIDENCE_SIZE_BYTES: usize = 30 * 1024;
 
 /// The Penumbra application, written as a bundle of [`Component`]s.
 ///


### PR DESCRIPTION
## Describe your changes

`pd network generate` and the application use consensus parameters defined in two different places which is confusing and error-prone.

This PR makes `pd network generate` import constants from the app.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

> This only affects new runs of `pd network generate`.
