### PR TITLE
app(rpc): expose simtrade service by default

### DIFF
--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -86,10 +86,7 @@ pub enum RootCommand {
             alias = "tendermint-addr",
         )]
         cometbft_addr: Url,
-        /// Enable expensive RPCs, such as the trade simulation service.
-        /// The trade simulation service allows clients to simulate trades without submitting them.
-        /// This is useful for approximating the cost of a trade before submitting it.
-        /// But, it is a potential DoS vector, so it is disabled by default.
+        /// Enable expensive RPCs, currently a no-op.
         #[clap(short, long, display_order = 500)]
         enable_expensive_rpc: bool,
     },


### PR DESCRIPTION
## Describe your changes

This PR makes pd's `--enable-expensive-rpc` flag a no-op and expose the application's trade simulation service by default.

## Issue ticket number and link

Close #4696 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Configuration change
