### PR TITLE
penumbra: prepare release `0.79-alpha.6`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "cnidarium"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "cometindex"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-frost"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "ark-ff",
  "decaf377 0.5.0",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "pcli"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "pclientd"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "pd"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4577,7 +4577,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-app"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-auction"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4759,7 +4759,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-auto-https"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "axum-server",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-bench"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-custody"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "argon2",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-eddy"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-funding"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5117,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "aes",
  "anyhow",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-measure"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-mock-client"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "cnidarium",
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-mock-consensus"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5250,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-mock-tendermint-proxy"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "penumbra-mock-consensus",
  "penumbra-proto",
@@ -5262,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-setup"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5478,7 +5478,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5530,7 +5530,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct-property-test"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "futures",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct-visualize"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tendermint-proxy"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5635,7 +5635,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-test-subscriber"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tower-trace"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "futures",
  "hex",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
@@ -5729,7 +5729,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-view"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -5787,7 +5787,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-wallet"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -5873,7 +5873,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pindexer"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "cometindex",
@@ -7727,7 +7727,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "summonerd"
-version = "0.79.0-alpha.5"
+version = "0.79.0-alpha.6"
 dependencies = [
  "anyhow",
  "ark-groth16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ push = false
 [workspace.package]
 authors    = ["Penumbra Labs <team@penumbra.zone>"]
 edition    = "2021"
-version    = "0.79.0-alpha.5"
+version    = "0.79.0-alpha.6"
 repository = "https://github.com/penumbra-zone/penumbra"
 homepage   = "https://penumbra.zone"
 license    = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Describe your changes

This prepare release `0.79-alpha.6` including the simtrade rpc changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Releng