### PR TITLE
fix typo in cometbft default path

### DIFF
--- a/deployments/systemd/cometbft.service
+++ b/deployments/systemd/cometbft.service
@@ -2,7 +2,7 @@
 Description=CometBFT for Penumbra
 
 [Service]
-ExecStart=/usr/local/bin/cometbft start --home /home/penumbra/.penumbra/network/node0/cometbft
+ExecStart=/usr/local/bin/cometbft start --home /home/penumbra/.penumbra/network_data/node0/cometbft
 Restart=no
 User=penumbra
 # Raise filehandle limit for RPC and P2P connections.


### PR DESCRIPTION
## Describe your changes
According to [document](https://guide.penumbra.zone/node/pd/join-network.html#running-pd-and-cometbft), cometbft path will be `~/.penumbra/network_data`, not `~/.penumbra/network`
