### PR TITLE
cleanup `LegacySwap` swap decryption path

### DIFF
--- a/crates/core/component/dex/src/swap/ciphertext.rs
+++ b/crates/core/component/dex/src/swap/ciphertext.rs
@@ -15,17 +15,13 @@ impl SwapCiphertext {
         commitment: note::StateCommitment,
     ) -> Result<SwapPlaintext> {
         let payload_key = PayloadKey::derive_swap(ovk, commitment);
-        self.decrypt_with_payload_key(&payload_key, commitment)
+        self.decrypt_with_payload_key(&payload_key)
     }
 
-    pub fn decrypt_with_payload_key(
-        &self,
-        payload_key: &PayloadKey,
-        commitment: note::StateCommitment,
-    ) -> Result<SwapPlaintext> {
+    pub fn decrypt_with_payload_key(&self, payload_key: &PayloadKey) -> Result<SwapPlaintext> {
         let swap_ciphertext = self.0;
         let decryption_result = payload_key
-            .decrypt_swap(swap_ciphertext.to_vec(), commitment)
+            .decrypt_swap(swap_ciphertext.to_vec())
             .map_err(|_| anyhow::anyhow!("unable to decrypt swap ciphertext"))?;
 
         // TODO: encapsulate plaintext encoding by making this a

--- a/crates/core/transaction/src/is_action.rs
+++ b/crates/core/transaction/src/is_action.rs
@@ -324,12 +324,8 @@ impl IsAction for Swap {
 
         let plaintext = txp.payload_keys.get(&commitment).and_then(|payload_key| {
             // Decrypt swap ciphertext
-            SwapCiphertext::decrypt_with_payload_key(
-                &self.body.payload.encrypted_swap,
-                payload_key,
-                commitment,
-            )
-            .ok()
+            SwapCiphertext::decrypt_with_payload_key(&self.body.payload.encrypted_swap, payload_key)
+                .ok()
         });
 
         ActionView::Swap(match plaintext {


### PR DESCRIPTION
## Describe your changes

This removes the `LegacySwap` symmetric encryption that is no longer used in Penumbra

## Issue ticket number and link

Closes #4501

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Swaps were not encrypted using this `LegacySwap` method on mainnet