### PR TITLE
fix: update FMD parameters when needed in compact block

### DIFF
--- a/crates/core/component/compact-block/src/component/manager.rs
+++ b/crates/core/component/compact-block/src/component/manager.rs
@@ -75,7 +75,10 @@ trait Inner: StateWrite {
             .get_current_fmd_parameters()
             .await
             .context("could not get FMD parameters")?;
-        let fmd_parameters = if previous_fmd_params != current_fmd_params || height == 0 {
+        let fmd_parameters = if (previous_fmd_params != current_fmd_params
+            && current_fmd_params.as_of_block_height == height)
+            || height == 0
+        {
             Some(current_fmd_params)
         } else {
             None

--- a/crates/core/component/compact-block/src/component/manager.rs
+++ b/crates/core/component/compact-block/src/component/manager.rs
@@ -67,12 +67,16 @@ trait Inner: StateWrite {
             (None, Vec::new())
         };
 
-        let fmd_parameters = if height == 0 {
-            Some(
-                self.get_current_fmd_parameters()
-                    .await
-                    .context("could not get FMD parameters")?,
-            )
+        let previous_fmd_params = self
+            .get_previous_fmd_parameters()
+            .await
+            .context("could not get FMD parameters")?;
+        let current_fmd_params = self
+            .get_current_fmd_parameters()
+            .await
+            .context("could not get FMD parameters")?;
+        let fmd_parameters = if previous_fmd_params != current_fmd_params {
+            Some(current_fmd_params)
         } else {
             None
         };

--- a/crates/core/component/compact-block/src/component/manager.rs
+++ b/crates/core/component/compact-block/src/component/manager.rs
@@ -75,7 +75,7 @@ trait Inner: StateWrite {
             .get_current_fmd_parameters()
             .await
             .context("could not get FMD parameters")?;
-        let fmd_parameters = if previous_fmd_params != current_fmd_params {
+        let fmd_parameters = if previous_fmd_params != current_fmd_params || height == 0 {
             Some(current_fmd_params)
         } else {
             None


### PR DESCRIPTION
## Describe your changes

This fixes the compact block generation such that updated FMD parameters are provided. This is required to use an algorithm in the future that dynamically updates the FMD parameters (see #1087)

## Issue ticket number and link

Closes #4714

## Checklist before requesting a review

- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > REPLACE THIS TEXT WITH RATIONALE (CAN BE BRIEF)
