### PR TITLE
gov: use saturating_sub as a defence-in-depth

### DIFF
--- a/crates/core/component/governance/src/component/view.rs
+++ b/crates/core/component/governance/src/component/view.rs
@@ -532,7 +532,7 @@ pub trait StateReadExt: StateRead + penumbra_stake::StateReadExt {
                 // proposal start, minus the total voting power used by delegators to that validator
                 // who have voted. Their votes will be added back in below, re-assigning their
                 // voting power to their chosen votes.
-                let effective_power = power - delegator_tally.total();
+                let effective_power = power.saturating_sub(delegator_tally.total());
                 tally += (vote, effective_power).into();
             }
             // Add the delegator votes in, regardless of if the validator has voted.


### PR DESCRIPTION
## Describe your changes

Uses saturating_sub as a defense in depth mechanism

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > defense in depth in a codepath that has not been executed