### PR TITLE
Update ics23 to 0.11.3, ibc-proto to 0.42.2, ibc-types to 0.14.1. Release v0.79.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,7 +816,7 @@ dependencies = [
  "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2 1.0.78",
@@ -2897,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.41.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4ee32b22d3b06f31529b956f4928e5c9a068d71e46cf6abfa19c31ca550553"
+checksum = "c1a6f2bbf7e1d12f98d8d54d9114231b865418d0f8b619c0873180eafdee07fd"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -2915,9 +2915,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba606d86e2015991f86a129935dbaeacd94beab72fb90a733c1b1ea76be708a2"
+checksum = "a6db4d6162cd9e7f99ca624eb26ab482fa55eee0d5e8018abd78eedcb30649b5"
 dependencies = [
  "ibc-types-core-channel",
  "ibc-types-core-client",
@@ -2933,9 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-channel"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fb64ef52086b727e5ae01da0e773f8ca9172ec1fd9d0aa1a79c0c2c610b17a"
+checksum = "fdc6a8d9b3722f1bbdd46f3bd8c8633d3431a38116d18cfc4bad300b10de617f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2966,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-client"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db9d4b136b9e84ccf581fec02bb9ebc4478ac0f145c526760ed4310b98741e7"
+checksum = "c6fbdf4baafe4342928fd3408069eea9fc71cd25050ed6b3cdf1e5002907a6cf"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2993,9 +2993,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-commitment"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2c527e14707dd0b2c7e6e2f6f62b0655c83154ae3eb1504e441d9d8f454ac6"
+checksum = "516a9c13338b16bfd41f4e59e1515a4c07fc4a0de72461af80de3b6ae7d6bec9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3028,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-connection"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8a326c00e9ba48059407478c826237fe39cc90dd2b47182484192926904fe7"
+checksum = "502fda3ff7eb80697cac5b0b2677ce60316f6611645387ebf9b6e113a10ea087"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3058,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-domain-type"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abc9619b9dd7201804f45fc7f335dda72d2e4d6f82d96e8fe3abf4585e6101b"
+checksum = "70bbfa53931e6be5b48441e15941cff35fb38e7acbca7717ee843af5d6e524ce"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3069,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-identifier"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "405880cf06fef65f51c5c91b7efbdcbc8d7eba0ac16b43538b36ebd17f21edea"
+checksum = "7d479d9c347e18b20c47a272e78d479d007bf54a3a321bf553473ea0298d1ef4"
 dependencies = [
  "displaydoc",
  "serde",
@@ -3080,9 +3080,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-lightclients-tendermint"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab22446058bd5afa50d64f8519a9107bbc5101ee65373df896314f52afa0fc6"
+checksum = "2ccc7e08879b8580952f754b9063855f2ae0bc7f39b534d80647a1b7b2a6544e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3117,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-path"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29e6fd8871fdced76402a3008219abf8773e527a46f120e0d76d6a3bb9706c1"
+checksum = "9310a095529b31936b4ed4bed6e0ebb8a5bf051449a24c1c22caea04d82ce3bb"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3140,9 +3140,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-timestamp"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d2e763838dbef62ca8a1344b4dd5b3919d685b4c61874183724644c912237a"
+checksum = "37004a958bc58fb18c7d2e715f68fd0d7baf2b531dac3985a5e2cf5c7c2c58d2"
 dependencies = [
  "bytes",
  "displaydoc",
@@ -3159,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-transfer"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad973ca1fbad8d0d1632ec0a329aecff8731bbb96395b7553d6b9fd749356d34"
+checksum = "5cf5827fe223b55cceff6b822cd65dd1acb93a694b9f129c5f3312e435ed2f9e"
 dependencies = [
  "displaydoc",
  "serde",
@@ -3182,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "ics23"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3b8be84e7285c73b88effdc3294b552277d6b0ec728ee016c861b7b9a2c19c"
+checksum = "18798160736c1e368938ba6967dbcb3c7afb3256b442a5506ba5222eebb68a5a"
 dependencies = [
  "anyhow",
  "blake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,10 +151,10 @@ hex                              = { version = "0.4.3" }
 http                             = { version = "0.2.9" }
 http-body                        = { version = "0.4.5" }
 humantime                        = { version = "2.1" }
-ibc-proto                        = { default-features = false, version = "0.41.0" }
-ibc-types                        = { default-features = false, version = "0.12.0" }
+ibc-proto                        = { default-features = false, version = "0.42.2" }
+ibc-types                        = { default-features = false, version = "0.14.1" }
 ibig                             = { version = "0.3" }
-ics23                            = { version = "0.11.0" }
+ics23                            = { version = "0.11.3" }
 im                               = { version = "^15.1.0" }
 indicatif                        = { version = "0.16" }
 jmt                              = { version = "0.10", features = ["migration"] }

--- a/crates/core/app/src/server/info.rs
+++ b/crates/core/app/src/server/info.rs
@@ -258,6 +258,7 @@ impl Info {
                     let id_chan = IdentifiedChannelEnd {
                         channel_id: chan_id,
                         port_id: PortId::transfer(),
+                        upgrade_sequence: channel.upgrade_sequence,
                         channel_end: channel,
                     };
                     channels.push(id_chan.into());
@@ -307,6 +308,7 @@ impl Info {
                         let id_chan = IdentifiedChannelEnd {
                             channel_id: chan_id,
                             port_id: PortId::transfer(),
+                            upgrade_sequence: channel.upgrade_sequence,
                             channel_end: channel,
                         };
                         channels.push(id_chan.into());

--- a/crates/core/component/ibc/src/component/msg_handler/channel_close_confirm.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/channel_close_confirm.rs
@@ -70,6 +70,8 @@ impl MsgHandler for MsgChannelCloseConfirm {
             remote: expected_counterparty,
             connection_hops: expected_connection_hops,
             version: channel.version.clone(),
+            // Penumbra does not currently support channel upgrades
+            upgrade_sequence: 0,
         };
 
         state

--- a/crates/core/component/ibc/src/component/msg_handler/channel_open_ack.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/channel_open_ack.rs
@@ -58,6 +58,8 @@ impl MsgHandler for MsgChannelOpenAck {
             remote: expected_counterparty,
             connection_hops: expected_connection_hops,
             version: self.version_on_b.clone(),
+            // Penumbra does not currently support channel upgrades
+            upgrade_sequence: 0,
         };
 
         state

--- a/crates/core/component/ibc/src/component/msg_handler/channel_open_confirm.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/channel_open_confirm.rs
@@ -65,6 +65,8 @@ impl MsgHandler for MsgChannelOpenConfirm {
             remote: expected_counterparty,
             connection_hops: expected_connection_hops,
             version: channel.version.clone(),
+            // Penumbra does not currently support channel upgrades
+            upgrade_sequence: 0,
         };
 
         state

--- a/crates/core/component/ibc/src/component/msg_handler/channel_open_init.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/channel_open_init.rs
@@ -57,6 +57,8 @@ impl MsgHandler for MsgChannelOpenInit {
             remote: Counterparty::new(self.port_id_on_b.clone(), None),
             connection_hops: self.connection_hops_on_a.clone(),
             version: self.version_proposal.clone(),
+            // Penumbra does not currently support channel upgrades
+            upgrade_sequence: 0,
         };
 
         state.put_channel(&channel_id, &self.port_id_on_a, new_channel.clone());

--- a/crates/core/component/ibc/src/component/msg_handler/channel_open_try.rs
+++ b/crates/core/component/ibc/src/component/msg_handler/channel_open_try.rs
@@ -49,6 +49,8 @@ impl MsgHandler for MsgChannelOpenTry {
                 .clone()
                 .ok_or_else(|| anyhow::anyhow!("no counterparty connection id provided"))?],
             version: self.version_supported_on_a.clone(),
+            // Penumbra does not currently support channel upgrades
+            upgrade_sequence: 0,
         };
 
         tracing::debug!(?self, ?expected_channel_on_a);
@@ -81,6 +83,8 @@ impl MsgHandler for MsgChannelOpenTry {
             remote: Counterparty::new(self.port_id_on_a.clone(), Some(self.chan_id_on_a.clone())),
             connection_hops: self.connection_hops_on_b.clone(),
             version: self.version_supported_on_a.clone(),
+            // Penumbra does not currently support channel upgrades
+            upgrade_sequence: 0,
         };
 
         state.put_channel(&channel_id, &self.port_id_on_b, new_channel.clone());

--- a/crates/core/component/ibc/src/component/rpc/consensus_query.rs
+++ b/crates/core/component/ibc/src/component/rpc/consensus_query.rs
@@ -4,7 +4,8 @@ use async_trait::async_trait;
 use ibc_proto::ibc::core::channel::v1::query_server::Query as ConsensusQuery;
 use ibc_proto::ibc::core::channel::v1::{
     Channel, PacketState, QueryChannelClientStateRequest, QueryChannelClientStateResponse,
-    QueryChannelConsensusStateRequest, QueryChannelConsensusStateResponse, QueryChannelRequest,
+    QueryChannelConsensusStateRequest, QueryChannelConsensusStateResponse,
+    QueryChannelParamsRequest, QueryChannelParamsResponse, QueryChannelRequest,
     QueryChannelResponse, QueryChannelsRequest, QueryChannelsResponse,
     QueryConnectionChannelsRequest, QueryConnectionChannelsResponse,
     QueryNextSequenceReceiveRequest, QueryNextSequenceReceiveResponse,
@@ -14,6 +15,7 @@ use ibc_proto::ibc::core::channel::v1::{
     QueryPacketCommitmentResponse, QueryPacketCommitmentsRequest, QueryPacketCommitmentsResponse,
     QueryPacketReceiptRequest, QueryPacketReceiptResponse, QueryUnreceivedAcksRequest,
     QueryUnreceivedAcksResponse, QueryUnreceivedPacketsRequest, QueryUnreceivedPacketsResponse,
+    QueryUpgradeErrorRequest, QueryUpgradeErrorResponse, QueryUpgradeRequest, QueryUpgradeResponse,
 };
 use ibc_proto::ibc::core::client::v1::{Height, IdentifiedClientState};
 use ibc_types::path::{
@@ -111,6 +113,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConsensusQuery for IbcQuery<HI> 
             let id_chan = IdentifiedChannelEnd {
                 channel_id: chan_id,
                 port_id: PortId::transfer(),
+                upgrade_sequence: channel.upgrade_sequence,
                 channel_end: channel,
             };
             channels.push(id_chan.into());
@@ -163,6 +166,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConsensusQuery for IbcQuery<HI> 
                 let id_chan = IdentifiedChannelEnd {
                     channel_id: chan_id,
                     port_id: PortId::transfer(),
+                    upgrade_sequence: channel.upgrade_sequence,
                     channel_end: channel,
                 };
                 channels.push(id_chan.into());
@@ -748,6 +752,35 @@ impl<HI: HostInterface + Send + Sync + 'static> ConsensusQuery for IbcQuery<HI> 
                 revision_number: 0,
                 revision_height: snapshot.version(),
             }),
+        }))
+    }
+
+    async fn upgrade_error(
+        &self,
+        _request: tonic::Request<QueryUpgradeErrorRequest>,
+    ) -> std::result::Result<tonic::Response<QueryUpgradeErrorResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(
+            "penumbra chains do not currently support channel upgrades (see https://github.com/penumbra-zone/penumbra/issues/2985)"
+        ))
+    }
+
+    async fn upgrade(
+        &self,
+        _request: tonic::Request<QueryUpgradeRequest>,
+    ) -> std::result::Result<tonic::Response<QueryUpgradeResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(
+            "penumbra chains do not currently support channel upgrades (see https://github.com/penumbra-zone/penumbra/issues/2985)"
+        ))
+    }
+
+    async fn channel_params(
+        &self,
+        _request: tonic::Request<QueryChannelParamsRequest>,
+    ) -> std::result::Result<tonic::Response<QueryChannelParamsResponse>, tonic::Status> {
+        Ok(tonic::Response::new(QueryChannelParamsResponse {
+            // This is only used to return a single param specifying the upgrade timeout.
+            // TODO: when upgrades are implemented, this will need to return the timeout duration.
+            params: None,
         }))
     }
 }

--- a/tools/proto-compiler/Cargo.toml
+++ b/tools/proto-compiler/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 anyhow = "1"
-ibc-proto = { version = "0.40.0" }
-ics23 = "0.11.0"
+ibc-proto = { version = "0.42.2" }
+ics23 = "0.11.3"
 pbjson = "0.6"
 pbjson-build = "0.6"
 pbjson-types = "0.6"


### PR DESCRIPTION
## Describe your changes
* Update `ics23` to `0.11.3`
* Update `ibc-proto` to `0.42.2`
* Update `ibc-types` to `0.14.1`

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > consensus and state breaking due to changes to ibc-proto. migration is necessary if any IBC data has been written to state.