### PR TITLE
Added CMake command to dev docs for linking against `librocksdb` 

### DIFF
--- a/docs/guide/src/dev/build.md
+++ b/docs/guide/src/dev/build.md
@@ -121,7 +121,7 @@ git submodule update --init
 
 # Build snappy using cmake.
 mkdir build
-cd build && cmake .. && make
+cd build && cmake ../ -DSNAPPY_BUILD_BENCHMARKS=OFF && make
 
 # Add an environment variable pointing to the build/ directory.
 SNAPPY_LIB_DIR=`pwd`


### PR DESCRIPTION
In the current docs for linking against `libsrockdb`, building `libsnappy.a` will fail because of an error thrown while building its third party benchmarks which are enabled by default.

## Describe your changes
This PR adds the CMake CLI option to the docs so that snappy's optional benchmarks are disabled by default.


## Issue ticket number and link
NA

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

This is a one line change to developer docs for linking against a crate dependency.
