### PR TITLE
Make pclientd/pcli default_home accessible when using them as libraries

### DIFF
--- a/crates/bin/pcli/src/lib.rs
+++ b/crates/bin/pcli/src/lib.rs
@@ -4,6 +4,8 @@
 use {
     crate::{command::*, config::PcliConfig},
     anyhow::Result,
+    camino::Utf8PathBuf,
+    directories::ProjectDirs,
     futures::StreamExt,
     penumbra_proto::{
         box_grpc_svc::BoxGrpcService, custody::v1::custody_service_client::CustodyServiceClient,
@@ -80,4 +82,12 @@ impl App {
 
         Ok(())
     }
+}
+
+pub fn default_home() -> Utf8PathBuf {
+    let path = ProjectDirs::from("zone", "penumbra", "pcli")
+        .expect("Failed to get platform data dir")
+        .data_dir()
+        .to_path_buf();
+    Utf8PathBuf::from_path_buf(path).expect("Platform default data dir was not UTF-8")
 }

--- a/crates/bin/pcli/src/opt.rs
+++ b/crates/bin/pcli/src/opt.rs
@@ -1,12 +1,12 @@
 use crate::{
     config::{CustodyConfig, GovernanceCustodyConfig, PcliConfig},
+    default_home,
     terminal::ActualTerminal,
     App, Command,
 };
 use anyhow::Result;
 use camino::Utf8PathBuf;
 use clap::Parser;
-use directories::ProjectDirs;
 use penumbra_custody::{null_kms::NullKms, soft_kms::SoftKms};
 use penumbra_proto::box_grpc_svc;
 use penumbra_proto::{
@@ -177,12 +177,4 @@ impl Opt {
         };
         Ok((app, self.cmd))
     }
-}
-
-fn default_home() -> Utf8PathBuf {
-    let path = ProjectDirs::from("zone", "penumbra", "pcli")
-        .expect("Failed to get platform data dir")
-        .data_dir()
-        .to_path_buf();
-    Utf8PathBuf::from_path_buf(path).expect("Platform default data dir was not UTF-8")
 }

--- a/crates/bin/pclientd/src/lib.rs
+++ b/crates/bin/pclientd/src/lib.rs
@@ -66,7 +66,7 @@ impl PclientdConfig {
     }
 }
 
-fn default_home() -> Utf8PathBuf {
+pub fn default_home() -> Utf8PathBuf {
     let path = ProjectDirs::from("zone", "penumbra", "pclientd")
         .expect("Failed to get platform data dir")
         .data_dir()


### PR DESCRIPTION
## Describe your changes

Changes the location and exposure of the `default_home` functions in `pcli`/`pclientd` so they can be accessed when used as libraries.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > minor change to client code organization