### PR TITLE
ci: add pindexer to penumbra container

### DIFF
--- a/deployments/containerfiles/Dockerfile
+++ b/deployments/containerfiles/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=build-env \
             /usr/src/penumbra/target/release/pcli \
             /usr/src/penumbra/target/release/pclientd \
             /usr/src/penumbra/target/release/pd \
-            /usr/src/penumbra/target/release/summonerd \
+            /usr/src/penumbra/target/release/pindexer \
             /usr/src/penumbra/target/release/tct-live-edit \
             /usr/bin/
 


### PR DESCRIPTION


## Describe your changes
Adding pindexer to the default container build, to make the built binary accessible in testing and deploy environments.

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > only affects ci builds of containers; no changes to application logic
