### PR TITLE
Fix: index events according to their local row id

### DIFF
--- a/crates/util/cometindex/src/indexer.rs
+++ b/crates/util/cometindex/src/indexer.rs
@@ -239,6 +239,8 @@ GROUP BY
     events.type, 
     blocks.height, 
     tx_results.tx_hash
+ORDER BY
+    events.rowid ASC
         "#,
     )
     .bind(watermark)


### PR DESCRIPTION
We use this row id as a watermark, and update it after every ingestion of an event. Previously, we were iterating over things in an undefined order, and effectively sometimes ingesting events out of order, causing bad things to happen to the watermark, leading to much FUN.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing
