### PR TITLE
Update to latest frontends

### DIFF
--- a/assets/minifront.zip
+++ b/assets/minifront.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f857f2869bac81315d1d80dd8b2a92000c8ae08ab2a370b51e6a0eba01bf2b26
-size 5061294
+oid sha256:ce08eb9abf2a83e59986fc9be614cce0e8441517bd34fc891cb3707bb72818eb
+size 5136308

--- a/assets/node-status.zip
+++ b/assets/node-status.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff23c8753c094d33d88b94cad5b60041e6f969ebad8712669be7178af9850a54
-size 1382123
+oid sha256:7cf0fd86616b7902c786dbac4dacb5aa421d477b608598e181d84d04acf2b6d6
+size 1384181


### PR DESCRIPTION
Been a few weeks since an update with the bundled frontends. Updating to latest main from `penumbra-zone/web`.