### PR TITLE
fix: don't crash pindexer on blocks without a timestamp

### DIFF
--- a/crates/bin/pindexer/src/block.rs
+++ b/crates/bin/pindexer/src/block.rs
@@ -39,9 +39,7 @@ CREATE TABLE IF NOT EXISTS block_details (
         _src_db: &PgPool,
     ) -> Result<(), anyhow::Error> {
         let pe = pb::EventBlockRoot::from_event(event.as_ref())?;
-        let timestamp = pe
-            .timestamp
-            .ok_or(anyhow!("block at height {} has no timestamp", pe.height))?;
+        let timestamp = pe.timestamp.unwrap_or_default();
 
         sqlx::query(
             "


### PR DESCRIPTION
## Describe your changes

this sets timestamp to default for blocks without one to

## Issue ticket number and link

fixes https://github.com/penumbra-zone/penumbra/issues/4761

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

indexer changes only
