### PR TITLE
Bug: correctly handle denoms with `/` in pcli tx lp

### DIFF
--- a/crates/core/component/dex/src/lp/order.rs
+++ b/crates/core/component/dex/src/lp/order.rs
@@ -31,9 +31,10 @@ pub struct SellOrder {
 
 /// This doesn't parse the values yet, because we need to inspect their units.
 fn parse_parts(input: &str) -> Result<(&str, &str, u32)> {
-    let (trade_part, fee_part) = match input.split_once('/') {
-        Some((trade_part, fee_part)) => (trade_part, fee_part),
-        None => (input, "0bps"),
+    let (trade_part, fee_part) = match input.rsplit_once('/') {
+        // In case we have a denom with a slash, and no fee
+        Some((trade_part, fee_part)) if fee_part.ends_with("bps") => (trade_part, fee_part),
+        _ => (input, "0bps"),
     };
 
     let Some((val1, val2)) = trade_part.split_once('@') else {


### PR DESCRIPTION
The parsing looked for the first occurrence of the slash for

nX@nY/fee

but if X or Y contains a slash, this will be incorrect.

This fixes this somewhat, by looking for the last slash, and only considering that a fee if it ends with bps.

This will not correctly handle a denom containing both a slash and ending with bps, but beyond that we'll need to change the format probably.
## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > client side change only, for pcli
