### PR TITLE
ci: build containers on merge or tag

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,14 +1,15 @@
 ---
 name: Create and publish container images
-# Build strategy: we want to build new containers immediately
-# prior to deploying testnets using those containers. We don't
-# trigger the container-build workflow on merge or tag events;
-# rather, we set `workflow_call` so the different deploy workflows
-# can execute this workflow and wait on its completion.
 on:
+  # Build on merge to main, or any tag push.
+  push:
+    branches:
+      - main
+    tags:
+      - '**[0-9]+.[0-9]+.[0-9]+*'
+  # Also support ad-hoc calls for workflow.
   workflow_call:
   workflow_dispatch:
-
 jobs:
   penumbra:
     runs-on: buildjet-16vcpu-ubuntu-2204
@@ -53,71 +54,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-  grafana:
-    # No need for a heavy runner, we're just copying in a few files, not compiling.
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Log in to the Docker Hub container registry (for pulls)
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Log in to the GitHub container registry (for pushes)
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/penumbra-zone/grafana
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64
-          file: deployments/containerfiles/Dockerfile-grafana
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-  galileo:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    # The upstream container references the Penumbra container by tag,
-    # so ensure it exists.
-    needs:
-      - penumbra
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      # We use the GHA Repository Dispatch functionality to trigger a container
-      # build in the penumbra-zone/galileo repo.
-      - name: Trigger remote build
-        shell: bash
-        env:
-          GITHUB_PAT: ${{ secrets.GH_PAT }}
-        run: |-
-          export PENUMBRA_VERSION='${{ github.event.inputs.image_tag || github.ref_name }}'
-          # Galileo only runs against public testnets, so skip building non-tagged versions.
-          if ! grep -q '^v' <<< "$PENUMBRA_VERSION" ; then
-            echo "Detected version '$PENUBRA_VERSION', skipping Galileo container build"
-            exit 0
-          fi
-          cd deployments/
-          ./scripts/gha-repository-dispatch penumbra-zone/galileo


### PR DESCRIPTION

## Describe your changes
We'd previously been triggering container builds on every merge to main, via the testnet deploy workflows, which were removed in #4678. Let's add triggers to build containers regularly, even though we're not deploying them automatically. Also cleans up unused builds like for galileo and grafana.

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > ci-only, no code changes
