### PR TITLE
Update to latest frontends

### DIFF
--- a/assets/minifront.zip
+++ b/assets/minifront.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce08eb9abf2a83e59986fc9be614cce0e8441517bd34fc891cb3707bb72818eb
-size 5136308
+oid sha256:1be13e3a1cfb0c2da2bb093764ff2fbdd2379f85f007b99a36fe722a2431bd04
+size 5136285

--- a/assets/node-status.zip
+++ b/assets/node-status.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7cf0fd86616b7902c786dbac4dacb5aa421d477b608598e181d84d04acf2b6d6
+oid sha256:bf59963275e4476fb52cbb210fd0239be9fb78d8fb8e7f04de9715f02e8a59be
 size 1384181


### PR DESCRIPTION
Been a few hours since an update with the bundled frontends. Updating to latest main from `penumbra-zone/web`.