### PR TITLE
feat: lp indexing

### DIFF
--- a/crates/bin/pindexer/src/block.rs
+++ b/crates/bin/pindexer/src/block.rs
@@ -1,5 +1,3 @@
-use crate::PD_COMPAT;
-use anyhow::anyhow;
 use cometindex::{async_trait, sqlx, AppView, ContextualizedEvent, PgTransaction};
 use penumbra_proto::{core::component::sct::v1 as pb, event::ProtoEvent};
 use sqlx::{types::chrono::DateTime, PgPool};
@@ -49,10 +47,10 @@ CREATE TABLE IF NOT EXISTS block_details (
             ",
         )
         .bind(i64::try_from(pe.height)?)
-        .bind(
-            DateTime::from_timestamp(timestamp.seconds, u32::try_from(timestamp.nanos)?)
-                .ok_or(anyhow!(format!("failed to convert timestamp. {PD_COMPAT}")))?,
-        )
+        .bind(DateTime::from_timestamp(
+            timestamp.seconds,
+            u32::try_from(timestamp.nanos)?,
+        ))
         .bind(pe.root.unwrap().inner)
         .execute(dbtx.as_mut())
         .await?;

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -14,50 +14,63 @@ DROP TYPE IF EXISTS Value CASCADE;
 DROP DOMAIN IF EXISTS Amount;
 
 CREATE DOMAIN Amount AS NUMERIC(39, 0) NOT NULL;
-CREATE TYPE Value AS (
-  amount Amount,
-  asset BYTEA
+CREATE TYPE Value AS
+(
+    amount Amount,
+    asset  BYTEA
 );
 
 
 -- Keeps track of changes to the dex's value circuit breaker.
-CREATE TABLE IF NOT EXISTS dex_value_circuit_breaker_change (
-  -- The asset being moved into or out of the dex.
-  asset_id BYTEA NOT NULL,
-  -- The flow, either positive, or negative, into the dex via this particular asset.
-  --
-  -- Because we're dealing with arbitrary assets, we need to use something which can store u128
-  flow Amount
+CREATE TABLE IF NOT EXISTS dex_value_circuit_breaker_change
+(
+    -- The asset being moved into or out of the dex.
+    asset_id BYTEA NOT NULL,
+    -- The flow, either positive, or negative, into the dex via this particular asset.
+    --
+    -- Because we're dealing with arbitrary assets, we need to use something which can store u128
+    flow     Amount
 );
 
 -- One step of an execution trace.
-CREATE TABLE IF NOT EXISTS trace_step (
-  id SERIAL PRIMARY KEY,
-  value Value
+CREATE TABLE IF NOT EXISTS trace_step
+(
+    id    SERIAL PRIMARY KEY,
+    value Value
 );
 
 -- A single trace, showing what a small amount of an input asset was exchanged for.
-CREATE TABLE IF NOT EXISTS trace (
-  id SERIAL PRIMARY KEY,
-  step_start INTEGER REFERENCES trace_step(id),
-  step_end INTEGER REFERENCES trace_step(id)
+CREATE TABLE IF NOT EXISTS trace
+(
+    id         SERIAL PRIMARY KEY,
+    step_start INTEGER REFERENCES trace_step (id),
+    step_end   INTEGER REFERENCES trace_step (id)
 );
 
 --- Represents instances where arb executions happened.
-CREATE TABLE IF NOT EXISTS arb (
-  height BIGINT PRIMARY KEY,
-  input Value,
-  output Value,
-  trace_start INTEGER REFERENCES trace(id),
-  trace_end INTEGER REFERENCES trace(id)
+CREATE TABLE IF NOT EXISTS arb
+(
+    height      BIGINT PRIMARY KEY,
+    input       Value,
+    output      Value,
+    trace_start INTEGER REFERENCES trace (id),
+    trace_end   INTEGER REFERENCES trace (id)
 );
 
 --- Represents LP updates
 CREATE TABLE IF NOT EXISTS lp_updates
 (
-    id           SERIAL PRIMARY KEY,
-    height       INT8    NOT NULL,
-    type         integer NOT NULL,
-    position_id  BYTEA   NOT NULL,
-    trading_pair BYTEA
+    id              SERIAL PRIMARY KEY,
+    height          INT8    NOT NULL,
+    type            integer NOT NULL,
+    position_id     BYTEA   NOT NULL,
+    asset_1         BYTEA,
+    asset_2         BYTEA,
+    reserves_1      Amount,
+    reserves_2      Amount,
+    trading_fee     INT8,
+    prev_reserves_1 Amount,
+    prev_reserves_2 Amount,
+    start_asset     BYTEA,
+    end_asset       BYTEA
 );

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -51,3 +51,13 @@ CREATE TABLE IF NOT EXISTS arb (
   trace_start INTEGER REFERENCES trace(id),
   trace_end INTEGER REFERENCES trace(id)
 );
+
+--- Represents LP updates
+CREATE TABLE IF NOT EXISTS lp_updates
+(
+    id           SERIAL PRIMARY KEY,
+    height       INT8    NOT NULL,
+    type         integer NOT NULL,
+    position_id  BYTEA   NOT NULL,
+    trading_pair BYTEA
+);

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -68,9 +68,9 @@ CREATE TABLE IF NOT EXISTS dex_lp (
   -- The fee, in basis points
   fee_bps Bps,
   -- How much of asset2 you get when swapping asset1.
-  price12 NUMERIC(39, 0) GENERATED ALWAYS AS (((1 - fee_bps::NUMERIC / 10000) * (p / q))::Amount) STORED,
+  price12 NUMERIC GENERATED ALWAYS AS (((1 - fee_bps::NUMERIC / 10000) * (p / q))) STORED,
   -- How much of asset1 you get when swapping asset2.
-  price21 NUMERIC(39, 0) GENERATED ALWAYS AS (((1 - fee_bps::NUMERIC / 10000) * (q / p))::Amount) STORED,
+  price21 NUMERIC GENERATED ALWAYS AS (((1 - fee_bps::NUMERIC / 10000) * (q / p))) STORED,
   -- Whether the position will be closed when all reserves are depleted
   close_on_fill BOOLEAN NOT NULL,
   -- The amount of reserves of asset 1.

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -20,6 +20,12 @@ CREATE TYPE Value AS
     asset  BYTEA
 );
 
+CREATE TYPE TradingPair AS
+(
+    asset_1 BYTEA,
+    asset_2 BYTEA
+);
+
 
 -- Keeps track of changes to the dex's value circuit breaker.
 CREATE TABLE IF NOT EXISTS dex_value_circuit_breaker_change
@@ -64,8 +70,7 @@ CREATE TABLE IF NOT EXISTS lp_updates
     height          INT8    NOT NULL,
     type            integer NOT NULL,
     position_id     BYTEA   NOT NULL,
-    asset_1         BYTEA,
-    asset_2         BYTEA,
+    pair            TradingPair,
     reserves_1      Amount,
     reserves_2      Amount,
     trading_fee     INT8,
@@ -74,3 +79,24 @@ CREATE TABLE IF NOT EXISTS lp_updates
     start_asset     BYTEA,
     end_asset       BYTEA
 );
+
+--- Represents current LP state
+CREATE OR REPLACE VIEW lp_positions AS
+WITH latest_updates AS (SELECT DISTINCT ON (position_id) position_id,
+                                                         pair,
+                                                         type AS status,
+                                                         reserves_1,
+                                                         reserves_2,
+                                                         trading_fee
+                        FROM lp_updates
+                        ORDER BY position_id, height DESC)
+SELECT position_id,
+       pair,
+       status,
+       reserves_1,
+       reserves_2,
+       trading_fee
+FROM latest_updates;
+
+-- Add an index on position_id for better performance
+CREATE INDEX IF NOT EXISTS idx_lp_updates_position_id ON lp_updates (position_id);

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -10,93 +10,106 @@
 -- tables, rather than needing to do a join with another table.
 
 
-DROP TYPE IF EXISTS Value CASCADE;
 DROP DOMAIN IF EXISTS Amount;
-
 CREATE DOMAIN Amount AS NUMERIC(39, 0) NOT NULL;
-CREATE TYPE Value AS
-(
-    amount Amount,
-    asset  BYTEA
-);
 
-CREATE TYPE TradingPair AS
-(
-    asset_1 BYTEA,
-    asset_2 BYTEA
+DROP TYPE IF EXISTS Value CASCADE;
+CREATE TYPE Value AS (
+  amount Amount,
+  asset BYTEA
 );
-
 
 -- Keeps track of changes to the dex's value circuit breaker.
-CREATE TABLE IF NOT EXISTS dex_value_circuit_breaker_change
-(
-    -- The asset being moved into or out of the dex.
-    asset_id BYTEA NOT NULL,
-    -- The flow, either positive, or negative, into the dex via this particular asset.
-    --
-    -- Because we're dealing with arbitrary assets, we need to use something which can store u128
-    flow     Amount
+CREATE TABLE IF NOT EXISTS dex_value_circuit_breaker_change (
+  -- The asset being moved into or out of the dex.
+  asset_id BYTEA NOT NULL,
+  -- The flow, either positive, or negative, into the dex via this particular asset.
+  --
+  -- Because we're dealing with arbitrary assets, we need to use something which can store u128
+  flow Amount
 );
 
 -- One step of an execution trace.
-CREATE TABLE IF NOT EXISTS trace_step
-(
-    id    SERIAL PRIMARY KEY,
-    value Value
+CREATE TABLE IF NOT EXISTS dex_trace_step (
+  id SERIAL PRIMARY KEY,
+  value Value
 );
 
 -- A single trace, showing what a small amount of an input asset was exchanged for.
-CREATE TABLE IF NOT EXISTS trace
-(
-    id         SERIAL PRIMARY KEY,
-    step_start INTEGER REFERENCES trace_step (id),
-    step_end   INTEGER REFERENCES trace_step (id)
+CREATE TABLE IF NOT EXISTS dex_trace (
+  id SERIAL PRIMARY KEY,
+  step_start INTEGER REFERENCES dex_trace_step(id),
+  step_end INTEGER REFERENCES dex_trace_step(id)
 );
 
 --- Represents instances where arb executions happened.
-CREATE TABLE IF NOT EXISTS arb
-(
-    height      BIGINT PRIMARY KEY,
-    input       Value,
-    output      Value,
-    trace_start INTEGER REFERENCES trace (id),
-    trace_end   INTEGER REFERENCES trace (id)
+CREATE TABLE IF NOT EXISTS dex_arb (
+  height BIGINT PRIMARY KEY,
+  input Value,
+  output Value,
+  trace_start INTEGER REFERENCES dex_trace(id),
+  trace_end INTEGER REFERENCES dex_trace(id)
 );
 
---- Represents LP updates
-CREATE TABLE IF NOT EXISTS lp_updates
-(
-    id              SERIAL PRIMARY KEY,
-    height          INT8    NOT NULL,
-    type            integer NOT NULL,
-    position_id     BYTEA   NOT NULL,
-    pair            TradingPair,
-    reserves_1      Amount,
-    reserves_2      Amount,
-    trading_fee     INT8,
-    prev_reserves_1 Amount,
-    prev_reserves_2 Amount,
-    start_asset     BYTEA,
-    end_asset       BYTEA
+DROP DOMAIN IF EXISTS Bps;
+CREATE DOMAIN Bps AS INTEGER CHECK(VALUE BETWEEN 0 and 10000);
+
+-- Holds the current state of a given liquidity position
+CREATE TABLE IF NOT EXISTS dex_lp (
+  id BYTEA PRIMARY KEY,
+  -- The enum for the current state of the position
+  state TEXT NOT NULL,
+  -- The first asset of the position
+  asset1 BYTEA NOT NULL,
+  -- The second asset of the position
+  asset2 BYTEA NOT NULL,
+  p Amount,
+  q Amount,
+  -- The fee, in basis points
+  fee_bps Bps,
+  -- How much of asset2 you get when swapping asset1.
+  price12 NUMERIC(39, 0) GENERATED ALWAYS AS (((1 - fee_bps::NUMERIC / 10000) * (p / q))::Amount) STORED,
+  -- How much of asset1 you get when swapping asset2.
+  price21 NUMERIC(39, 0) GENERATED ALWAYS AS (((1 - fee_bps::NUMERIC / 10000) * (q / p))::Amount) STORED,
+  -- Whether the position will be closed when all reserves are depleted
+  close_on_fill BOOLEAN NOT NULL,
+  -- The amount of reserves of asset 1.
+  reserves1 Amount,
+  -- The amount of reserves of asset 2.
+  reserves2 Amount
 );
+-- So that we can easily query positions by ascending price
+CREATE INDEX ON dex_lp(asset1, price12);
+CREATE INDEX ON dex_lp(asset2, price21);
 
---- Represents current LP state
-CREATE OR REPLACE VIEW lp_positions AS
-WITH latest_updates AS (SELECT DISTINCT ON (position_id) position_id,
-                                                         pair,
-                                                         type AS status,
-                                                         reserves_1,
-                                                         reserves_2,
-                                                         trading_fee
-                        FROM lp_updates
-                        ORDER BY position_id, height DESC)
-SELECT position_id,
-       pair,
-       status,
-       reserves_1,
-       reserves_2,
-       trading_fee
-FROM latest_updates;
+-- Holds update events to liquidity position
+CREATE TABLE IF NOT EXISTS dex_lp_update (
+  id SERIAL PRIMARY KEY,
+  -- The block height where the update occurred.
+  height BIGINT NOT NULL,
+  -- The identifier for the position
+  position_id BYTEA NOT NULL,
+  -- The new state of the position
+  state TEXT NOT NULL,
+  -- The new reserves of asset1 (potentially null)
+  reserves1 NUMERIC(39, 0),
+  -- The new reserves of asset2 (potentially null)
+  reserves2 NUMERIC(39, 0),
+  -- If present, a reference to the execution table, for execution events
+  execution_id INTEGER
+);
+CREATE INDEX ON dex_lp_update(position_id, height DESC, id DESC);
+CREATE INDEX ON dex_lp_update(execution_id);
 
--- Add an index on position_id for better performance
-CREATE INDEX IF NOT EXISTS idx_lp_updates_position_id ON lp_updates (position_id);
+-- Holds data related to execution events
+CREATE TABLE IF NOT EXISTS dex_lp_execution (
+  id SERIAL PRIMARY KEY,
+  -- The amount of asset1 that was pushed into (or pulled out of, if negative) this position.
+  inflow1 Amount,
+  -- As above, with asset2.
+  inflow2 Amount,
+  -- The start asset for this execution.
+  context_start BYTEA NOT NULL,
+  -- The end asset for this execution.
+  context_end BYTEA NOT NULL
+);

--- a/crates/bin/pindexer/src/dex/mod.rs
+++ b/crates/bin/pindexer/src/dex/mod.rs
@@ -48,7 +48,6 @@ enum Event {
         trading_pair: TradingPair,
         reserves_1: Amount,
         reserves_2: Amount,
-        sequence: u32,
     },
     /// A parsed version of [pb::EventPositionClose]
     PositionClose {
@@ -345,14 +344,12 @@ impl<'a> TryFrom<&'a ContextualizedEvent> for Event {
                     .reserves_2
                     .ok_or(anyhow!("missing reserves_2"))?
                     .try_into()?;
-                let sequence = pe.sequence.try_into()?;
                 Ok(Self::PositionWithdraw {
                     height,
                     position_id,
                     trading_pair,
                     reserves_1,
                     reserves_2,
-                    sequence,
                 })
             }
             // LP Open

--- a/crates/bin/pindexer/src/dex/mod.rs
+++ b/crates/bin/pindexer/src/dex/mod.rs
@@ -179,8 +179,8 @@ impl Event {
             } => {
                 sqlx::query(
                     "
-            INSERT INTO lp_updates (height, type, position_id, asset_1, asset_2, reserves_1, reserves_2, trading_fee)
-            VALUES ($1, $2, $3)
+            INSERT INTO lp_updates (height, type, position_id, pair, reserves_1, reserves_2, trading_fee)
+            VALUES ($1, $2, $3, ($4, $5), $6, $7, $8)
             ",
                 )
                 .bind(*height as i64)
@@ -223,8 +223,8 @@ impl Event {
             } => {
                 sqlx::query(
                     "
-            INSERT INTO lp_updates (height, type, position_id, asset_1, asset_2, reserves_1, reserves_2)
-            VALUES ($1, $2, $3)
+            INSERT INTO lp_updates (height, type, position_id, pair, reserves_1, reserves_2)
+            VALUES ($1, $2, $3, ($4, $5), $6, $7)
             ",
                 )
                 .bind(*height as i64)
@@ -251,9 +251,9 @@ impl Event {
             } => {
                 sqlx::query(
                     "
-            INSERT INTO lp_updates (height, type, position_id, asset_1, asset_2, reserves_1,
+            INSERT INTO lp_updates (height, type, position_id, pair, reserves_1,
              reserves_2, prev_reserves_1, prev_reserves_2, start_asset, end_asset)
-            VALUES ($1, $2, $3)
+            VALUES ($1, $2, $3, ($4, $5), $6, $7, $8, $9, $10, $11)
             ",
                 )
                 .bind(*height as i64)

--- a/crates/bin/pindexer/src/lib.rs
+++ b/crates/bin/pindexer/src/lib.rs
@@ -7,5 +7,3 @@ pub mod dex;
 pub mod shielded_pool;
 mod sql;
 pub mod stake;
-
-pub(crate) const PD_COMPAT: &'static str = "Check that your pd and pindexer versions match. See pd compatibility section in README for more information.";


### PR DESCRIPTION
## Describe your changes

implements lp positions and execution indexing

TODO from reviews:
- [x] We want to store the trading pair likely as a new derived type (tuple) of (BYTEA, BYTEA)
- [x] We definitely need a table storing the current state of any given position, including permanent information like the trading pair, price, fees.
- [x] We need to include the reserve amounts in the lp_updates table, to have a history of the reserves over time.
- [x] Price info, for both updates and current state

## Issue ticket number and link

fixes #4739 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

indexer-only changes
