### PR TITLE
feat: swaps indexing

### DIFF
--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -117,7 +117,7 @@ CREATE TABLE IF NOT EXISTS dex_lp_execution (
 );
 
 --- Represents instances where swap executions happened.
-CREATE TABLE IF NOT EXISTS swap
+CREATE TABLE IF NOT EXISTS dex_swap
 (
     height      BIGINT PRIMARY KEY,
     input       Value,

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -14,19 +14,21 @@ DROP DOMAIN IF EXISTS Amount;
 CREATE DOMAIN Amount AS NUMERIC(39, 0) NOT NULL;
 
 DROP TYPE IF EXISTS Value CASCADE;
-CREATE TYPE Value AS (
-  amount Amount,
-  asset BYTEA
+CREATE TYPE Value AS
+(
+    amount Amount,
+    asset  BYTEA
 );
 
 -- Keeps track of changes to the dex's value circuit breaker.
-CREATE TABLE IF NOT EXISTS dex_value_circuit_breaker_change (
-  -- The asset being moved into or out of the dex.
-  asset_id BYTEA NOT NULL,
-  -- The flow, either positive, or negative, into the dex via this particular asset.
-  --
-  -- Because we're dealing with arbitrary assets, we need to use something which can store u128
-  flow Amount
+CREATE TABLE IF NOT EXISTS dex_value_circuit_breaker_change
+(
+    -- The asset being moved into or out of the dex.
+    asset_id BYTEA NOT NULL,
+    -- The flow, either positive, or negative, into the dex via this particular asset.
+    --
+    -- Because we're dealing with arbitrary assets, we need to use something which can store u128
+    flow     Amount
 );
 
 -- One step of an execution trace.
@@ -112,4 +114,14 @@ CREATE TABLE IF NOT EXISTS dex_lp_execution (
   context_start BYTEA NOT NULL,
   -- The end asset for this execution.
   context_end BYTEA NOT NULL
+);
+
+--- Represents instances where swap executions happened.
+CREATE TABLE IF NOT EXISTS swap
+(
+    height      BIGINT PRIMARY KEY,
+    input       Value,
+    output      Value,
+    trace_start INTEGER REFERENCES dex_trace (id),
+    trace_end   INTEGER REFERENCES dex_trace (id)
 );

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -120,8 +120,6 @@ CREATE TABLE IF NOT EXISTS dex_lp_execution (
 CREATE TABLE IF NOT EXISTS dex_swap
 (
     height      BIGINT PRIMARY KEY,
-    input       Value,
-    output      Value,
     trace_start INTEGER REFERENCES dex_trace (id),
     trace_end   INTEGER REFERENCES dex_trace (id),
     pair_asset_id_1  BYTEA NOT NULL,

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -123,5 +123,13 @@ CREATE TABLE IF NOT EXISTS swap
     input       Value,
     output      Value,
     trace_start INTEGER REFERENCES dex_trace (id),
-    trace_end   INTEGER REFERENCES dex_trace (id)
+    trace_end   INTEGER REFERENCES dex_trace (id),
+    pair_asset_id_1  BYTEA NOT NULL,
+    pair_asset_id_2  BYTEA NOT NULL,
+    unfilled_1 Amount NOT NULL,
+    unfilled_2 Amount NOT NULL,
+    delta_1 Amount NOT NULL,
+    delta_2 Amount NOT NULL,
+    lambda_1 Amount NOT NULL,
+    lambda_2 Amount NOT NULL
 );

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -115,7 +115,7 @@ CREATE TABLE IF NOT EXISTS dex_lp_execution (
 );
 
 --- Represents instances where swap executions happened.
-CREATE TABLE IF NOT EXISTS dex_swap (
+CREATE TABLE IF NOT EXISTS dex_batch_swap (
   height BIGINT PRIMARY KEY,
   trace_start INTEGER REFERENCES dex_trace (id),
   trace_end INTEGER REFERENCES dex_trace (id),

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -117,14 +117,16 @@ CREATE TABLE IF NOT EXISTS dex_lp_execution (
 --- Represents instances where swap executions happened.
 CREATE TABLE IF NOT EXISTS dex_batch_swap (
   height BIGINT PRIMARY KEY,
-  trace_start INTEGER REFERENCES dex_trace (id),
-  trace_end INTEGER REFERENCES dex_trace (id),
-  pair_asset_id_1 BYTEA NOT NULL,
-  pair_asset_id_2 BYTEA NOT NULL,
-  unfilled_1 Amount NOT NULL,
-  unfilled_2 Amount NOT NULL,
-  delta_1 Amount NOT NULL,
-  delta_2 Amount NOT NULL,
-  lambda_1 Amount NOT NULL,
-  lambda_2 Amount NOT NULL
+  trace12_start INTEGER REFERENCES dex_trace (id),
+  trace12_end INTEGER REFERENCES dex_trace (id),
+  trace21_start INTEGER REFERENCES dex_trace (id),
+  trace21_end INTEGER REFERENCES dex_trace (id),
+  pair_asset1 BYTEA NOT NULL,
+  pair_asset2 BYTEA NOT NULL,
+  unfilled1 Amount NOT NULL,
+  unfilled2 Amount NOT NULL,
+  delta1 Amount NOT NULL,
+  delta2 Amount NOT NULL,
+  lambda1 Amount NOT NULL,
+  lambda2 Amount NOT NULL
 );

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -14,21 +14,19 @@ DROP DOMAIN IF EXISTS Amount;
 CREATE DOMAIN Amount AS NUMERIC(39, 0) NOT NULL;
 
 DROP TYPE IF EXISTS Value CASCADE;
-CREATE TYPE Value AS
-(
-    amount Amount,
-    asset  BYTEA
+CREATE TYPE Value AS (
+  amount Amount,
+  asset BYTEA
 );
 
 -- Keeps track of changes to the dex's value circuit breaker.
-CREATE TABLE IF NOT EXISTS dex_value_circuit_breaker_change
-(
-    -- The asset being moved into or out of the dex.
-    asset_id BYTEA NOT NULL,
-    -- The flow, either positive, or negative, into the dex via this particular asset.
-    --
-    -- Because we're dealing with arbitrary assets, we need to use something which can store u128
-    flow     Amount
+CREATE TABLE IF NOT EXISTS dex_value_circuit_breaker_change (
+  -- The asset being moved into or out of the dex.
+  asset_id BYTEA NOT NULL,
+  -- The flow, either positive, or negative, into the dex via this particular asset.
+  --
+  -- Because we're dealing with arbitrary assets, we need to use something which can store u128
+  flow Amount
 );
 
 -- One step of an execution trace.
@@ -117,17 +115,16 @@ CREATE TABLE IF NOT EXISTS dex_lp_execution (
 );
 
 --- Represents instances where swap executions happened.
-CREATE TABLE IF NOT EXISTS dex_swap
-(
-    height      BIGINT PRIMARY KEY,
-    trace_start INTEGER REFERENCES dex_trace (id),
-    trace_end   INTEGER REFERENCES dex_trace (id),
-    pair_asset_id_1  BYTEA NOT NULL,
-    pair_asset_id_2  BYTEA NOT NULL,
-    unfilled_1 Amount NOT NULL,
-    unfilled_2 Amount NOT NULL,
-    delta_1 Amount NOT NULL,
-    delta_2 Amount NOT NULL,
-    lambda_1 Amount NOT NULL,
-    lambda_2 Amount NOT NULL
+CREATE TABLE IF NOT EXISTS dex_swap (
+  height BIGINT PRIMARY KEY,
+  trace_start INTEGER REFERENCES dex_trace (id),
+  trace_end INTEGER REFERENCES dex_trace (id),
+  pair_asset_id_1 BYTEA NOT NULL,
+  pair_asset_id_2 BYTEA NOT NULL,
+  unfilled_1 Amount NOT NULL,
+  unfilled_2 Amount NOT NULL,
+  delta_1 Amount NOT NULL,
+  delta_2 Amount NOT NULL,
+  lambda_1 Amount NOT NULL,
+  lambda_2 Amount NOT NULL
 );

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -140,7 +140,7 @@ CREATE TABLE IF NOT EXISTS dex_swap (
   id SERIAL PRIMARY KEY,
   height BIGINT NOT NULL,
   value1 Value,
-  value2 Value,
+  value2 Value
 );
 
 CREATE INDEX ON dex_swap(height, id);

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -130,3 +130,15 @@ CREATE TABLE IF NOT EXISTS dex_batch_swap (
   lambda1 Amount NOT NULL,
   lambda2 Amount NOT NULL
 );
+
+-- Represents instances of invididual swaps into the batch.
+CREATE TABLE IF NOT EXISTS dex_swap (
+  id SERIAL PRIMARY KEY,
+  height BIGINT NOT NULL,
+  value1 Value,
+  value2 Value,
+);
+
+CREATE INDEX ON dex_swap(height, id);
+CREATE INDEX ON dex_swap(((value1).asset));
+CREATE INDEX ON dex_swap(((value2).asset));

--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -121,8 +121,8 @@ CREATE TABLE IF NOT EXISTS dex_batch_swap (
   trace12_end INTEGER REFERENCES dex_trace (id),
   trace21_start INTEGER REFERENCES dex_trace (id),
   trace21_end INTEGER REFERENCES dex_trace (id),
-  pair_asset1 BYTEA NOT NULL,
-  pair_asset2 BYTEA NOT NULL,
+  asset1 BYTEA NOT NULL,
+  asset2 BYTEA NOT NULL,
   unfilled1 Amount NOT NULL,
   unfilled2 Amount NOT NULL,
   delta1 Amount NOT NULL,
@@ -130,6 +130,10 @@ CREATE TABLE IF NOT EXISTS dex_batch_swap (
   lambda1 Amount NOT NULL,
   lambda2 Amount NOT NULL
 );
+
+CREATE INDEX ON dex_batch_swap(height);
+CREATE INDEX ON dex_batch_swap(asset1, height);
+CREATE INDEX ON dex_batch_swap(asset2, height);
 
 -- Represents instances of invididual swaps into the batch.
 CREATE TABLE IF NOT EXISTS dex_swap (

--- a/crates/bin/pindexer/src/dex/mod.rs
+++ b/crates/bin/pindexer/src/dex/mod.rs
@@ -7,7 +7,6 @@ use penumbra_dex::lp::position::{Id, Position};
 use penumbra_dex::lp::{self, TradingFunction};
 use penumbra_dex::{DirectedTradingPair, SwapExecution};
 use penumbra_num::Amount;
-use penumbra_proto::core::component::dex::v1::BatchSwapOutputData;
 use penumbra_proto::{event::ProtoEvent, penumbra::core::component::dex::v1 as pb};
 use sqlx::{PgPool, Postgres, Transaction};
 

--- a/crates/bin/pindexer/src/dex/mod.rs
+++ b/crates/bin/pindexer/src/dex/mod.rs
@@ -546,7 +546,7 @@ impl<'a> TryFrom<&'a ContextualizedEvent> for Event {
                 Ok(Self::BatchSwap {
                     height,
                     execution,
-                    output_data: batch_swap_output_data,
+                    output_data,
                 })
             }
             x => Err(anyhow!(format!("unrecognized event kind: {x}"))),

--- a/crates/bin/pindexer/src/dex/mod.rs
+++ b/crates/bin/pindexer/src/dex/mod.rs
@@ -370,7 +370,7 @@ impl Event {
                     }
                     trace_end = Some(id);
                 }
-                sqlx::query(r#"INSERT INTO swap VALUES ($1, (CAST($2 AS Amount), $3),
+                sqlx::query(r#"INSERT INTO dex_swap VALUES ($1, (CAST($2 AS Amount), $3),
                  (CAST($4 AS AMOUNT), $5), $6, $7, $8, $9, CAST($10 AS AMOUNT), CAST($11 AS AMOUNT),
                   CAST($12 AS AMOUNT), CAST($13 AS AMOUNT), CAST($14 AS AMOUNT), CAST($15 AS AMOUNT),;"#)
                     .bind(i64::try_from(*height)?)

--- a/crates/bin/pindexer/src/dex/mod.rs
+++ b/crates/bin/pindexer/src/dex/mod.rs
@@ -35,7 +35,7 @@ enum Event {
         execution: SwapExecution,
     },
     /// A parsed version of [pb::EventBatchSwap]
-    Swap {
+    BatchSwap {
         height: u64,
         execution: SwapExecution,
     },
@@ -68,11 +68,11 @@ impl Event {
         "penumbra.core.component.dex.v1.EventValueCircuitBreakerCredit",
         "penumbra.core.component.dex.v1.EventValueCircuitBreakerDebit",
         "penumbra.core.component.dex.v1.EventArbExecution",
-        "penumbra.core.component.dex.v1.EventBatchSwap",
         "penumbra.core.component.dex.v1.EventPositionWithdraw",
         "penumbra.core.component.dex.v1.EventPositionOpen",
         "penumbra.core.component.dex.v1.EventPositionClose",
         "penumbra.core.component.dex.v1.EventPositionExecution",
+        "penumbra.core.component.dex.v1.EventBatchSwap",
     ];
 
     /// Index this event, using the handle to the postgres transaction.
@@ -335,7 +335,7 @@ impl Event {
                 .await?;
                 Ok(())
             }
-            Event::Swap { height, execution } => {
+            Event::BatchSwap { height, execution } => {
                 let mut trace_start = None;
                 let mut trace_end = None;
                 for trace in &execution.traces {
@@ -518,14 +518,14 @@ impl<'a> TryFrom<&'a ContextualizedEvent> for Event {
                 })
             }
             // Batch Swap
-            x if x == Event::NAMES[3] => {
+            x if x == Event::NAMES[7] => {
                 let pe = pb::EventBatchSwap::from_event(event.as_ref())?;
                 let height = event.block_height;
                 let execution = pe
                     .swap_execution_1_for_2
                     .ok_or(anyhow!("missing swap execution"))?
                     .try_into()?;
-                Ok(Self::Swap { height, execution })
+                Ok(Self::BatchSwap { height, execution })
             }
             x => Err(anyhow!(format!("unrecognized event kind: {x}"))),
         }

--- a/crates/bin/pindexer/src/dex/mod.rs
+++ b/crates/bin/pindexer/src/dex/mod.rs
@@ -370,7 +370,7 @@ impl Event {
                     }
                     trace_end = Some(id);
                 }
-                sqlx::query(r#"INSERT INTO dex_swap VALUES ($1, (CAST($2 AS Amount), $3),
+                sqlx::query(r#"INSERT INTO dex_batch_swap VALUES ($1, (CAST($2 AS Amount), $3),
                  (CAST($4 AS AMOUNT), $5), $6, $7, $8, $9, CAST($10 AS AMOUNT), CAST($11 AS AMOUNT),
                   CAST($12 AS AMOUNT), CAST($13 AS AMOUNT), CAST($14 AS AMOUNT), CAST($15 AS AMOUNT),;"#)
                     .bind(i64::try_from(*height)?)


### PR DESCRIPTION
## Describe your changes
implements indexing of swaps to satisfy the `/api/swaps` endpoint

- [x] There's also an event for Swap, so we should name the event in the code to BatchSwap to avoid confusion.
- [x] We probably want to record some more information in the swap table, like having the trading pair there, the total amount of inputs and outputs for each asset, the unfilled amounts, et.c

## Issue ticket number and link

fixes #4744

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  Indexer-only changes
