### PR TITLE
events: record `EventPositionClose` when closing positions manually

### DIFF
--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -205,6 +205,7 @@ pub trait PositionManager: StateWrite + PositionRead {
 
         self.update_position(id, Some(prev_state), new_state)
             .await?;
+        self.record_proto(event::position_close_by_id(*id));
 
         Ok(())
     }


### PR DESCRIPTION
There are currently two ways for a position to get closed:

  1. automatically by the DEX, for an auto-close position,
  2. at the end of the block, after being *queued* for closure in the in the action handler.

For 2., we weren't emitting the event.
This commit changes things so that we do, in fact, emit the event in this case, for a position that has not yet been closed.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Only adds new events.
