### PR TITLE
Update frontends to latest 957ab2a

### DIFF
--- a/assets/minifront.zip
+++ b/assets/minifront.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1be13e3a1cfb0c2da2bb093764ff2fbdd2379f85f007b99a36fe722a2431bd04
-size 5136285
+oid sha256:74c9d6395a48de4fb6fede856cb48f76ebb88f56472c79e2974bef0d5e2c2511
+size 5150122

--- a/assets/node-status.zip
+++ b/assets/node-status.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf59963275e4476fb52cbb210fd0239be9fb78d8fb8e7f04de9715f02e8a59be
+oid sha256:ef586037dd4f66d25bd3867be14dc53383d9d20f0a39b78faec2653c27783106
 size 1384181


### PR DESCRIPTION
Contains updates in minifront that allow to workaround fee issues w/ prax v11.9 (v11.10 in review)