### PR TITLE
feat(dev): add grpcui to nix dev env

### DIFF
--- a/deployments/compose/process-compose-dev-tooling.yml
+++ b/deployments/compose/process-compose-dev-tooling.yml
@@ -1,0 +1,25 @@
+---
+# A process-compose configuration for running a dev-centric debugging and introspection
+# tooling for Penumbra, such as gRPC UI, for exploring protobuf interfaces.
+version: "0.5"
+log_level: info
+is_strict: true
+
+processes:
+  # Run gRPC UI for interactive protobuf exploration in a web UI: http://localhost:8100
+  grpcui:
+    command: grpcui -v -open-browser=false -port 8100 -plaintext localhost:8080
+    readiness_probe:
+      http_get:
+        host: 127.0.0.1
+        scheme: http
+        path: "/"
+        port: 8100
+      initial_delay_seconds: 10
+      period_seconds: 5
+      failure_threshold: 3
+    availability:
+      restart: exit_on_failure
+    depends_on:
+      pd:
+        condition: process_healthy

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,17 @@
             vendorHash = "sha256-0iqI/Z8rqDyQ7JqSrsqA9kADqF6qZy8NxTDNjAYYHts=";
           };
 
+          # Build grpcui from source, for Reflection v1 support.
+          # https://github.com/fullstorydev/grpcui/issues/322
+          # To update the grpcui hash values, run:
+          # nix-prefetch-git --url https://github.com/fullstorydev/grpcui --rev 483f037ec98b89200353c696d990324318f8df98
+          grpcUiRelease = {
+            version = "1.4.2-pre.1";
+            sha256 = "sha256-3vjJNa1bXoMGZXPRyVqhxYZPX5FDp8Efy+w6gdx0pXE=";
+            vendorHash = "sha256-j7ZJeO9vhjOoR8aOOJymDM6D7mPAJQoD4O6AyAsErRY=";
+            rev = "483f037ec98b89200353c696d990324318f8df98";
+          };
+
           # Set up for Rust builds, pinned to the Rust toolchain version in the Penumbra repository
           overlays = [ (import rust-overlay) ];
           pkgs = import nixpkgs { inherit system overlays; };
@@ -91,6 +102,25 @@
               license = licenses.asl20;
             };
           }).overrideAttrs (_: { doCheck = false; }); # Disable tests to improve build times
+
+          # grpcui
+          grpcui = (buildGoModule rec {
+            pname = "grpcui";
+            version = grpcUiRelease.version;
+            subPackages = [ "cmd/grpcui" ];
+            src = fetchFromGitHub {
+              owner = "fullstorydev";
+              repo = "grpcui";
+              rev = "${grpcUiRelease.rev}";
+              hash = grpcUiRelease.sha256;
+            };
+            vendorHash = grpcUiRelease.vendorHash;
+            meta = {
+              description = "An interactive web UI for gRPC, along the lines of postman";
+              homepage = "https://github.com/fullstorydev/grpcui";
+              license = licenses.mit;
+            };
+          }).overrideAttrs (_: { doCheck = false; }); # Disable tests to improve build times
         in rec {
           packages = { inherit penumbra cometbft; };
           apps = {
@@ -117,6 +147,7 @@
               cometbft
               grafana
               grpcurl
+              grpcui
               just
               mdbook
               mdbook-katex

--- a/justfile
+++ b/justfile
@@ -8,7 +8,8 @@ dev:
     ./deployments/scripts/check-nix-shell && \
         ./deployments/scripts/run-local-devnet.sh \
         --config ./deployments/compose/process-compose-postgres.yml \
-        --config ./deployments/compose/process-compose-metrics.yml
+        --config ./deployments/compose/process-compose-metrics.yml \
+        --config ./deployments/compose/process-compose-dev-tooling.yml
 
 # Formats the rust files in the project.
 fmt:


### PR DESCRIPTION
## Describe your changes
Adds a version of grpcui to the local nix dev env. Includes logic to build the go binary from source, via nix, because the released version of grpcui upstream still uses the old v1alpha reflection API, which is incompatible with current versions of `pd`.


## Issue ticket number and link

Refs #4392.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > dev tooling only, no changes to app logic
