### PR TITLE
Write command for querying community pool balance correctly

### DIFF
--- a/docs/protocol/src/community_pool.md
+++ b/docs/protocol/src/community_pool.md
@@ -22,7 +22,7 @@ To query the current Community Pool balance, use `pcli query community-pool bala
 asset or its asset ID (display denominations are not currently accepted). For example:
 
 ```bash
-pcli query Community Pool balance upenumbra
+pcli query community-pool balance upenumbra
 ```
 
 Community Pool spend proposals are only accepted for voting if they would not overdraw the current funds in the


### PR DESCRIPTION
## Describe your changes
An example command in the documentation says `Community Pool` instead of `community-pool`.

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [X] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > documentation-only change