### PR TITLE
refactor(governance): update StateWriteExt::signal_upgrade comment

### DIFF
--- a/crates/core/component/governance/src/component/view.rs
+++ b/crates/core/component/governance/src/component/view.rs
@@ -956,7 +956,7 @@ pub trait StateWriteExt: StateWrite + penumbra_ibc::component::ConnectionStateWr
     /// Records the next upgrade height.
     /// After commititng the height, the chain should halt and wait for an upgrade.
     /// It re-uses the same mechanism as emergency halting that prevents the chain from
-    /// restarting without incrementing the application `TOTAL_HALT_COUNT`.
+    /// restarting, without setting `halt_bit`.
     async fn signal_upgrade(&mut self, height: u64) -> Result<()> {
         self.nonverifiable_put_raw(
             state_key::upgrades::next_upgrade().into(),


### PR DESCRIPTION
## Describe your changes

`StateWriteExt::signal_upgrade` is infallible and doesn't await on anything, so its function signature can be simplified to not be async and not return a `Result<()>` that's always `Ok(())`.

Also fixes a comment referring to `TOTAL_HALT_COUNT`, which is now a boolean and not a count.

## Checklist before requesting a review

- [X] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > No change to behavior