### PR TITLE
build: fix nix-build via allowing asset files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,8 +64,13 @@
                 sha256 = "${penumbraRelease.sha256}";
               };
               filter = path: type:
-                # Retain proving and verification parameters, and no-lfs marker file ...
-                (builtins.match ".*\.(no_lfs|param|bin)$" path != null) ||
+                # Retain non-rust asset files as build inputs:
+                # * no_lfs, param, bin: proving and verification parameters
+                # * zip: frontend bundled assets
+                # * sql: database schema files for indexing
+                # * csv: default genesis allocations for testnet generation
+                # * json: default validator info for testnet generation
+                (builtins.match ".*\.(no_lfs|param|bin|zip|sql|csv|json)$" path != null) ||
                 # ... as well as all the normal cargo source files:
                 (craneLib.filterCargoSources path type);
             };


### PR DESCRIPTION

## Describe your changes
Adds a comprehensive allow-list of file extensions to the nix build context. Includes zip files, which will fail a build as of #4782, and other flat file inputs like CSV and JSON for testnet generation. Also adds the `pindexer` binary to the nix-build outputs.

## Issue ticket number and link
Refs #4782. Doesn't close it, because it'd be nice to tack on a CI job that guards against breakage. Will follow up with that separately.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > build logic only, no changes to app code
  
## Testing and review

1. Make sure you've got nix installed (see [dev env docs](https://guide.penumbra.zone/dev/dev-env) if you need help)
2. Run `nix build` in the repo root
3. Ensure no errors, exits 0.