### PR TITLE
Print the position id when generating a position

### DIFF
--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -957,7 +957,7 @@ impl TxCmd {
                 let position = order.as_position(&asset_cache, OsRng)?;
                 tracing::info!(?position);
 
-                println!("Position id:{}", position.id().to_string());
+                println!("Position id: {}", position.id());
 
                 let plan = Planner::new(OsRng)
                     .set_gas_prices(gas_prices)

--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -957,6 +957,8 @@ impl TxCmd {
                 let position = order.as_position(&asset_cache, OsRng)?;
                 tracing::info!(?position);
 
+                println!("Position id:{}", position.id().to_string());
+
                 let plan = Planner::new(OsRng)
                     .set_gas_prices(gas_prices)
                     .set_fee_tier(order.fee_tier().into())


### PR DESCRIPTION
Resolves issue #4792 

Prints the position Id when creating a new liquidity position
