### PR TITLE
pcli: print position ID when creating limit orders

### DIFF
--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -953,6 +953,9 @@ impl TxCmd {
                 let position = order.as_position(&asset_cache, OsRng)?;
                 tracing::info!(?position);
 
+                let id = position.id();
+                println!("Creating position {}", id);
+
                 let plan = Planner::new(OsRng)
                     .set_gas_prices(gas_prices)
                     .set_fee_tier(order.fee_tier().into())


### PR DESCRIPTION
## Describe your changes

Changes pcli to print out a position ID when creating limit orders, making it easier for a user to crossreference with a DEX explorer.

## Issue ticket number and link

No issue

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > only trivial changes to pcli