### PR TITLE
pcli: add un-advertised support for importing Prax registry data

### DIFF
--- a/crates/bin/pcli/src/opt.rs
+++ b/crates/bin/pcli/src/opt.rs
@@ -155,8 +155,17 @@ impl Opt {
                 let path = self.home.join(crate::VIEW_FILE_NAME);
                 tracing::info!(%path, "using local view service");
 
+                let registry_path = self.home.join("registry.json");
+                // Check if the path exists or set it to nojne
+                let registry_path = if registry_path.exists() {
+                    Some(registry_path)
+                } else {
+                    None
+                };
+
                 let svc = ViewServer::load_or_initialize(
                     Some(path),
+                    registry_path,
                     &config.full_viewing_key,
                     config.grpc_url.clone(),
                 )

--- a/crates/core/app/tests/app_can_sweep_a_collection_of_small_notes.rs
+++ b/crates/core/app/tests/app_can_sweep_a_collection_of_small_notes.rs
@@ -116,6 +116,7 @@ async fn app_can_sweep_a_collection_of_small_notes() -> anyhow::Result<()> {
     let view_server = {
         penumbra_view::ViewServer::load_or_initialize(
             None::<&camino::Utf8Path>,
+            None::<&camino::Utf8Path>,
             &*test_keys::FULL_VIEWING_KEY,
             grpc_url,
         )

--- a/crates/core/app/tests/view_server_can_be_served_on_localhost.rs
+++ b/crates/core/app/tests/view_server_can_be_served_on_localhost.rs
@@ -92,6 +92,7 @@ async fn view_server_can_be_served_on_localhost() -> anyhow::Result<()> {
     let view_server = {
         penumbra_view::ViewServer::load_or_initialize(
             None::<&camino::Utf8Path>,
+            None::<&camino::Utf8Path>,
             &*test_keys::FULL_VIEWING_KEY,
             grpc_url,
         )

--- a/crates/core/asset/src/asset/denom_metadata.rs
+++ b/crates/core/asset/src/asset/denom_metadata.rs
@@ -30,6 +30,7 @@ pub struct Metadata {
 }
 
 // These are constructed by the asset registry.
+#[derive(Debug)]
 pub(super) struct Inner {
     // The Penumbra asset ID
     id: Id,

--- a/crates/core/asset/src/asset/denom_metadata.rs
+++ b/crates/core/asset/src/asset/denom_metadata.rs
@@ -317,16 +317,19 @@ impl Metadata {
         if amount == 0u64.into() {
             return self.default_unit();
         }
+        let mut selected_index = 0;
+        let mut selected_exponent = 0;
         for (unit_index, unit) in self.inner.units.iter().enumerate() {
             let unit_amount = Amount::from(10u128.pow(unit.exponent as u32));
-            if amount >= unit_amount {
-                return Unit {
-                    unit_index,
-                    inner: self.inner.clone(),
-                };
+            if unit_amount <= amount && unit.exponent >= selected_exponent {
+                selected_index = unit_index;
+                selected_exponent = unit.exponent;
             }
         }
-        self.base_unit()
+        return Unit {
+            unit_index: selected_index,
+            inner: self.inner.clone(),
+        };
     }
 
     pub fn starts_with(&self, prefix: &str) -> bool {

--- a/crates/view/src/service.rs
+++ b/crates/view/src/service.rs
@@ -100,6 +100,7 @@ impl ViewServer {
     )]
     pub async fn load_or_initialize(
         storage_path: Option<impl AsRef<Utf8Path>>,
+        registry_path: Option<impl AsRef<Utf8Path>>,
         fvk: &FullViewingKey,
         node: Url,
     ) -> anyhow::Result<Self> {
@@ -107,6 +108,10 @@ impl ViewServer {
             .tap(|_| tracing::trace!("loading or initializing storage"))
             .await?
             .tap(|_| tracing::debug!("storage is ready"));
+
+        if let Some(registry_path) = registry_path {
+            storage.load_asset_metadata(registry_path).await?;
+        }
 
         Self::new(storage, node)
             .tap(|_| tracing::trace!("constructing view server"))

--- a/crates/view/src/storage/schema.sql
+++ b/crates/view/src/storage/schema.sql
@@ -15,7 +15,8 @@ CREATE TABLE sync_height (height BIGINT NOT NULL);
 -- used for storing a cache of known assets
 CREATE TABLE assets (
     asset_id                BLOB PRIMARY KEY NOT NULL,
-    denom                   TEXT NOT NULL
+    denom                   TEXT NOT NULL,
+    metadata                TEXT NOT NULL
 );
 
 -- the shape information about the sct


### PR DESCRIPTION
This makes a minimal set of changes to allow `pcli` to make use of the Prax registry. In order to not pre-empt more comprehensive planning about how such an integration should work, this PR just changes `pcli` so that if the registry is placed in a `registry.json` file in the `pcli` home directory, it will be imported into the view database on startup.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > client-side changes only