### PR TITLE
Cleanup tendermint proxy code, fix proxy timestamp handling

### DIFF
--- a/crates/test/mock-tendermint-proxy/src/proxy.rs
+++ b/crates/test/mock-tendermint-proxy/src/proxy.rs
@@ -193,7 +193,11 @@ impl TendermintProxyService for TestNodeProxy {
             .get(&height)
             .cloned()
             .map(penumbra_proto::tendermint::types::Block::try_from)
-            .transpose()?;
+            .transpose()
+            .or_else(|e| {
+                tracing::warn!(?height, error = ?e, "proxy: error fetching blocks");
+                Err(tonic::Status::internal("error fetching blocks"))
+            })?;
         let block_id = block
             .as_ref() // is this off-by-one? should we be getting the id of the last commit?
             .and_then(|b| b.last_commit.as_ref())


### PR DESCRIPTION
## Describe your changes

This PR cleans up the tendermint proxy code by removing the usage of tonic error types and fixes a bug in the proxy timestamp handling.

## Checklist before requesting a review

- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > The timestamp handling change does not affect consensus because it only affects values returned to clients via the tendermint proxy, which is mostly unused. Any usage of these incorrect timestamps would be noticed as frequent and random failures which haven't been reported.