### PR TITLE
Add ability to set fixed time and block duration callback in test node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5179,10 +5179,12 @@ dependencies = [
 name = "penumbra-mock-tendermint-proxy"
 version = "0.80.0"
 dependencies = [
+ "pbjson-types",
  "penumbra-mock-consensus",
  "penumbra-proto",
  "tap",
  "tendermint",
+ "tendermint-proto",
  "tonic",
  "tracing",
 ]

--- a/crates/core/app/tests/app_blocktimes_increment.rs
+++ b/crates/core/app/tests/app_blocktimes_increment.rs
@@ -1,0 +1,99 @@
+use {
+    self::common::BuilderExt,
+    cnidarium::TempStorage,
+    penumbra_app::{
+        genesis::{self, AppState},
+        server::consensus::Consensus,
+    },
+    penumbra_mock_consensus::TestNode,
+    std::time::Duration,
+    tap::{Tap, TapFallible},
+};
+
+mod common;
+
+/// This is more of a test of test code; this ensures
+/// that the mock tendermint's block times are set and increment as expected.
+#[tokio::test]
+async fn mock_tendermint_block_times_correct() -> anyhow::Result<()> {
+    // Install a test logger, and acquire some temporary storage.
+    let guard = common::set_tracing_subscriber();
+    let storage = TempStorage::new().await?;
+
+    // Fixed start time:
+    let start_time = tendermint::Time::parse_from_rfc3339("2022-02-11T17:30:50.425417198Z")?;
+
+    // Define our application state, and start the test node.
+    let mut test_node = {
+        let app_state = AppState::Content(
+            genesis::Content::default().with_chain_id(TestNode::<()>::CHAIN_ID.to_string()),
+        );
+        let consensus = Consensus::new(storage.as_ref().clone());
+        // This should use the default time callback of 5s
+        TestNode::builder()
+            .single_validator()
+            .with_penumbra_auto_app_state(app_state)?
+            .with_initial_timestamp(start_time)
+            .init_chain(consensus)
+            .await
+            .tap_ok(|e| tracing::info!(hash = %e.last_app_hash_hex(), "finished init chain"))?
+    };
+
+    // The test node's time should be the initial timestamp before any blocks are committed
+    assert_eq!(*test_node.timestamp(), start_time);
+
+    // Test a handful of block executions
+    for i in 0..10 {
+        // Execute a block on the test node
+        test_node.block().execute().await?;
+
+        // Ensure the time has incremented by 5 seconds
+        assert_eq!(
+            *test_node.timestamp(),
+            start_time
+                .checked_add(Duration::from_secs(5 * (i + 1)))
+                .unwrap()
+        );
+    }
+
+    // Now do it with a different duration.
+    let block_duration = Duration::from_secs(13);
+    let storage = TempStorage::new().await?;
+    let mut test_node = {
+        let app_state = AppState::Content(
+            genesis::Content::default().with_chain_id(TestNode::<()>::CHAIN_ID.to_string()),
+        );
+        let consensus = Consensus::new(storage.as_ref().clone());
+        // This should use the default time callback of 5s
+        TestNode::builder()
+            .single_validator()
+            .with_penumbra_auto_app_state(app_state)?
+            .with_initial_timestamp(start_time)
+            // Set a callback to add 13 seconds instead
+            .ts_callback(move |t| t.checked_add(block_duration).unwrap())
+            .init_chain(consensus)
+            .await
+            .tap_ok(|e| tracing::info!(hash = %e.last_app_hash_hex(), "finished init chain"))?
+    };
+
+    // The test node's time should be the initial timestamp before any blocks are committed
+    assert_eq!(*test_node.timestamp(), start_time);
+
+    // Test a handful of block executions
+    for i in 0..10 {
+        // Execute a block on the test node
+        test_node.block().execute().await?;
+
+        // Ensure the time has incremented by 5 seconds
+        assert_eq!(
+            *test_node.timestamp(),
+            start_time.checked_add(block_duration * (i + 1)).unwrap()
+        );
+    }
+
+    // Free our temporary storage.
+    Ok(())
+        .tap(|_| drop(test_node))
+        .tap(|_| drop(storage))
+        .tap(|_| drop(guard))
+}

--- a/crates/test/mock-consensus/src/builder/init_chain.rs
+++ b/crates/test/mock-consensus/src/builder/init_chain.rs
@@ -39,6 +39,8 @@ impl Builder {
             app_state: Some(app_state),
             keyring,
             on_block,
+            initial_timestamp,
+            ts_callback,
         } = self
         else {
             bail!("builder was not fully initialized")
@@ -71,6 +73,8 @@ impl Builder {
             last_app_hash: app_hash.as_bytes().to_owned(),
             keyring,
             on_block,
+            timestamp: initial_timestamp.unwrap_or(Time::now()),
+            ts_callback: ts_callback.unwrap_or(Box::new(default_ts_callback)),
         })
     }
 

--- a/crates/test/mock-consensus/src/lib.rs
+++ b/crates/test/mock-consensus/src/lib.rs
@@ -32,6 +32,7 @@
 use {
     ed25519_consensus::{SigningKey, VerificationKey},
     std::collections::BTreeMap,
+    tendermint::Time,
 };
 
 pub mod block;
@@ -84,10 +85,17 @@ pub struct TestNode<C> {
     keyring: Keyring,
     /// A callback that will be invoked when a new block is constructed.
     on_block: Option<OnBlockFn>,
+    /// A callback that will be invoked when a new block is committed, to produce the next timestamp.
+    ts_callback: TsCallbackFn,
+    /// The current timestamp of the node.
+    timestamp: Time,
 }
 
 /// A type alias for the `TestNode::on_block` callback.
 pub type OnBlockFn = Box<dyn FnMut(tendermint::Block) + Send + Sync + 'static>;
+
+/// A type alias for the `TestNode::ts_callback` callback.
+pub type TsCallbackFn = Box<dyn Fn(Time) -> Time + Send + Sync + 'static>;
 
 /// An ordered map of consensus keys.
 ///
@@ -102,6 +110,11 @@ impl<C> TestNode<C> {
     /// Returns the last `app_hash` value, represented as a slice of bytes.
     pub fn last_app_hash(&self) -> &[u8] {
         &self.last_app_hash
+    }
+
+    /// Returns the last `timestamp` value.
+    pub fn timestamp(&self) -> &Time {
+        &self.timestamp
     }
 
     /// Returns the last `app_hash` value, represented as a hexadecimal string.

--- a/crates/test/mock-tendermint-proxy/Cargo.toml
+++ b/crates/test/mock-tendermint-proxy/Cargo.toml
@@ -8,9 +8,11 @@ homepage.workspace   = true
 license.workspace    = true
 
 [dependencies]
+pbjson-types            = { workspace = true }
 penumbra-mock-consensus = { workspace = true }
 penumbra-proto          = { workspace = true, features = ["rpc", "tendermint"] }
 tap                     = { workspace = true }
 tendermint              = { workspace = true }
+tendermint-proto        = { workspace = true }
 tonic                   = { workspace = true }
 tracing                 = { workspace = true }


### PR DESCRIPTION
## Describe your changes

This enhances test code reproducibility by allowing a fixed timestamp and block timing to be set rather than using system time.

## Issue ticket number and link

#3759

## Checklist before requesting a review

- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > only affects tests