### PR TITLE
No longer display withdrawn auction NFTs when viewing balance in pcli

### DIFF
--- a/crates/bin/pcli/src/command/view/balance.rs
+++ b/crates/bin/pcli/src/command/view/balance.rs
@@ -80,10 +80,10 @@ impl BalanceCmd {
                         (*index, asset.value(sum.into()))
                     })
                 })
-                // Exclude withdrawn LPNFTs.
+                // Exclude withdrawn LPNFTs and withdrawn auction NFTs.
                 .filter(|(_, value)| match asset_cache.get(&value.asset_id) {
                     None => true,
-                    Some(denom) => !denom.is_withdrawn_position_nft(),
+                    Some(denom) => !denom.is_withdrawn_position_nft() && !denom.is_withdrawn_auction_nft(),
                 });
 
             for (index, value) in rows {

--- a/crates/bin/pcli/src/command/view/balance.rs
+++ b/crates/bin/pcli/src/command/view/balance.rs
@@ -83,7 +83,9 @@ impl BalanceCmd {
                 // Exclude withdrawn LPNFTs and withdrawn auction NFTs.
                 .filter(|(_, value)| match asset_cache.get(&value.asset_id) {
                     None => true,
-                    Some(denom) => !denom.is_withdrawn_position_nft() && !denom.is_withdrawn_auction_nft(),
+                    Some(denom) => {
+                        !denom.is_withdrawn_position_nft() && !denom.is_withdrawn_auction_nft()
+                    }
                 });
 
             for (index, value) in rows {

--- a/crates/core/asset/src/asset/denom_metadata.rs
+++ b/crates/core/asset/src/asset/denom_metadata.rs
@@ -345,6 +345,10 @@ impl Metadata {
         self.starts_with("auctionnft_")
     }
 
+    pub fn is_withdrawn_auction_nft(&self) -> bool {
+        self.starts_with("auctionnft_2")
+    }
+
     pub fn is_opened_position_nft(&self) -> bool {
         let prefix = "lpnft_opened_".to_string();
 


### PR DESCRIPTION
## Describe your changes
pcli no longer displays withdrawn auction NFTs when running ```pcli view balance```

## Issue ticket number and link
#4820 

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason: I have only modified what pcli filters out before displaying balances and added a function in denom_metadata that matches a similar function for LPNFTs.

  > After completing a number of auctions, viewing my balances through pcli has become increasingly difficult due to all of my previously withdrawn auction NFTs. I decided to not filter out closed auction positions so they can serve as a reminder to withdraw them, matching the default behavior of the swap frontend.
