### PR TITLE
Perform channel handshake in IBC state machine tests

### DIFF
--- a/crates/core/app/tests/ibc_handshake.rs
+++ b/crates/core/app/tests/ibc_handshake.rs
@@ -69,7 +69,7 @@ async fn ibc_handshake() -> anyhow::Result<()> {
         chain_b_ibc,
     };
 
-    // Perform the IBC connection handshake between the two chains.
+    // Perform the IBC connection and channel handshakes between the two chains.
     // TODO: some testing of failure cases of the handshake process would be good
     relayer.handshake().await?;
 


### PR DESCRIPTION
## Describe your changes

This extends the IBC state machine tests to perform a channel handshake after the successful connection handshake. This is the final prerequisite to performing IBC transfers between chains in tests.

## Checklist before requesting a review

- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > tests only