### PR TITLE
build: bump rust to 1.80

### DIFF
--- a/crates/bin/pindexer/Cargo.toml
+++ b/crates/bin/pindexer/Cargo.toml
@@ -17,7 +17,7 @@ cometindex = {workspace = true}
 num-bigint = { version = "0.4" }
 penumbra-shielded-pool = {workspace = true, default-features = false}
 penumbra-stake = {workspace = true, default-features = false}
-penumbra-app = {workspace = true, default-features = false}
+penumbra-app = {workspace = true}
 penumbra-dex = {workspace = true, default-features = false}
 penumbra-governance = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}

--- a/crates/core/app/tests/common/temp_storage_ext.rs
+++ b/crates/core/app/tests/common/temp_storage_ext.rs
@@ -8,6 +8,7 @@ use {
 #[async_trait]
 pub trait TempStorageExt: Sized {
     async fn apply_genesis(self, genesis: AppState) -> anyhow::Result<Self>;
+    #[allow(dead_code)]
     async fn apply_default_genesis(self) -> anyhow::Result<Self>;
     async fn new_with_penumbra_prefixes() -> anyhow::Result<TempStorage>;
 }

--- a/crates/core/app/tests/common/test_node_ext.rs
+++ b/crates/core/app/tests/common/test_node_ext.rs
@@ -1,3 +1,6 @@
+// These mock-consensus helper traits aren't consumed just yet
+#![allow(dead_code)]
+
 use {
     async_trait::async_trait, cnidarium::TempStorage, penumbra_mock_consensus::TestNode,
     penumbra_sct::component::clock::EpochRead as _, tap::Tap,

--- a/crates/core/app/tests/common/validator_read_ext.rs
+++ b/crates/core/app/tests/common/validator_read_ext.rs
@@ -1,3 +1,6 @@
+// These mock-consensus helper traits aren't consumed just yet.
+#![allow(dead_code)]
+
 use {
     async_trait::async_trait,
     futures::TryStreamExt,

--- a/crates/core/component/auction/src/component/auction.rs
+++ b/crates/core/component/auction/src/component/auction.rs
@@ -200,5 +200,5 @@ pub(crate) trait AuctionCircuitBreaker: StateWrite {
 
 impl<T: StateWrite + ?Sized> AuctionCircuitBreaker for T {}
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {}

--- a/crates/core/component/auction/src/component/auction_store.rs
+++ b/crates/core/component/auction/src/component/auction_store.rs
@@ -54,5 +54,5 @@ pub trait AuctionStoreRead: StateRead {
 
 impl<T: StateRead + ?Sized> AuctionStoreRead for T {}
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {}

--- a/crates/core/component/governance/src/proposal.rs
+++ b/crates/core/component/governance/src/proposal.rs
@@ -202,29 +202,21 @@ impl TryFrom<ProposalToml> for Proposal {
 
 /// The specific kind of a proposal.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "clap", derive(clap::Subcommand))]
 #[serde(try_from = "pb::ProposalKind", into = "pb::ProposalKind")]
 pub enum ProposalKind {
     /// A signaling proposal.
-    #[cfg_attr(feature = "clap", clap(display_order = 100))]
     Signaling,
     /// An emergency proposal.
-    #[cfg_attr(feature = "clap", clap(display_order = 200))]
     Emergency,
     /// A parameter change proposal.
-    #[cfg_attr(feature = "clap", clap(display_order = 300))]
     ParameterChange,
     /// A Community Pool spend proposal.
-    #[cfg_attr(feature = "clap", clap(display_order = 400))]
     CommunityPoolSpend,
     /// An upgrade proposal.
-    #[cfg_attr(feature = "clap", clap(display_order = 500))]
     UpgradePlan,
     /// A proposal to freeze an IBC client.
-    #[cfg_attr(feature = "clap", clap(display_order = 600))]
     FreezeIbcClient,
     /// A proposal to unfreeze an IBC client.
-    #[cfg_attr(feature = "clap", clap(display_order = 700))]
     UnfreezeIbcClient,
 }
 

--- a/crates/core/component/governance/src/vote.rs
+++ b/crates/core/component/governance/src/vote.rs
@@ -11,16 +11,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(try_from = "pb::Vote", into = "pb::Vote")]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-#[cfg_attr(feature = "clap", derive(clap::Subcommand))]
 pub enum Vote {
     /// Vote to approve the proposal.
-    #[cfg_attr(feature = "clap", clap(display_order = 100))]
     Yes,
     /// Vote is to reject the proposal.
-    #[cfg_attr(feature = "clap", clap(display_order = 200))]
     No,
     /// Vote to abstain from the proposal.
-    #[cfg_attr(feature = "clap", clap(display_order = 300))]
     Abstain,
 }
 

--- a/crates/crypto/proof-setup/Cargo.toml
+++ b/crates/crypto/proof-setup/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = {workspace = true}
 ark-ec = {workspace = true, default-features = false}
 ark-ff = {workspace = true, default-features = false}
 ark-groth16 = {workspace = true, default-features = false}
-ark-poly = { version = "0.4.2", default_features = false }
+ark-poly = { version = "0.4.2", default-features = false }
 ark-relations = {workspace = true}
 ark-serialize = {workspace = true}
 blake2b_simd = {workspace = true}

--- a/crates/util/tower-trace/src/trace/service_span.rs
+++ b/crates/util/tower-trace/src/trace/service_span.rs
@@ -101,8 +101,6 @@ pub mod make {
         _p: PhantomData<fn(T, R)>,
     }
 
-    #[cfg(feature = "tower-layer")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tower-layer")))]
     pub fn layer<T, R, G>(get_span: G) -> MakeLayer<T, R, G>
     where
         G: GetSpan<T> + Clone,

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721058578,
-        "narHash": "sha256-fs/PVa3H5dS1//4BjecWi3nitXm5fRObx0JxXIAo+JA=",
+        "lastModified": 1724537630,
+        "narHash": "sha256-gpqINM71zp3kw5XYwUXa84ZtPnCmLLnByuFoYesT1bY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "17e5109bb1d9fb393d70fba80988f7d70d1ded1a",
+        "rev": "3e08f4b1fc9aaede5dd511d8f5f4ef27501e49b0",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720957393,
-        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
+        "lastModified": 1724819573,
+        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
+        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721096425,
-        "narHash": "sha256-9/58mnoDCyBHsJZwTg3MfgX3kgVqP/SzGMy0WnnWII8=",
+        "lastModified": 1724898214,
+        "narHash": "sha256-4yMO9+Lsr3zqTf4clAGGag/bfNTmc/ITOXbJQcOEok4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1c95d396d7395829b5c06bea84fb1dd23169ca42",
+        "rev": "0bc2c784e3a6ce30a2ab1b9f47325ccbed13039f",
         "type": "github"
       },
       "original": {

--- a/justfile
+++ b/justfile
@@ -15,6 +15,10 @@ dev:
 fmt:
     cargo fmt --all
 
+# Runs 'cargo check' on all rust files in the project.
+check:
+  RUSTFLAGS="-D warnings" cargo check --release --all-targets
+
 # Render livereload environment for editing the Protocol documentation.
 protocol-docs:
     # Access local docs at http://127.0.0.1:3002

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,8 @@
 [toolchain]
 # We set a specific version of rust so that CI workflows use the same
 # version development environments do.
-channel = "1.75"
-components = [ "rustfmt" ]
+channel = "1.80"
+components = [ "rustfmt", "rust-analyzer" ]
 # Include wasm toolchain, for CI tests to check wasm32 build targets still work,
 # to avoid downstream breakage in `penumbra-wasm` crate, in the web repo.
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
## Describe your changes
Cleans up some unused cfg_attrs that weren't previously generating warnings. All are cosmetic, and don't affect application functionality.

Also adds the `rust-analyzer` component the rust-toolchain toml, ensuring that the correct version of rust-analyzer (corresponding to the channel specified in toolchain.toml) is used, so that developers can easily hook up their IDEs.

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > no change to app behavior: updates build tooling, and removes unused config-attributes in source code.
