### PR TITLE
Properly sum Penumbra-minted values returned in total supply API

### DIFF
--- a/crates/core/component/shielded-pool/src/component/rpc/bank_query.rs
+++ b/crates/core/component/shielded-pool/src/component/rpc/bank_query.rs
@@ -30,7 +30,7 @@ use super::Server;
 impl BankQuery for Server {
     /// Returns the total supply for all IBC assets.
     /// Internally-minted assets (Penumbra tokens, LP tokens, delegation tokens, etc.)
-    /// are also included but the supplies are hardcoded at 0 for now.
+    /// are also included but the supplies are will only reflect what has been transferred out.
     ///
     /// TODO: Implement a way to fetch the total supply for these assets.
     /// TODO: implement pagination
@@ -107,7 +107,11 @@ impl BankQuery for Server {
             }
             let denom_metadata = denom_metadata.expect("should not be an error");
 
-            total_supply.insert(denom_metadata, amount);
+            // Add to the total supply seen for this denom.
+            total_supply
+                .entry(denom_metadata)
+                .and_modify(|a| *a += amount)
+                .or_insert(amount);
         }
 
         Ok(tonic::Response::new(QueryTotalSupplyResponse {


### PR DESCRIPTION
## Describe your changes

This fixes an issue in the `TotalSupply` API where tokens minted on Penumbra and received from different counterparties weren't correctly summing together.

It should be noted that this API returns two subtly different values depending on the asset:

* For a Penumbra-minted token, it's really the "Total Outstanding IBC Supply" API rather than the "Total Supply" API -- it will return the amount of the token that has been sent to and remains on other chains
* For an externally-originating token, it indicates the total supply of the token transferred into and remaining on the Penumbra chain

## Checklist before requesting a review

- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > no consensus changes