### PR TITLE
chore: update minifront bundled assets

### DIFF
--- a/assets/minifront.zip
+++ b/assets/minifront.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74c9d6395a48de4fb6fede856cb48f76ebb88f56472c79e2974bef0d5e2c2511
-size 5150122
+oid sha256:620aca062812b68edb1635deb74c62e340181476510b63daee53195178757f20
+size 5253302

--- a/assets/node-status.zip
+++ b/assets/node-status.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ef586037dd4f66d25bd3867be14dc53383d9d20f0a39b78faec2653c27783106
-size 1384181
+oid sha256:3bf95883f7466b7247d455d2e830c1754dd0c45cf6a3cf78e0f0d83fb9d202fc
+size 1240860


### PR DESCRIPTION

## Describe your changes
Updated to latest minifront and node-status apps from the penumbra-zone/web repo, commit a8a5f41f7d791059e47f873c6948a26a057e674b.

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > front-end assets only, no changes to consensus logic