### PR TITLE
chore: update team email address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ tag = true
 push = false
 
 [workspace.package]
-authors    = ["Penumbra Labs <team@penumbra.zone>"]
+authors    = ["Penumbra Labs <team@penumbralabs.xyz"]
 edition    = "2021"
 version    = "0.80.4"
 repository = "https://github.com/penumbra-zone/penumbra"


### PR DESCRIPTION
## Describe your changes
Updates the email address used for the Penumbra Labs team in the cargo manifest. There's only one point of update, because the crates all reference the top-level workspace fields. Other crates outside the protocol monorepo will need to be updated separately.

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > package metadata only, no changes to app code
  
## Related changes in other packages

Here's a concise list of similar changes across other repositories, to aid in review:

- https://github.com/penumbra-zone/tower-abci/pull/54
- https://github.com/penumbra-zone/jmt/pull/118
- https://github.com/penumbra-zone/standard-penumbra-explorer/pull/1
- https://github.com/penumbra-zone/schemata/pull/1