### PR TITLE
pindexer: Allow for multiple BatchSwaps in a single block

### DIFF
--- a/crates/bin/pindexer/src/dex/dex.sql
+++ b/crates/bin/pindexer/src/dex/dex.sql
@@ -116,7 +116,8 @@ CREATE TABLE IF NOT EXISTS dex_lp_execution (
 
 --- Represents instances where swap executions happened.
 CREATE TABLE IF NOT EXISTS dex_batch_swap (
-  height BIGINT PRIMARY KEY,
+  id SERIAL PRIMARY KEY,
+  height BIGINT NOT NULL,
   trace12_start INTEGER REFERENCES dex_trace (id),
   trace12_end INTEGER REFERENCES dex_trace (id),
   trace21_start INTEGER REFERENCES dex_trace (id),

--- a/crates/bin/pindexer/src/dex/mod.rs
+++ b/crates/bin/pindexer/src/dex/mod.rs
@@ -368,7 +368,7 @@ impl Event {
                     insert_swap_execution(dbtx, execution12.as_ref()).await?;
                 let (trace21_start, trace21_end) =
                     insert_swap_execution(dbtx, execution21.as_ref()).await?;
-                sqlx::query(r#"INSERT INTO dex_batch_swap VALUES ($1, $2, $3, $4, $5, $6, $7, CAST($8 AS Amount), CAST($9 AS Amount), CAST($10 AS Amount), CAST($11 AS Amount), CAST($12 AS Amount), CAST($13 AS Amount));"#)
+                sqlx::query(r#"INSERT INTO dex_batch_swap VALUES (DEFAULT, $1, $2, $3, $4, $5, $6, $7, CAST($8 AS Amount), CAST($9 AS Amount), CAST($10 AS Amount), CAST($11 AS Amount), CAST($12 AS Amount), CAST($13 AS Amount));"#)
                     .bind(i64::try_from(*height)?)
                     .bind(trace12_start)
                     .bind(trace12_end)


### PR DESCRIPTION
This fixes a bug where we assumed there was only one swap per block, ignoring the fact that each trading pair will have a different batch swap.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only
