### PR TITLE
cometindex: speedup by committing event changes in batches of 1000

### DIFF
--- a/crates/util/cometindex/src/indexer.rs
+++ b/crates/util/cometindex/src/indexer.rs
@@ -179,7 +179,6 @@ impl Indexer {
 
             relevant_events += 1;
 
-            // Otherwise we have something to process. Make a dbtx
             for index in indexes {
                 if index.is_relevant(&event.as_ref().kind) {
                     tracing::debug!(?event, ?index, "relevant to index");
@@ -190,7 +189,7 @@ impl Indexer {
             update_watermark(&mut dbtx, event.local_rowid).await?;
             // Only commit in batches of <= 1000 events, for about a 5x performance increase when
             // catching up.
-            if scanned_events % 1000 == 0 {
+            if relevant_events % 1000 == 0 {
                 dbtx.commit().await?;
                 dbtx = dst_db.begin().await?;
             }


### PR DESCRIPTION
Instead of creating one transaction for each event we need to index, we instead only close this transaction every 1000 events (or when when we've caught up to the database).

This gives about a 5x performance in catch up speed.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only
