### PR TITLE
planner: implement getters for action list

### DIFF
--- a/crates/core/transaction/src/action_list.rs
+++ b/crates/core/transaction/src/action_list.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use penumbra_proto::core::transaction::v1::Action;
 use std::collections::BTreeMap;
 
 use crate::plan::MemoPlan;
@@ -29,6 +30,21 @@ pub struct ActionList {
 }
 
 impl ActionList {
+    /// Returns an immutable reference to a list of action plans.
+    pub fn actions(&self) -> &Vec<ActionPlan> {
+        &self.actions
+    }
+
+    /// Returns an immutable reference to a map of change outputs.
+    pub fn change_outputs(&self) -> &BTreeMap<asset::Id, OutputPlan> {
+        &self.change_outputs
+    }
+
+    /// Returns an immutable reference to the fee.
+    pub fn fee(&self) -> &Fee {
+        &self.fee
+    }
+
     /// Returns true if the resulting transaction would require a memo.
     pub fn requires_memo(&self) -> bool {
         let has_change_outputs = !self.change_outputs.is_empty();

--- a/crates/core/transaction/src/action_list.rs
+++ b/crates/core/transaction/src/action_list.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use penumbra_proto::core::transaction::v1::Action;
 use std::collections::BTreeMap;
 
 use crate::plan::MemoPlan;


### PR DESCRIPTION
## Describe your changes

public getters that return immutable reference to fields in the [ActionList](https://github.com/penumbra-zone/penumbra/blob/main/crates/core/transaction/src/action_list.rs#L21) struct.

## Issue ticket number and link

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:
