### PR TITLE
governance: add `overflow-checks` crate-wide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,12 @@ x86_64-unknown-linux-gnu = "buildjet-32vcpu-ubuntu-2204"
 [profile.dist]
 inherits = "release"
 
+[profile.dev.package.penumbra-governance]
+overflow-checks = true
+
+[profile.release.package.penumbra-governance]
+overflow-checks = true
+
 # config for 'cargo release'
 [workspace.metadata.release]
 # Instruct cargo-release to increment versions for all packages in the workspace in lockstep.


### PR DESCRIPTION
## Describe your changes

Adds a guard against underflow/overflows for the `penumbra-governance` crate

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Provided that there are not underflows/overflows, this should not be consensus-breaking