### PR TITLE
fix(ibc): use `HostInterface` for all block height reads in ibc server

### DIFF
--- a/crates/core/component/ibc/src/component/rpc/client_query.rs
+++ b/crates/core/component/ibc/src/component/rpc/client_query.rs
@@ -60,7 +60,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ClientQuery for IbcQuery<HI> {
                 client_state,
                 proof: proof.encode_to_vec(),
                 proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                    revision_height: snapshot.get_block_height().await.map_err(|e| {
+                    revision_height: HI::get_block_height(&snapshot).await.map_err(|e| {
                         tonic::Status::aborted(format!("couldn't decode height: {e}"))
                     })? + 1,
                     revision_number: HI::get_revision_number(&snapshot).await.map_err(|e| {
@@ -144,7 +144,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ClientQuery for IbcQuery<HI> {
                 consensus_state,
                 proof: proof.encode_to_vec(),
                 proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                    revision_height: snapshot.get_block_height().await.map_err(|e| {
+                    revision_height: HI::get_block_height(&snapshot).await.map_err(|e| {
                         tonic::Status::aborted(format!("couldn't decode height: {e}"))
                     })? + 1,
                     revision_number: HI::get_revision_number(&snapshot).await.map_err(|e| {

--- a/crates/core/component/ibc/src/component/rpc/client_query.rs
+++ b/crates/core/component/ibc/src/component/rpc/client_query.rs
@@ -11,7 +11,6 @@ use ibc_proto::ibc::core::client::v1::{
     QueryUpgradedClientStateResponse, QueryUpgradedConsensusStateRequest,
     QueryUpgradedConsensusStateResponse,
 };
-use penumbra_sct::component::clock::EpochRead;
 use prost::Message;
 
 use ibc_types::core::client::ClientId;
@@ -55,19 +54,19 @@ impl<HI: HostInterface + Send + Sync + 'static> ClientQuery for IbcQuery<HI> {
             .transpose()
             .map_err(|e| tonic::Status::aborted(format!("couldn't decode client state: {e}")))?;
 
-        let res =
-            QueryClientStateResponse {
-                client_state,
-                proof: proof.encode_to_vec(),
-                proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                    revision_height: HI::get_block_height(&snapshot).await.map_err(|e| {
-                        tonic::Status::aborted(format!("couldn't decode height: {e}"))
-                    })? + 1,
-                    revision_number: HI::get_revision_number(&snapshot).await.map_err(|e| {
-                        tonic::Status::aborted(format!("couldn't decode height: {e}"))
-                    })?,
-                }),
-            };
+        let res = QueryClientStateResponse {
+            client_state,
+            proof: proof.encode_to_vec(),
+            proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
+                revision_height: HI::get_block_height(&snapshot)
+                    .await
+                    .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
+                    + 1,
+                revision_number: HI::get_revision_number(&snapshot)
+                    .await
+                    .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?,
+            }),
+        };
 
         Ok(tonic::Response::new(res))
     }
@@ -139,19 +138,19 @@ impl<HI: HostInterface + Send + Sync + 'static> ClientQuery for IbcQuery<HI> {
             .transpose()
             .map_err(|e| tonic::Status::aborted(format!("couldn't decode consensus state: {e}")))?;
 
-        let res =
-            QueryConsensusStateResponse {
-                consensus_state,
-                proof: proof.encode_to_vec(),
-                proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                    revision_height: HI::get_block_height(&snapshot).await.map_err(|e| {
-                        tonic::Status::aborted(format!("couldn't decode height: {e}"))
-                    })? + 1,
-                    revision_number: HI::get_revision_number(&snapshot).await.map_err(|e| {
-                        tonic::Status::aborted(format!("couldn't decode height: {e}"))
-                    })?,
-                }),
-            };
+        let res = QueryConsensusStateResponse {
+            consensus_state,
+            proof: proof.encode_to_vec(),
+            proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
+                revision_height: HI::get_block_height(&snapshot)
+                    .await
+                    .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
+                    + 1,
+                revision_number: HI::get_revision_number(&snapshot)
+                    .await
+                    .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?,
+            }),
+        };
 
         Ok(tonic::Response::new(res))
     }

--- a/crates/core/component/ibc/src/component/rpc/connection_query.rs
+++ b/crates/core/component/ibc/src/component/rpc/connection_query.rs
@@ -16,7 +16,6 @@ use ibc_types::path::{
     ClientConnectionPath, ClientConsensusStatePath, ClientStatePath, ConnectionPath,
 };
 use ibc_types::DomainType;
-use penumbra_sct::component::clock::EpochRead as _;
 use prost::Message;
 use std::str::FromStr;
 
@@ -59,19 +58,19 @@ impl<HI: HostInterface + Send + Sync + 'static> ConnectionQuery for IbcQuery<HI>
         let conn =
             conn.map_err(|e| tonic::Status::aborted(format!("couldn't decode connection: {e}")))?;
 
-        let res =
-            QueryConnectionResponse {
-                connection: conn,
-                proof: proof.encode_to_vec(),
-                proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                    revision_height: HI::get_block_height(&snapshot).await.map_err(|e| {
-                        tonic::Status::aborted(format!("couldn't decode height: {e}"))
-                    })? + 1,
-                    revision_number: HI::get_revision_number(&snapshot).await.map_err(|e| {
-                        tonic::Status::aborted(format!("couldn't decode height: {e}"))
-                    })?,
-                }),
-            };
+        let res = QueryConnectionResponse {
+            connection: conn,
+            proof: proof.encode_to_vec(),
+            proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
+                revision_height: HI::get_block_height(&snapshot)
+                    .await
+                    .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
+                    + 1,
+                revision_number: HI::get_revision_number(&snapshot)
+                    .await
+                    .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?,
+            }),
+        };
 
         Ok(tonic::Response::new(res))
     }

--- a/crates/core/component/ibc/src/component/rpc/connection_query.rs
+++ b/crates/core/component/ibc/src/component/rpc/connection_query.rs
@@ -64,7 +64,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConnectionQuery for IbcQuery<HI>
                 connection: conn,
                 proof: proof.encode_to_vec(),
                 proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                    revision_height: snapshot.get_block_height().await.map_err(|e| {
+                    revision_height: HI::get_block_height(&snapshot).await.map_err(|e| {
                         tonic::Status::aborted(format!("couldn't decode height: {e}"))
                     })? + 1,
                     revision_number: HI::get_revision_number(&snapshot).await.map_err(|e| {
@@ -168,8 +168,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConnectionQuery for IbcQuery<HI>
             connection_paths,
             proof: proof.encode_to_vec(),
             proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                revision_height: snapshot
-                    .get_block_height()
+                revision_height: HI::get_block_height(&snapshot)
                     .await
                     .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
                     + 1,
@@ -222,8 +221,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConnectionQuery for IbcQuery<HI>
             identified_client_state: Some(identified_client_state),
             proof: proof.encode_to_vec(),
             proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                revision_height: snapshot
-                    .get_block_height()
+                revision_height: HI::get_block_height(&snapshot)
                     .await
                     .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
                     + 1,
@@ -280,7 +278,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConnectionQuery for IbcQuery<HI>
                 client_id: client_id.to_string(),
                 proof: proof.encode_to_vec(),
                 proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                    revision_height: snapshot.get_block_height().await.map_err(|e| {
+                    revision_height: HI::get_block_height(&snapshot).await.map_err(|e| {
                         tonic::Status::aborted(format!("couldn't decode height: {e}"))
                     })? + 1,
                     revision_number: HI::get_revision_number(&snapshot).await.map_err(|e| {

--- a/crates/core/component/ibc/src/component/rpc/consensus_query.rs
+++ b/crates/core/component/ibc/src/component/rpc/consensus_query.rs
@@ -25,7 +25,6 @@ use ibc_types::DomainType;
 use ibc_types::core::channel::{ChannelId, IdentifiedChannelEnd, PortId};
 
 use ibc_types::core::connection::ConnectionId;
-use penumbra_sct::component::clock::EpochRead as _;
 use prost::Message;
 
 use std::str::FromStr;
@@ -68,19 +67,19 @@ impl<HI: HostInterface + Send + Sync + 'static> ConsensusQuery for IbcQuery<HI> 
         let channel =
             channel.map_err(|e| tonic::Status::aborted(format!("couldn't decode channel: {e}")))?;
 
-        let res =
-            QueryChannelResponse {
-                channel,
-                proof: proof.encode_to_vec(),
-                proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                    revision_height: HI::get_block_height(&snapshot).await.map_err(|e| {
-                        tonic::Status::aborted(format!("couldn't decode height: {e}"))
-                    })? + 1,
-                    revision_number: HI::get_revision_number(&snapshot).await.map_err(|e| {
-                        tonic::Status::aborted(format!("couldn't decode height: {e}"))
-                    })?,
-                }),
-            };
+        let res = QueryChannelResponse {
+            channel,
+            proof: proof.encode_to_vec(),
+            proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
+                revision_height: HI::get_block_height(&snapshot)
+                    .await
+                    .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
+                    + 1,
+                revision_number: HI::get_revision_number(&snapshot)
+                    .await
+                    .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?,
+            }),
+        };
 
         Ok(tonic::Response::new(res))
     }

--- a/crates/core/component/ibc/src/component/rpc/consensus_query.rs
+++ b/crates/core/component/ibc/src/component/rpc/consensus_query.rs
@@ -73,7 +73,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConsensusQuery for IbcQuery<HI> 
                 channel,
                 proof: proof.encode_to_vec(),
                 proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                    revision_height: snapshot.get_block_height().await.map_err(|e| {
+                    revision_height: HI::get_block_height(&snapshot).await.map_err(|e| {
                         tonic::Status::aborted(format!("couldn't decode height: {e}"))
                     })? + 1,
                     revision_number: HI::get_revision_number(&snapshot).await.map_err(|e| {
@@ -258,8 +258,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConsensusQuery for IbcQuery<HI> 
             identified_client_state: Some(identified_client_state),
             proof: proof.encode_to_vec(),
             proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                revision_height: snapshot
-                    .get_block_height()
+                revision_height: HI::get_block_height(&snapshot)
                     .await
                     .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
                     + 1,
@@ -351,8 +350,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConsensusQuery for IbcQuery<HI> 
             client_id: connection.client_id.clone().to_string(),
             proof: proof.encode_to_vec(),
             proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                revision_height: snapshot
-                    .get_block_height()
+                revision_height: HI::get_block_height(&snapshot)
                     .await
                     .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
                     + 1,
@@ -398,8 +396,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConsensusQuery for IbcQuery<HI> 
             commitment,
             proof: proof.encode_to_vec(),
             proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                revision_height: snapshot
-                    .get_block_height()
+                revision_height: HI::get_block_height(&snapshot)
                     .await
                     .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
                     + 1,
@@ -501,8 +498,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConsensusQuery for IbcQuery<HI> 
             received: receipt.is_some(),
             proof: proof.encode_to_vec(),
             proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                revision_height: snapshot
-                    .get_block_height()
+                revision_height: HI::get_block_height(&snapshot)
                     .await
                     .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
                     + 1,
@@ -546,8 +542,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConsensusQuery for IbcQuery<HI> 
             acknowledgement,
             proof: proof.encode_to_vec(),
             proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                revision_height: snapshot
-                    .get_block_height()
+                revision_height: HI::get_block_height(&snapshot)
                     .await
                     .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
                     + 1,
@@ -745,8 +740,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConsensusQuery for IbcQuery<HI> 
             next_sequence_receive: next_recv_sequence,
             proof: proof.encode_to_vec(),
             proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                revision_height: snapshot
-                    .get_block_height()
+                revision_height: HI::get_block_height(&snapshot)
                     .await
                     .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
                     + 1,
@@ -787,8 +781,7 @@ impl<HI: HostInterface + Send + Sync + 'static> ConsensusQuery for IbcQuery<HI> 
             next_sequence_send: next_send_sequence,
             proof: proof.encode_to_vec(),
             proof_height: Some(ibc_proto::ibc::core::client::v1::Height {
-                revision_height: snapshot
-                    .get_block_height()
+                revision_height: HI::get_block_height(&snapshot)
                     .await
                     .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
                     + 1,


### PR DESCRIPTION
## Describe your changes
previously, the IBC gRPC server was accessing penumbra-specific state. this updates the server to use `HostInterface` for all block height reads.

## Issue ticket number and link

n/a

## Checklist before requesting a review

- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > only affects gRPC server responses
