### PR TITLE
pcli: disable warning post-mainnet

### DIFF
--- a/crates/bin/pcli/src/main.rs
+++ b/crates/bin/pcli/src/main.rs
@@ -10,8 +10,8 @@ use pcli::{command::*, opt::Opt};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Display a warning message to the user so they don't get upset when all their tokens are lost.
-    if std::env::var("PCLI_UNLEASH_DANGER").is_err() {
+    // Preserved for posterity and memory
+    if std::env::var("PCLI_DISPLAY_WARNING").is_ok() {
         pcli::warning::display();
     }
 


### PR DESCRIPTION
## Describe your changes

Removes the testnet-specific warning message from `pcli`. I remember merging this months ago but it is not in the main branch.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > `pcli` changes only