### PR TITLE
pindexer supply with destruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5822,6 +5822,7 @@ dependencies = [
  "penumbra-asset",
  "penumbra-auction",
  "penumbra-dex",
+ "penumbra-fee",
  "penumbra-governance",
  "penumbra-keys",
  "penumbra-num",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5820,6 +5820,7 @@ dependencies = [
  "num-bigint",
  "penumbra-app",
  "penumbra-asset",
+ "penumbra-auction",
  "penumbra-dex",
  "penumbra-governance",
  "penumbra-keys",

--- a/crates/bin/pindexer/Cargo.toml
+++ b/crates/bin/pindexer/Cargo.toml
@@ -18,6 +18,7 @@ num-bigint = { version = "0.4" }
 penumbra-shielded-pool = {workspace = true, default-features = false}
 penumbra-stake = {workspace = true, default-features = false}
 penumbra-app = {workspace = true}
+penumbra-auction = {workspace = true, default-features = false}
 penumbra-dex = {workspace = true, default-features = false}
 penumbra-keys = {workspace = true, default-features = false}
 penumbra-governance = {workspace = true, default-features = false}

--- a/crates/bin/pindexer/Cargo.toml
+++ b/crates/bin/pindexer/Cargo.toml
@@ -20,6 +20,7 @@ penumbra-stake = {workspace = true, default-features = false}
 penumbra-app = {workspace = true}
 penumbra-auction = {workspace = true, default-features = false}
 penumbra-dex = {workspace = true, default-features = false}
+penumbra-fee = {workspace = true, default-features = false}
 penumbra-keys = {workspace = true, default-features = false}
 penumbra-governance = {workspace = true, default-features = false}
 penumbra-num = {workspace = true, default-features = false}


### PR DESCRIPTION
## Describe your changes

This adjusts the total supply indexer to account for whether or not value is locked in the dex, the auction component, or locked away after fees and arbitrage.

This matters because a significant amount of the native token has been locked in arbitrage, so this affects the end result by about 50% (in terms of net new supply)

Merge https://github.com/penumbra-zone/penumbra/pull/4863 first.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only.