### PR TITLE
Pindexer auction

### DIFF
--- a/crates/bin/pindexer/src/auction/auction.sql
+++ b/crates/bin/pindexer/src/auction/auction.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS auction_dutch_update (
   -- Serves only as a primary key.
   id SERIAL PRIMARY KEY,
   -- Points to the description of the auction.
-  auction_id BYTE NOT NULL REFERENCES auction_dutch_description (id),
+  auction_id BYTEA NOT NULL REFERENCES auction_dutch_description (id),
   -- The height of this update.
   height BIGINT NOT NULL,
   -- 0 -> opened, 1 -> closed, >= 2 -> withdrawn.
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS auction_dutch_update (
   -- If present, the current position being managed by the auction.
   position_id BYTEA,
   -- The next height at which a change to the positions will happen.
-  next_trigger INT,
+  next_trigger BIGINT,
   -- The current reserves of the input asset.
   in_reserves NUMERIC(39, 0) NOT NULL,
   -- The current reserves of the output asset.

--- a/crates/bin/pindexer/src/auction/auction.sql
+++ b/crates/bin/pindexer/src/auction/auction.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS auction_dutch_description (
+  -- The auction identifier.
+  id BYTEA PRIMARY KEY,
+  -- The input asset.
+  in_asset BYTEA NOT NULL,
+  -- The input amount.
+  in_amount NUMERIC(39, 0) NOT NULL,
+  -- The desired output asset.
+  out_asset BYTEA NOT NULL,
+  -- The maximum amount of output to get.
+  out_max NUMERIC(39, 0) NOT NULL,
+  -- The minimum amount of output to get.
+  out_min NUMERIC(39, 0) NOT NULL,
+  -- The height the auction starts at.
+  start_height BIGINT NOT NULL,
+  -- The height the auction ends at.
+  end_height BIGINT NOT NULL,
+  -- The number of steps to take.
+  step_count BIGINT NOT NULL,
+  nonce BYTEA NOT NULL
+);
+
+-- To easily lookup auctions by ascending input amount.
+CREATE INDEX ON auction_dutch_description(in_asset, in_amount);
+
+CREATE TABLE IF NOT EXISTS auction_dutch_update (
+  -- Serves only as a primary key.
+  id SERIAL PRIMARY KEY,
+  -- Points to the description of the auction.
+  auction_id BYTE NOT NULL REFERENCES auction_dutch_description (id),
+  -- The height of this update.
+  height BIGINT NOT NULL,
+  -- 0 -> opened, 1 -> closed, >= 2 -> withdrawn.
+  state INT NOT NULL,
+  -- If present, the current position being managed by the auction.
+  position_id BYTEA,
+  -- The next height at which a change to the positions will happen.
+  next_trigger INT,
+  -- The current reserves of the input asset.
+  in_reserves NUMERIC(39, 0) NOT NULL,
+  -- The current reserves of the output asset.
+  out_reserves NUMERIC(39, 0) NOT NULL
+);
+-- To be able to easily find updates for a given auction.
+CREATE INDEX ON auction_dutch_update(auction_id, height);
+

--- a/crates/bin/pindexer/src/auction/auction.sql
+++ b/crates/bin/pindexer/src/auction/auction.sql
@@ -32,6 +32,8 @@ CREATE TABLE IF NOT EXISTS auction_dutch_update (
   height BIGINT NOT NULL,
   -- 0 -> opened, 1 -> closed, >= 2 -> withdrawn.
   state INT NOT NULL,
+  -- 0 -> no reason, 1 -> expired, 2 -> filled, 3 -> closed
+  ended_reason INT,
   -- If present, the current position being managed by the auction.
   position_id BYTEA,
   -- The next height at which a change to the positions will happen.

--- a/crates/bin/pindexer/src/auction/mod.rs
+++ b/crates/bin/pindexer/src/auction/mod.rs
@@ -1,0 +1,122 @@
+use anyhow::anyhow;
+use cometindex::ContextualizedEvent;
+use penumbra_auction::auction::{
+    dutch::{DutchAuctionDescription, DutchAuctionState},
+    AuctionId,
+};
+use penumbra_proto::{core::component::auction::v1 as pb, event::ProtoEvent};
+
+#[derive(Clone, Copy)]
+enum EventKind {
+    DutchScheduled,
+    DutchUpdated,
+    DutchEnded,
+    DutchWithdrawn,
+}
+
+impl EventKind {
+    /// The string tag of this kind of event.
+    ///
+    /// This is used to match the raw ABCI events with this kind.
+    fn tag(&self) -> &'static str {
+        const TAGS: [&'static str; 4] = [
+            "penumbra.core.component.auction.v1.EventDutchAuctionScheduled",
+            "penumbra.core.component.auction.v1.EventDutchAuctionUpdated",
+            "penumbra.core.component.auction.v1.EventDutchAuctionEnded",
+            "penumbra.core.component.auction.v1.EventDutchAuctionWithdrawn",
+        ];
+        let ix: usize = match *self {
+            EventKind::DutchScheduled => 0,
+            EventKind::DutchUpdated => 1,
+            EventKind::DutchEnded => 2,
+            EventKind::DutchWithdrawn => 3,
+        };
+        TAGS[ix]
+    }
+}
+
+impl TryFrom<&str> for EventKind {
+    type Error = anyhow::Error;
+
+    fn try_from(tag: &str) -> Result<Self, Self::Error> {
+        use EventKind::*;
+
+        for kind in [DutchScheduled, DutchUpdated, DutchEnded, DutchWithdrawn] {
+            if tag == kind.tag() {
+                return Ok(kind);
+            }
+        }
+        return Err(anyhow!("unexpected event kind: {tag}"));
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Event {
+    DutchScheduled {
+        id: AuctionId,
+        description: DutchAuctionDescription,
+    },
+    DutchUpdated {
+        id: AuctionId,
+        state: DutchAuctionState,
+    },
+    DutchEnded {
+        id: AuctionId,
+        state: DutchAuctionState,
+        // We don't have anything better to represent this with.
+        reason: pb::event_dutch_auction_ended::Reason,
+    },
+    DutchWithdrawn {
+        id: AuctionId,
+        state: DutchAuctionState,
+    },
+}
+
+impl TryFrom<&ContextualizedEvent> for Event {
+    type Error = anyhow::Error;
+
+    fn try_from(event: &ContextualizedEvent) -> Result<Self, Self::Error> {
+        match EventKind::try_from(event.event.kind.as_str())? {
+            EventKind::DutchScheduled => {
+                let pe = pb::EventDutchAuctionScheduled::from_event(event.as_ref())?;
+                let id = pe
+                    .auction_id
+                    .ok_or(anyhow!("missing auction id"))?
+                    .try_into()?;
+                let description = pe
+                    .description
+                    .ok_or(anyhow!("missing description"))?
+                    .try_into()?;
+                Ok(Event::DutchScheduled { id, description })
+            }
+            EventKind::DutchUpdated => {
+                let pe = pb::EventDutchAuctionUpdated::from_event(event.as_ref())?;
+                let id = pe
+                    .auction_id
+                    .ok_or(anyhow!("missing auction id"))?
+                    .try_into()?;
+                let state = pe.state.ok_or(anyhow!("missing state"))?.try_into()?;
+                Ok(Event::DutchUpdated { id, state })
+            }
+            EventKind::DutchEnded => {
+                let pe = pb::EventDutchAuctionEnded::from_event(event.as_ref())?;
+                let id = pe
+                    .auction_id
+                    .ok_or(anyhow!("missing auction id"))?
+                    .try_into()?;
+                let state = pe.state.ok_or(anyhow!("missing state"))?.try_into()?;
+                let reason = pe.reason.try_into()?;
+                Ok(Event::DutchEnded { id, state, reason })
+            }
+            EventKind::DutchWithdrawn => {
+                let pe = pb::EventDutchAuctionWithdrawn::from_event(event.as_ref())?;
+                let id = pe
+                    .auction_id
+                    .ok_or(anyhow!("missing auction id"))?
+                    .try_into()?;
+                let state = pe.state.ok_or(anyhow!("missing state"))?.try_into()?;
+                Ok(Event::DutchWithdrawn { id, state })
+            }
+        }
+    }
+}

--- a/crates/bin/pindexer/src/auction/mod.rs
+++ b/crates/bin/pindexer/src/auction/mod.rs
@@ -1,10 +1,11 @@
 use anyhow::anyhow;
-use cometindex::ContextualizedEvent;
+use cometindex::{async_trait, AppView, ContextualizedEvent, PgTransaction};
 use penumbra_auction::auction::{
     dutch::{DutchAuctionDescription, DutchAuctionState},
     AuctionId,
 };
 use penumbra_proto::{core::component::auction::v1 as pb, event::ProtoEvent};
+use sqlx::PgPool;
 
 #[derive(Clone, Copy)]
 enum EventKind {
@@ -118,5 +119,143 @@ impl TryFrom<&ContextualizedEvent> for Event {
                 Ok(Event::DutchWithdrawn { id, state })
             }
         }
+    }
+}
+
+async fn create_dutch_auction_description(
+    dbtx: &mut PgTransaction<'_>,
+    id: AuctionId,
+    description: &DutchAuctionDescription,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "
+    INSERT INTO
+        auction_dutch_description 
+    VALUES (
+        $1,
+        $2,
+        $3::NUMERIC(39, 0),
+        $4,
+        $5::NUMERIC(39, 0),
+        $6::NUMERIC(39, 0),
+        $7,
+        $8, 
+        $9, 
+        $10
+    )",
+    )
+    .bind(id.0)
+    .bind(&description.input.asset_id.to_bytes())
+    .bind(&description.input.amount.to_string())
+    .bind(&description.output_id.to_bytes())
+    .bind(&description.max_output.to_string())
+    .bind(&description.min_output.to_string())
+    .bind(i64::try_from(description.start_height)?)
+    .bind(i64::try_from(description.end_height)?)
+    .bind(i64::try_from(description.step_count)?)
+    .bind(&description.nonce)
+    .execute(dbtx.as_mut())
+    .await?;
+    Ok(())
+}
+
+async fn create_dutch_auction_update(
+    dbtx: &mut PgTransaction<'_>,
+    height: u64,
+    id: AuctionId,
+    state: &DutchAuctionState,
+    reason: Option<pb::event_dutch_auction_ended::Reason>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "
+    INSERT INTO
+        auction_dutch_update 
+    VALUES (
+        DEFAULT,
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6,
+        $7::NUMERIC(39, 0),
+        $8::NUMERIC(39, 0)
+    )",
+    )
+    .bind(&id.0)
+    .bind(i64::try_from(height)?)
+    .bind(i32::try_from(state.sequence)?)
+    .bind(reason.map(|x| {
+        use pb::event_dutch_auction_ended::Reason::*;
+        match x {
+            Unspecified => 0i32,
+            Expired => 1,
+            Filled => 2,
+            ClosedByOwner => 3,
+        }
+    }))
+    .bind(state.current_position.map(|x| x.0))
+    .bind(
+        state
+            .next_trigger
+            .map(|x| i64::try_from(u64::from(x)))
+            .transpose()?,
+    )
+    .bind(&state.input_reserves.to_string())
+    .bind(&state.output_reserves.to_string())
+    .execute(dbtx.as_mut())
+    .await?;
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct Component {}
+
+impl Component {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl AppView for Component {
+    async fn init_chain(
+        &self,
+        dbtx: &mut PgTransaction,
+        _app_state: &serde_json::Value,
+    ) -> anyhow::Result<()> {
+        for statement in include_str!("auction.sql").split(";") {
+            sqlx::query(statement).execute(dbtx.as_mut()).await?;
+        }
+        Ok(())
+    }
+
+    fn is_relevant(&self, type_str: &str) -> bool {
+        EventKind::try_from(type_str).is_ok()
+    }
+
+    #[tracing::instrument(skip_all, fields(height = event.block_height, name = event.event.kind.as_str()))]
+    async fn index_event(
+        &self,
+        dbtx: &mut PgTransaction,
+        event: &ContextualizedEvent,
+        _src_db: &PgPool,
+    ) -> anyhow::Result<()> {
+        let height = event.block_height;
+        match Event::try_from(event)? {
+            Event::DutchScheduled { id, description } => {
+                create_dutch_auction_description(dbtx, id, &description).await?;
+            }
+            Event::DutchUpdated { id, state } => {
+                create_dutch_auction_update(dbtx, height, id, &state, None).await?;
+            }
+            Event::DutchEnded { id, state, reason } => {
+                create_dutch_auction_update(dbtx, height, id, &state, Some(reason)).await?;
+            }
+            Event::DutchWithdrawn { id, state } => {
+                create_dutch_auction_update(dbtx, height, id, &state, None).await?;
+            }
+        };
+        Ok(())
     }
 }

--- a/crates/bin/pindexer/src/indexer_ext.rs
+++ b/crates/bin/pindexer/src/indexer_ext.rs
@@ -12,5 +12,6 @@ impl IndexerExt for cometindex::Indexer {
             .with_index(crate::governance::GovernanceProposals {})
             .with_index(crate::dex::Component::new())
             .with_index(crate::supply::Component::new())
+            .with_index(crate::auction::Component::new())
     }
 }

--- a/crates/bin/pindexer/src/lib.rs
+++ b/crates/bin/pindexer/src/lib.rs
@@ -1,5 +1,6 @@
 pub use cometindex::{opt::Options, AppView, ContextualizedEvent, Indexer, PgPool, PgTransaction};
 
+pub mod auction;
 mod indexer_ext;
 pub use indexer_ext::IndexerExt;
 pub mod block;

--- a/crates/core/component/auction/src/component/dutch_auction.rs
+++ b/crates/core/component/auction/src/component/dutch_auction.rs
@@ -3,9 +3,9 @@ use std::pin::Pin;
 
 use crate::auction::dutch::{DutchAuction, DutchAuctionDescription, DutchAuctionState};
 use crate::auction::AuctionId;
-use crate::component::trigger_data::TriggerData;
 use crate::component::AuctionCircuitBreaker;
 use crate::component::AuctionStoreRead;
+use crate::trigger_data::TriggerData;
 use crate::{event, state_key};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -58,6 +58,7 @@ pub(crate) trait DutchAuctionManager: StateWrite {
             .try_next_trigger_height(current_height)
             .expect("action validation guarantees the auction is not expired");
 
+        // TODO: make a PR to replace this with the initial_state() method.
         let state = DutchAuctionState {
             sequence: 0,
             current_position: None,

--- a/crates/core/component/auction/src/component/mod.rs
+++ b/crates/core/component/auction/src/component/mod.rs
@@ -4,7 +4,6 @@ mod auction_store;
 mod dutch_auction;
 pub mod metrics;
 pub mod rpc;
-mod trigger_data;
 
 pub use auction::Auction;
 pub(crate) use auction::AuctionCircuitBreaker;

--- a/crates/core/component/auction/src/lib.rs
+++ b/crates/core/component/auction/src/lib.rs
@@ -7,6 +7,7 @@ pub mod event;
 pub mod genesis;
 pub mod params;
 pub mod state_key;
+mod trigger_data;
 
 #[cfg(feature = "component")]
 pub mod component;

--- a/crates/core/component/auction/src/trigger_data.rs
+++ b/crates/core/component/auction/src/trigger_data.rs
@@ -86,7 +86,7 @@ impl TriggerData {
 
 #[cfg(test)]
 mod tests {
-    use crate::component::trigger_data::TriggerData;
+    use super::TriggerData;
 
     #[test]
     fn test_current_height_equals_start_height() {


### PR DESCRIPTION
## Describe your changes

This adds an auction indexing component to pindexer.

Also, I added a utility function to the auction component to get the initial state of an auction from its description; this is useful so that the indexer always has some state of an auction.
I did not make the consensus code actually *use* this new function, but a subsequent refactor PR to use it would be nice to avoid code duplication, but in the interest of not adding new review burden, this PR does not do that.

Instead, reviewers, please check that I only moved code around, and that I only made more things visible in the crate.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing changes + above comments on the auction component.
