### PR TITLE
Fix IBC asset regex in denom metadata

### DIFF
--- a/crates/core/asset/src/asset/denom_metadata.rs
+++ b/crates/core/asset/src/asset/denom_metadata.rs
@@ -371,7 +371,8 @@ impl Metadata {
     /// if this is an IBC transferred asset, `None` otherwise.
     pub fn ibc_transfer_path(&self) -> anyhow::Result<Option<(String, String)>> {
         let base_denom = self.base_denom().denom;
-        let re = Regex::new(r"^(?<path>transfer/channel-[0-9]+)/(?<denom>\w+)$")
+        // The base denom portion of an IBC asset path may contain slashes: https://github.com/cosmos/ibc/issues/737
+        let re = Regex::new(r"^(?<path>transfer/channel-[0-9]+)/(?<denom>[\w\/]+)$")
             .context("error instantiating denom matching regex")?;
 
         let Some(caps) = re.captures(&base_denom) else {


### PR DESCRIPTION
## Describe your changes

This fixes a bug in the `ibc_transfer_path` method that did not properly handle all IBC denoms, specifically those containing slashes, for example `transfer/channel-4/factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/shitmos`.

## Issue ticket number and link

Discovered when investigating #4834 however this doesn't close out the issue.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > affected method only called in display formatting right now
