### PR TITLE
pindexer: add a nicer error when a checkpoint genesis is used

### DIFF
--- a/crates/bin/pindexer/src/lib.rs
+++ b/crates/bin/pindexer/src/lib.rs
@@ -5,6 +5,7 @@ pub use indexer_ext::IndexerExt;
 pub mod block;
 pub mod dex;
 pub mod ibc;
+mod parsing;
 pub mod shielded_pool;
 mod sql;
 pub mod stake;

--- a/crates/bin/pindexer/src/parsing.rs
+++ b/crates/bin/pindexer/src/parsing.rs
@@ -1,0 +1,27 @@
+use anyhow::{anyhow, Context as _};
+use penumbra_app::genesis::{AppState, Content};
+use serde_json::Value;
+
+const GENESIS_NO_CONTENT_ERROR: &'static str = r#"
+Error: using an upgrade genesis file instead of an initial genesis file.
+
+This genesis file only contains a checkpoint hash of the state,
+rather than information about how the initial state of the chain was initialized,
+at the very first genesis.
+
+Make sure that you're using the very first genesis file, before any upgrades.
+"#;
+
+/// Attempt to parse content from a value.
+///
+/// This is useful to get the initial chain state for app views.
+///
+/// This has a nice error message, so you should use this.
+pub fn parse_content(data: Value) -> anyhow::Result<Content> {
+    let app_state: AppState = serde_json::from_value(data)
+        .context("error decoding app_state json: make sure that this is a penumbra genesis file")?;
+    let content = app_state
+        .content()
+        .ok_or(anyhow!(GENESIS_NO_CONTENT_ERROR))?;
+    Ok(content.clone())
+}


### PR DESCRIPTION
This adds an informative error explaining that we need the *original* genesis file, before any upgrades, and why.

Closes #4880

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only
