### PR TITLE
4869(ish) dex rich events

### DIFF
--- a/crates/core/component/dex/src/component/action_handler/position/close.rs
+++ b/crates/core/component/dex/src/component/action_handler/position/close.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use cnidarium::StateWrite;
 use cnidarium_component::ActionHandler;
-use penumbra_proto::StateWriteProto as _;
+use penumbra_proto::{DomainType as _, StateWriteProto as _};
 
 use crate::{component::PositionManager, event, lp::action::PositionClose};
 
@@ -25,7 +25,12 @@ impl ActionHandler for PositionClose {
         state.queue_close_position(self.position_id);
 
         // queue position close you will...
-        state.record_proto(event::queue_position_close(self));
+        state.record_proto(
+            event::EventQueuePositionClose {
+                position_id: self.position_id,
+            }
+            .to_proto(),
+        );
 
         Ok(())
     }

--- a/crates/core/component/dex/src/component/action_handler/swap.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use cnidarium::StateWrite;
 use cnidarium_component::ActionHandler;
 use penumbra_proof_params::SWAP_PROOF_VERIFICATION_KEY;
-use penumbra_proto::StateWriteProto;
+use penumbra_proto::{DomainType as _, StateWriteProto};
 use penumbra_sct::component::source::SourceContext;
 
 use crate::{
@@ -66,7 +66,7 @@ impl ActionHandler for Swap {
         );
         state.add_recently_accessed_asset(swap.body.trading_pair.asset_2(), fixed_candidates);
 
-        state.record_proto(event::swap(self));
+        state.record_proto(event::EventSwap::from(self).to_proto());
 
         Ok(())
     }

--- a/crates/core/component/dex/src/component/action_handler/swap_claim.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap_claim.rs
@@ -7,7 +7,7 @@ use penumbra_txhash::TransactionContext;
 
 use cnidarium::{StateRead, StateWrite};
 use penumbra_proof_params::SWAPCLAIM_PROOF_VERIFICATION_KEY;
-use penumbra_proto::StateWriteProto;
+use penumbra_proto::{DomainType as _, StateWriteProto};
 use penumbra_sct::component::{
     source::SourceContext,
     tree::{SctManager, VerificationExt},
@@ -95,7 +95,7 @@ impl ActionHandler for SwapClaim {
 
         state.nullify(self.body.nullifier, source).await;
 
-        state.record_proto(event::swap_claim(self));
+        state.record_proto(event::EventSwapClaim::from(self).to_proto());
 
         Ok(())
     }

--- a/crates/core/component/dex/src/component/arb.rs
+++ b/crates/core/component/dex/src/component/arb.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use cnidarium::{StateDelta, StateWrite};
 use penumbra_asset::{asset, Value};
-use penumbra_proto::StateWriteProto as _;
+use penumbra_proto::{DomainType as _, StateWriteProto as _};
 use penumbra_sct::component::clock::EpochRead;
 use tracing::instrument;
 
@@ -134,7 +134,13 @@ pub trait Arbitrage: StateWrite + Sized {
             .await?;
 
         // Emit an ABCI event detailing the arb execution.
-        self_mut.record_proto(event::arb_execution(height, se));
+        self_mut.record_proto(
+            event::EventArbExecution {
+                height,
+                swap_execution: se,
+            }
+            .to_proto(),
+        );
         return Ok(Some(Value {
             amount: arb_profit,
             asset_id: arb_token,

--- a/crates/core/component/dex/src/component/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/component/circuit_breaker/value.rs
@@ -39,7 +39,14 @@ pub(crate) trait ValueCircuitBreaker: StateWrite {
         tracing::debug!(?prev_balance, ?new_balance, "crediting the dex VCB");
         self.put(state_key::value_balance(&value.asset_id), new_balance);
 
-        self.record_proto(event::vcb_credit(value.asset_id, prev_balance, new_balance));
+        self.record_proto(
+            event::EventValueCircuitBreakerCredit {
+                asset_id: value.asset_id,
+                previous_balance: prev_balance,
+                new_balance,
+            }
+            .to_proto(),
+        );
         Ok(())
     }
 

--- a/crates/core/component/dex/src/component/circuit_breaker/value.rs
+++ b/crates/core/component/dex/src/component/circuit_breaker/value.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use cnidarium::{StateRead, StateWrite};
 use penumbra_asset::{asset, Value};
 use penumbra_num::Amount;
-use penumbra_proto::{StateReadProto, StateWriteProto};
+use penumbra_proto::{DomainType, StateReadProto, StateWriteProto};
 use tonic::async_trait;
 use tracing::instrument;
 
@@ -61,7 +61,14 @@ pub(crate) trait ValueCircuitBreaker: StateWrite {
         tracing::debug!(?prev_balance, ?new_balance, "crediting the dex VCB");
         self.put(state_key::value_balance(&value.asset_id), new_balance);
 
-        self.record_proto(event::vcb_debit(value.asset_id, prev_balance, new_balance));
+        self.record_proto(
+            event::EventValueCircuitBreakerDebit {
+                asset_id: value.asset_id,
+                previous_balance: prev_balance,
+                new_balance,
+            }
+            .to_proto(),
+        );
         Ok(())
     }
 }

--- a/crates/core/component/dex/src/component/dex.rs
+++ b/crates/core/component/dex/src/component/dex.rs
@@ -10,7 +10,7 @@ use penumbra_asset::{Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_fee::component::StateWriteExt as _;
 use penumbra_fee::Fee;
 use penumbra_num::Amount;
-use penumbra_proto::{StateReadProto, StateWriteProto};
+use penumbra_proto::{DomainType as _, StateReadProto, StateWriteProto};
 use tendermint::v0_37::abci;
 use tracing::instrument;
 
@@ -399,11 +399,14 @@ pub(crate) trait InternalDexWrite: StateWrite {
         self.object_put(state_key::pending_outputs(), outputs);
 
         // Also generate an ABCI event for indexing:
-        self.record_proto(event::batch_swap(
-            output_data,
-            swap_execution_1_for_2,
-            swap_execution_2_for_1,
-        ));
+        self.record_proto(
+            event::EventBatchSwap {
+                batch_swap_output_data: output_data,
+                swap_execution_1_for_2,
+                swap_execution_2_for_1,
+            }
+            .to_proto(),
+        );
 
         Ok(())
     }

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -349,7 +349,9 @@ pub trait PositionManager: StateWrite + PositionRead {
 
         // We have already short-circuited no-op execution updates, so we can emit an execution
         // event and not worry about duplicates.
-        self.record_proto(event::position_execution(&prev_state, &new_state, context));
+        self.record_proto(
+            event::EventPositionExecution::in_context(&prev_state, &new_state, context).to_proto(),
+        );
 
         // Handle "close-on-fill": automatically flip the position state to "closed" if
         // either of the reserves are zero.
@@ -431,7 +433,9 @@ pub trait PositionManager: StateWrite + PositionRead {
 
         // Record an event prior to updating the position state, so we have access to
         // the current reserves.
-        self.record_proto(event::position_withdraw(position_id, &prev_state));
+        self.record_proto(
+            event::EventPositionWithdraw::in_context(position_id, &prev_state).to_proto(),
+        );
 
         // Grab a copy of the final reserves of the position to return to the caller.
         let reserves = prev_state.reserves.balance(&prev_state.phi.pair);

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -279,7 +279,7 @@ pub trait PositionManager: StateWrite + PositionRead {
         self.mark_trading_pair_as_active(position.phi.pair);
 
         // Finally, record the new position state.
-        self.record_proto(event::position_open(&position));
+        self.record_proto(event::EventPositionOpen::from(position.clone()).to_proto());
         self.update_position(&id, None, position).await?;
 
         Ok(())

--- a/crates/core/component/dex/src/component/position_manager.rs
+++ b/crates/core/component/dex/src/component/position_manager.rs
@@ -205,7 +205,7 @@ pub trait PositionManager: StateWrite + PositionRead {
 
         self.update_position(id, Some(prev_state), new_state)
             .await?;
-        self.record_proto(event::position_close_by_id(*id));
+        self.record_proto(event::EventPositionClose { position_id: *id }.to_proto());
 
         Ok(())
     }
@@ -365,7 +365,7 @@ pub trait PositionManager: StateWrite + PositionRead {
                 );
 
                 new_state.state = position::State::Closed;
-                self.record_proto(event::position_close_by_id(position_id));
+                self.record_proto(event::EventPositionClose { position_id }.to_proto());
             }
         }
 

--- a/crates/core/component/dex/src/event.rs
+++ b/crates/core/component/dex/src/event.rs
@@ -114,16 +114,54 @@ pub fn arb_execution(height: u64, swap_execution: SwapExecution) -> pb::EventArb
     }
 }
 
-pub fn vcb_credit(
-    asset_id: asset::Id,
-    previous_balance: Amount,
-    new_balance: Amount,
-) -> pb::EventValueCircuitBreakerCredit {
-    pb::EventValueCircuitBreakerCredit {
-        asset_id: Some(asset_id.into()),
-        previous_balance: Some(previous_balance.into()),
-        new_balance: Some(new_balance.into()),
+#[derive(Clone, Debug)]
+pub struct EventValueCircuitBreakerCredit {
+    pub asset_id: asset::Id,
+    pub previous_balance: Amount,
+    pub new_balance: Amount,
+}
+
+impl TryFrom<pb::EventValueCircuitBreakerCredit> for EventValueCircuitBreakerCredit {
+    type Error = anyhow::Error;
+
+    fn try_from(value: pb::EventValueCircuitBreakerCredit) -> Result<Self, Self::Error> {
+        fn inner(
+            value: pb::EventValueCircuitBreakerCredit,
+        ) -> anyhow::Result<EventValueCircuitBreakerCredit> {
+            Ok(EventValueCircuitBreakerCredit {
+                asset_id: value
+                    .asset_id
+                    .ok_or(anyhow!("missing `asset_id`"))?
+                    .try_into()?,
+                previous_balance: value
+                    .previous_balance
+                    .ok_or(anyhow!("missing `previous_balance`"))?
+                    .try_into()?,
+                new_balance: value
+                    .new_balance
+                    .ok_or(anyhow!("missing `new_balance`"))?
+                    .try_into()?,
+            })
+        }
+        inner(value).context(format!(
+            "parsing {}",
+            pb::EventValueCircuitBreakerCredit::NAME
+        ))
     }
+}
+
+impl From<EventValueCircuitBreakerCredit> for pb::EventValueCircuitBreakerCredit {
+    fn from(value: EventValueCircuitBreakerCredit) -> Self {
+        Self {
+            asset_id: Some(value.asset_id.into()),
+            previous_balance: Some(value.previous_balance.into()),
+            new_balance: Some(value.new_balance.into()),
+        }
+    }
+}
+
+impl DomainType for EventValueCircuitBreakerCredit {
+    type Proto = pb::EventValueCircuitBreakerCredit;
 }
 
 #[derive(Clone, Debug)]

--- a/crates/core/component/dex/src/event.rs
+++ b/crates/core/component/dex/src/event.rs
@@ -126,16 +126,54 @@ pub fn vcb_credit(
     }
 }
 
-pub fn vcb_debit(
-    asset_id: asset::Id,
-    previous_balance: Amount,
-    new_balance: Amount,
-) -> pb::EventValueCircuitBreakerDebit {
-    pb::EventValueCircuitBreakerDebit {
-        asset_id: Some(asset_id.into()),
-        previous_balance: Some(previous_balance.into()),
-        new_balance: Some(new_balance.into()),
+#[derive(Clone, Debug)]
+pub struct EventValueCircuitBreakerDebit {
+    pub asset_id: asset::Id,
+    pub previous_balance: Amount,
+    pub new_balance: Amount,
+}
+
+impl TryFrom<pb::EventValueCircuitBreakerDebit> for EventValueCircuitBreakerDebit {
+    type Error = anyhow::Error;
+
+    fn try_from(value: pb::EventValueCircuitBreakerDebit) -> Result<Self, Self::Error> {
+        fn inner(
+            value: pb::EventValueCircuitBreakerDebit,
+        ) -> anyhow::Result<EventValueCircuitBreakerDebit> {
+            Ok(EventValueCircuitBreakerDebit {
+                asset_id: value
+                    .asset_id
+                    .ok_or(anyhow!("missing `asset_id`"))?
+                    .try_into()?,
+                previous_balance: value
+                    .previous_balance
+                    .ok_or(anyhow!("missing `previous_balance`"))?
+                    .try_into()?,
+                new_balance: value
+                    .new_balance
+                    .ok_or(anyhow!("missing `new_balance`"))?
+                    .try_into()?,
+            })
+        }
+        inner(value).context(format!(
+            "parsing {}",
+            pb::EventValueCircuitBreakerDebit::NAME
+        ))
     }
+}
+
+impl From<EventValueCircuitBreakerDebit> for pb::EventValueCircuitBreakerDebit {
+    fn from(value: EventValueCircuitBreakerDebit) -> Self {
+        Self {
+            asset_id: Some(value.asset_id.into()),
+            previous_balance: Some(value.previous_balance.into()),
+            new_balance: Some(value.new_balance.into()),
+        }
+    }
+}
+
+impl DomainType for EventValueCircuitBreakerDebit {
+    type Proto = pb::EventValueCircuitBreakerDebit;
 }
 
 #[derive(Clone, Debug)]

--- a/crates/core/component/dex/src/event.rs
+++ b/crates/core/component/dex/src/event.rs
@@ -55,10 +55,37 @@ pub fn position_close(action: &PositionClose) -> pb::EventPositionClose {
     }
 }
 
-pub fn queue_position_close(action: &PositionClose) -> pb::EventQueuePositionClose {
-    pb::EventQueuePositionClose {
-        position_id: Some(action.position_id.into()),
+#[derive(Clone, Debug)]
+pub struct EventQueuePositionClose {
+    pub position_id: position::Id,
+}
+
+impl TryFrom<pb::EventQueuePositionClose> for EventQueuePositionClose {
+    type Error = anyhow::Error;
+
+    fn try_from(value: pb::EventQueuePositionClose) -> Result<Self, Self::Error> {
+        fn inner(value: pb::EventQueuePositionClose) -> anyhow::Result<EventQueuePositionClose> {
+            Ok(EventQueuePositionClose {
+                position_id: value
+                    .position_id
+                    .ok_or(anyhow!("missing `position_id`"))?
+                    .try_into()?,
+            })
+        }
+        inner(value).context(format!("parsing {}", pb::EventQueuePositionClose::NAME))
     }
+}
+
+impl From<EventQueuePositionClose> for pb::EventQueuePositionClose {
+    fn from(value: EventQueuePositionClose) -> Self {
+        Self {
+            position_id: Some(value.position_id.into()),
+        }
+    }
+}
+
+impl DomainType for EventQueuePositionClose {
+    type Proto = pb::EventQueuePositionClose;
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Describe your changes

Towards #4869; since doing that requires parsing some dex events, I took the opportunity to fill out the rest of the events in the dex.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > event emission only
  
## Requested Review

Some sanity checks that this PR doesn't accidentally change how events are emitted would be nice.
