### PR TITLE
docs: add testing steps to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,15 @@
 ## Describe your changes
 
+<!--
+Describe what's changed and why. If interactive testing is required, explain
+to the reviewer how the PR should be tested.
+-->
+
 ## Issue ticket number and link
 
 ## Checklist before requesting a review
+
+- [ ] I have added guiding text to explain how a reviewer should test these changes.
 
 - [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:
 


### PR DESCRIPTION
## Describe your changes

Updates the PR github template to include mention of testing steps. Including those in a form template will help with organizing review and reducing review backlog.

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > docs-only, no code changes
