### PR TITLE
Add a command to query all open positions in a PCLI wallet

### DIFF
--- a/crates/bin/pcli/src/command/view.rs
+++ b/crates/bin/pcli/src/command/view.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 
 use address::AddressCmd;
 use balance::BalanceCmd;
+use lps::LpsCmd;
 use noble_address::NobleAddressCmd;
 use staked::StakedCmd;
 use transaction_hashes::TransactionHashesCmd;
@@ -15,6 +16,7 @@ use self::auction::AuctionCmd;
 mod address;
 mod auction;
 mod balance;
+mod lps;
 mod noble_address;
 mod staked;
 mod wallet_id;
@@ -48,6 +50,8 @@ pub enum ViewCmd {
     ListTransactionHashes(TransactionHashesCmd),
     /// Displays a transaction's details by hash.
     Tx(TxCmd),
+    /// View information about the liquidity positions you control.
+    Lps(LpsCmd),
 }
 
 impl ViewCmd {
@@ -63,6 +67,7 @@ impl ViewCmd {
             ViewCmd::Sync => false,
             ViewCmd::ListTransactionHashes(transactions_cmd) => transactions_cmd.offline(),
             ViewCmd::Tx(tx_cmd) => tx_cmd.offline(),
+            ViewCmd::Lps(lps_cmd) => lps_cmd.offline(),
         }
     }
 
@@ -110,6 +115,7 @@ impl ViewCmd {
                     .exec(&full_viewing_key, view_client, channel)
                     .await?;
             }
+            ViewCmd::Lps(cmd) => cmd.exec(app).await?,
         }
 
         Ok(())

--- a/crates/bin/pcli/src/command/view.rs
+++ b/crates/bin/pcli/src/command/view.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use address::AddressCmd;
 use balance::BalanceCmd;
-use lps::LpsCmd;
+use lps::LiquidityPositionsCmd;
 use noble_address::NobleAddressCmd;
 use staked::StakedCmd;
 use transaction_hashes::TransactionHashesCmd;
@@ -51,7 +51,8 @@ pub enum ViewCmd {
     /// Displays a transaction's details by hash.
     Tx(TxCmd),
     /// View information about the liquidity positions you control.
-    Lps(LpsCmd),
+    #[clap(visible_alias = "lps")]
+    LiquidityPositions(LiquidityPositionsCmd),
 }
 
 impl ViewCmd {
@@ -67,7 +68,7 @@ impl ViewCmd {
             ViewCmd::Sync => false,
             ViewCmd::ListTransactionHashes(transactions_cmd) => transactions_cmd.offline(),
             ViewCmd::Tx(tx_cmd) => tx_cmd.offline(),
-            ViewCmd::Lps(lps_cmd) => lps_cmd.offline(),
+            ViewCmd::LiquidityPositions(lps_cmd) => lps_cmd.offline(),
         }
     }
 
@@ -115,7 +116,7 @@ impl ViewCmd {
                     .exec(&full_viewing_key, view_client, channel)
                     .await?;
             }
-            ViewCmd::Lps(cmd) => cmd.exec(app).await?,
+            ViewCmd::LiquidityPositions(cmd) => cmd.exec(app).await?,
         }
 
         Ok(())

--- a/crates/bin/pcli/src/command/view/lps.rs
+++ b/crates/bin/pcli/src/command/view/lps.rs
@@ -10,9 +10,9 @@ use penumbra_view::ViewClient;
 use crate::{command::utils, App};
 
 #[derive(Debug, clap::Args)]
-pub struct LpsCmd {}
+pub struct LiquidityPositionsCmd {}
 
-impl LpsCmd {
+impl LiquidityPositionsCmd {
     pub fn offline(&self) -> bool {
         false
     }

--- a/crates/bin/pcli/src/command/view/lps.rs
+++ b/crates/bin/pcli/src/command/view/lps.rs
@@ -1,0 +1,48 @@
+use anyhow::{anyhow, Result};
+use futures::stream::TryStreamExt;
+use penumbra_dex::lp::position::{Position, State};
+use penumbra_proto::core::component::dex::v1::{
+    query_service_client::QueryServiceClient as DexQueryServiceClient,
+    LiquidityPositionsByIdRequest,
+};
+use penumbra_view::ViewClient;
+
+use crate::{command::utils, App};
+
+#[derive(Debug, clap::Args)]
+pub struct LpsCmd {}
+
+impl LpsCmd {
+    pub fn offline(&self) -> bool {
+        false
+    }
+
+    pub async fn exec(&self, app: &mut App) -> Result<()> {
+        let my_position_ids = app
+            .view()
+            .owned_position_ids(Some(State::Opened), None)
+            .await?;
+        let mut dex_client = DexQueryServiceClient::new(app.pd_channel().await?);
+
+        let positions_stream = dex_client
+            .liquidity_positions_by_id(LiquidityPositionsByIdRequest {
+                position_id: my_position_ids.into_iter().map(Into::into).collect(),
+            })
+            .await?
+            .into_inner()
+            .map_err(|e| anyhow!("eror fetching liquidity positions: {}", e))
+            .and_then(|msg| async move {
+                msg.data
+                    .ok_or_else(|| anyhow!("missing liquidity position in response"))
+                    .map(Position::try_from)?
+            });
+
+        let asset_cache = app.view().assets().await?;
+
+        let positions = positions_stream.try_collect::<Vec<_>>().await?;
+
+        println!("{}", utils::render_positions(&asset_cache, &positions));
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #4825.

## Describe your changes

This adds a command: `pcli v lps` which displays all open liquidity positions owned by the wallet.

To test, try, e.g:

```
pcli tx position replicate linear --lower
-price 0.4 --upper-price 0.8 penumbra:gm 100gm --current-price 0.5

pcli v lps
```

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > PCLI only.