### PR TITLE
pindexer: insights: correctly handle Arb and Fees

### DIFF
--- a/crates/bin/pindexer/src/insights/mod.rs
+++ b/crates/bin/pindexer/src/insights/mod.rs
@@ -422,7 +422,7 @@ impl AppView for Component {
                     self.price_numeraire,
                     Box::new(move |supply| {
                         Ok(Supply {
-                            total: supply.total + amount,
+                            total: supply.total - amount,
                             ..supply
                         })
                     }),
@@ -442,7 +442,7 @@ impl AppView for Component {
                     self.price_numeraire,
                     Box::new(move |supply| {
                         Ok(Supply {
-                            total: supply.total + profit,
+                            total: supply.total - profit,
                             ..supply
                         })
                     }),


### PR DESCRIPTION
Previously, these were being added to the supply, instead of subtracted.

This causes the supply in the insights dashboard to be slightly inflated.

## Testing

To test, run pindexer and compare the following queries:
```
SELECT (
  SELECT SUM(um) as staked_um
    FROM (
      SELECT * FROM supply_validators
    ) validators
    LEFT JOIN LATERAL (
      SELECT um
      FROM supply_total_staked
      WHERE validator_id = id
      ORDER BY height DESC
      LIMIT 1
    ) staked_lateral ON TRUE)
+ um + auction + dex FROM supply_total_unstaked ORDER BY height DESC LIMIT 1;
```
```
SELECT total FROM insights_supply ORDER BY height DESC LIMIT 1;
```

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Pindexer only