### PR TITLE
chore: update f4jumble to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,8 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "f4jumble"
-version = "0.0.0"
-source = "git+https://github.com/zcash/librustzcash?rev=2425a0869098e3b0588ccd73c42716bcf418612c#2425a0869098e3b0588ccd73c42716bcf418612c"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
 dependencies = [
  "blake2b_simd 1.0.2",
 ]

--- a/crates/core/keys/Cargo.toml
+++ b/crates/core/keys/Cargo.toml
@@ -27,7 +27,7 @@ decaf377-ka = {workspace = true}
 decaf377-rdsa = {workspace = true}
 derivative = {workspace = true}
 ethnum = {workspace = true}
-f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "2425a0869098e3b0588ccd73c42716bcf418612c" }
+f4jumble = "0.1.0"
 hex = {workspace = true}
 hmac = "0.12.0"
 ibig = {workspace = true}

--- a/crates/core/keys/src/address.rs
+++ b/crates/core/keys/src/address.rs
@@ -363,8 +363,7 @@ impl TryFrom<&[u8]> for Address {
             anyhow::bail!("address malformed");
         }
 
-        let unjumbled_bytes =
-            f4jumble_inv(jumbled_bytes).ok_or_else(|| anyhow::anyhow!("invalid address"))?;
+        let unjumbled_bytes = f4jumble_inv(jumbled_bytes).context("invalid address")?;
         let mut bytes = Cursor::new(unjumbled_bytes);
 
         let mut diversifier_bytes = [0u8; 16];


### PR DESCRIPTION
## Describe your changes

Updates the old git dependency to a suitable published version from crates.io. To review, see the diff review posted in #4921. I'd prefer that reviewers replicate that work, and confirm that 1) the procedure used for obtaining relevant sources was sound; and 2) the code changes in the dep introduced by this diff are acceptable.

## Issue ticket number and link

Refs #4921.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > The dep appears to function the same in pre and post version bump, as does our modified error handling of its return values. Reviewers should confirm those statements are true, and if so, then there's no affect on consensus. 
