### PR TITLE
fix: update dependencies in parameter-setup crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5235,6 +5235,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-parameter-setup"
+version = "0.1.0"
+dependencies = [
+ "ark-groth16",
+ "ark-serialize",
+ "decaf377",
+ "penumbra-community-pool",
+ "penumbra-dex",
+ "penumbra-governance",
+ "penumbra-proof-params",
+ "penumbra-proof-setup",
+ "penumbra-shielded-pool",
+ "penumbra-stake",
+ "rand_core",
+]
+
+[[package]]
 name = "penumbra-proof-params"
 version = "0.80.8"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 resolver = "2"
 
-exclude = ["tools/proto-compiler", "tools/parameter-setup"]
+exclude = ["tools/proto-compiler"]
 
 # Also remember to add to deployments/scripts/rust-docs
 members = [
@@ -55,6 +55,7 @@ members = [
   "crates/view",
   "crates/wallet",
   "tools/summonerd",
+  "tools/parameter-setup",
 ]
 
 # Config for 'cargo dist'

--- a/tools/parameter-setup/Cargo.toml
+++ b/tools/parameter-setup/Cargo.toml
@@ -20,7 +20,7 @@ penumbra-shielded-pool = { path = "../../crates/core/component/shielded-pool/", 
 penumbra-stake = { path = "../../crates/core/component/stake/", features = [
     "component",
 ] }
-ark-groth16 = "0.4"
-ark-serialize = "0.4"
-decaf377 = { version = "0.5", features = ["r1cs"] }
-rand_core = "0.6.4"
+ark-groth16 = { workspace = true }
+ark-serialize = { workspace = true }
+decaf377 = { workspace = true, features = ["r1cs"] }
+rand_core = { workspace = true }


### PR DESCRIPTION
## Describe your changes

The parameter-setup crate was broken due to outdated dependencies. The options here are:
1. add this tool to the workspace
2. keep the dependencies updated instead of using workspace inheritance

Option 1 is more maintainable. Even though the parameters are fixed now due to mainnet, folks may try to use this crate for debugging - the scenario that motivated this commit.

To test: I followed the steps in https://guide.penumbra.zone/dev/parameter_setup to ensure we could run the parameter setup. 

## Issue ticket number and link

This was discovered while debugging #4927

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > this is a dev only change
