### PR TITLE
ci: fix container build for parameter-setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,5 @@
 !deployments/relayer/
 # summonerd tool, for orchestrating contributions
 !tools/summonerd/
+# parameter setup tool, for wrangling circuit configuration
+!tools/parameter-setup/


### PR DESCRIPTION

## Describe your changes
Follow-up to #4930, in which we inadvertently broken container builds, due to a workspace dependency being introduced. We don't build container images on every PR push, so CI passed fine, only failing when trying to build/deploy post-merge. Tacked on a small change to address.

For testing, leave it to me: I'll re-deploy after this lands to get it going. 


## Issue ticket number and link
Refs #4933.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > build logic only, no changes to consensus