### PR TITLE
pindexer: implement override for hardcoded values in app views

### DIFF
--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -480,8 +480,8 @@ mod summary {
         now AS (
             SELECT price, liquidity            
             FROM snapshots
-            WHERE time >= $3
-            ORDER BY time ASC
+            WHERE time <= $3
+            ORDER BY time DESC
             LIMIT 1
         ),
         sums AS (

--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -546,6 +546,7 @@ mod summary {
                 SELECT asset_start as asset, price
                 FROM dex_ex_pairs_summary
                 WHERE asset_end = $1
+                AND liquidity >= $2
                 UNION VALUES ($1, 1.0)
             ),
             converted_pairs_summary AS (

--- a/crates/bin/pindexer/src/indexer_ext.rs
+++ b/crates/bin/pindexer/src/indexer_ext.rs
@@ -1,11 +1,9 @@
-use std::str::FromStr;
-
 pub trait IndexerExt: Sized {
-    fn with_default_penumbra_app_views(self) -> Self;
+    fn with_default_penumbra_app_views(self, options: &crate::Options) -> Self;
 }
 
 impl IndexerExt for cometindex::Indexer {
-    fn with_default_penumbra_app_views(self) -> Self {
+    fn with_default_penumbra_app_views(self, options: &crate::Options) -> Self {
         self.with_index(Box::new(crate::block::Block {}))
             .with_index(Box::new(crate::stake::ValidatorSet {}))
             .with_index(Box::new(crate::stake::Slashings {}))
@@ -13,21 +11,13 @@ impl IndexerExt for cometindex::Indexer {
             .with_index(Box::new(crate::stake::UndelegationTxs {}))
             .with_index(Box::new(crate::governance::GovernanceProposals {}))
             .with_index(Box::new(crate::dex_ex::Component::new(
-                penumbra_sdk_asset::asset::Id::from_str(
-                    // USDC
-                    "passet1w6e7fvgxsy6ccy3m8q0eqcuyw6mh3yzqu3uq9h58nu8m8mku359spvulf6",
-                )
-                .expect("should be able to parse passet"),
-                1000.0 * 1_000_000.0,
+                options.indexing_denom,
+                options.dex_ex_min_liquidity as f64,
             )))
             .with_index(Box::new(crate::supply::Component::new()))
             .with_index(Box::new(crate::ibc::Component::new()))
-            .with_index(Box::new(crate::insights::Component::new(
-                penumbra_sdk_asset::asset::Id::from_str(
-                    // USDC
-                    "passet1w6e7fvgxsy6ccy3m8q0eqcuyw6mh3yzqu3uq9h58nu8m8mku359spvulf6",
-                )
-                .ok(),
-            )))
+            .with_index(Box::new(crate::insights::Component::new(Some(
+                options.indexing_denom,
+            ))))
     }
 }

--- a/crates/bin/pindexer/src/lib.rs
+++ b/crates/bin/pindexer/src/lib.rs
@@ -1,7 +1,8 @@
-pub use cometindex::{opt::Options, AppView, ContextualizedEvent, Indexer, PgPool, PgTransaction};
+pub use cometindex::{AppView, ContextualizedEvent, Indexer, PgPool, PgTransaction};
 
 mod indexer_ext;
 pub use indexer_ext::IndexerExt;
+use penumbra_asset::asset;
 pub mod block;
 pub mod dex_ex;
 pub mod ibc;
@@ -11,3 +12,18 @@ pub mod stake;
 pub mod supply;
 
 pub mod governance;
+
+#[derive(clap::Parser, Clone, Debug)]
+pub struct Options {
+    #[clap(flatten)]
+    pub cometindex: cometindex::opt::Options,
+    /// The denom to use for indexing related components, of the form passet1...
+    #[clap(
+        long,
+        default_value = "passet1w6e7fvgxsy6ccy3m8q0eqcuyw6mh3yzqu3uq9h58nu8m8mku359spvulf6"
+    )]
+    pub indexing_denom: asset::Id,
+    /// The minimum liquidity for the indexing denom in the dex explorer app view.
+    #[clap(long, default_value = "100000000")]
+    pub dex_ex_min_liquidity: u128,
+}

--- a/crates/bin/pindexer/src/lib.rs
+++ b/crates/bin/pindexer/src/lib.rs
@@ -2,7 +2,7 @@ pub use cometindex::{AppView, ContextualizedEvent, Indexer, PgPool, PgTransactio
 
 mod indexer_ext;
 pub use indexer_ext::IndexerExt;
-use penumbra_asset::asset;
+use penumbra_sdk_asset::asset;
 pub mod block;
 pub mod dex_ex;
 pub mod ibc;

--- a/crates/bin/pindexer/src/main.rs
+++ b/crates/bin/pindexer/src/main.rs
@@ -4,9 +4,10 @@ use pindexer::{Indexer, IndexerExt as _, Options};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    Indexer::new(Options::parse())
+    let opts = Options::parse();
+    Indexer::new(opts.cometindex.clone())
         .with_default_tracing()
-        .with_default_penumbra_app_views()
+        .with_default_penumbra_app_views(&opts)
         .run()
         .await?;
 


### PR DESCRIPTION
## Describe your changes

This adds two flags:

```
 --indexing-denom <INDEXING_DENOM>
            The denom to use for indexing related components, of the form passet1... [default:
            passet1w6e7fvgxsy6ccy3m8q0eqcuyw6mh3yzqu3uq9h58nu8m8mku359spvulf6
```

for setting the denom used for indexing (instead of USDC)

and

```
--dex-ex-min-liquidity <DEX_EX_MIN_LIQUIDITY>
            The minimum liquidity for the indexing denom in the dex explorer app view [default:
            100000000]
```
for overriding the minimum liquidity in terms of that asset for a pair to be considered in the aggregate dex explorer summary.

Closes #4920.

For testing, we can try running this against the testnet with different values.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing
