### PR TITLE
ci: fix cargo-release version interpolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-parameter-setup"
-version = "0.1.0"
+version = "0.80.8"
 dependencies = [
  "ark-groth16",
  "ark-serialize",

--- a/tools/parameter-setup/Cargo.toml
+++ b/tools/parameter-setup/Cargo.toml
@@ -1,26 +1,22 @@
 [package]
 name = "penumbra-parameter-setup"
-version = "0.1.0"
-edition = "2021"
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
 publish = false
+repository = { workspace = true }
+version = { workspace = true }
 
 [dependencies]
-penumbra-proof-params = { path = "../../crates/crypto/proof-params" }
-penumbra-proof-setup = { path = "../../crates/crypto/proof-setup", features = [
-    "parallel",
-] }
-penumbra-dex = { path = "../../crates/core/component/dex/" }
-penumbra-community-pool = { path = "../../crates/core/component/community-pool/", features = [
-    "component",
-] }
-penumbra-governance = { path = "../../crates/core/component/governance/" }
-penumbra-shielded-pool = { path = "../../crates/core/component/shielded-pool/", features = [
-    "parallel",
-] }
-penumbra-stake = { path = "../../crates/core/component/stake/", features = [
-    "component",
-] }
 ark-groth16 = { workspace = true }
 ark-serialize = { workspace = true }
 decaf377 = { workspace = true, features = ["r1cs"] }
+penumbra-community-pool = { workspace = true , features = ["component"] }
+penumbra-dex = { workspace = true }
+penumbra-governance = { workspace = true }
+penumbra-proof-params = { workspace = true }
+penumbra-proof-setup = { workspace = true, features = ["parallel"] }
+penumbra-shielded-pool = { workspace = true, features = ["parallel"] }
+penumbra-stake = { workspace = true, features = ["component"] }
 rand_core = { workspace = true }


### PR DESCRIPTION
## Describe your changes

Updates the package metadata for the `parameter-setup` crate, which was recently pulled into the workspace. Without these changes, `cargo-release` was failing to add a version number to the automatically generated commit message.



## Issue ticket number and link

Refs #4928, #4930.

## Testing and review

If you care to verify the results locally, you can:

```
git checkout -b my-feature-branch
cargo release 0.80.9 --execute # this won't push anything, but will require cleanup
git show # to view the commit message
```

Make sure that the generated commit message says "chore: release version 0.80.9", _not_ "chore: release version {{version}}". If you ran these steps, **you must clean up**:

```
git checkout main
git tag -d v0.80.9
git branch -D my-feature-branch
```

If you forget to delete the tag, then when 0.80.9 is actually released, you won't be able to pull the tag from github. 

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > package metadata only, no changes to application code
