### PR TITLE
pindexer: implement symmetrization of charts

### DIFF
--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -645,7 +645,7 @@ impl Events {
     }
 
     fn with_candle(&mut self, pair: DirectedTradingPair, candle: Candle) {
-        // Popular both this pair and the flipped pair, and if the flipped pair
+        // Populate both this pair and the flipped pair, and if the flipped pair
         // is already populated, we need to mix the two candles together.
         let flip = pair.flip();
         let new_candle = match self.candles.get(&flip).cloned() {

--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -24,6 +24,10 @@ mod candle {
     use penumbra_dex::CandlestickData;
     use std::fmt::Display;
 
+    fn geo_mean(a: f64, b: f64) -> f64 {
+        (a * b).sqrt()
+    }
+
     /// Candlestick data, unmoored from the prison of a particular block height.
     ///
     /// In other words, this can represent candlesticks which span arbitrary windows,
@@ -56,6 +60,31 @@ mod candle {
             self.high = self.high.max(that.high);
             self.direct_volume += that.direct_volume;
             self.swap_volume += that.swap_volume;
+        }
+
+        /// Mix this candle with a candle going in the opposite direction of the pair.
+        pub fn mix(&mut self, op: &Self) {
+            // We use the geometric mean, resulting in all the prices in a.mix(b) being
+            // the inverse of the prices in b.mix(a), and the volumes being equal.
+            self.close /= geo_mean(self.close, op.close);
+            self.open /= geo_mean(self.open, op.open);
+            self.low = self.low.min(1.0 / op.low);
+            self.high = self.high.min(1.0 / op.high);
+            // Using the closing price to look backwards at volume.
+            self.direct_volume += op.direct_volume / self.close;
+            self.swap_volume += op.swap_volume / self.close;
+        }
+
+        /// Flip this candle to get the equivalent in the other direction.
+        pub fn flip(&self) -> Self {
+            Self {
+                open: 1.0 / self.open,
+                close: 1.0 / self.close,
+                low: 1.0 / self.low,
+                high: 1.0 / self.high,
+                direct_volume: self.direct_volume / self.close,
+                swap_volume: self.swap_volume / self.close,
+            }
         }
     }
 
@@ -616,14 +645,20 @@ impl Events {
     }
 
     fn with_candle(&mut self, pair: DirectedTradingPair, candle: Candle) {
-        match self.candles.get_mut(&pair) {
-            None => {
-                self.candles.insert(pair, candle);
+        // Popular both this pair and the flipped pair, and if the flipped pair
+        // is already populated, we need to mix the two candles together.
+        let flip = pair.flip();
+        let new_candle = match self.candles.get(&flip).cloned() {
+            None => candle,
+            Some(flipped) => {
+                let mut out = candle;
+                out.mix(&flipped);
+                out
             }
-            Some(current) => {
-                current.merge(&candle);
-            }
-        }
+        };
+
+        self.candles.insert(pair, new_candle);
+        self.candles.insert(flip, new_candle.flip());
     }
 
     fn metric(&mut self, pair: &DirectedTradingPair) -> &mut PairMetrics {


### PR DESCRIPTION
Now charts implement price information from both directions of a pair.

This is needed for correct rendering on the dex explorer.

For testing, run a local copy of the dex explorer and notice that now both charts are better inverses of each other.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing
