### PR TITLE
pindexer: store indexing denom in dex explorer metadata table

### DIFF
--- a/crates/bin/pindexer/src/dex_ex/schema.sql
+++ b/crates/bin/pindexer/src/dex_ex/schema.sql
@@ -76,3 +76,9 @@ CREATE TABLE IF NOT EXISTS dex_ex_aggregate_summary (
   top_price_mover_end BYTEA NOT NULL,
   top_price_mover_change_percent FLOAT8 NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS dex_ex_metadata (
+  id INT PRIMARY KEY,
+  -- The asset id to use for prices in places such as the aggregate summary.
+  quote_asset_id BYTEA NOT NULL
+);


### PR DESCRIPTION
This allows the dex explorer to read it out, which makes having separate testnet / mainnet logic easier.

This makes it easier to swap between mainnet and testnet data.

For testing, run pindexer, verify that the metadata is there.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only
