### PR TITLE
pindexer: dex_ex: correct denom conversion in aggregate summary

### DIFF
--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -530,14 +530,15 @@ mod summary {
                 SELECT
                     asset_start, asset_end,
                     (dex_ex_pairs_summary.price - greatest(price_then, 0.000001)) / greatest(price_then, 0.000001) * 100 AS price_change,
-                    liquidity * eligible_denoms.price AS liquidity,
-                    direct_volume_over_window * eligible_denoms.price as dv,
-                    swap_volume_over_window * eligible_denoms.price as sv,
+                    liquidity * ed_end.price AS liquidity,
+                    direct_volume_over_window * ed_start.price AS dv,
+                    swap_volume_over_window * ed_start.price AS sv,
                     trades_over_window as trades
                 FROM dex_ex_pairs_summary
-                JOIN eligible_denoms
-                ON eligible_denoms.asset = asset_end
-                WHERE the_window = $3
+                JOIN eligible_denoms AS ed_end
+                ON ed_end.asset = asset_end
+                JOIN eligible_denoms AS ed_start
+                ON ed_start.asset = asset_start
             ),
             sums AS (
                 SELECT

--- a/crates/bin/pindexer/src/indexer_ext.rs
+++ b/crates/bin/pindexer/src/indexer_ext.rs
@@ -18,7 +18,7 @@ impl IndexerExt for cometindex::Indexer {
                     "passet1w6e7fvgxsy6ccy3m8q0eqcuyw6mh3yzqu3uq9h58nu8m8mku359spvulf6",
                 )
                 .expect("should be able to parse passet"),
-                100.0 * 1000_0000.0,
+                1000.0 * 1_000_000.0,
             )))
             .with_index(Box::new(crate::supply::Component::new()))
             .with_index(Box::new(crate::ibc::Component::new()))


### PR DESCRIPTION
## Describe your changes

There was previously a bug here, where we used the wrong price for converting the volumes to USDC, resulting in an absurdly large purported aggregate volume.
This corrects the usage of denoms so that the number we get is reasonable.

To test, run the indexer and read out the aggregate summary table, and look for odd values
## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing
