### PR TITLE
fix: Correct typo in 'infaillible' to 'infallible'

### DIFF
--- a/crates/cnidarium/tests/migration.rs
+++ b/crates/cnidarium/tests/migration.rs
@@ -106,7 +106,7 @@ async fn test_simple_migration() -> anyhow::Result<()> {
         .latest_snapshot()
         .root_hash()
         .await
-        .expect("infaillible");
+        .expect("infallible");
 
     for (i, (key, value)) in kvs.clone().into_iter().enumerate() {
         let snapshot = storage.latest_snapshot();


### PR DESCRIPTION
Corrected the typo "infaillible" to "infallible" across the codebase. This change ensures proper spelling and alignment with standard English usage. There are no functional changes, only textual corrections.

## Describe your changes

<!--
This PR fixes a spelling error by replacing the term "infaillible" with "infallible" in relevant code comments and strings. The correction improves clarity and maintains adherence to standard English conventions. There is no impact on functionality.
-->

## Issue ticket number and link
This is a minor textual correction and does not correspond to a specific issue ticket.


## Checklist before requesting a review

- [X] I have added guiding text to explain how a reviewer should test these changes.

- [X] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:
- This change only involves correcting a typo in comments and strings, without modifying the code logic or behavior.

