### PR TITLE
ibc(rpc): always do snapshot selection for proof apis

### DIFF
--- a/crates/core/component/ibc/src/component/rpc/connection_query.rs
+++ b/crates/core/component/ibc/src/component/rpc/connection_query.rs
@@ -103,7 +103,8 @@ impl<HI: HostInterface + Send + Sync + 'static> ConnectionQuery for IbcQuery<HI>
         let snapshot = self.storage.latest_snapshot();
         let height = HI::get_block_height(&snapshot)
             .await
-            .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?;
+            .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?
+            + 1;
 
         let connection_counter = snapshot
             .get_connection_counter()

--- a/crates/core/component/ibc/src/component/rpc/connection_query.rs
+++ b/crates/core/component/ibc/src/component/rpc/connection_query.rs
@@ -29,12 +29,11 @@ use super::IbcQuery;
 #[async_trait]
 impl<HI: HostInterface + Send + Sync + 'static> ConnectionQuery for IbcQuery<HI> {
     /// Connection queries an IBC connection end.
+    #[tracing::instrument(skip(self), err, level = "debug")]
     async fn connection(
         &self,
         request: tonic::Request<QueryConnectionRequest>,
     ) -> std::result::Result<tonic::Response<QueryConnectionResponse>, tonic::Status> {
-        tracing::debug!("querying connection {:?}", request);
-
         let snapshot = match determine_snapshot_from_metadata(self.storage.clone(), request.metadata()) {
             Err(err) => return Err(tonic::Status::aborted(
                 format!("could not determine the correct snapshot to open given the `\"height\"` header of the request: {err:#}")
@@ -96,12 +95,15 @@ impl<HI: HostInterface + Send + Sync + 'static> ConnectionQuery for IbcQuery<HI>
     }
 
     /// Connections queries all the IBC connections of a chain.
+    #[tracing::instrument(skip(self), err, level = "debug")]
     async fn connections(
         &self,
         _request: tonic::Request<QueryConnectionsRequest>,
     ) -> std::result::Result<tonic::Response<QueryConnectionsResponse>, tonic::Status> {
         let snapshot = self.storage.latest_snapshot();
-        let height = snapshot.version() + 1;
+        let height = HI::get_block_height(&snapshot)
+            .await
+            .map_err(|e| tonic::Status::aborted(format!("couldn't decode height: {e}")))?;
 
         let connection_counter = snapshot
             .get_connection_counter()
@@ -143,11 +145,17 @@ impl<HI: HostInterface + Send + Sync + 'static> ConnectionQuery for IbcQuery<HI>
     }
     /// ClientConnections queries the connection paths associated with a client
     /// state.
+    #[tracing::instrument(skip(self), err, level = "debug")]
     async fn client_connections(
         &self,
         request: tonic::Request<QueryClientConnectionsRequest>,
     ) -> std::result::Result<tonic::Response<QueryClientConnectionsResponse>, tonic::Status> {
-        let snapshot = self.storage.latest_snapshot();
+        let snapshot = match determine_snapshot_from_metadata(self.storage.clone(), request.metadata()) {
+            Err(err) => return Err(tonic::Status::aborted(
+                format!("could not determine the correct snapshot to open given the `\"height\"` header of the request: {err:#}")
+            )),
+            Ok(snapshot) => snapshot,
+        };
         let client_id = &ClientId::from_str(&request.get_ref().client_id)
             .map_err(|e| tonic::Status::aborted(format!("invalid client id: {e}")))?;
 
@@ -187,12 +195,18 @@ impl<HI: HostInterface + Send + Sync + 'static> ConnectionQuery for IbcQuery<HI>
     }
     /// ConnectionClientState queries the client state associated with the
     /// connection.
+    #[tracing::instrument(skip(self), err, level = "debug")]
     async fn connection_client_state(
         &self,
         request: tonic::Request<QueryConnectionClientStateRequest>,
     ) -> std::result::Result<tonic::Response<QueryConnectionClientStateResponse>, tonic::Status>
     {
-        let snapshot = self.storage.latest_snapshot();
+        let snapshot = match determine_snapshot_from_metadata(self.storage.clone(), request.metadata()) {
+            Err(err) => return Err(tonic::Status::aborted(
+                format!("could not determine the correct snapshot to open given the `\"height\"` header of the request: {err:#}")
+            )),
+            Ok(snapshot) => snapshot,
+        };
         let connection_id = &ConnectionId::from_str(&request.get_ref().connection_id)
             .map_err(|e| tonic::Status::aborted(format!("invalid connection id: {e}")))?;
 
@@ -240,12 +254,18 @@ impl<HI: HostInterface + Send + Sync + 'static> ConnectionQuery for IbcQuery<HI>
     }
     /// ConnectionConsensusState queries the consensus state associated with the
     /// connection.
+    #[tracing::instrument(skip(self), err, level = "debug")]
     async fn connection_consensus_state(
         &self,
         request: tonic::Request<QueryConnectionConsensusStateRequest>,
     ) -> std::result::Result<tonic::Response<QueryConnectionConsensusStateResponse>, tonic::Status>
     {
-        let snapshot = self.storage.latest_snapshot();
+        let snapshot = match determine_snapshot_from_metadata(self.storage.clone(), request.metadata()) {
+            Err(err) => return Err(tonic::Status::aborted(
+                format!("could not determine the correct snapshot to open given the `\"height\"` header of the request: {err:#}")
+            )),
+            Ok(snapshot) => snapshot,
+        };
         let consensus_state_height = ibc_types::core::client::Height {
             revision_number: request.get_ref().revision_number,
             revision_height: request.get_ref().revision_height,

--- a/crates/core/component/ibc/src/component/rpc/utils.rs
+++ b/crates/core/component/ibc/src/component/rpc/utils.rs
@@ -20,12 +20,15 @@ pub(in crate::component::rpc) fn determine_snapshot_from_metadata(
 ) -> anyhow::Result<Snapshot> {
     let height = determine_height_from_metadata(metadata)
         .context("failed to determine height from metadata")?;
+
+    debug!(?height, "determining snapshot from height header");
+
     if height.revision_height == 0 {
         Ok(storage.latest_snapshot())
     } else {
         storage
             .snapshot(height.revision_height)
-            .context("failed to create state snapshot from IBC height in height header")
+            .context("failed to create state snapshot from IBC height header")
     }
 }
 


### PR DESCRIPTION
## Describe your changes

This PR:
- instruments IBC gRPC spans on `DEBUG`
- prefer using the `HostInterface` trait to hardcoding height/revision for gRPC responses
- systematically defer to the query height hint (in the gRPC headers) for **every API that returns a proof** (extending #4905, cc @noot)

We will be able to rip out all of the header selection logic once `https://github.com/cosmos/ibc-go/pull/7303` is merged.

## Checklist before requesting a review

- [ ] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > RPC
