### PR TITLE
fix: typos in documentation files

### DIFF
--- a/testnets/078-deimos-8/README.md
+++ b/testnets/078-deimos-8/README.md
@@ -1,4 +1,4 @@
 # Testnet 78
 
-Testnet 78 was released as a chain upgrade, carrying over the allocations first used
+Testnet 78 was released as a chain upgrade, carrying over the allocations first used in 
 Testnet 75. See details in https://github.com/penumbra-zone/penumbra/issues/4582.


### PR DESCRIPTION
Corrected `allocations first used Testnet 75` to `allocations first used in Testnet 75`