### PR TITLE
Pindexer metrics fix

### DIFF
--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -50,6 +50,8 @@ mod candle {
 
     impl Candle {
         pub fn from_candlestick_data(data: &CandlestickData) -> Self {
+            // We want the direct volume in the other direction, and we consistently
+            // use the closing price as a conversion for that.
             Self {
                 open: data.open,
                 close: data.close,
@@ -88,8 +90,8 @@ mod candle {
                 close: 1.0 / self.close,
                 low: 1.0 / self.low,
                 high: 1.0 / self.high,
-                direct_volume: self.direct_volume / self.close,
-                swap_volume: self.swap_volume / self.close,
+                direct_volume: self.direct_volume * self.close,
+                swap_volume: self.swap_volume * self.close,
             }
         }
     }

--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -547,6 +547,7 @@ mod summary {
                 ON ed_end.asset = asset_end
                 JOIN eligible_denoms AS ed_start
                 ON ed_start.asset = asset_start
+                WHERE the_window = $3
             ),
             sums AS (
                 SELECT

--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -50,8 +50,9 @@ mod candle {
 
     impl Candle {
         pub fn from_candlestick_data(data: &CandlestickData) -> Self {
-            // We want the direct volume in the other direction, and we consistently
-            // use the closing price as a conversion for that.
+            // The volume is tracked in terms of input asset.
+            // We can use the closing price (aka. the common clearing price) to convert
+            // the volume to the other direction i.e, the batch swap output.
             Self {
                 open: data.open,
                 close: data.close,


### PR DESCRIPTION
## Describe your changes

This fixes two bugs in pindexer:
1. Volumes in aggregate and per pair summary were far too high.
2. The different windows of the aggregate summary all reported the same value.

Bug 1. stemmed from multiplying by a price rather than dividing by it when mixing two directions of a candle.

Bug 2. was just a missing filter in an SQL query.

To test, run pindexer again, and do some sanity checks on the aggregate summary, and pair summaries for pairs like USDC / UM.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only
