### PR TITLE
Erwan/pindexer swap execs

### DIFF
--- a/crates/bin/pindexer/src/dex_ex/schema.sql
+++ b/crates/bin/pindexer/src/dex_ex/schema.sql
@@ -196,7 +196,7 @@ CREATE TABLE IF NOT EXISTS dex_ex_batch_swap_traces (
   -- Each hop in the list contains an asset id.
   asset_hops BYTEA[] NOT NULL,
   -- Each hop in the list contains an amount.
-  amount_hops BYTEA[] NOT NULL,
+  amount_hops NUMERIC(39)[] NOT NULL,
   -- Each hop in the list contains a position ID.
   position_id_hops BYTEA[] NOT NULL
 );

--- a/crates/bin/pindexer/src/dex_ex/schema.sql
+++ b/crates/bin/pindexer/src/dex_ex/schema.sql
@@ -165,30 +165,40 @@ CREATE TABLE IF NOT EXISTS dex_ex_position_withdrawals (
 CREATE INDEX ON dex_ex_position_withdrawals (height);
 CREATE INDEX ON dex_ex_position_withdrawals (position_id, height);
 
+-- This table tracks individual execution traces for a directed batch swap.
 CREATE TABLE IF NOT EXISTS dex_ex_batch_swap_traces (
+  -- Primary key
   rowid SERIAL PRIMARY KEY,
+
+  -- The height of the block the batch swap was included in.
+  height INTEGER NOT NULL,
+  -- The time the batch swap was included in a block.
+  time TIMESTAMPTZ NOT NULL,
+
+  -- The amount of asset 1 consumed by the micro execution in raw denom.
+  input NUMERIC(39) NOT NULL,
+  -- The amount of asset 2 produced by the micro execution in raw denom.
+  output NUMERIC(39) NOT NULL,
+
+  -- The amount of asset 1 consumed by the macro execution.
+  batch_input NUMERIC(39) NOT NULL,
+  -- The amount of asset 2 produced by the macro execution.
+  batch_output NUMERIC(39) NOT NULL,
+  -- The price (output/input) as a float
+  price_float DOUBLE PRECISION NOT NULL,
+
+
   -- The directed start asset of the batch swap.
   asset_start BYTEA NOT NULL,
   -- The directed end asset of the batch swap.
   asset_end BYTEA NOT NULL,
-  -- The time the batch swap was included in a block.
-  time TIMESTAMPTZ NOT NULL,
-  -- The height of the block the batch swap was included in.
-  height INTEGER NOT NULL,
+
   -- Each hop in the list contains an asset id.
   asset_hops BYTEA[] NOT NULL,
   -- Each hop in the list contains an amount.
   amount_hops BYTEA[] NOT NULL,
   -- Each hop in the list contains a position ID.
-  position_id_hops BYTEA[] NOT NULL,
-  -- The amount of asset 1 consumed by the micro execution
-  input NUMERIC(39) NOT NULL,
-  -- The amount of asset 2 produced by the micro execution
-  output NUMERIC(39) NOT NULL,
-  -- The amount of asset 1 consumed by the macro execution
-  batch_input NUMERIC(39) NOT NULL,
-  -- The amount of asset 2 produced by the macro execution
-  batch_output NUMERIC(39) NOT NULL,
+  position_id_hops BYTEA[] NOT NULL
 );
 
 CREATE INDEX ON dex_ex_batch_swap_traces (time, height);

--- a/crates/bin/pindexer/src/dex_ex/schema.sql
+++ b/crates/bin/pindexer/src/dex_ex/schema.sql
@@ -165,6 +165,36 @@ CREATE TABLE IF NOT EXISTS dex_ex_position_withdrawals (
 CREATE INDEX ON dex_ex_position_withdrawals (height);
 CREATE INDEX ON dex_ex_position_withdrawals (position_id, height);
 
+CREATE TABLE IF NOT EXISTS dex_ex_batch_swap_traces (
+  rowid SERIAL PRIMARY KEY,
+  -- The directed start asset of the batch swap.
+  asset_start BYTEA NOT NULL,
+  -- The directed end asset of the batch swap.
+  asset_end BYTEA NOT NULL,
+  -- The time the batch swap was included in a block.
+  time TIMESTAMPTZ NOT NULL,
+  -- The height of the block the batch swap was included in.
+  height INTEGER NOT NULL,
+  -- Each hop in the list contains an asset id.
+  asset_hops BYTEA[] NOT NULL,
+  -- Each hop in the list contains an amount.
+  amount_hops BYTEA[] NOT NULL,
+  -- Each hop in the list contains a position ID.
+  position_id_hops BYTEA[] NOT NULL,
+  -- The amount of asset 1 consumed by the micro execution
+  input NUMERIC(39) NOT NULL,
+  -- The amount of asset 2 produced by the micro execution
+  output NUMERIC(39) NOT NULL,
+  -- The amount of asset 1 consumed by the macro execution
+  batch_input NUMERIC(39) NOT NULL,
+  -- The amount of asset 2 produced by the macro execution
+  batch_output NUMERIC(39) NOT NULL,
+);
+
+CREATE INDEX ON dex_ex_batch_swap_traces (time, height);
+CREATE INDEX ON dex_ex_batch_swap_traces (asset_start, asset_end);
+-- TODO(erwan): We can add a GIN index on the position id later.
+
 ALTER TABLE dex_ex_position_executions
   ADD CONSTRAINT fk_position_executions
   FOREIGN KEY (position_id) REFERENCES dex_ex_position_state(position_id);


### PR DESCRIPTION
## Describe your changes

This PR adds a `dex_ex_batch_swap_traces` table that tracks batch swap execution traces.

Notably, the schema contains a price float, but no input/output amount floats for now. This is good to have, but we can add it later and it's not immediately useful to the intended consumer of this data.


```sql
-- This table tracks individual execution traces for a directed batch swap.
CREATE TABLE IF NOT EXISTS dex_ex_batch_swap_traces (
  -- Primary key
  rowid SERIAL PRIMARY KEY,

  -- The height of the block the batch swap was included in.
  height INTEGER NOT NULL,
  -- The time the batch swap was included in a block.
  time TIMESTAMPTZ NOT NULL,

  -- The amount of asset 1 consumed by the micro execution in raw denom.
  input NUMERIC(39) NOT NULL,
  -- The amount of asset 2 produced by the micro execution in raw denom.
  output NUMERIC(39) NOT NULL,

  -- The amount of asset 1 consumed by the macro execution.
  batch_input NUMERIC(39) NOT NULL,
  -- The amount of asset 2 produced by the macro execution.
  batch_output NUMERIC(39) NOT NULL,
  -- The price (output/input) as a float
  price_float DOUBLE PRECISION NOT NULL,


  -- The directed start asset of the batch swap.
  asset_start BYTEA NOT NULL,
  -- The directed end asset of the batch swap.
  asset_end BYTEA NOT NULL,

  -- Each hop in the list contains an asset id.
  asset_hops BYTEA[] NOT NULL,
  -- Each hop in the list contains an amount.
  amount_hops NUMERIC(39)[] NOT NULL,
  -- Each hop in the list contains a position ID.
  position_id_hops BYTEA[] NOT NULL
);

CREATE INDEX ON dex_ex_batch_swap_traces (time, height);
CREATE INDEX ON dex_ex_batch_swap_traces (asset_start, asset_end);
```

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > pindexer changes