### PR TITLE
dex: hotfix for 2025-01-18 chain halt (alternative)

### DIFF
--- a/crates/core/component/dex/src/component/action_handler/position/close.rs
+++ b/crates/core/component/dex/src/component/action_handler/position/close.rs
@@ -2,9 +2,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use cnidarium::StateWrite;
 use cnidarium_component::ActionHandler;
-use penumbra_proto::{DomainType as _, StateWriteProto as _};
 
-use crate::{component::PositionManager, event, lp::action::PositionClose};
+use crate::{component::PositionManager, lp::action::PositionClose};
 
 #[async_trait]
 /// Debits an opened position NFT and credits a closed position NFT.
@@ -22,15 +21,7 @@ impl ActionHandler for PositionClose {
         // lose the ability to do block-scoped JIT liquidity, where a single
         // transaction opens and closes a position, keeping liquidity live only
         // during that block's batch swap execution.
-        state.queue_close_position(self.position_id);
-
-        // queue position close you will...
-        state.record_proto(
-            event::EventQueuePositionClose {
-                position_id: self.position_id,
-            }
-            .to_proto(),
-        );
+        state.queue_close_position(self.position_id).await?;
 
         Ok(())
     }


### PR DESCRIPTION
## Describe your changes

This commit fixes the chain halt that occurred on 2025-01-18 at block 3093519.

### What happened (short version):

A transaction was submitted that contained both `PositionClose` and `PositionWithdraw` actions for the same position `P`, which had been auto-closed by the DEX. In `DeliverTx`, the `PositionClose` action queued the position for closure by ID, and the `PositionWithdraw` action checked that the position state was closed and then updated it to Withdrawn. Later, in `EndBlock`, the queued position closure was executed. The position state was not Opened or Closed, triggering an assertion.

### Why it happened

- Mempool tx checking does not execute end block so this didn't get filtered out
- The position closure method allows the position closure to be a no-op, but only for positions in the closed state
- Because the position was withdrawn, the state was unexpected

### What this does

Avoid queueing the position for closure unless it is Opened.