### PR TITLE
ci: disable refinement workflow for now

### DIFF
--- a/.github/workflows/new-issues-labeled-needs-refinement.yml
+++ b/.github/workflows/new-issues-labeled-needs-refinement.yml
@@ -1,20 +1,20 @@
 # Adds the `needs-refinement` label to newly opened issues.
-name: New issues need refinement
-on:
-  issues:
-    types:
-      - opened
-jobs:
-  label_issues:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number }}
-          # Separate multiple labels with commas if other labels are ever
-          # needed e.g., `needs-refinement,foo`.
-          LABELS: needs-refinement
+# name: New issues need refinement
+# on:
+#   issues:
+#     types:
+#       - opened
+# jobs:
+#   label_issues:
+#     runs-on: ubuntu-latest
+#     permissions:
+#       issues: write
+#     steps:
+#       - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+#         env:
+#           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#           GH_REPO: ${{ github.repository }}
+#           NUMBER: ${{ github.event.issue.number }}
+#           # Separate multiple labels with commas if other labels are ever
+#           # needed e.g., `needs-refinement,foo`.
+#           LABELS: needs-refinement


### PR DESCRIPTION
## Describe your changes

This comments out the refinement workflow for now, rather than remove it, since it's a good example for future process work using actions. 