### PR TITLE
pcli: add delegate-many transaction command reading from a CSV file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4389,6 +4389,7 @@ dependencies = [
  "colored",
  "colored_json",
  "comfy-table",
+ "csv",
  "decaf377",
  "decaf377-rdsa",
  "dialoguer",

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -45,6 +45,7 @@ clap = {workspace = true, features = ["derive", "env"]}
 colored = "2.1.0"
 colored_json = "4.1"
 comfy-table = "5"
+csv = "1"
 decaf377 = {workspace = true, default-features = true}
 decaf377-rdsa = {workspace = true}
 dialoguer = "0.10.4"


### PR DESCRIPTION
## Describe your changes

Adds a `pcli tx delegate-many` command that allows delegations based on a CSV file.

Example CSV file:

```
penumbravalid10n2srs5257a6nxq9x3fhcsqyc0wh8q2lp7f80qd7wlmzdm6znypse23mmh,0.123
penumbravalid1aglayhqq2ec5yfgx8ljqrd9ypnma5uu46hsd0d77dakgu4nywuyqk29d0m,0.201
penumbravalid1lr6rqawqmwetsr8dvdefrpeh7zuamj2ka9jgmesn2xxfgf49hsys79rz9j,0.256
```

Transaction: f7d386906f5fabc88a5eb051d31bfd45cb51049a7f92f231ed33be3ef6314151

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.
  - Can check the supplied tx

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Client-side changes to pcli only.