### PR TITLE
asset: add `coingecko_id` to `Metadata` struct

### DIFF
--- a/crates/core/asset/src/asset/denom_metadata.rs
+++ b/crates/core/asset/src/asset/denom_metadata.rs
@@ -49,6 +49,7 @@ pub(super) struct Inner {
     display_index: usize,
     name: String,
     symbol: String,
+    coingecko_id: String,
 }
 
 impl DomainType for Metadata {
@@ -68,7 +69,7 @@ impl From<&Inner> for pb::Metadata {
             images: inner.images.clone(),
             badges: inner.badges.clone(),
             priority_score: inner.priority_score,
-            coingecko_id: String::new(),
+            coingecko_id: inner.coingecko_id.clone(),
         }
     }
 }
@@ -136,6 +137,7 @@ impl TryFrom<pb::Metadata> for Inner {
             images: value.images,
             badges: value.badges,
             priority_score: value.priority_score,
+            coingecko_id: value.coingecko_id,
         })
     }
 }
@@ -259,6 +261,7 @@ impl Inner {
             images: Vec::new(),
             badges: Vec::new(),
             priority_score: 0,
+            coingecko_id: String::new(),
         }
     }
 }
@@ -435,6 +438,7 @@ impl Debug for Metadata {
             symbol,
             priority_score,
             badges,
+            coingecko_id,
         } = inner.as_ref();
 
         f.debug_struct("Metadata")
@@ -448,6 +452,7 @@ impl Debug for Metadata {
             .field("display_index", display_index)
             .field("name", name)
             .field("symbol", symbol)
+            .field("coingecko_id", coingecko_id)
             .finish()
     }
 }


### PR DESCRIPTION
Extends the `Inner` struct in `denom_metadata.rs` to include a `coingecko_id` field. Updates related methods to handle the new field, including `From`, `TryFrom`, `Debug`, and default initialization.

## Issue ticket number and link

https://github.com/prax-wallet/registry/issues/121

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:
