### PR TITLE
Implement check and execute for LQT votes

### DIFF
--- a/crates/core/component/funding/Cargo.toml
+++ b/crates/core/component/funding/Cargo.toml
@@ -14,6 +14,7 @@ component = [
     "penumbra-sdk-proto/cnidarium",
     "penumbra-sdk-community-pool/component",
     "penumbra-sdk-distributions/component",
+    "penumbra-sdk-governance/component",
     "penumbra-sdk-sct/component",
     "penumbra-sdk-shielded-pool/component",
     "penumbra-sdk-stake/component",

--- a/crates/core/component/funding/src/component.rs
+++ b/crates/core/component/funding/src/component.rs
@@ -3,7 +3,6 @@ mod state_key;
 pub mod view;
 use ::metrics::{gauge, histogram};
 pub use metrics::register_metrics;
-pub(crate) mod liquidity_tournament;
 
 /* Component implementation */
 use penumbra_sdk_asset::{Value, STAKING_TOKEN_ASSET_ID};

--- a/crates/core/component/funding/src/component.rs
+++ b/crates/core/component/funding/src/component.rs
@@ -3,6 +3,7 @@ mod state_key;
 pub mod view;
 use ::metrics::{gauge, histogram};
 pub use metrics::register_metrics;
+pub(crate) mod liquidity_tournament;
 
 /* Component implementation */
 use penumbra_sdk_asset::{Value, STAKING_TOKEN_ASSET_ID};

--- a/crates/core/component/funding/src/component/liquidity_tournament/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/mod.rs
@@ -1,1 +1,2 @@
 pub mod nullifier;
+pub mod votes;

--- a/crates/core/component/funding/src/component/liquidity_tournament/nullifier/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/nullifier/mod.rs
@@ -6,7 +6,6 @@ use cnidarium::{StateRead, StateWrite};
 use penumbra_sdk_proto::{StateReadProto, StateWriteProto};
 use penumbra_sdk_sct::{component::clock::EpochRead, Nullifier};
 
-#[allow(dead_code)]
 #[async_trait]
 pub trait NullifierRead: StateRead {
     /// Returns the `TransactionId` if the nullifier has been spent; otherwise, returns None.
@@ -34,7 +33,6 @@ pub trait NullifierRead: StateRead {
 
 impl<T: StateRead + ?Sized> NullifierRead for T {}
 
-#[allow(dead_code)]
 #[async_trait]
 pub trait NullifierWrite: StateWrite {
     /// Sets the LQT nullifier in the NV storage.

--- a/crates/core/component/funding/src/component/liquidity_tournament/votes/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/votes/mod.rs
@@ -1,0 +1,26 @@
+use async_trait::async_trait;
+use cnidarium::StateWrite;
+use penumbra_sdk_asset::asset;
+use penumbra_sdk_keys::Address;
+
+use crate::component::state_key;
+
+#[async_trait]
+pub trait StateWriteExt: StateWrite {
+    // Keeping this as returning a result to not have to touch other code if it changes to return an error.
+    async fn tally(
+        &mut self,
+        epoch: u64,
+        asset: asset::Id,
+        power: u64,
+        voter: &Address,
+    ) -> anyhow::Result<()> {
+        self.nonverifiable_put_raw(
+            state_key::lqt::v1::votes::receipt(epoch, asset, power, voter).to_vec(),
+            Vec::default(),
+        );
+        Ok(())
+    }
+}
+
+impl<T: StateWrite + ?Sized> StateWriteExt for T {}

--- a/crates/core/component/funding/src/component/state_key.rs
+++ b/crates/core/component/funding/src/component/state_key.rs
@@ -42,7 +42,6 @@ pub mod lqt {
             const POWER_LEN: usize = 8;
             const RECEIPT_LEN: usize = PREFIX_LEN + ASSET_LEN + POWER_LEN + ADDRESS_LEN_BYTES;
 
-            #[allow(dead_code)] // TODO: remove once used
             /// When present, indicates that an address voted for a particular asset, with a given power.
             ///
             /// To get the values ordered by descending voting power, use [`prefix`];

--- a/crates/core/component/funding/src/component/state_key.rs
+++ b/crates/core/component/funding/src/component/state_key.rs
@@ -12,5 +12,60 @@ pub mod lqt {
                 format!("funding/lqt/v1/nullifier/{epoch_index:020}/lookup/{nullifier}")
             }
         }
+
+        pub mod votes {
+            use penumbra_sdk_asset::asset;
+            use penumbra_sdk_keys::{address::ADDRESS_LEN_BYTES, Address};
+
+            const PART0: &'static str = "funding/lqt/v1/votes/";
+            const EPOCH_LEN: usize = 20;
+            const PART1: &'static str = "/by_asset/";
+            const PREFIX_LEN: usize = PART0.len() + EPOCH_LEN + PART1.len();
+
+            /// A prefix for accessing the votes in a given epoch, c.f. [`power_asset_address`];
+            pub(crate) fn prefix(epoch_index: u64) -> [u8; PREFIX_LEN] {
+                let mut bytes = [0u8; PREFIX_LEN];
+
+                let rest = &mut bytes;
+                let (bytes_part0, rest) = rest.split_at_mut(PART0.len());
+                let (bytes_epoch_index, bytes_part1) = rest.split_at_mut(EPOCH_LEN);
+
+                bytes_part0.copy_from_slice(PART0.as_bytes());
+                bytes_epoch_index
+                    .copy_from_slice(format!("{epoch_index:0w$}", w = EPOCH_LEN).as_bytes());
+                bytes_part1.copy_from_slice(PART1.as_bytes());
+
+                bytes
+            }
+
+            const ASSET_LEN: usize = 32;
+            const POWER_LEN: usize = 8;
+            const RECEIPT_LEN: usize = PREFIX_LEN + ASSET_LEN + POWER_LEN + ADDRESS_LEN_BYTES;
+
+            #[allow(dead_code)] // TODO: remove once used
+            /// When present, indicates that an address voted for a particular asset, with a given power.
+            ///
+            /// To get the values ordered by descending voting power, use [`prefix`];
+            pub(crate) fn receipt(
+                epoch_index: u64,
+                asset: asset::Id,
+                power: u64,
+                voter: &Address,
+            ) -> [u8; RECEIPT_LEN] {
+                let mut bytes = [0u8; RECEIPT_LEN];
+
+                let rest = &mut bytes;
+                let (bytes_prefix, rest) = rest.split_at_mut(PREFIX_LEN);
+                let (bytes_asset, rest) = rest.split_at_mut(ASSET_LEN);
+                let (bytes_power, bytes_voter) = rest.split_at_mut(POWER_LEN);
+
+                bytes_prefix.copy_from_slice(&prefix(epoch_index));
+                bytes_asset.copy_from_slice(&asset.to_bytes());
+                bytes_power.copy_from_slice(&((!power).to_be_bytes()));
+                bytes_voter.copy_from_slice(&voter.to_vec());
+
+                bytes
+            }
+        }
     }
 }

--- a/crates/core/component/funding/src/liquidity_tournament/action/mod.rs
+++ b/crates/core/component/funding/src/liquidity_tournament/action/mod.rs
@@ -1,6 +1,9 @@
 use anyhow::{anyhow, Context};
 use decaf377_rdsa::{Signature, SpendAuth, VerificationKey};
-use penumbra_sdk_asset::{asset::Denom, balance, Value};
+use penumbra_sdk_asset::{
+    asset::{self, Denom, REGISTRY},
+    balance, Value,
+};
 use penumbra_sdk_keys::Address;
 use penumbra_sdk_proto::{core::component::funding::v1 as pb, DomainType};
 use penumbra_sdk_sct::Nullifier;
@@ -32,6 +35,17 @@ pub struct LiquidityTournamentVoteBody {
     pub nullifier: Nullifier,
     /// The key that must be used to vote.
     pub rk: VerificationKey<SpendAuth>,
+}
+
+impl LiquidityTournamentVoteBody {
+    /// Get the asset id that should be incentivized.
+    ///
+    /// This will return None if the denom is not a base denom.
+    pub fn incentivized_id(&self) -> Option<asset::Id> {
+        REGISTRY
+            .parse_denom(&self.incentivized.denom)
+            .map(|x| x.id())
+    }
 }
 
 impl DomainType for LiquidityTournamentVoteBody {


### PR DESCRIPTION
Closes #5032.

The check and execute logic for the action handler is still missing the nullifier check, but there's an obvious insertion point for adding that logic.

Testing deferred.