### PR TITLE
funding: LQT nullifier set for epoch

### DIFF
--- a/crates/core/app-tests/tests/spend.rs
+++ b/crates/core/app-tests/tests/spend.rs
@@ -65,6 +65,7 @@ async fn spend_happy_path() -> anyhow::Result<()> {
     let transaction_context = TransactionContext {
         anchor: root,
         effect_hash: EffectHash(dummy_effect_hash),
+        transaction_id: [0; 32],
     };
 
     // 3. Simulate execution of the Spend action
@@ -189,6 +190,7 @@ async fn invalid_dummy_spend() {
     let transaction_context = TransactionContext {
         anchor: root,
         effect_hash: EffectHash(dummy_effect_hash),
+        transaction_id: [0; 32],
     };
 
     // 3. Simulate execution of the Spend action

--- a/crates/core/app-tests/tests/spend.rs
+++ b/crates/core/app-tests/tests/spend.rs
@@ -17,7 +17,7 @@ use penumbra_sdk_sct::{
 use penumbra_sdk_shielded_pool::{
     component::ShieldedPool, Note, SpendPlan, SpendProof, SpendProofPrivate, SpendProofPublic,
 };
-use penumbra_sdk_txhash::{EffectHash, TransactionContext};
+use penumbra_sdk_txhash::{EffectHash, TransactionContext, TransactionId};
 use rand_core::{OsRng, SeedableRng};
 use std::{ops::Deref, sync::Arc};
 use tendermint::abci;
@@ -65,7 +65,7 @@ async fn spend_happy_path() -> anyhow::Result<()> {
     let transaction_context = TransactionContext {
         anchor: root,
         effect_hash: EffectHash(dummy_effect_hash),
-        transaction_id: [0; 32],
+        transaction_id: TransactionId([0; 32]),
     };
 
     // 3. Simulate execution of the Spend action
@@ -190,7 +190,7 @@ async fn invalid_dummy_spend() {
     let transaction_context = TransactionContext {
         anchor: root,
         effect_hash: EffectHash(dummy_effect_hash),
-        transaction_id: [0; 32],
+        transaction_id: TransactionId([0; 32]),
     };
 
     // 3. Simulate execution of the Spend action

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -690,7 +690,7 @@ pub trait StateReadExt: StateRead {
         let distributions_params = self.get_distributions_params().await?;
         let ibc_params = self.get_ibc_params().await?;
         let fee_params = self.get_fee_params().await?;
-        let funding_params = self.get_staking_funding_params().await?;
+        let funding_params = self.get_funding_params().await?;
         let governance_params = self.get_governance_params().await?;
         let sct_params = self.get_sct_params().await?;
         let shielded_pool_params = self.get_shielded_pool_params().await?;
@@ -812,7 +812,7 @@ pub trait StateWriteExt: StateWrite {
         self.put_community_pool_params(community_pool_params);
         self.put_distributions_params(distributions_params);
         self.put_fee_params(fee_params);
-        self.put_staking_funding_params(funding_params);
+        self.put_funding_params(funding_params);
         self.put_governance_params(governance_params);
         self.put_ibc_params(ibc_params);
         self.put_sct_params(sct_params);

--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -690,7 +690,7 @@ pub trait StateReadExt: StateRead {
         let distributions_params = self.get_distributions_params().await?;
         let ibc_params = self.get_ibc_params().await?;
         let fee_params = self.get_fee_params().await?;
-        let funding_params = self.get_funding_params().await?;
+        let funding_params = self.get_staking_funding_params().await?;
         let governance_params = self.get_governance_params().await?;
         let sct_params = self.get_sct_params().await?;
         let shielded_pool_params = self.get_shielded_pool_params().await?;
@@ -812,7 +812,7 @@ pub trait StateWriteExt: StateWrite {
         self.put_community_pool_params(community_pool_params);
         self.put_distributions_params(distributions_params);
         self.put_fee_params(fee_params);
-        self.put_funding_params(funding_params);
+        self.put_staking_funding_params(funding_params);
         self.put_governance_params(governance_params);
         self.put_ibc_params(ibc_params);
         self.put_sct_params(sct_params);

--- a/crates/core/component/funding/src/component.rs
+++ b/crates/core/component/funding/src/component.rs
@@ -9,6 +9,7 @@ use penumbra_sdk_asset::{Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_sdk_proto::{DomainType, StateWriteProto};
 use penumbra_sdk_stake::component::validator_handler::ValidatorDataRead;
 pub use view::{StateReadExt, StateWriteExt};
+pub(crate) mod liquidity_tournament;
 
 use std::sync::Arc;
 

--- a/crates/core/component/funding/src/component.rs
+++ b/crates/core/component/funding/src/component.rs
@@ -33,7 +33,7 @@ impl Component for Funding {
         match app_state {
             None => { /* no-op */ }
             Some(genesis) => {
-                state.put_staking_funding_params(genesis.funding_params.clone());
+                state.put_funding_params(genesis.funding_params.clone());
             }
         };
     }

--- a/crates/core/component/funding/src/component.rs
+++ b/crates/core/component/funding/src/component.rs
@@ -32,7 +32,7 @@ impl Component for Funding {
         match app_state {
             None => { /* no-op */ }
             Some(genesis) => {
-                state.put_funding_params(genesis.funding_params.clone());
+                state.put_staking_funding_params(genesis.funding_params.clone());
             }
         };
     }

--- a/crates/core/component/funding/src/component/liquidity_tournament/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/mod.rs
@@ -1,0 +1,1 @@
+pub mod nullifier;

--- a/crates/core/component/funding/src/component/liquidity_tournament/nullifier/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/nullifier/mod.rs
@@ -23,7 +23,10 @@ pub trait NullifierRead: StateRead {
         let tx_id: Option<TransactionId> = self
             .nonverifiable_get(&nullifier_key.as_bytes())
             .await
-            .expect("infallible");
+            .expect(&format!(
+                "failed to retrieve key {} from non-verifiable storage",
+                nullifier_key,
+            ));
 
         tx_id
     }

--- a/crates/core/component/funding/src/component/liquidity_tournament/nullifier/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/nullifier/mod.rs
@@ -6,6 +6,7 @@ use cnidarium::{StateRead, StateWrite};
 use penumbra_sdk_proto::{StateReadProto, StateWriteProto};
 use penumbra_sdk_sct::{component::clock::EpochRead, Nullifier};
 
+#[allow(dead_code)]
 #[async_trait]
 pub trait NullifierRead: StateRead {
     /// Gets the transaction id associated with the given nullifier from the JMT.
@@ -17,10 +18,8 @@ pub trait NullifierRead: StateRead {
             .expect("epoch is always set")
             .index;
 
-        let nullifier_key = &state_key::lqt::v1::nf::by_epoch::lqt_nullifier_lookup_for_txid(
-            epoch_index,
-            &nullifier,
-        );
+        let nullifier_key =
+            &state_key::lqt::v1::nullifier::lqt_nullifier_lookup_for_txid(epoch_index, &nullifier);
 
         let tx_id: Option<TransactionId> = self
             .nonverifiable_get(&nullifier_key.as_bytes())
@@ -33,14 +32,13 @@ pub trait NullifierRead: StateRead {
 
 impl<T: StateRead + ?Sized> NullifierRead for T {}
 
+#[allow(dead_code)]
 #[async_trait]
 pub trait NullifierWrite: StateWrite {
     /// Sets the LQT nullifier in the JMT.
     fn put_lqt_nullifier(&mut self, epoch_index: u64, nullifier: Nullifier, tx_id: TransactionId) {
-        let nullifier_key = state_key::lqt::v1::nf::by_epoch::lqt_nullifier_lookup_for_txid(
-            epoch_index,
-            &nullifier,
-        );
+        let nullifier_key =
+            state_key::lqt::v1::nullifier::lqt_nullifier_lookup_for_txid(epoch_index, &nullifier);
 
         self.put(nullifier_key, tx_id);
     }

--- a/crates/core/component/funding/src/component/liquidity_tournament/nullifier/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/nullifier/mod.rs
@@ -1,0 +1,49 @@
+use async_trait::async_trait;
+use penumbra_sdk_txhash::TransactionId;
+
+use crate::component::state_key;
+use cnidarium::{StateRead, StateWrite};
+use penumbra_sdk_proto::{StateReadProto, StateWriteProto};
+use penumbra_sdk_sct::{component::clock::EpochRead, Nullifier};
+
+#[async_trait]
+pub trait NullifierRead: StateRead {
+    /// Gets the transaction id associated with the given nullifier from the JMT.
+    async fn get_txid_from_nullifier(&self, nullifier: Nullifier) -> Option<TransactionId> {
+        // Grab the ambient epoch index.
+        let epoch_index = self
+            .get_current_epoch()
+            .await
+            .expect("epoch is always set")
+            .index;
+
+        let nullifier_key = &state_key::lqt::v1::nf::by_epoch::lqt_nullifier_lookup_for_txid(
+            epoch_index,
+            &nullifier,
+        );
+
+        let tx_id: Option<TransactionId> = self
+            .nonverifiable_get(&nullifier_key.as_bytes())
+            .await
+            .expect("infallible");
+
+        tx_id
+    }
+}
+
+impl<T: StateRead + ?Sized> NullifierRead for T {}
+
+#[async_trait]
+pub trait NullifierWrite: StateWrite {
+    /// Sets the LQT nullifier in the JMT.
+    fn put_lqt_nullifier(&mut self, epoch_index: u64, nullifier: Nullifier, tx_id: TransactionId) {
+        let nullifier_key = state_key::lqt::v1::nf::by_epoch::lqt_nullifier_lookup_for_txid(
+            epoch_index,
+            &nullifier,
+        );
+
+        self.put(nullifier_key, tx_id);
+    }
+}
+
+impl<T: StateWrite + ?Sized> NullifierWrite for T {}

--- a/crates/core/component/funding/src/component/state_key.rs
+++ b/crates/core/component/funding/src/component/state_key.rs
@@ -1,3 +1,9 @@
-pub fn funding_parameters() -> &'static str {
+use penumbra_sdk_sct::Nullifier;
+
+pub fn staking_funding_parameters() -> &'static str {
     "funding/parameters"
+}
+
+pub fn lqt_nullifier_lookup_for_txid(epoch_index: u64, nullifier: &Nullifier) -> String {
+    format!("funding/lqt/v1/nf/by_epoch/{epoch_index:020}/lookup/{nullifier}")
 }

--- a/crates/core/component/funding/src/component/state_key.rs
+++ b/crates/core/component/funding/src/component/state_key.rs
@@ -1,4 +1,4 @@
-pub fn staking_funding_parameters() -> &'static str {
+pub fn funding_parameters() -> &'static str {
     "funding/parameters"
 }
 

--- a/crates/core/component/funding/src/component/state_key.rs
+++ b/crates/core/component/funding/src/component/state_key.rs
@@ -1,9 +1,20 @@
-use penumbra_sdk_sct::Nullifier;
-
 pub fn staking_funding_parameters() -> &'static str {
     "funding/parameters"
 }
 
-pub fn lqt_nullifier_lookup_for_txid(epoch_index: u64, nullifier: &Nullifier) -> String {
-    format!("funding/lqt/v1/nf/by_epoch/{epoch_index:020}/lookup/{nullifier}")
+pub mod lqt {
+    pub mod v1 {
+        pub mod nf {
+            pub mod by_epoch {
+                use penumbra_sdk_sct::Nullifier;
+
+                pub(crate) fn lqt_nullifier_lookup_for_txid(
+                    epoch_index: u64,
+                    nullifier: &Nullifier,
+                ) -> String {
+                    format!("funding/lqt/v1/nf/by_epoch/{epoch_index:020}/lookup/{nullifier}")
+                }
+            }
+        }
+    }
 }

--- a/crates/core/component/funding/src/component/state_key.rs
+++ b/crates/core/component/funding/src/component/state_key.rs
@@ -7,10 +7,8 @@ pub mod lqt {
         pub mod nullifier {
             use penumbra_sdk_sct::Nullifier;
 
-            pub(crate) fn lqt_nullifier_lookup_for_txid(
-                epoch_index: u64,
-                nullifier: &Nullifier,
-            ) -> String {
+            /// A nullifier set indexed by epoch, mapping each epoch to its corresponding `TransactionId`.
+            pub(crate) fn key(epoch_index: u64, nullifier: &Nullifier) -> String {
                 format!("funding/lqt/v1/nullifier/{epoch_index:020}/lookup/{nullifier}")
             }
         }

--- a/crates/core/component/funding/src/component/state_key.rs
+++ b/crates/core/component/funding/src/component/state_key.rs
@@ -4,16 +4,14 @@ pub fn staking_funding_parameters() -> &'static str {
 
 pub mod lqt {
     pub mod v1 {
-        pub mod nf {
-            pub mod by_epoch {
-                use penumbra_sdk_sct::Nullifier;
+        pub mod nullifier {
+            use penumbra_sdk_sct::Nullifier;
 
-                pub(crate) fn lqt_nullifier_lookup_for_txid(
-                    epoch_index: u64,
-                    nullifier: &Nullifier,
-                ) -> String {
-                    format!("funding/lqt/v1/nf/by_epoch/{epoch_index:020}/lookup/{nullifier}")
-                }
+            pub(crate) fn lqt_nullifier_lookup_for_txid(
+                epoch_index: u64,
+                nullifier: &Nullifier,
+            ) -> String {
+                format!("funding/lqt/v1/nullifier/{epoch_index:020}/lookup/{nullifier}")
             }
         }
     }

--- a/crates/core/component/funding/src/component/view.rs
+++ b/crates/core/component/funding/src/component/view.rs
@@ -1,11 +1,8 @@
-use async_trait::async_trait;
-use penumbra_sdk_txhash::TransactionId;
-
 use crate::{component::state_key, params::FundingParameters};
 use anyhow::Result;
+use async_trait::async_trait;
 use cnidarium::{StateRead, StateWrite};
 use penumbra_sdk_proto::{StateReadProto, StateWriteProto};
-use penumbra_sdk_sct::{component::clock::EpochRead, Nullifier};
 
 #[async_trait]
 pub trait StateReadExt: StateRead {
@@ -14,25 +11,6 @@ pub trait StateReadExt: StateRead {
         self.get(state_key::staking_funding_parameters())
             .await?
             .ok_or_else(|| anyhow::anyhow!("Missing FundingParameters"))
-    }
-
-    /// Gets the transaction id associated with the given nullifier from the JMT.
-    async fn get_txid_from_nullifier(&self, nullifier: Nullifier) -> Option<TransactionId> {
-        // Grab the ambient epoch index.
-        let epoch_index = self
-            .get_current_epoch()
-            .await
-            .expect("epoch is always set")
-            .index;
-
-        let nullifier_key = &state_key::lqt_nullifier_lookup_for_txid(epoch_index, &nullifier);
-
-        let tx_id: Option<TransactionId> = self
-            .nonverifiable_get(&nullifier_key.as_bytes())
-            .await
-            .expect("infallible");
-
-        tx_id
     }
 }
 
@@ -43,13 +21,6 @@ pub trait StateWriteExt: StateWrite + StateReadExt {
     /// Set the Funding parameters in the JMT.
     fn put_staking_funding_params(&mut self, params: FundingParameters) {
         self.put(state_key::staking_funding_parameters().into(), params)
-    }
-
-    // Sets the LQT nullifier in the JMT.
-    fn put_lqt_nullifier(&mut self, epoch_index: u64, nullifier: Nullifier, tx_id: TransactionId) {
-        let nullifier_key = state_key::lqt_nullifier_lookup_for_txid(epoch_index, &nullifier);
-
-        self.put(nullifier_key, tx_id);
     }
 }
 impl<T: StateWrite + ?Sized> StateWriteExt for T {}

--- a/crates/core/component/funding/src/component/view.rs
+++ b/crates/core/component/funding/src/component/view.rs
@@ -17,7 +17,7 @@ pub trait StateReadExt: StateRead {
     }
 
     /// Gets the funding module chain parameters from the JMT.
-    async fn get_txid_from_nullifier(&self, nullifier: Nullifier) -> Result<TransactionId> {
+    async fn get_txid_from_nullifier(&self, nullifier: Nullifier) -> Option<TransactionId> {
         // Grab the ambient epoch index.
         let epoch_index = self
             .get_current_epoch()
@@ -27,12 +27,12 @@ pub trait StateReadExt: StateRead {
 
         let nullifier_key = &state_key::lqt_nullifier_lookup_for_txid(epoch_index, &nullifier);
 
-        let tx_id: TransactionId = self
+        let tx_id: Option<TransactionId> = self
             .nonverifiable_get(&nullifier_key.as_bytes())
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("infallible"))?;
+            .await
+            .expect("infallible");
 
-        Ok(tx_id)
+        tx_id
     }
 }
 

--- a/crates/core/component/funding/src/component/view.rs
+++ b/crates/core/component/funding/src/component/view.rs
@@ -1,17 +1,38 @@
 use async_trait::async_trait;
+use penumbra_sdk_txhash::TransactionId;
 
 use crate::{component::state_key, params::FundingParameters};
 use anyhow::Result;
 use cnidarium::{StateRead, StateWrite};
 use penumbra_sdk_proto::{StateReadProto, StateWriteProto};
+use penumbra_sdk_sct::{component::clock::EpochRead, Nullifier};
 
 #[async_trait]
 pub trait StateReadExt: StateRead {
     /// Gets the funding module chain parameters from the JMT.
-    async fn get_funding_params(&self) -> Result<FundingParameters> {
-        self.get(state_key::funding_parameters())
+    async fn get_staking_funding_params(&self) -> Result<FundingParameters> {
+        self.get(state_key::staking_funding_parameters())
             .await?
             .ok_or_else(|| anyhow::anyhow!("Missing FundingParameters"))
+    }
+
+    /// Gets the funding module chain parameters from the JMT.
+    async fn get_txid_from_nullifier(&self, nullifier: Nullifier) -> Result<TransactionId> {
+        // Grab the ambient epoch index.
+        let epoch_index = self
+            .get_current_epoch()
+            .await
+            .expect("epoch is always set")
+            .index;
+
+        let nullifier_key = &state_key::lqt_nullifier_lookup_for_txid(epoch_index, &nullifier);
+
+        let tx_id: TransactionId = self
+            .nonverifiable_get(&nullifier_key.as_bytes())
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("infallible"))?;
+
+        Ok(tx_id)
     }
 }
 
@@ -20,8 +41,14 @@ impl<T: StateRead + ?Sized> StateReadExt for T {}
 #[async_trait]
 pub trait StateWriteExt: StateWrite + StateReadExt {
     /// Set the Funding parameters in the JMT.
-    fn put_funding_params(&mut self, params: FundingParameters) {
-        self.put(state_key::funding_parameters().into(), params)
+    fn put_staking_funding_params(&mut self, params: FundingParameters) {
+        self.put(state_key::staking_funding_parameters().into(), params)
+    }
+
+    fn put_lqt_nullifier(&mut self, epoch_index: u64, nullifier: Nullifier, tx_id: TransactionId) {
+        let nullifier_key = state_key::lqt_nullifier_lookup_for_txid(epoch_index, &nullifier);
+
+        self.put(nullifier_key, tx_id);
     }
 }
 impl<T: StateWrite + ?Sized> StateWriteExt for T {}

--- a/crates/core/component/funding/src/component/view.rs
+++ b/crates/core/component/funding/src/component/view.rs
@@ -7,7 +7,7 @@ use penumbra_sdk_proto::{StateReadProto, StateWriteProto};
 #[async_trait]
 pub trait StateReadExt: StateRead {
     /// Gets the funding module chain parameters from the JMT.
-    async fn get_staking_funding_params(&self) -> Result<FundingParameters> {
+    async fn get_funding_params(&self) -> Result<FundingParameters> {
         self.get(state_key::staking_funding_parameters())
             .await?
             .ok_or_else(|| anyhow::anyhow!("Missing FundingParameters"))
@@ -19,7 +19,7 @@ impl<T: StateRead + ?Sized> StateReadExt for T {}
 #[async_trait]
 pub trait StateWriteExt: StateWrite + StateReadExt {
     /// Set the Funding parameters in the JMT.
-    fn put_staking_funding_params(&mut self, params: FundingParameters) {
+    fn put_funding_params(&mut self, params: FundingParameters) {
         self.put(state_key::staking_funding_parameters().into(), params)
     }
 }

--- a/crates/core/component/funding/src/component/view.rs
+++ b/crates/core/component/funding/src/component/view.rs
@@ -16,7 +16,7 @@ pub trait StateReadExt: StateRead {
             .ok_or_else(|| anyhow::anyhow!("Missing FundingParameters"))
     }
 
-    /// Gets the funding module chain parameters from the JMT.
+    /// Gets the transaction id associated with the given nullifier from the JMT.
     async fn get_txid_from_nullifier(&self, nullifier: Nullifier) -> Option<TransactionId> {
         // Grab the ambient epoch index.
         let epoch_index = self
@@ -45,6 +45,7 @@ pub trait StateWriteExt: StateWrite + StateReadExt {
         self.put(state_key::staking_funding_parameters().into(), params)
     }
 
+    // Sets the LQT nullifier in the JMT.
     fn put_lqt_nullifier(&mut self, epoch_index: u64, nullifier: Nullifier, tx_id: TransactionId) {
         let nullifier_key = state_key::lqt_nullifier_lookup_for_txid(epoch_index, &nullifier);
 

--- a/crates/core/component/funding/src/component/view.rs
+++ b/crates/core/component/funding/src/component/view.rs
@@ -8,7 +8,7 @@ use penumbra_sdk_proto::{StateReadProto, StateWriteProto};
 pub trait StateReadExt: StateRead {
     /// Gets the funding module chain parameters from the JMT.
     async fn get_funding_params(&self) -> Result<FundingParameters> {
-        self.get(state_key::staking_funding_parameters())
+        self.get(state_key::funding_parameters())
             .await?
             .ok_or_else(|| anyhow::anyhow!("Missing FundingParameters"))
     }
@@ -20,7 +20,7 @@ impl<T: StateRead + ?Sized> StateReadExt for T {}
 pub trait StateWriteExt: StateWrite + StateReadExt {
     /// Set the Funding parameters in the JMT.
     fn put_funding_params(&mut self, params: FundingParameters) {
-        self.put(state_key::staking_funding_parameters().into(), params)
+        self.put(state_key::funding_parameters().into(), params)
     }
 }
 impl<T: StateWrite + ?Sized> StateWriteExt for T {}

--- a/crates/core/transaction/src/transaction.rs
+++ b/crates/core/transaction/src/transaction.rs
@@ -144,6 +144,7 @@ impl Transaction {
         TransactionContext {
             anchor: self.anchor,
             effect_hash: self.effect_hash(),
+            transaction_id: self.id(),
         }
     }
 

--- a/crates/core/txhash/src/context.rs
+++ b/crates/core/txhash/src/context.rs
@@ -1,4 +1,4 @@
-use crate::EffectHash;
+use crate::{EffectHash, TransactionId};
 use penumbra_sdk_tct as tct;
 
 /// Stateless verification context for a transaction.
@@ -10,4 +10,6 @@ pub struct TransactionContext {
     pub anchor: tct::Root,
     /// The transaction's effect hash.
     pub effect_hash: EffectHash,
+    /// The transaction's id.
+    pub transaction_id: TransactionId,
 }


### PR DESCRIPTION
## Describe your changes

state key for epoch-scoped nullifier set (mapping nullifiers with their associated transaction id), serving as a precursor for performing the necessary stateful [nullifier check](https://github.com/penumbra-zone/penumbra/pull/5033/files#diff-a0986b8d223ab5b1c5536ba06bde1ede6d08f635eb97b386549ecfb55a4f2a4bR112). Additionally, augments the transaction context with `TransactionId`. 

## Issue ticket number and link

references https://github.com/penumbra-zone/penumbra/issues/5029

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > LQT branch
