### PR TITLE
Implement "Bank" extension trait for liquidity tournament

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5219,6 +5219,7 @@ dependencies = [
  "metrics 0.24.1",
  "penumbra-sdk-asset",
  "penumbra-sdk-community-pool",
+ "penumbra-sdk-dex",
  "penumbra-sdk-distributions",
  "penumbra-sdk-governance",
  "penumbra-sdk-keys",

--- a/crates/core/component/funding/Cargo.toml
+++ b/crates/core/component/funding/Cargo.toml
@@ -13,6 +13,7 @@ component = [
     "cnidarium",
     "penumbra-sdk-proto/cnidarium",
     "penumbra-sdk-community-pool/component",
+    "penumbra-sdk-dex/component",
     "penumbra-sdk-distributions/component",
     "penumbra-sdk-governance/component",
     "penumbra-sdk-sct/component",
@@ -26,6 +27,7 @@ parallel = [
     "ark-groth16/parallel",
     "decaf377/parallel",
     "decaf377-rdsa/parallel",
+    "penumbra-sdk-dex/parallel",
     "penumbra-sdk-tct/parallel",
     "penumbra-sdk-shielded-pool/parallel",
     "penumbra-sdk-governance/parallel"
@@ -45,6 +47,7 @@ futures = {workspace = true, optional = true}
 metrics = {workspace = true, optional = true}
 penumbra-sdk-asset = {workspace = true, default-features = true}
 penumbra-sdk-community-pool = {workspace = true, default-features = false}
+penumbra-sdk-dex = {workspace = true, default-features = false}
 penumbra-sdk-distributions = {workspace = true, default-features = false}
 penumbra-sdk-governance = {workspace = true, default-features = false}
 penumbra-sdk-keys = {workspace = true, default-features = false}

--- a/crates/core/component/funding/src/component/liquidity_tournament/bank.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/bank.rs
@@ -1,47 +1,14 @@
 use async_trait::async_trait;
 use cnidarium::StateWrite;
 use penumbra_sdk_asset::{Value, STAKING_TOKEN_ASSET_ID};
-use penumbra_sdk_community_pool::StateWriteExt as _;
 use penumbra_sdk_dex::component::PositionManager as _;
 use penumbra_sdk_dex::lp::position;
-use penumbra_sdk_distributions::component::{StateReadExt as _, StateWriteExt as _};
 use penumbra_sdk_keys::Address;
-use penumbra_sdk_num::{fixpoint::U128x128, Amount};
+use penumbra_sdk_num::Amount;
 use penumbra_sdk_sct::component::clock::EpochRead as _;
 use penumbra_sdk_sct::CommitmentSource;
 use penumbra_sdk_shielded_pool::component::NoteManager as _;
 use penumbra_sdk_txhash::TransactionId;
-
-/// Move a fraction of the budget, up to the entire budget, from the community pool.
-///
-/// This will return the amount pulled (in terms of the staking token).
-async fn appropriate_budget(
-    mut state: impl StateWrite,
-    fraction: U128x128,
-) -> anyhow::Result<Amount> {
-    // For our purposes, no budget is the same as an explicit budget of 0.
-    let budget = state
-        .get_lqt_reward_issuance_for_epoch()
-        .unwrap_or_default();
-    // IMO this method should have just expected to begin with.
-    let portion = fraction
-        .apply_to_amount(&budget)
-        .expect(&format!("failed to apply {fraction} to {budget:?}"));
-    // This fraction may be > 1.0, in which case we need to not over-appropriate
-    let (new_budget, portion) = match budget.checked_sub(&portion) {
-        Some(new_budget) => (new_budget, portion),
-        // portion > budget, so eat the whole budget.
-        None => (0u64.into(), budget),
-    };
-    state.set_lqt_reward_issuance_for_epoch(new_budget);
-    state
-        .community_pool_withdraw(Value {
-            asset_id: *STAKING_TOKEN_ASSET_ID,
-            amount: portion,
-        })
-        .await?;
-    Ok(portion)
-}
 
 #[allow(dead_code)]
 #[async_trait]
@@ -52,13 +19,12 @@ async fn appropriate_budget(
 /// and credited towards the appropriate destination (i.e. positions or new notes).
 pub trait Bank: StateWrite + Sized {
     /// Move a fraction of our issuance budget towards an address, by minting a note.
-    async fn reward_fraction_to_voter(
+    async fn reward_to_voter(
         &mut self,
-        fraction: U128x128,
+        reward: Amount,
         voter: &Address,
         tx_hash: TransactionId,
     ) -> anyhow::Result<()> {
-        let reward = appropriate_budget(&mut self, fraction).await?;
         let epoch = self
             .get_current_epoch()
             .await
@@ -79,12 +45,7 @@ pub trait Bank: StateWrite + Sized {
     }
 
     /// Move a fraction of our issuance budget towards a position, increasing its reserves.
-    async fn reward_fraction_to_position(
-        &mut self,
-        fraction: U128x128,
-        lp: position::Id,
-    ) -> anyhow::Result<()> {
-        let reward = appropriate_budget(&mut self, fraction).await?;
+    async fn reward_to_position(&mut self, reward: Amount, lp: position::Id) -> anyhow::Result<()> {
         self.reward_position(lp, reward).await?;
         Ok(())
     }

--- a/crates/core/component/funding/src/component/liquidity_tournament/bank.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/bank.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+use cnidarium::StateWrite;
+use penumbra_sdk_dex::lp::position;
+use penumbra_sdk_keys::Address;
+use penumbra_sdk_num::fixpoint::U128x128;
+
+#[allow(dead_code)]
+#[async_trait]
+/// The bank strictly controls issuance of rewards in the liquidity tournament.
+///
+/// This ensures that rewards do not exceed the issuance budget, and are immediately
+/// debited from the appropriate source (which happens to be the community pool),
+/// and credited towards the appropriate destination (i.e. positions or new notes).
+pub trait Bank: StateWrite {
+    /// Move a fraction of our issuance budget towards an address, by minting a note.
+    async fn reward_fraction_to_voter(
+        &mut self,
+        _fraction: U128x128,
+        _voter: &Address,
+    ) -> anyhow::Result<()> {
+        unimplemented!()
+    }
+
+    /// Move a fraction of our issuance budget towards a position, increasing its reserves.
+    async fn reward_fraction_to_position(
+        &mut self,
+        _fraction: U128x128,
+        _lp: position::Id,
+    ) -> anyhow::Result<()> {
+        unimplemented!()
+    }
+}

--- a/crates/core/component/funding/src/component/liquidity_tournament/bank.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/bank.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use cnidarium::StateWrite;
 use penumbra_sdk_asset::{Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_sdk_community_pool::StateWriteExt as _;
+use penumbra_sdk_dex::component::PositionManager as _;
 use penumbra_sdk_dex::lp::position;
 use penumbra_sdk_distributions::component::{StateReadExt as _, StateWriteExt as _};
 use penumbra_sdk_keys::Address;
@@ -80,9 +81,11 @@ pub trait Bank: StateWrite + Sized {
     /// Move a fraction of our issuance budget towards a position, increasing its reserves.
     async fn reward_fraction_to_position(
         &mut self,
-        _fraction: U128x128,
-        _lp: position::Id,
+        fraction: U128x128,
+        lp: position::Id,
     ) -> anyhow::Result<()> {
-        unimplemented!()
+        let reward = appropriate_budget(&mut self, fraction).await?;
+        self.reward_position(lp, reward).await?;
+        Ok(())
     }
 }

--- a/crates/core/component/funding/src/component/liquidity_tournament/bank.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/bank.rs
@@ -1,8 +1,43 @@
 use async_trait::async_trait;
 use cnidarium::StateWrite;
+use penumbra_sdk_asset::{Value, STAKING_TOKEN_ASSET_ID};
+use penumbra_sdk_community_pool::{StateReadExt as _, StateWriteExt as _};
 use penumbra_sdk_dex::lp::position;
+use penumbra_sdk_distributions::component::{StateReadExt as _, StateWriteExt as _};
 use penumbra_sdk_keys::Address;
-use penumbra_sdk_num::fixpoint::U128x128;
+use penumbra_sdk_num::{fixpoint::U128x128, Amount};
+
+/// Move a fraction of the budget, up to the entire budget, from the community pool.
+///
+/// This will return the amount pulled (in terms of the staking token).
+#[allow(dead_code)]
+async fn appropriate_budget(
+    mut state: impl StateWrite,
+    fraction: U128x128,
+) -> anyhow::Result<Amount> {
+    // For our purposes, no budget is the same as an explicit budget of 0.
+    let budget = state
+        .get_lqt_reward_issuance_for_epoch()
+        .unwrap_or_default();
+    // IMO this method should have just expected to begin with.
+    let portion = fraction
+        .apply_to_amount(&budget)
+        .expect(&format!("failed to apply {fraction} to {budget:?}"));
+    // This fraction may be > 1.0, in which case we need to not over-appropriate
+    let (new_budget, portion) = match budget.checked_sub(&portion) {
+        Some(new_budget) => (new_budget, portion),
+        // portion > budget, so eat the whole budget.
+        None => (0u64.into(), budget),
+    };
+    state.set_lqt_reward_issuance_for_epoch(new_budget);
+    state
+        .community_pool_withdraw(Value {
+            asset_id: *STAKING_TOKEN_ASSET_ID,
+            amount: portion,
+        })
+        .await?;
+    Ok(portion)
+}
 
 #[allow(dead_code)]
 #[async_trait]

--- a/crates/core/component/funding/src/component/liquidity_tournament/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/mod.rs
@@ -1,2 +1,3 @@
+pub mod bank;
 pub mod nullifier;
 pub mod votes;


### PR DESCRIPTION
## Describe your changes

This trait is responsible for the actual accounting of moving funds around, to be later consumed by the end epoch handler, which figures out what portion of the rewards needs to go where. The bank will just actually move fractions of its budget in the community pool to the requested locations, atomically.

Testing deferred.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > yes indeed
