### PR TITLE
Modify get/put current source to take in just a transaction ID

### DIFF
--- a/crates/core/app/src/action_handler/transaction.rs
+++ b/crates/core/app/src/action_handler/transaction.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use cnidarium::{StateRead, StateWrite};
 use penumbra_sdk_fee::component::FeePay as _;
-use penumbra_sdk_sct::{component::source::SourceContext, CommitmentSource};
+use penumbra_sdk_sct::component::source::SourceContext;
 use penumbra_sdk_shielded_pool::component::ClueManager;
 use penumbra_sdk_transaction::{gas::GasCost as _, Transaction};
 use tokio::task::JoinSet;
@@ -107,10 +107,7 @@ impl AppActionHandler for Transaction {
     async fn check_and_execute<S: StateWrite>(&self, mut state: S) -> Result<()> {
         // While we have access to the full Transaction, hash it to
         // obtain a NoteSource we can cache for various actions.
-        let source = CommitmentSource::Transaction {
-            id: Some(self.id().0),
-        };
-        state.put_current_source(Some(source));
+        state.put_current_source(Some(self.id()));
 
         // Check and record the transaction's fee payment,
         // before doing the rest of execution.

--- a/crates/core/component/dex/src/component/action_handler/swap.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap.rs
@@ -55,7 +55,7 @@ impl ActionHandler for Swap {
         // Record the swap commitment in the state.
         let source = state.get_current_source().expect("source is set");
         state
-            .add_swap_payload(self.body.payload.clone(), source)
+            .add_swap_payload(self.body.payload.clone(), source.into())
             .await;
 
         // Mark the assets for the swap's trading pair as accessed during this block.

--- a/crates/core/component/dex/src/component/action_handler/swap_claim.rs
+++ b/crates/core/component/dex/src/component/action_handler/swap_claim.rs
@@ -87,13 +87,13 @@ impl ActionHandler for SwapClaim {
             .expect("source is set during tx execution");
 
         state
-            .add_rolled_up_payload(self.body.output_1_commitment, source.clone())
+            .add_rolled_up_payload(self.body.output_1_commitment, source.into())
             .await;
         state
-            .add_rolled_up_payload(self.body.output_2_commitment, source.clone())
+            .add_rolled_up_payload(self.body.output_2_commitment, source.into())
             .await;
 
-        state.nullify(self.body.nullifier, source).await;
+        state.nullify(self.body.nullifier, source.into()).await;
 
         state.record_proto(event::EventSwapClaim::from(self).to_proto());
 

--- a/crates/core/component/sct/src/component/source.rs
+++ b/crates/core/component/sct/src/component/source.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
 use cnidarium::StateWrite;
+use penumbra_sdk_txhash::TransactionId;
 
-use crate::{state_key, CommitmentSource};
+use crate::state_key;
 
-/// A helper trait for placing a `CommitmentSource` as ambient context during execution.
+/// A helper trait for placing a transaction id as an ambient source during execution.
 #[async_trait]
 pub trait SourceContext: StateWrite {
-    fn put_current_source(&mut self, source: Option<CommitmentSource>) {
+    fn put_current_source(&mut self, source: Option<TransactionId>) {
         if let Some(source) = source {
             self.object_put(state_key::ambient::current_source(), source)
         } else {
@@ -14,7 +15,7 @@ pub trait SourceContext: StateWrite {
         }
     }
 
-    fn get_current_source(&self) -> Option<CommitmentSource> {
+    fn get_current_source(&self) -> Option<TransactionId> {
         self.object_get(state_key::ambient::current_source())
     }
 
@@ -22,9 +23,7 @@ pub trait SourceContext: StateWrite {
     ///
     /// The `counter` field allows distinguishing hashes at different stages of the test.
     fn put_mock_source(&mut self, counter: u8) {
-        self.put_current_source(Some(CommitmentSource::Transaction {
-            id: Some([counter; 32]),
-        }))
+        self.put_current_source(Some(TransactionId([counter; 32])))
     }
 }
 impl<T: StateWrite + ?Sized> SourceContext for T {}

--- a/crates/core/component/sct/src/source.rs
+++ b/crates/core/component/sct/src/source.rs
@@ -141,3 +141,9 @@ impl TryFrom<pb::CommitmentSource> for CommitmentSource {
         })
     }
 }
+
+impl From<TransactionId> for CommitmentSource {
+    fn from(id: TransactionId) -> Self {
+        Self::Transaction { id: Some(id.0) }
+    }
+}

--- a/crates/core/component/shielded-pool/src/component/action_handler/output.rs
+++ b/crates/core/component/shielded-pool/src/component/action_handler/output.rs
@@ -31,7 +31,7 @@ impl ActionHandler for Output {
             .expect("source should be set during execution");
 
         state
-            .add_note_payload(self.body.note_payload.clone(), source)
+            .add_note_payload(self.body.note_payload.clone(), source.into())
             .await;
 
         state.record_proto(

--- a/crates/core/component/shielded-pool/src/component/action_handler/spend.rs
+++ b/crates/core/component/shielded-pool/src/component/action_handler/spend.rs
@@ -46,7 +46,7 @@ impl ActionHandler for Spend {
 
         let source = state.get_current_source().expect("source should be set");
 
-        state.nullify(self.body.nullifier, source).await;
+        state.nullify(self.body.nullifier, source.into()).await;
 
         // Also record an ABCI event for transaction indexing.
         state.record_proto(


### PR DESCRIPTION
Right now this is only ever a transaction id, and for LQT work, we need to be able to just use a transaction ID, so it's better to reify that, and change a few uses to wrap it in a source, versus having to unwrap it, introducing a spurious failure case

Smoke tests should be sufficient.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This state is always initialized before being read, so there's no issue in changing the type we store under this state key ; reviewers should double check this.
