### PR TITLE
Plumb transaction id into LQT vote action handlers

### DIFF
--- a/crates/core/app-tests/tests/spend.rs
+++ b/crates/core/app-tests/tests/spend.rs
@@ -17,7 +17,7 @@ use penumbra_sdk_sct::{
 use penumbra_sdk_shielded_pool::{
     component::ShieldedPool, Note, SpendPlan, SpendProof, SpendProofPrivate, SpendProofPublic,
 };
-use penumbra_sdk_txhash::{EffectHash, TransactionContext, TransactionId};
+use penumbra_sdk_txhash::{EffectHash, TransactionContext};
 use rand_core::{OsRng, SeedableRng};
 use std::{ops::Deref, sync::Arc};
 use tendermint::abci;
@@ -65,7 +65,6 @@ async fn spend_happy_path() -> anyhow::Result<()> {
     let transaction_context = TransactionContext {
         anchor: root,
         effect_hash: EffectHash(dummy_effect_hash),
-        transaction_id: TransactionId([0; 32]),
     };
 
     // 3. Simulate execution of the Spend action
@@ -190,7 +189,6 @@ async fn invalid_dummy_spend() {
     let transaction_context = TransactionContext {
         anchor: root,
         effect_hash: EffectHash(dummy_effect_hash),
-        transaction_id: TransactionId([0; 32]),
     };
 
     // 3. Simulate execution of the Spend action

--- a/crates/core/transaction/src/transaction.rs
+++ b/crates/core/transaction/src/transaction.rs
@@ -144,7 +144,6 @@ impl Transaction {
         TransactionContext {
             anchor: self.anchor,
             effect_hash: self.effect_hash(),
-            transaction_id: self.id(),
         }
     }
 

--- a/crates/core/txhash/src/context.rs
+++ b/crates/core/txhash/src/context.rs
@@ -1,4 +1,4 @@
-use crate::{EffectHash, TransactionId};
+use crate::EffectHash;
 use penumbra_sdk_tct as tct;
 
 /// Stateless verification context for a transaction.
@@ -10,6 +10,4 @@ pub struct TransactionContext {
     pub anchor: tct::Root,
     /// The transaction's effect hash.
     pub effect_hash: EffectHash,
-    /// The transaction's id.
-    pub transaction_id: TransactionId,
 }


### PR DESCRIPTION
## Describe your changes

This uses the newly added ambient tx id to populate the LQT nullifier key, making the logic in check and execute final.

This also removes the addition of the tx id to the TransactionContext. My understanding was that this was thought to be necessary to plumb the tx id for this action. Not particularly opposed to keeping that though.

Testing deferred.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason: