### PR TITLE
community pool: use concurrent build

### DIFF
--- a/crates/core/app/src/action_handler/actions/submit.rs
+++ b/crates/core/app/src/action_handler/actions/submit.rs
@@ -346,18 +346,23 @@ async fn build_community_pool_transaction(
     transaction_plan: TransactionPlan,
 ) -> Result<Transaction> {
     let effect_hash = transaction_plan.effect_hash(&COMMUNITY_POOL_FULL_VIEWING_KEY)?;
-    transaction_plan.build(
-        &COMMUNITY_POOL_FULL_VIEWING_KEY,
-        &WitnessData {
-            anchor: penumbra_sdk_tct::Tree::new().root(),
-            state_commitment_proofs: Default::default(),
-        },
-        &AuthorizationData {
-            effect_hash: Some(effect_hash),
-            spend_auths: Default::default(),
-            delegator_vote_auths: Default::default(),
-        },
-    )
+    Ok(transaction_plan
+        .build_concurrent(
+            &COMMUNITY_POOL_FULL_VIEWING_KEY,
+            &WitnessData {
+                anchor: penumbra_sdk_tct::Tree::new().root(),
+                state_commitment_proofs: Default::default(),
+            },
+            &AuthorizationData {
+                effect_hash: Some(effect_hash),
+                spend_auths: Default::default(),
+                delegator_vote_auths: Default::default(),
+            },
+        )
+        .await
+        .expect(
+            "community pool transactions are always well-formed and should never fail to build",
+        ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Describe your changes

uses concurrent build for community pool transactions

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason: