### PR TITLE
Implement LQT reward distribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5231,7 +5231,6 @@ dependencies = [
  "penumbra-sdk-tct",
  "penumbra-sdk-txhash",
  "proptest",
- "rand_chacha",
  "serde",
  "tendermint 0.40.1",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5230,6 +5230,8 @@ dependencies = [
  "penumbra-sdk-stake",
  "penumbra-sdk-tct",
  "penumbra-sdk-txhash",
+ "proptest",
+ "rand_chacha",
  "serde",
  "tendermint 0.40.1",
  "tracing",

--- a/crates/core/component/dex/src/component/position_manager/volume_tracker.rs
+++ b/crates/core/component/dex/src/component/position_manager/volume_tracker.rs
@@ -1,17 +1,12 @@
-#![allow(unused_imports, unused_variables, dead_code)]
-use anyhow::Result;
 use cnidarium::StateWrite;
 use penumbra_sdk_asset::{asset, STAKING_TOKEN_ASSET_ID};
 use penumbra_sdk_num::Amount;
-use position::State::*;
 use tracing::instrument;
 
 use crate::component::lqt::LqtRead;
 use crate::lp::position::{self, Position};
-use crate::state_key::{engine, lqt};
-use crate::{trading_pair, DirectedTradingPair, TradingPair};
+use crate::state_key::lqt;
 use async_trait::async_trait;
-use penumbra_sdk_proto::{StateReadProto, StateWriteProto};
 use penumbra_sdk_sct::component::clock::EpochRead;
 
 #[async_trait]

--- a/crates/core/component/funding/Cargo.toml
+++ b/crates/core/component/funding/Cargo.toml
@@ -65,4 +65,3 @@ tracing = {workspace = true}
 
 [dev-dependencies]
 proptest = {workspace = true}
-rand_chacha = {workspace = true}

--- a/crates/core/component/funding/Cargo.toml
+++ b/crates/core/component/funding/Cargo.toml
@@ -64,3 +64,5 @@ tendermint = {workspace = true}
 tracing = {workspace = true}
 
 [dev-dependencies]
+proptest = {workspace = true}
+rand_chacha = {workspace = true}

--- a/crates/core/component/funding/proptest-regressions/component/liquidity_tournament/rewards/gauge.txt
+++ b/crates/core/component/funding/proptest-regressions/component/liquidity_tournament/rewards/gauge.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 24bbf94f146a127f2cf51f3c824dc7757206dacfa45ddcd70114af24b6af9d82 # shrinks to votes = []
+cc 1465ed329b6bbb288fc62d1efa564b579bdb1300ff6ad38e1d5378e9a0c0e32a # shrinks to votes = [(0, 392972866, 0), (0, 1, 1)]

--- a/crates/core/component/funding/src/component.rs
+++ b/crates/core/component/funding/src/component.rs
@@ -67,7 +67,9 @@ impl Component for Funding {
         let state = Arc::get_mut(state).expect("state should be unique");
         let funding_execution_start = std::time::Instant::now();
 
-        liquidity_tournament::distribute_rewards(&mut *state).await?;
+        if let Err(e) = liquidity_tournament::distribute_rewards(&mut *state).await {
+            tracing::error!("while processing LQT rewards: {}", e);
+        }
 
         // Here, we want to process the funding rewards for the epoch that just ended. To do this,
         // we pull the funding queue that the staking component has prepared for us, as well as the

--- a/crates/core/component/funding/src/component.rs
+++ b/crates/core/component/funding/src/component.rs
@@ -7,7 +7,6 @@ pub use metrics::register_metrics;
 /* Component implementation */
 use penumbra_sdk_asset::{Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_sdk_proto::{DomainType, StateWriteProto};
-use penumbra_sdk_sct::component::source::SourceContext as _;
 use penumbra_sdk_stake::component::validator_handler::ValidatorDataRead;
 pub use view::{StateReadExt, StateWriteExt};
 pub(crate) mod liquidity_tournament;
@@ -68,10 +67,7 @@ impl Component for Funding {
         let state = Arc::get_mut(state).expect("state should be unique");
         let funding_execution_start = std::time::Instant::now();
 
-        let tx_source = state
-            .get_current_source()
-            .expect("source transaction should be set");
-        liquidity_tournament::distribute_rewards(&mut *state, tx_source).await?;
+        liquidity_tournament::distribute_rewards(&mut *state).await?;
 
         // Here, we want to process the funding rewards for the epoch that just ended. To do this,
         // we pull the funding queue that the staking component has prepared for us, as well as the

--- a/crates/core/component/funding/src/component.rs
+++ b/crates/core/component/funding/src/component.rs
@@ -67,6 +67,8 @@ impl Component for Funding {
         let state = Arc::get_mut(state).expect("state should be unique");
         let funding_execution_start = std::time::Instant::now();
 
+        liquidity_tournament::distribute_rewards(&mut *state).await?;
+
         // Here, we want to process the funding rewards for the epoch that just ended. To do this,
         // we pull the funding queue that the staking component has prepared for us, as well as the
         // base rate data for the epoch that just ended.

--- a/crates/core/component/funding/src/component.rs
+++ b/crates/core/component/funding/src/component.rs
@@ -7,6 +7,7 @@ pub use metrics::register_metrics;
 /* Component implementation */
 use penumbra_sdk_asset::{Value, STAKING_TOKEN_ASSET_ID};
 use penumbra_sdk_proto::{DomainType, StateWriteProto};
+use penumbra_sdk_sct::component::source::SourceContext as _;
 use penumbra_sdk_stake::component::validator_handler::ValidatorDataRead;
 pub use view::{StateReadExt, StateWriteExt};
 pub(crate) mod liquidity_tournament;
@@ -67,7 +68,10 @@ impl Component for Funding {
         let state = Arc::get_mut(state).expect("state should be unique");
         let funding_execution_start = std::time::Instant::now();
 
-        liquidity_tournament::distribute_rewards(&mut *state).await?;
+        let tx_source = state
+            .get_current_source()
+            .expect("source transaction should be set");
+        liquidity_tournament::distribute_rewards(&mut *state, tx_source).await?;
 
         // Here, we want to process the funding rewards for the epoch that just ended. To do this,
         // we pull the funding queue that the staking component has prepared for us, as well as the

--- a/crates/core/component/funding/src/component/liquidity_tournament/bank.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/bank.rs
@@ -10,7 +10,6 @@ use penumbra_sdk_sct::CommitmentSource;
 use penumbra_sdk_shielded_pool::component::NoteManager as _;
 use penumbra_sdk_txhash::TransactionId;
 
-#[allow(dead_code)]
 #[async_trait]
 /// The bank strictly controls issuance of rewards in the liquidity tournament.
 ///
@@ -25,6 +24,9 @@ pub trait Bank: StateWrite + Sized {
         voter: &Address,
         tx_hash: TransactionId,
     ) -> anyhow::Result<()> {
+        if reward == Amount::default() {
+            return Ok(());
+        }
         let epoch = self
             .get_current_epoch()
             .await
@@ -46,7 +48,12 @@ pub trait Bank: StateWrite + Sized {
 
     /// Move a fraction of our issuance budget towards a position, increasing its reserves.
     async fn reward_to_position(&mut self, reward: Amount, lp: position::Id) -> anyhow::Result<()> {
+        if reward == Amount::default() {
+            return Ok(());
+        }
         self.reward_position(lp, reward).await?;
         Ok(())
     }
 }
+
+impl<T: StateWrite + Sized> Bank for T {}

--- a/crates/core/component/funding/src/component/liquidity_tournament/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/mod.rs
@@ -1,3 +1,6 @@
 pub mod bank;
 pub mod nullifier;
+mod rewards;
 pub mod votes;
+
+pub use rewards::distribute_rewards;

--- a/crates/core/component/funding/src/component/liquidity_tournament/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/mod.rs
@@ -1,4 +1,4 @@
-pub mod bank;
+mod bank;
 pub mod nullifier;
 mod rewards;
 pub mod votes;

--- a/crates/core/component/funding/src/component/liquidity_tournament/rewards/gauge.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/rewards/gauge.rs
@@ -1,0 +1,131 @@
+use std::collections::BTreeMap;
+
+use penumbra_sdk_asset::asset;
+use penumbra_sdk_num::{fixpoint::U128x128, Percentage};
+
+/// The type we use for "shares" of the vote pie.
+pub type Share = U128x128;
+
+// exists to isolate decisions about division edge cases.
+fn create_share(portion: u128, total: u128) -> Share {
+    Share::ratio(portion, total.max(1)).expect("not dividing by 0")
+}
+
+/// A gauge is used to tally up votes in the tournament.
+#[derive(Clone, Debug)]
+pub struct Gauge<'s> {
+    total: u128,
+    asset_tally: BTreeMap<asset::Id, (u128, BTreeMap<&'s [u8], u128>)>,
+}
+
+impl<'s> Gauge<'s> {
+    /// The state with no votes.
+    pub fn empty() -> Self {
+        Self {
+            total: 0u128,
+            asset_tally: BTreeMap::new(),
+        }
+    }
+
+    /// Tally a vote into this gauge.
+    ///
+    /// Voting twice is the same as voting once with that combined power:
+    /// ```
+    ///  vote(A, p1, V) ; vote(A, p2, V) = vote(A, p1 + p2, V)`
+    /// ```
+    pub fn tally(&mut self, vote: asset::Id, power: u64, voter: &'s [u8]) {
+        let power = u128::from(power);
+        // Increment the total vote power, then per asset, then per voter.
+        self.total += power;
+        let asset_entry = self
+            .asset_tally
+            .entry(vote)
+            .or_insert((0u128, BTreeMap::new()));
+        asset_entry.0 += power;
+        *asset_entry.1.entry(voter).or_insert(0u128) += power;
+    }
+
+    /// Finish tallying up votes, producing a finalized gauge for calculating rewards.
+    ///
+    /// `gauge_threshold` is the percentage of the vote an asset much reach in order
+    pub fn finalize(
+        self,
+        gauge_threshold: Percentage,
+        max_voters_per_asset: usize,
+    ) -> FinalizedGauge<'s> {
+        let gauge_share = Share::from(gauge_threshold);
+        // First, let's figure out what assets remain after the threshold.
+        let assets = {
+            // We'll accumulate the power of the filtered assets here,
+            let mut filtered_power = 0u128;
+            // and those assets here. We store the raw power for now.
+            let mut filtered_assets = Vec::<(u128, asset::Id)>::new();
+            for (&asset, &(power, _)) in self.asset_tally.iter() {
+                let share = create_share(power, self.total);
+                // Disregard unpopular assets.
+                if share < Share::from(gauge_share) {
+                    continue;
+                }
+                filtered_power += power;
+                filtered_assets.push((power, asset));
+            }
+            // Now, we need to figure out what share of the remaining power each asset is.
+            let assets = filtered_assets
+                .into_iter()
+                .map(|(power, asset)| (create_share(power, filtered_power), asset))
+                .collect::<Vec<_>>();
+
+            assets
+        };
+        // Now, let's figure out the remaining voters, and the share they have of *that* pie.
+        let voters = {
+            let mut voters_power = 0u128;
+            // The idea here is to take the top N voters for each asset, and put them in this map.
+            let mut filtered_voters = BTreeMap::<&'s [u8], u128>::new();
+            for (_, asset) in assets.iter() {
+                let ranked_voters_for_this_asset = self.asset_tally[asset]
+                    .1
+                    .iter()
+                    .map(|(voter, power)| (power, voter))
+                    .collect::<BTreeMap<_, _>>();
+                // Now, by iterating in reverse, we can take the top N.
+                ranked_voters_for_this_asset
+                    .into_iter()
+                    .rev()
+                    .take(max_voters_per_asset)
+                    .for_each(|(power, voter)| {
+                        voters_power += power;
+                        *filtered_voters.entry(voter).or_insert(0u128) += power;
+                    });
+            }
+            // Now, convert this into the share each voter has;
+            let voters = filtered_voters
+                .into_iter()
+                .map(|(voter, power)| (create_share(power, voters_power), voter))
+                .collect::<Vec<_>>();
+            voters
+        };
+
+        FinalizedGauge { assets, voters }
+    }
+}
+
+/// The result of the gauge after tallying votes.
+///
+/// This allows easily querying which assets received what share of the vote,
+/// and which voters
+#[derive(Clone, Debug)]
+pub struct FinalizedGauge<'s> {
+    assets: Vec<(Share, asset::Id)>,
+    voters: Vec<(Share, &'s [u8])>,
+}
+
+impl<'s> FinalizedGauge<'s> {
+    pub fn asset_shares(&self) -> impl Iterator<Item = (Share, asset::Id)> + use<'_> {
+        self.assets.iter().copied()
+    }
+
+    pub fn voter_shares(&self) -> impl Iterator<Item = (Share, &'s [u8])> + use<'s, '_> {
+        self.voters.iter().copied()
+    }
+}

--- a/crates/core/component/funding/src/component/liquidity_tournament/rewards/gauge.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/rewards/gauge.rs
@@ -129,3 +129,76 @@ impl<'s> FinalizedGauge<'s> {
         self.voters.iter().copied()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use penumbra_sdk_governance::VotingReceiptToken;
+    use proptest::prelude::*;
+    use rand_chacha::rand_core::SeedableRng as _;
+
+    fn finalize(gauge: Gauge) -> FinalizedGauge {
+        gauge.finalize(Percentage::from_percent(10), 10)
+    }
+
+    fn trace(gauge: Gauge) -> (BTreeMap<asset::Id, Share>, BTreeMap<Vec<u8>, Share>) {
+        let result = finalize(gauge);
+        (
+            result.asset_shares().map(|(s, a)| (a, s)).collect(),
+            result
+                .voter_shares()
+                .map(|(s, v)| (v.to_vec(), s))
+                .collect(),
+        )
+    }
+
+    // so that we can easily pass in references to slices.
+    const ALL_BYTES: [u8; 256] = {
+        let mut arr = [0u8; 256];
+        let mut i = 0;
+        while i < 256 {
+            arr[i] = i as u8;
+            i += 1;
+        }
+        arr
+    };
+
+    fn addr_for(byte: u8) -> &'static [u8] {
+        let i = usize::from(byte);
+        &ALL_BYTES[i..i + 1]
+    }
+
+    fn asset_for(byte: u8) -> asset::Id {
+        asset::Id(u64::from(byte).into())
+    }
+
+    fn voting_power_combines_inner(votes: Vec<(u8, u32, u8)>) {
+        // Calculate gauge without deduplication.
+        let gauge = {
+            let mut out = Gauge::empty();
+            for (asset, power, voter) in votes.iter().copied() {
+                out.tally(asset_for(asset), power.into(), addr_for(voter));
+            }
+            out
+        };
+        let gauge_dedup = {
+            let mut deduped = BTreeMap::new();
+            for (asset, power, voter) in votes.into_iter() {
+                *deduped.entry((asset, voter)).or_insert(0u64) += u64::from(power);
+            }
+            let mut out = Gauge::empty();
+            for ((asset, voter), power) in deduped.into_iter() {
+                out.tally(asset_for(asset), power, addr_for(voter));
+            }
+            out
+        };
+        assert_eq!(trace(gauge), trace(gauge_dedup));
+    }
+
+    proptest! {
+        #[test]
+        fn voting_power_combines(votes in proptest::collection::vec((0u8..10, any::<u32>(), any::<u8>()), 0..100)) {
+            voting_power_combines_inner(votes);
+        }
+    }
+}

--- a/crates/core/component/funding/src/component/liquidity_tournament/rewards/gauge.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/rewards/gauge.rs
@@ -201,4 +201,11 @@ mod test {
             voting_power_combines_inner(votes);
         }
     }
+
+    #[test]
+    fn test_no_votes() {
+        let (assets, voters) = trace(finalize(Gauge::empty()));
+        assert!(assets.is_empty());
+        assert!(voters.is_empty());
+    }
 }

--- a/crates/core/component/funding/src/component/liquidity_tournament/rewards/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/rewards/mod.rs
@@ -40,10 +40,7 @@ async fn position_shares(
     Ok(tallies)
 }
 
-pub async fn distribute_rewards(
-    mut state: impl StateWrite + Sized,
-    tx_source: TransactionId,
-) -> anyhow::Result<()> {
+pub async fn distribute_rewards(mut state: impl StateWrite + Sized) -> anyhow::Result<()> {
     let current_epoch = state.get_current_epoch().await?;
     let params = state.get_funding_params().await?;
 
@@ -93,8 +90,9 @@ pub async fn distribute_rewards(
         let voter_addr = Address::try_from(voter)?;
         let reward = (Share::from(params.liquidity_tournament.delegator_share) * voter_share)?
             .apply_to_amount(&initial_budget)?;
+        // TODO: use a real transaction id or ids.
         state
-            .reward_to_voter(reward, &voter_addr, tx_source)
+            .reward_to_voter(reward, &voter_addr, TransactionId::default())
             .await?;
         current_budget = current_budget
             .checked_sub(&reward)

--- a/crates/core/component/funding/src/component/liquidity_tournament/rewards/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/rewards/mod.rs
@@ -1,0 +1,5 @@
+use cnidarium::StateWrite;
+
+pub async fn distribute_rewards(mut _state: impl StateWrite) -> anyhow::Result<()> {
+    todo!()
+}

--- a/crates/core/component/funding/src/component/liquidity_tournament/rewards/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/rewards/mod.rs
@@ -1,5 +1,8 @@
 use cnidarium::StateWrite;
 
+#[allow(dead_code)]
+mod gauge;
+
 pub async fn distribute_rewards(mut _state: impl StateWrite) -> anyhow::Result<()> {
     todo!()
 }

--- a/crates/core/component/funding/src/component/liquidity_tournament/rewards/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/rewards/mod.rs
@@ -35,7 +35,9 @@ async fn position_shares(
     }
     // Then divide each volume by the total volume, to get a relevant share.
     for x in &mut tallies {
-        *x = ((x.0 / Share::from(total))?, x.1);
+        // If we divide by 0, just treat all positions as having 0 share.
+        let share = (x.0 / Share::from(total)).unwrap_or_default();
+        *x = (share, x.1);
     }
     Ok(tallies)
 }

--- a/crates/core/component/funding/src/component/liquidity_tournament/rewards/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/rewards/mod.rs
@@ -1,8 +1,135 @@
-use cnidarium::StateWrite;
+use anyhow::anyhow;
+use cnidarium::{StateRead, StateWrite};
+use futures::stream::StreamExt as _;
+use penumbra_sdk_asset::{asset, Value, STAKING_TOKEN_ASSET_ID};
+use penumbra_sdk_community_pool::component::StateWriteExt as _;
+use penumbra_sdk_dex::{component::LqtRead as _, lp::position};
+use penumbra_sdk_distributions::component::StateReadExt as _;
+use penumbra_sdk_keys::address::ADDRESS_LEN_BYTES;
+use penumbra_sdk_keys::Address;
+use penumbra_sdk_sct::component::clock::EpochRead as _;
+use penumbra_sdk_txhash::TransactionId;
 
-#[allow(dead_code)]
+use super::bank::Bank as _;
+use super::votes::StateReadExt as _;
+use crate::component::StateReadExt as _;
+
 mod gauge;
+use gauge::{Gauge, Share};
 
-pub async fn distribute_rewards(mut _state: impl StateWrite) -> anyhow::Result<()> {
-    todo!()
+async fn position_shares(
+    state: impl StateRead,
+    epoch: u64,
+    asset: asset::Id,
+    top_n: usize,
+) -> anyhow::Result<Vec<(Share, position::Id)>> {
+    let mut stream = state.positions_by_volume_stream(epoch, asset)?.take(top_n);
+    let mut total = 0u128;
+    // This will end up containing the volume of each lp.
+    let mut tallies = Vec::new();
+    while let Some(x) = stream.next().await {
+        let (_, lp, volume) = x?;
+        let volume = volume.value();
+        total += volume;
+        tallies.push((Share::from(volume), lp));
+    }
+    // Then divide each volume by the total volume, to get a relevant share.
+    for x in &mut tallies {
+        *x = ((x.0 / Share::from(total))?, x.1);
+    }
+    Ok(tallies)
+}
+
+pub async fn distribute_rewards(
+    mut state: impl StateWrite + Sized,
+    tx_source: TransactionId,
+) -> anyhow::Result<()> {
+    let current_epoch = state.get_current_epoch().await?;
+    let params = state.get_funding_params().await?;
+
+    // Because of borrow checking shenanigans, we first collect all the votes,
+    // in the form of a big blob of bytes for voter addresses, and individual tuples
+    // for the asset, power tallies.
+
+    // 80 KB of memory should be enough for anybody.
+    let mut all_voter_bytes = Vec::<u8>::with_capacity(ADDRESS_LEN_BYTES * 1000);
+    let mut tallies = Vec::new();
+    let mut vote_receipts = state.vote_receipts(current_epoch.index);
+    while let Some(x) = vote_receipts.next().await {
+        let (asset, power, voter_bytes) = x?;
+        all_voter_bytes.extend_from_slice(&voter_bytes);
+        tallies.push((asset, power));
+    }
+    // Now actually tally things up.
+    let mut gauge = Gauge::empty();
+    for ((asset, power), voter) in tallies
+        .into_iter()
+        .zip(all_voter_bytes.chunks_exact(ADDRESS_LEN_BYTES))
+    {
+        gauge.tally(asset, power, voter);
+    }
+    let finalized = gauge.finalize(
+        params.liquidity_tournament.gauge_threshold,
+        usize::try_from(params.liquidity_tournament.max_delegators)?,
+    );
+
+    // Get the initial budget, and immediately withdraw it from the community pool.
+    let initial_budget = state
+        .get_lqt_reward_issuance_for_epoch(current_epoch.index)
+        .await
+        .unwrap_or_default();
+    state
+        .community_pool_withdraw(Value {
+            asset_id: *STAKING_TOKEN_ASSET_ID,
+            amount: initial_budget,
+        })
+        .await?;
+    // Now, we keep a running mutable current budget, because we distribute fractions of
+    // the initial budget, which should not be modified.
+    let mut current_budget = initial_budget;
+
+    // First, distribute rewards to voters.
+    for (voter_share, voter) in finalized.voter_shares() {
+        let voter_addr = Address::try_from(voter)?;
+        let reward = (Share::from(params.liquidity_tournament.delegator_share) * voter_share)?
+            .apply_to_amount(&initial_budget)?;
+        state
+            .reward_to_voter(reward, &voter_addr, tx_source)
+            .await?;
+        current_budget = current_budget
+            .checked_sub(&reward)
+            .ok_or(anyhow!("LQT rewards exceeded budget"))?;
+    }
+
+    // Next, distribute rewards to positions.
+    let lp_reward_share = Share::from(params.liquidity_tournament.delegator_share.complement());
+    for (asset_share, asset) in finalized.asset_shares() {
+        for (lp_share, lp) in position_shares(
+            &state,
+            current_epoch.index,
+            asset,
+            params.liquidity_tournament.max_positions.try_into()?,
+        )
+        .await?
+        {
+            // What fraction goes to lps, then of that, to this asset, then of that, to this lp.
+            let reward =
+                ((lp_reward_share * asset_share)? * lp_share)?.apply_to_amount(&initial_budget)?;
+            state.reward_to_position(reward, lp).await?;
+            current_budget = current_budget
+                .checked_sub(&reward)
+                .ok_or(anyhow!("LQT rewards exceeded budget"))?;
+        }
+    }
+
+    // Finally, move whatever budget remains back into the community pool.
+    // We expect this to be some dust amount, because of rounding.
+    state
+        .community_pool_deposit(Value {
+            asset_id: *STAKING_TOKEN_ASSET_ID,
+            amount: current_budget,
+        })
+        .await;
+
+    Ok(())
 }

--- a/crates/core/component/funding/src/component/liquidity_tournament/votes/mod.rs
+++ b/crates/core/component/funding/src/component/liquidity_tournament/votes/mod.rs
@@ -8,10 +8,8 @@ use penumbra_sdk_keys::Address;
 
 use crate::component::state_key;
 
-#[allow(dead_code)]
-#[async_trait]
 pub trait StateReadExt: StateRead {
-    async fn vote_receipts(
+    fn vote_receipts(
         &self,
         epoch: u64,
     ) -> Pin<Box<dyn Stream<Item = anyhow::Result<(asset::Id, u64, Vec<u8>)>> + Send + 'static>>

--- a/crates/core/component/funding/src/component/state_key.rs
+++ b/crates/core/component/funding/src/component/state_key.rs
@@ -83,7 +83,7 @@ pub mod lqt {
                 let (bytes_power, bytes_voter) = rest.split_at(POWER_LEN);
 
                 let asset = asset::Id::try_from(bytes_asset)?;
-                let power = u64::from_be_bytes(bytes_power.try_into()?);
+                let power = !u64::from_be_bytes(bytes_power.try_into()?);
                 let voter = bytes_voter.to_vec();
 
                 Ok((asset, power, voter))

--- a/crates/core/component/funding/src/component/state_key.rs
+++ b/crates/core/component/funding/src/component/state_key.rs
@@ -65,6 +65,29 @@ pub mod lqt {
 
                 bytes
             }
+
+            /// Parse the output of [`receipt`] back into its parts.
+            ///
+            /// We return a `Vec<u8>` instead of an `Address`, because tallying
+            /// wants to defer parsing the address until later, comparing encodings instead.
+            pub(crate) fn parse_receipt(key: &[u8]) -> anyhow::Result<(asset::Id, u64, Vec<u8>)> {
+                anyhow::ensure!(
+                    key.len() == RECEIPT_LEN,
+                    "key length was {}, expected {}",
+                    key.len(),
+                    RECEIPT_LEN
+                );
+                let rest = key;
+                let (_bytes_prefix, rest) = rest.split_at(PREFIX_LEN);
+                let (bytes_asset, rest) = rest.split_at(ASSET_LEN);
+                let (bytes_power, bytes_voter) = rest.split_at(POWER_LEN);
+
+                let asset = asset::Id::try_from(bytes_asset)?;
+                let power = u64::from_be_bytes(bytes_asset.try_into()?);
+                let voter = bytes_voter.to_vec();
+
+                Ok((asset, power, voter))
+            }
         }
     }
 }

--- a/crates/core/component/funding/src/component/state_key.rs
+++ b/crates/core/component/funding/src/component/state_key.rs
@@ -83,7 +83,7 @@ pub mod lqt {
                 let (bytes_power, bytes_voter) = rest.split_at(POWER_LEN);
 
                 let asset = asset::Id::try_from(bytes_asset)?;
-                let power = u64::from_be_bytes(bytes_asset.try_into()?);
+                let power = u64::from_be_bytes(bytes_power.try_into()?);
                 let voter = bytes_voter.to_vec();
 
                 Ok((asset, power, voter))

--- a/crates/core/num/src/percentage/mod.rs
+++ b/crates/core/num/src/percentage/mod.rs
@@ -1,3 +1,5 @@
+use crate::fixpoint::U128x128;
+
 /// Represents a percentage value.
 ///
 /// Useful for more robust typesafety, versus just passing around a `u64` which
@@ -21,6 +23,12 @@ impl Percentage {
     /// Given an arbitrary `u64`, produce a percentage, *saturating* at 100.
     pub fn from_percent(p: u64) -> Self {
         Self(u64::min(p.into(), 100))
+    }
+}
+
+impl From<Percentage> for U128x128 {
+    fn from(value: Percentage) -> Self {
+        Self::ratio(value.to_percent(), 100).expect("dividing by 100 should succeed")
     }
 }
 

--- a/crates/core/num/src/percentage/mod.rs
+++ b/crates/core/num/src/percentage/mod.rs
@@ -24,6 +24,11 @@ impl Percentage {
     pub fn from_percent(p: u64) -> Self {
         Self(u64::min(p.into(), 100))
     }
+
+    /// Given p%, return (1 - p)%.
+    pub fn complement(self) -> Self {
+        Self(100 - self.0)
+    }
 }
 
 impl From<Percentage> for U128x128 {


### PR DESCRIPTION
## Describe your changes

This integrates the recent work in the funding component, providing a full implementation of the reward calculation and distribution logic, running at the end of each epoch.

There are some unit and prop tests for some core tallying logic, but we'll need to do manual testing of the various RPCs an what not later.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:
