### PR TITLE
chore: bump cometbft version to 0.37.15

### DIFF
--- a/deployments/compose/docker-compose.dev.yml
+++ b/deployments/compose/docker-compose.dev.yml
@@ -57,7 +57,7 @@ services:
 
   # The CometBFT node
   cometbft-node0:
-    image: "docker.io/cometbft/cometbft:v0.37.9"
+    image: "docker.io/cometbft/cometbft:v0.37.15"
     ports:
       - "26656:26656"
       - "26657:26657"

--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -57,7 +57,7 @@ services:
 
   # The CometBFT node
   cometbft-node0:
-    image: "docker.io/cometbft/cometbft:v0.37.9"
+    image: "docker.io/cometbft/cometbft:v0.37.15"
     ports:
       - "26656:26656"
       - "26657:26657"

--- a/deployments/scripts/install-cometbft
+++ b/deployments/scripts/install-cometbft
@@ -5,7 +5,7 @@ set -euo pipefail
 
 
 # Sane defaults
-COMETBFT_VERSION="${COMETBFT_VERSION:-0.37.9}"
+COMETBFT_VERSION="${COMETBFT_VERSION:-0.37.15}"
 
 # Download and extract
 cometbft_download_url="https://github.com/cometbft/cometbft/releases/download/v${COMETBFT_VERSION}/cometbft_${COMETBFT_VERSION}_linux_amd64.tar.gz"

--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,11 @@
           # nix-prefetch-git --url https://github.com/cometbft/cometbft --rev <tag>
           # and review the output.
           cometBftRelease = {
-            version = "0.37.9";
-            sha256 = "sha256-4LUdDlDog4kbiwyGo5fZEvtDXa6sIm+SKlSBWq1angc=";
-            vendorHash = "sha256-0iqI/Z8rqDyQ7JqSrsqA9kADqF6qZy8NxTDNjAYYHts=";
+            version = "0.37.15";
+            # Set `sha256` to the value `hash` in the nix-prefetch-git output.
+            sha256 = "sha256-sX3hehsMNWWiQYbepMcdVoUAqz+lK4x76/ohjGb/J08=";
+            # Set `vendorHash` to "", run `nix build`, and review the hash.
+            vendorHash = "sha256-F6km3YpvfdpPeIJB1FwA5lQvPda11odny0EHPD8B6kw=";
           };
 
           # Build grpcui from source, for Reflection v1 support.


### PR DESCRIPTION


## Describe your changes

The cometbft version bump is to include patches to security issues. See details in [0]. We already updated the project documentation in [1].

[0] https://github.com/cometbft/cometbft/blob/v0.37.15/CHANGELOG.md#v03715
[1] https://github.com/penumbra-zone/guide/pull/52

## Checklist before requesting a review


- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > no changes to app code, bumping deps for related tooling
