### PR TITLE
Add compact block cost to LQT vote action

### DIFF
--- a/crates/core/transaction/src/gas.rs
+++ b/crates/core/transaction/src/gas.rs
@@ -313,8 +313,8 @@ fn liquidity_tournament_vote_gas_cost() -> Gas {
         + 64
         // ZKLiquidityTournamentVoteProof proof = 3;
         + ZKPROOF_SIZE,
-        // For the rest, c.f. `delegator_vote_gas_cost`
-        compact_block_space: 0,
+        // Each vote will, pessimistically, create one output for the reward.
+        compact_block_space: NOTEPAYLOAD_SIZE,
         verification: 1000,
         execution: 10,
     }


### PR DESCRIPTION
## Describe your changes

This is probably the most important one to get right.

Previously this was zero, but this commit changes it to be the same cost as an output action.

This is because, in the worst case scenario, each vote results in minting a note.
Fewer notes can be minted because we cap the number of voters each asset will tally,
but in practice we might be well under this limit.

No testing needed.

## Issue ticket number and link

Closes #5053.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:
