### PR TITLE
ci: make workflows runnable ad-hoc

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -1,9 +1,10 @@
 name: protobuf
 on:
-  # Exclude feature branches, only run if the PR is targeting main.
+  # Run against all PRs, regardless of feature branch target.
   pull_request:
-    branches:
-      - "main"
+  # Also support ad-hoc calls for workflow.
+  workflow_call:
+  workflow_dispatch:
 jobs:
   # Ensure there are no breaking changes to the protocol specs,
   # by running the "buf lint" action against the changes in this PR.

--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -1,13 +1,19 @@
 name: protobuf
-# We want to rebuild on every commit to main, and also for named testnet tags,
-# so that API users can pick a tagged version of the protobuf definitions
-# to use against a matching testnet.
+# We're keeping the protodefs stable at v1, via buf lint checks on PRs.
+# Therefore it's safe to publish on every commit to main (and also tags).
 on:
   push:
     branches:
       - main
+      # Consider automatically publishing on upcoming protocol changes,
+      # to allow integration in downstream, e.g. web dependencies.
+      # - protocol/*
     tags:
       - '**'
+  # Also support ad-hoc calls for workflow
+  workflow_call:
+  workflow_dispatch:
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,5 +1,9 @@
 name: docs-lint
-on: pull_request
+on:
+  pull_request:
+  # Also support ad-hoc calls for workflow.
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   rustdocs:

--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -1,10 +1,10 @@
 name: docs
-
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
 


### PR DESCRIPTION
## Describe your changes

We want to publish the protobuf changes in `protocol/lqt_support` (#5010) to unblock web integrations. In order to run the workflow ad-hoc on a branch, we need to permit `workflow_dispatch` runs. The `workflow_call` additions are not currently used, but have been in the past, and permit triggering via cross-repo API.

While authoring these changes, I noticed that the protobuf lint job is _not_ running against feature branches, meaning the PRs into `protocol/lqt_support` have skipped that check. We've been careful in authoring the proto changes, but we should still verify that check passes on the feature branch, prior to publishing.


## Issue ticket number and link
Refs #5010. 

## Checklist before requesting a review


- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > no code changes, only affects CI. will result in new protobuf changes to published to the repo. 
