### PR TITLE
ci: enable pindexer integration tests

### DIFF
--- a/deployments/compose/process-compose-smoke-test.yml
+++ b/deployments/compose/process-compose-smoke-test.yml
@@ -56,6 +56,21 @@ processes:
     availability:
       restart: exit_on_failure
 
+  # Run `pindexer` integration tests.
+  test-pindexer:
+    command: >-
+      cargo nextest run --release -p pindexer --features network-integration
+    log_location: deployments/logs/smoke-test-pindexer.log
+    depends_on:
+      pd:
+        condition: process_healthy
+      cometbft:
+        condition: process_started
+      test-pcli:
+        condition: process_completed
+    availability:
+      restart: exit_on_failure
+
   # Run `pd` integration tests. These run last, as the metrics checks
   # will be empty unless actual work has been performed.
   test-pd:
@@ -66,7 +81,7 @@ processes:
         condition: process_healthy
       cometbft:
         condition: process_started
-      test-pcli:
+      test-pindexer:
         condition: process_completed
     availability:
       restart: exit_on_failure
@@ -83,6 +98,8 @@ processes:
       test-pclientd:
         condition: process_completed_successfully
       test-pcli:
+        condition: process_completed_successfully
+      test-pindexer:
         condition: process_completed_successfully
     availability:
       exit_on_end: true

--- a/deployments/scripts/smoke-test.sh
+++ b/deployments/scripts/smoke-test.sh
@@ -37,11 +37,10 @@ fi
 cargo build --release -p pcli -p pclientd -p pd
 
 # Reuse existing dev-env script
-# Temporary: cannot set ``--config ./deployments/compose/process-compose-postgres.yml`
-# because pindexer is currently failing due to GH4999.
 if ! "${repo_root}/deployments/scripts/run-local-devnet.sh" \
         --config ./deployments/compose/process-compose-metrics.yml \
         --config ./deployments/compose/process-compose-dev-tooling.yml \
+        --config ./deployments/compose/process-compose-postgres.yml \
         --config ./deployments/compose/process-compose-smoke-test.yml \
         ; then
     >&2 echo "ERROR: smoke tests failed"


### PR DESCRIPTION


## Describe your changes

Follow-up to #5009, in which these tests were introduced, and #5048, which refactored the smoke tests to make additions like this easier.

## Issue ticket number and link
See above.

## Testing and review

The tests were already merged, this is just enabling them in CI, so CI passing, specifically on the smoke-test job, is enough.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > tests/ci only, no changes to application code
