### PR TITLE
pcli: support multiple lp withdrawals

### DIFF
--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -1485,15 +1485,13 @@ impl TxCmd {
 
                     let reserves = position.reserves;
                     let pair = position.phi.pair;
-                    let prev_seq = match position.state {
-                        State::Withdrawn { sequence } => sequence,
+                    let next_seq = match position.state {
+                        State::Withdrawn { sequence } => sequence + 1,
+                        State::Closed => 0,
                         _ => {
                             anyhow::bail!("position {} is not in a withdrawable state", position_id)
                         }
                     };
-
-                    let next_seq = prev_seq + 1;
-
                     planner.position_withdraw(
                         *position_id,
                         reserves.try_into()?,

--- a/crates/view/src/planner.rs
+++ b/crates/view/src/planner.rs
@@ -199,12 +199,13 @@ impl<R: RngCore + CryptoRng> Planner<R> {
         position_id: position::Id,
         reserves: Reserves,
         pair: TradingPair,
+        next_sequence: u64,
     ) -> &mut Self {
         self.action_list.push(PositionWithdrawPlan {
             reserves,
             position_id,
             pair,
-            sequence: 0,
+            sequence: next_sequence,
             rewards: Vec::new(),
         });
         self

--- a/crates/view/src/service.rs
+++ b/crates/view/src/service.rs
@@ -747,7 +747,7 @@ impl ViewService for ViewServer {
                     tonic::Status::invalid_argument(format!("Could not parse pair: {e:#}"))
                 })?;
 
-            planner.position_withdraw(position_id, reserves, trading_pair);
+            planner.position_withdraw(position_id, reserves, trading_pair, 0);
         }
 
         // Insert any ICS20 withdrawals.


### PR DESCRIPTION
## Describe your changes

Now we can use `pcli tx withdraw <id>` to withdraw a position multiple times, increasing its sequence. We fetch the reserves on every try so that the balance commitment is always accurate.

To view the output, use `pcli v balance --by-note` this is unfortunate but wontfix now.

## Issue ticket number and link
#5069 

## Checklist before requesting a review

- [ ] I have added guiding text to explain how a reviewer should test these changes.

- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > REPLACE THIS TEXT WITH RATIONALE (CAN BE BRIEF)
