### PR TITLE
chore: bump app version 9 -> 10

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -10,3 +10,5 @@
 | 7 (Mainnet)               | v0.79.x                | v0.37.x  |   v1     |
 | 8 (Mainnet)               | v0.80.x                | v0.37.x  |   v1     |
 | 9 (Mainnet)               | v0.81.x                | v0.37.x  |   v1     |
+| 9 (Mainnet)               | v1.0.x                 | v0.37.x  |   v1     |
+| 10 (Mainnet)              | v2.0.x                 | v0.37.x  |   v1     |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "cometindex"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-frost"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -4373,7 +4373,7 @@ dependencies = [
 
 [[package]]
 name = "pcli"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "pclientd"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "pd"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-app"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4747,7 +4747,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-app-tests"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-asset"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auction"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4932,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auto-https"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "axum-server",
@@ -4944,7 +4944,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-bench"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -4988,7 +4988,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-community-pool"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-compact-block"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-custody"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-dex"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5153,7 +5153,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-distributions"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-eddy"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-fee"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-funding"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-groth16",
@@ -5252,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-governance"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-ibc"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-keys"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-measure"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5412,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-mock-client"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "cnidarium",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-mock-consensus"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-mock-tendermint-proxy"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "hex",
  "pbjson-types",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-num"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-parameter-setup"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "ark-groth16",
  "ark-serialize",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-params"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-setup"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proto"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-sct"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-shielded-pool"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-stake"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct-property-test"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct-visualize"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tendermint-proxy"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-test-subscriber"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tower-trace"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "futures",
  "hex",
@@ -5888,7 +5888,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-transaction"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-txhash"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-view"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -6016,7 +6016,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-wallet"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -6102,7 +6102,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pindexer"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6205,7 +6205,7 @@ dependencies = [
 
 [[package]]
 name = "pmonitor"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8223,7 +8223,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "summonerd"
-version = "1.0.1"
+version = "2.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-groth16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ rate-limit = { existing-packages = 50 }
 [workspace.package]
 authors    = ["Penumbra Labs <team@penumbralabs.xyz"]
 edition    = "2021"
-version    = "1.0.1"
+version    = "2.0.0-alpha.0"
 repository = "https://github.com/penumbra-zone/penumbra"
 homepage   = "https://penumbra.zone"
 license    = "MIT OR Apache-2.0"
@@ -142,12 +142,12 @@ chacha20poly1305                 = { version = "0.9.0" }
 chrono                           = { default-features = false, version = "0.4" }
 clap                             = { version = "3.2" }
 cnidarium                        = { version = "0.83", default-features = false}
-cnidarium-component              = { default-features = false, version = "1.0.1", path = "crates/cnidarium-component" }
-cometindex                       = { version = "1.0.1", path = "crates/util/cometindex" }
+cnidarium-component              = { default-features = false, version = "2.0.0-alpha.0", path = "crates/cnidarium-component" }
+cometindex                       = { version = "2.0.0-alpha.0", path = "crates/util/cometindex" }
 criterion                        = { version = "0.4" }
 decaf377                         = { default-features = false, version = "0.10.1" }
-decaf377-fmd                     = { version = "1.0.1", path = "crates/crypto/decaf377-fmd" }
-decaf377-ka                      = { version = "1.0.1", path = "crates/crypto/decaf377-ka" }
+decaf377-fmd                     = { version = "2.0.0-alpha.0", path = "crates/crypto/decaf377-fmd" }
+decaf377-ka                      = { version = "2.0.0-alpha.0", path = "crates/crypto/decaf377-ka" }
 decaf377-rdsa                    = { version = "0.11.0" }
 derivative                       = { version = "2.2" }
 directories                      = { version = "4.0.1" }
@@ -175,36 +175,36 @@ once_cell                        = { version = "1.8" }
 parking_lot                      = { version = "0.12.1" }
 pbjson                           = { version = "0.7.0" }
 pbjson-types                     = { version = "0.7.0" }
-penumbra-sdk-app                     = { default-features = false, version = "1.0.1", path = "crates/core/app" }
-penumbra-sdk-asset                   = { default-features = false, version = "1.0.1", path = "crates/core/asset" }
-penumbra-sdk-community-pool          = { default-features = false, version = "1.0.1", path = "crates/core/component/community-pool" }
-penumbra-sdk-compact-block           = { default-features = false, version = "1.0.1", path = "crates/core/component/compact-block" }
-penumbra-sdk-custody                 = { version = "1.0.1", path = "crates/custody" }
-penumbra-sdk-auction                 = { default-features = false, version = "1.0.1", path = "crates/core/component/auction" }
-penumbra-sdk-dex                     = { default-features = false, version = "1.0.1", path = "crates/core/component/dex" }
-penumbra-sdk-distributions           = { default-features = false, version = "1.0.1", path = "crates/core/component/distributions" }
-penumbra-sdk-fee                     = { default-features = false, version = "1.0.1", path = "crates/core/component/fee" }
-penumbra-sdk-funding                 = { default-features = false, version = "1.0.1", path = "crates/core/component/funding" }
-penumbra-sdk-governance              = { default-features = false, version = "1.0.1", path = "crates/core/component/governance" }
-penumbra-sdk-ibc                     = { default-features = false, version = "1.0.1", path = "crates/core/component/ibc" }
-penumbra-sdk-keys                    = { default-features = false, version = "1.0.1", path = "crates/core/keys" }
-penumbra-sdk-mock-client             = { version = "1.0.1", path = "crates/test/mock-client" }
-penumbra-sdk-mock-consensus          = { version = "1.0.1", path = "crates/test/mock-consensus" }
-penumbra-sdk-mock-tendermint-proxy   = { version = "1.0.1", path = "crates/test/mock-tendermint-proxy" }
-penumbra-sdk-num                     = { default-features = false, version = "1.0.1", path = "crates/core/num" }
-penumbra-sdk-proof-params            = { default-features = false, version = "1.0.1", path = "crates/crypto/proof-params" }
-penumbra-sdk-proof-setup             = { version = "1.0.1", path = "crates/crypto/proof-setup" }
-penumbra-sdk-proto                   = { default-features = false, version = "1.0.1", path = "crates/proto" }
-penumbra-sdk-sct                     = { default-features = false, version = "1.0.1", path = "crates/core/component/sct" }
-penumbra-sdk-shielded-pool           = { default-features = false, version = "1.0.1", path = "crates/core/component/shielded-pool" }
-penumbra-sdk-stake                   = { default-features = false, version = "1.0.1", path = "crates/core/component/stake" }
-penumbra-sdk-tct                     = { default-features = false, version = "1.0.1", path = "crates/crypto/tct" }
-penumbra-sdk-test-subscriber         = { version = "1.0.1", path = "crates/test/tracing-subscriber" }
-penumbra-sdk-tower-trace             = { version = "1.0.1", path = "crates/util/tower-trace" }
-penumbra-sdk-transaction             = { default-features = false, version = "1.0.1", path = "crates/core/transaction" }
-penumbra-sdk-txhash                  = { default-features = false, version = "1.0.1", path = "crates/core/txhash" }
-penumbra-sdk-view                    = { version = "1.0.1", path = "crates/view" }
-penumbra-sdk-wallet                  = { version = "1.0.1", path = "crates/wallet" }
+penumbra-sdk-app                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/app" }
+penumbra-sdk-asset                   = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/asset" }
+penumbra-sdk-community-pool          = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/community-pool" }
+penumbra-sdk-compact-block           = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/compact-block" }
+penumbra-sdk-custody                 = { version = "2.0.0-alpha.0", path = "crates/custody" }
+penumbra-sdk-auction                 = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/auction" }
+penumbra-sdk-dex                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/dex" }
+penumbra-sdk-distributions           = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/distributions" }
+penumbra-sdk-fee                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/fee" }
+penumbra-sdk-funding                 = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/funding" }
+penumbra-sdk-governance              = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/governance" }
+penumbra-sdk-ibc                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/ibc" }
+penumbra-sdk-keys                    = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/keys" }
+penumbra-sdk-mock-client             = { version = "2.0.0-alpha.0", path = "crates/test/mock-client" }
+penumbra-sdk-mock-consensus          = { version = "2.0.0-alpha.0", path = "crates/test/mock-consensus" }
+penumbra-sdk-mock-tendermint-proxy   = { version = "2.0.0-alpha.0", path = "crates/test/mock-tendermint-proxy" }
+penumbra-sdk-num                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/num" }
+penumbra-sdk-proof-params            = { default-features = false, version = "2.0.0-alpha.0", path = "crates/crypto/proof-params" }
+penumbra-sdk-proof-setup             = { version = "2.0.0-alpha.0", path = "crates/crypto/proof-setup" }
+penumbra-sdk-proto                   = { default-features = false, version = "2.0.0-alpha.0", path = "crates/proto" }
+penumbra-sdk-sct                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/sct" }
+penumbra-sdk-shielded-pool           = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/shielded-pool" }
+penumbra-sdk-stake                   = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/stake" }
+penumbra-sdk-tct                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/crypto/tct" }
+penumbra-sdk-test-subscriber         = { version = "2.0.0-alpha.0", path = "crates/test/tracing-subscriber" }
+penumbra-sdk-tower-trace             = { version = "2.0.0-alpha.0", path = "crates/util/tower-trace" }
+penumbra-sdk-transaction             = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/transaction" }
+penumbra-sdk-txhash                  = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/txhash" }
+penumbra-sdk-view                    = { version = "2.0.0-alpha.0", path = "crates/view" }
+penumbra-sdk-wallet                  = { version = "2.0.0-alpha.0", path = "crates/wallet" }
 pin-project                      = { version = "1.0.12" }
 pin-project-lite                 = { version = "0.2.9" }
 poseidon377                      = { version = "1.2.0" }

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -61,7 +61,7 @@ once_cell                        = { workspace = true }
 pbjson-types                     = { workspace = true }
 penumbra-sdk-app                     = { workspace = true, default-features = true }
 penumbra-sdk-asset                   = { workspace = true, default-features = true }
-penumbra-sdk-auto-https              = { version = "1.0.1", path = "../../util/auto-https" }
+penumbra-sdk-auto-https              = { version = "2.0.0-alpha.0", path = "../../util/auto-https" }
 penumbra-sdk-compact-block           = { workspace = true, default-features = true }
 penumbra-sdk-custody                 = { workspace = true }
 penumbra-sdk-auction                 = { workspace = true, features = ["parallel"], default-features = true }
@@ -76,7 +76,7 @@ penumbra-sdk-sct                     = { workspace = true, default-features = tr
 penumbra-sdk-shielded-pool           = { workspace = true, features = ["parallel"], default-features = true }
 penumbra-sdk-stake                   = { workspace = true, features = ["parallel"], default-features = true }
 penumbra-sdk-tct                     = { workspace = true, default-features = true }
-penumbra-sdk-tendermint-proxy        = { version = "1.0.1", path = "../../util/tendermint-proxy" }
+penumbra-sdk-tendermint-proxy        = { version = "2.0.0-alpha.0", path = "../../util/tendermint-proxy" }
 penumbra-sdk-tower-trace             = { workspace = true }
 penumbra-sdk-transaction             = { workspace = true, default-features = true }
 pin-project                      = { workspace = true }

--- a/crates/bin/pmonitor/Cargo.toml
+++ b/crates/bin/pmonitor/Cargo.toml
@@ -24,7 +24,7 @@ colored = "2.1.0"
 directories = {workspace = true}
 futures = {workspace = true}
 indicatif = {workspace = true}
-pcli = {version = "1.0.1", path = "../pcli", default-features = true}
+pcli = {version = "2.0.0-alpha.0", path = "../pcli", default-features = true}
 penumbra-sdk-app = {workspace = true}
 penumbra-sdk-asset = {workspace = true, default-features = false}
 penumbra-sdk-compact-block = {workspace = true, default-features = false}

--- a/crates/core/app/src/app_version.rs
+++ b/crates/core/app/src/app_version.rs
@@ -1,6 +1,6 @@
 /// Representation of the Penumbra application version. Notably, this is distinct
 /// from the crate version(s). This number should only ever be incremented.
-pub const APP_VERSION: u64 = 9;
+pub const APP_VERSION: u64 = 10;
 
 cfg_if::cfg_if! {
     if #[cfg(feature="component")] {

--- a/crates/core/app/src/app_version/component.rs
+++ b/crates/core/app/src/app_version/component.rs
@@ -16,7 +16,8 @@ fn version_to_software_version(version: u64) -> &'static str {
         6 => "v0.77.x",
         7 => "v0.79.x",
         8 => "v0.80.x",
-        9 => "v0.81.x",
+        9 => "v1.0.x",
+        10 => "v2.0.x",
         _ => "unknown",
     }
 }

--- a/crates/custody/Cargo.toml
+++ b/crates/custody/Cargo.toml
@@ -17,7 +17,7 @@ blake2b_simd = {workspace = true}
 bytes = {workspace = true, features = ["serde"]}
 chacha20poly1305 = {workspace = true}
 decaf377 = {workspace = true}
-decaf377-frost = { version = "1.0.1", path = "../crypto/decaf377-frost" }
+decaf377-frost = { version = "2.0.0-alpha.0", path = "../crypto/decaf377-frost" }
 decaf377-ka = {workspace = true}
 decaf377-rdsa = {workspace = true}
 ed25519-consensus = {workspace = true}


### PR DESCRIPTION
## Describe your changes
Bumps the protocol version to denote the addition of LQT functionality. Also bumps the crate versions from 1.0.x -> 2.0.x, as an alpha. No tag has been created, to avoid triggering the formal release workflows, since we're still testing.

## Issue ticket number and link

#5010.

## Testing and review

I'm submitting this PR ahead of a planned testnet upgrade, so we'll shortly learn how effective the overall upgrade process is. However, special attention should be given to the proposed versions strings. In particular, the transition from `0.81.x` to `1.0.x` maintained compatibility with APP_VERSION 9, and that may present difficulties during the upgrade for nodes on one or the other version.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > explicitly denotes consensus-breaking changes, and therefore targets a protocol feature branch, rather than main
