### PR TITLE
pd: add no-op migration for APP_VERSION 10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "cometindex"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-frost"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -4373,7 +4373,7 @@ dependencies = [
 
 [[package]]
 name = "pcli"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "pclientd"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "pd"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-app"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4747,7 +4747,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-app-tests"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-asset"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auction"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4932,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auto-https"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "axum-server",
@@ -4944,7 +4944,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-bench"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -4988,7 +4988,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-community-pool"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-compact-block"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-custody"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-dex"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5153,7 +5153,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-distributions"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-eddy"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-fee"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-funding"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-groth16",
@@ -5252,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-governance"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-ibc"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-keys"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-measure"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5412,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-mock-client"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "cnidarium",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-mock-consensus"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-mock-tendermint-proxy"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "hex",
  "pbjson-types",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-num"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-parameter-setup"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "ark-groth16",
  "ark-serialize",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-params"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-setup"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proto"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-sct"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-shielded-pool"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-stake"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct-property-test"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct-visualize"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tendermint-proxy"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-test-subscriber"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tower-trace"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "futures",
  "hex",
@@ -5888,7 +5888,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-transaction"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-txhash"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-view"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -6016,7 +6016,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-wallet"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -6102,7 +6102,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pindexer"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6205,7 +6205,7 @@ dependencies = [
 
 [[package]]
 name = "pmonitor"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8223,7 +8223,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "summonerd"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "ark-groth16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ rate-limit = { existing-packages = 50 }
 [workspace.package]
 authors    = ["Penumbra Labs <team@penumbralabs.xyz"]
 edition    = "2021"
-version    = "2.0.0-alpha.0"
+version    = "2.0.0-alpha.1"
 repository = "https://github.com/penumbra-zone/penumbra"
 homepage   = "https://penumbra.zone"
 license    = "MIT OR Apache-2.0"
@@ -142,12 +142,12 @@ chacha20poly1305                 = { version = "0.9.0" }
 chrono                           = { default-features = false, version = "0.4" }
 clap                             = { version = "3.2" }
 cnidarium                        = { version = "0.83", default-features = false}
-cnidarium-component              = { default-features = false, version = "2.0.0-alpha.0", path = "crates/cnidarium-component" }
-cometindex                       = { version = "2.0.0-alpha.0", path = "crates/util/cometindex" }
+cnidarium-component              = { default-features = false, version = "2.0.0-alpha.1", path = "crates/cnidarium-component" }
+cometindex                       = { version = "2.0.0-alpha.1", path = "crates/util/cometindex" }
 criterion                        = { version = "0.4" }
 decaf377                         = { default-features = false, version = "0.10.1" }
-decaf377-fmd                     = { version = "2.0.0-alpha.0", path = "crates/crypto/decaf377-fmd" }
-decaf377-ka                      = { version = "2.0.0-alpha.0", path = "crates/crypto/decaf377-ka" }
+decaf377-fmd                     = { version = "2.0.0-alpha.1", path = "crates/crypto/decaf377-fmd" }
+decaf377-ka                      = { version = "2.0.0-alpha.1", path = "crates/crypto/decaf377-ka" }
 decaf377-rdsa                    = { version = "0.11.0" }
 derivative                       = { version = "2.2" }
 directories                      = { version = "4.0.1" }
@@ -175,36 +175,36 @@ once_cell                        = { version = "1.8" }
 parking_lot                      = { version = "0.12.1" }
 pbjson                           = { version = "0.7.0" }
 pbjson-types                     = { version = "0.7.0" }
-penumbra-sdk-app                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/app" }
-penumbra-sdk-asset                   = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/asset" }
-penumbra-sdk-community-pool          = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/community-pool" }
-penumbra-sdk-compact-block           = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/compact-block" }
-penumbra-sdk-custody                 = { version = "2.0.0-alpha.0", path = "crates/custody" }
-penumbra-sdk-auction                 = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/auction" }
-penumbra-sdk-dex                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/dex" }
-penumbra-sdk-distributions           = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/distributions" }
-penumbra-sdk-fee                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/fee" }
-penumbra-sdk-funding                 = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/funding" }
-penumbra-sdk-governance              = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/governance" }
-penumbra-sdk-ibc                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/ibc" }
-penumbra-sdk-keys                    = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/keys" }
-penumbra-sdk-mock-client             = { version = "2.0.0-alpha.0", path = "crates/test/mock-client" }
-penumbra-sdk-mock-consensus          = { version = "2.0.0-alpha.0", path = "crates/test/mock-consensus" }
-penumbra-sdk-mock-tendermint-proxy   = { version = "2.0.0-alpha.0", path = "crates/test/mock-tendermint-proxy" }
-penumbra-sdk-num                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/num" }
-penumbra-sdk-proof-params            = { default-features = false, version = "2.0.0-alpha.0", path = "crates/crypto/proof-params" }
-penumbra-sdk-proof-setup             = { version = "2.0.0-alpha.0", path = "crates/crypto/proof-setup" }
-penumbra-sdk-proto                   = { default-features = false, version = "2.0.0-alpha.0", path = "crates/proto" }
-penumbra-sdk-sct                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/sct" }
-penumbra-sdk-shielded-pool           = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/shielded-pool" }
-penumbra-sdk-stake                   = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/component/stake" }
-penumbra-sdk-tct                     = { default-features = false, version = "2.0.0-alpha.0", path = "crates/crypto/tct" }
-penumbra-sdk-test-subscriber         = { version = "2.0.0-alpha.0", path = "crates/test/tracing-subscriber" }
-penumbra-sdk-tower-trace             = { version = "2.0.0-alpha.0", path = "crates/util/tower-trace" }
-penumbra-sdk-transaction             = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/transaction" }
-penumbra-sdk-txhash                  = { default-features = false, version = "2.0.0-alpha.0", path = "crates/core/txhash" }
-penumbra-sdk-view                    = { version = "2.0.0-alpha.0", path = "crates/view" }
-penumbra-sdk-wallet                  = { version = "2.0.0-alpha.0", path = "crates/wallet" }
+penumbra-sdk-app                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/app" }
+penumbra-sdk-asset                   = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/asset" }
+penumbra-sdk-community-pool          = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/community-pool" }
+penumbra-sdk-compact-block           = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/compact-block" }
+penumbra-sdk-custody                 = { version = "2.0.0-alpha.1", path = "crates/custody" }
+penumbra-sdk-auction                 = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/auction" }
+penumbra-sdk-dex                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/dex" }
+penumbra-sdk-distributions           = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/distributions" }
+penumbra-sdk-fee                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/fee" }
+penumbra-sdk-funding                 = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/funding" }
+penumbra-sdk-governance              = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/governance" }
+penumbra-sdk-ibc                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/ibc" }
+penumbra-sdk-keys                    = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/keys" }
+penumbra-sdk-mock-client             = { version = "2.0.0-alpha.1", path = "crates/test/mock-client" }
+penumbra-sdk-mock-consensus          = { version = "2.0.0-alpha.1", path = "crates/test/mock-consensus" }
+penumbra-sdk-mock-tendermint-proxy   = { version = "2.0.0-alpha.1", path = "crates/test/mock-tendermint-proxy" }
+penumbra-sdk-num                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/num" }
+penumbra-sdk-proof-params            = { default-features = false, version = "2.0.0-alpha.1", path = "crates/crypto/proof-params" }
+penumbra-sdk-proof-setup             = { version = "2.0.0-alpha.1", path = "crates/crypto/proof-setup" }
+penumbra-sdk-proto                   = { default-features = false, version = "2.0.0-alpha.1", path = "crates/proto" }
+penumbra-sdk-sct                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/sct" }
+penumbra-sdk-shielded-pool           = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/shielded-pool" }
+penumbra-sdk-stake                   = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/stake" }
+penumbra-sdk-tct                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/crypto/tct" }
+penumbra-sdk-test-subscriber         = { version = "2.0.0-alpha.1", path = "crates/test/tracing-subscriber" }
+penumbra-sdk-tower-trace             = { version = "2.0.0-alpha.1", path = "crates/util/tower-trace" }
+penumbra-sdk-transaction             = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/transaction" }
+penumbra-sdk-txhash                  = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/txhash" }
+penumbra-sdk-view                    = { version = "2.0.0-alpha.1", path = "crates/view" }
+penumbra-sdk-wallet                  = { version = "2.0.0-alpha.1", path = "crates/wallet" }
 pin-project                      = { version = "1.0.12" }
 pin-project-lite                 = { version = "0.2.9" }
 poseidon377                      = { version = "1.2.0" }

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -61,7 +61,7 @@ once_cell                        = { workspace = true }
 pbjson-types                     = { workspace = true }
 penumbra-sdk-app                     = { workspace = true, default-features = true }
 penumbra-sdk-asset                   = { workspace = true, default-features = true }
-penumbra-sdk-auto-https              = { version = "2.0.0-alpha.0", path = "../../util/auto-https" }
+penumbra-sdk-auto-https              = { version = "2.0.0-alpha.1", path = "../../util/auto-https" }
 penumbra-sdk-compact-block           = { workspace = true, default-features = true }
 penumbra-sdk-custody                 = { workspace = true }
 penumbra-sdk-auction                 = { workspace = true, features = ["parallel"], default-features = true }
@@ -76,7 +76,7 @@ penumbra-sdk-sct                     = { workspace = true, default-features = tr
 penumbra-sdk-shielded-pool           = { workspace = true, features = ["parallel"], default-features = true }
 penumbra-sdk-stake                   = { workspace = true, features = ["parallel"], default-features = true }
 penumbra-sdk-tct                     = { workspace = true, default-features = true }
-penumbra-sdk-tendermint-proxy        = { version = "2.0.0-alpha.0", path = "../../util/tendermint-proxy" }
+penumbra-sdk-tendermint-proxy        = { version = "2.0.0-alpha.1", path = "../../util/tendermint-proxy" }
 penumbra-sdk-tower-trace             = { workspace = true }
 penumbra-sdk-transaction             = { workspace = true, default-features = true }
 pin-project                      = { workspace = true }

--- a/crates/bin/pd/src/main.rs
+++ b/crates/bin/pd/src/main.rs
@@ -12,7 +12,7 @@ use cnidarium::Storage;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use pd::{
     cli::{NetworkCommand, Opt, RootCommand},
-    migrate::Migration::{Mainnet2, ReadyToStart},
+    migrate::Migration::{Mainnet3, ReadyToStart},
     network::{
         config::{get_network_dir, parse_tm_address, url_has_necessary_parts},
         generate::NetworkConfig,
@@ -502,7 +502,7 @@ async fn main() -> anyhow::Result<()> {
 
             let genesis_start = pd::migrate::last_block_timestamp(pd_home.clone()).await?;
             tracing::info!(?genesis_start, "last block timestamp");
-            Mainnet2
+            Mainnet3
                 .migrate(pd_home.clone(), comet_home, Some(genesis_start), force)
                 .instrument(pd_migrate_span)
                 .await

--- a/crates/bin/pd/src/migrate.rs
+++ b/crates/bin/pd/src/migrate.rs
@@ -6,6 +6,7 @@
 //! in order to be compatible with the network post-chain-upgrade.
 mod mainnet1;
 mod mainnet2;
+mod mainnet3;
 mod reset_halt_bit;
 mod simple;
 mod testnet72;
@@ -60,6 +61,9 @@ pub enum Migration {
     /// Mainnet-2 migration:
     /// - no-op
     Mainnet2,
+    /// Mainnet-3 migration:
+    /// - no-op
+    Mainnet3,
 }
 
 impl Migration {
@@ -111,6 +115,9 @@ impl Migration {
             }
             Migration::Mainnet2 => {
                 mainnet2::migrate(storage, pd_home.clone(), genesis_start).await?;
+            }
+            Migration::Mainnet3 => {
+                mainnet3::migrate(storage, pd_home.clone(), genesis_start).await?;
             }
             // We keep historical migrations around for now, this will help inform an abstracted
             // design. Feel free to remove it if it's causing you trouble.

--- a/crates/bin/pd/src/migrate/mainnet3.rs
+++ b/crates/bin/pd/src/migrate/mainnet3.rs
@@ -1,0 +1,102 @@
+//! Migration for shipping consensus-breaking LQT functionality.
+//!
+//! This migration is a no-op in terms of state. It'll perform the required
+//! APP_VERSION munging for UIP-6, and generate the usual new genesis and validator
+//! watermark files.
+use cnidarium::{StateDelta, Storage};
+use jmt::RootHash;
+use penumbra_sdk_app::app::StateReadExt as _;
+use penumbra_sdk_app::app_version::migrate_app_version;
+use penumbra_sdk_governance::StateWriteExt;
+use penumbra_sdk_sct::component::clock::EpochManager;
+use penumbra_sdk_sct::component::clock::EpochRead;
+use std::path::PathBuf;
+use tracing::instrument;
+
+use crate::network::generate::NetworkConfig;
+
+/// Run the full migration, emitting a new genesis event, representing historical state.
+#[instrument]
+pub async fn migrate(
+    storage: Storage,
+    pd_home: PathBuf,
+    genesis_start: Option<tendermint::time::Time>,
+) -> anyhow::Result<()> {
+    // Setup:
+    let initial_state = storage.latest_snapshot();
+    let chain_id = initial_state.get_chain_id().await?;
+    let root_hash = initial_state
+        .root_hash()
+        .await
+        .expect("chain state has a root hash");
+    // We obtain the pre-upgrade hash solely to log it as a result.
+    let pre_upgrade_root_hash: RootHash = root_hash.into();
+    let pre_upgrade_height = initial_state
+        .get_block_height()
+        .await
+        .expect("chain state has a block height");
+    let post_upgrade_height = pre_upgrade_height.wrapping_add(1);
+
+    let mut delta = StateDelta::new(initial_state);
+    let (migration_duration, post_upgrade_root_hash) = {
+        let start_time = std::time::SystemTime::now();
+
+        migrate_app_version(&mut delta, 10).await?;
+
+        // Reset the application height and halt flag.
+        delta.ready_to_start();
+        delta.put_block_height(0u64);
+
+        // Finally, commit the changes to the chain state.
+        let post_upgrade_root_hash = storage.commit_in_place(delta).await?;
+        tracing::info!(?post_upgrade_root_hash, "post-migration root hash");
+
+        (
+            start_time.elapsed().expect("start is set"),
+            post_upgrade_root_hash,
+        )
+    };
+    storage.release().await;
+
+    // The migration is complete, now we need to generate a genesis file. To do this, we need
+    // to lookup a validator view from the chain, and specify the post-upgrade app hash and
+    // initial height.
+    let app_state = penumbra_sdk_app::genesis::Content {
+        chain_id,
+        ..Default::default()
+    };
+    let mut genesis = NetworkConfig::make_genesis(app_state.clone()).expect("can make genesis");
+    genesis.app_hash = post_upgrade_root_hash
+        .0
+        .to_vec()
+        .try_into()
+        .expect("infallible conversion");
+
+    genesis.initial_height = post_upgrade_height as i64;
+    genesis.genesis_time = genesis_start.unwrap_or_else(|| {
+        let now = tendermint::time::Time::now();
+        tracing::info!(%now, "no genesis time provided, detecting a testing setup");
+        now
+    });
+    let checkpoint = post_upgrade_root_hash.0.to_vec();
+    let genesis = NetworkConfig::make_checkpoint(genesis, Some(checkpoint));
+    let genesis_json = serde_json::to_string(&genesis).expect("can serialize genesis");
+    tracing::info!("genesis: {}", genesis_json);
+    let genesis_path = pd_home.join("genesis.json");
+    std::fs::write(genesis_path, genesis_json).expect("can write genesis");
+
+    let validator_state_path = pd_home.join("priv_validator_state.json");
+    let fresh_validator_state = crate::network::generate::NetworkValidator::initial_state();
+    std::fs::write(validator_state_path, fresh_validator_state).expect("can write validator state");
+
+    tracing::info!(
+        pre_upgrade_height,
+        post_upgrade_height,
+        ?pre_upgrade_root_hash,
+        ?post_upgrade_root_hash,
+        duration = migration_duration.as_secs(),
+        "successful migration!"
+    );
+
+    Ok(())
+}

--- a/crates/bin/pmonitor/Cargo.toml
+++ b/crates/bin/pmonitor/Cargo.toml
@@ -24,7 +24,7 @@ colored = "2.1.0"
 directories = {workspace = true}
 futures = {workspace = true}
 indicatif = {workspace = true}
-pcli = {version = "2.0.0-alpha.0", path = "../pcli", default-features = true}
+pcli = {version = "2.0.0-alpha.1", path = "../pcli", default-features = true}
 penumbra-sdk-app = {workspace = true}
 penumbra-sdk-asset = {workspace = true, default-features = false}
 penumbra-sdk-compact-block = {workspace = true, default-features = false}

--- a/crates/core/app/src/app_version/component.rs
+++ b/crates/core/app/src/app_version/component.rs
@@ -30,7 +30,9 @@ enum CheckContext {
 
 /// Check that the expected version matches the found version, if it set.
 /// This will return an error if the versions do not match.
+#[tracing::instrument]
 fn check_version(ctx: CheckContext, expected: u64, found: Option<u64>) -> anyhow::Result<()> {
+    tracing::debug!("running version check");
     let found = found.unwrap_or(expected);
     if found == expected {
         return Ok(());

--- a/crates/custody/Cargo.toml
+++ b/crates/custody/Cargo.toml
@@ -17,7 +17,7 @@ blake2b_simd = {workspace = true}
 bytes = {workspace = true, features = ["serde"]}
 chacha20poly1305 = {workspace = true}
 decaf377 = {workspace = true}
-decaf377-frost = { version = "2.0.0-alpha.0", path = "../crypto/decaf377-frost" }
+decaf377-frost = { version = "2.0.0-alpha.1", path = "../crypto/decaf377-frost" }
 decaf377-ka = {workspace = true}
 decaf377-rdsa = {workspace = true}
 ed25519-consensus = {workspace = true}


### PR DESCRIPTION

## Describe your changes

Follow-up to #5073, which should have included a no-op migration.

## Issue ticket number and link

Towards #5010. 

## Testing and review

This work will  be used to perform a chain upgrade on the PL testnet. Once that's done, we should expect CI to pass fully on this PR, in particular the "testnet-integration" suite.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > provides migration logic for proposed protocol-breaking changes