### PR TITLE
Bugfix: LQT effect hash calculation

### DIFF
--- a/crates/core/component/funding/src/liquidity_tournament/action/mod.rs
+++ b/crates/core/component/funding/src/liquidity_tournament/action/mod.rs
@@ -96,6 +96,12 @@ impl From<LiquidityTournamentVoteBody> for pb::LiquidityTournamentVoteBody {
     }
 }
 
+impl EffectingData for LiquidityTournamentVoteBody {
+    fn effect_hash(&self) -> EffectHash {
+        EffectHash::from_proto_effecting_data(&self.to_proto())
+    }
+}
+
 /// The action used to vote in the liquidity tournament.
 ///
 /// This vote is towards a particular asset whose liquidity should be incentivized,
@@ -148,7 +154,7 @@ impl From<ActionLiquidityTournamentVote> for pb::ActionLiquidityTournamentVote {
 
 impl EffectingData for ActionLiquidityTournamentVote {
     fn effect_hash(&self) -> EffectHash {
-        EffectHash::from_proto_effecting_data(&self.to_proto())
+        self.body.effect_hash()
     }
 }
 


### PR DESCRIPTION
## Describe your changes

Seems like the effect hash calculation for LQT votes was wrong, in that it erroneously included the authorization data and proof, which would make such actions effectively impossible to construct.

This corrects things so that the effect hash is only calculated over the actual body of the vote.

Testing deferred.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This breaks consensus not only with main, but also with the tentatively applied testnet upgrade :grimacing: 
