### PR TITLE
lqt: wire action handlers for vote action

### DIFF
--- a/crates/core/app/src/action_handler/actions.rs
+++ b/crates/core/app/src/action_handler/actions.rs
@@ -56,7 +56,7 @@ impl AppActionHandler for Action {
             Action::ActionDutchAuctionSchedule(action) => action.check_stateless(()).await,
             Action::ActionDutchAuctionEnd(action) => action.check_stateless(()).await,
             Action::ActionDutchAuctionWithdraw(action) => action.check_stateless(()).await,
-            Action::ActionLiquidityTournamentVote(_action) => todo!(),
+            Action::ActionLiquidityTournamentVote(action) => action.check_stateless(context).await,
         }
     }
 
@@ -98,7 +98,7 @@ impl AppActionHandler for Action {
             Action::ActionDutchAuctionSchedule(action) => action.check_historical(state).await,
             Action::ActionDutchAuctionEnd(action) => action.check_historical(state).await,
             Action::ActionDutchAuctionWithdraw(action) => action.check_historical(state).await,
-            Action::ActionLiquidityTournamentVote(_action) => todo!(),
+            Action::ActionLiquidityTournamentVote(action) => action.check_historical(state).await,
         }
     }
 
@@ -140,7 +140,7 @@ impl AppActionHandler for Action {
             Action::ActionDutchAuctionSchedule(action) => action.check_and_execute(state).await,
             Action::ActionDutchAuctionEnd(action) => action.check_and_execute(state).await,
             Action::ActionDutchAuctionWithdraw(action) => action.check_and_execute(state).await,
-            Action::ActionLiquidityTournamentVote(_action) => todo!(),
+            Action::ActionLiquidityTournamentVote(action) => action.check_and_execute(state).await,
         }
     }
 }


### PR DESCRIPTION
Previously we had a todo!() there, woops.

I've actually tested that this, combined with changes in another staged pr, allow one to submit votes.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Consensus breaking relative to testnet too.
