### PR TITLE
chore: bump lqt version to 2.0.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "cometindex"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-frost"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "ark-ff",
  "decaf377",
@@ -4373,7 +4373,7 @@ dependencies = [
 
 [[package]]
 name = "pcli"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4457,7 +4457,7 @@ dependencies = [
 
 [[package]]
 name = "pclientd"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "pd"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-app"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4747,7 +4747,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-app-tests"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-asset"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auction"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4932,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-auto-https"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "axum-server",
@@ -4944,7 +4944,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-bench"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -4988,7 +4988,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-community-pool"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-compact-block"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-custody"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-dex"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5153,7 +5153,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-distributions"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5172,7 +5172,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-eddy"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-fee"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-funding"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-groth16",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-governance"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5307,7 +5307,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-ibc"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-keys"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "aes",
  "anyhow",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-measure"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-mock-client"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "cnidarium",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-mock-consensus"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-mock-tendermint-proxy"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "hex",
  "pbjson-types",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-num"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5502,7 +5502,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-parameter-setup"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "ark-groth16",
  "ark-serialize",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-params"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proof-setup"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5574,7 +5574,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proto"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5609,7 +5609,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-sct"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5646,7 +5646,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-shielded-pool"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5700,7 +5700,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-stake"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct-property-test"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "futures",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct-visualize"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -5828,7 +5828,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tendermint-proxy"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5860,7 +5860,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-test-subscriber"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -5868,7 +5868,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tower-trace"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "futures",
  "hex",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-transaction"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5945,7 +5945,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-txhash"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
@@ -5958,7 +5958,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-view"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -6017,7 +6017,7 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-wallet"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -6103,7 +6103,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pindexer"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6206,7 +6206,7 @@ dependencies = [
 
 [[package]]
 name = "pmonitor"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8224,7 +8224,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "summonerd"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "ark-groth16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ rate-limit = { existing-packages = 50 }
 [workspace.package]
 authors    = ["Penumbra Labs <team@penumbralabs.xyz"]
 edition    = "2021"
-version    = "2.0.0-alpha.1"
+version    = "2.0.0-alpha.2"
 repository = "https://github.com/penumbra-zone/penumbra"
 homepage   = "https://penumbra.zone"
 license    = "MIT OR Apache-2.0"
@@ -142,12 +142,12 @@ chacha20poly1305                 = { version = "0.9.0" }
 chrono                           = { default-features = false, version = "0.4" }
 clap                             = { version = "3.2" }
 cnidarium                        = { version = "0.83", default-features = false}
-cnidarium-component              = { default-features = false, version = "2.0.0-alpha.1", path = "crates/cnidarium-component" }
-cometindex                       = { version = "2.0.0-alpha.1", path = "crates/util/cometindex" }
+cnidarium-component              = { default-features = false, version = "2.0.0-alpha.2", path = "crates/cnidarium-component" }
+cometindex                       = { version = "2.0.0-alpha.2", path = "crates/util/cometindex" }
 criterion                        = { version = "0.4" }
 decaf377                         = { default-features = false, version = "0.10.1" }
-decaf377-fmd                     = { version = "2.0.0-alpha.1", path = "crates/crypto/decaf377-fmd" }
-decaf377-ka                      = { version = "2.0.0-alpha.1", path = "crates/crypto/decaf377-ka" }
+decaf377-fmd                     = { version = "2.0.0-alpha.2", path = "crates/crypto/decaf377-fmd" }
+decaf377-ka                      = { version = "2.0.0-alpha.2", path = "crates/crypto/decaf377-ka" }
 decaf377-rdsa                    = { version = "0.11.0" }
 derivative                       = { version = "2.2" }
 directories                      = { version = "4.0.1" }
@@ -175,36 +175,36 @@ once_cell                        = { version = "1.8" }
 parking_lot                      = { version = "0.12.1" }
 pbjson                           = { version = "0.7.0" }
 pbjson-types                     = { version = "0.7.0" }
-penumbra-sdk-app                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/app" }
-penumbra-sdk-asset                   = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/asset" }
-penumbra-sdk-community-pool          = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/community-pool" }
-penumbra-sdk-compact-block           = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/compact-block" }
-penumbra-sdk-custody                 = { version = "2.0.0-alpha.1", path = "crates/custody" }
-penumbra-sdk-auction                 = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/auction" }
-penumbra-sdk-dex                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/dex" }
-penumbra-sdk-distributions           = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/distributions" }
-penumbra-sdk-fee                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/fee" }
-penumbra-sdk-funding                 = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/funding" }
-penumbra-sdk-governance              = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/governance" }
-penumbra-sdk-ibc                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/ibc" }
-penumbra-sdk-keys                    = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/keys" }
-penumbra-sdk-mock-client             = { version = "2.0.0-alpha.1", path = "crates/test/mock-client" }
-penumbra-sdk-mock-consensus          = { version = "2.0.0-alpha.1", path = "crates/test/mock-consensus" }
-penumbra-sdk-mock-tendermint-proxy   = { version = "2.0.0-alpha.1", path = "crates/test/mock-tendermint-proxy" }
-penumbra-sdk-num                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/num" }
-penumbra-sdk-proof-params            = { default-features = false, version = "2.0.0-alpha.1", path = "crates/crypto/proof-params" }
-penumbra-sdk-proof-setup             = { version = "2.0.0-alpha.1", path = "crates/crypto/proof-setup" }
-penumbra-sdk-proto                   = { default-features = false, version = "2.0.0-alpha.1", path = "crates/proto" }
-penumbra-sdk-sct                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/sct" }
-penumbra-sdk-shielded-pool           = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/shielded-pool" }
-penumbra-sdk-stake                   = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/component/stake" }
-penumbra-sdk-tct                     = { default-features = false, version = "2.0.0-alpha.1", path = "crates/crypto/tct" }
-penumbra-sdk-test-subscriber         = { version = "2.0.0-alpha.1", path = "crates/test/tracing-subscriber" }
-penumbra-sdk-tower-trace             = { version = "2.0.0-alpha.1", path = "crates/util/tower-trace" }
-penumbra-sdk-transaction             = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/transaction" }
-penumbra-sdk-txhash                  = { default-features = false, version = "2.0.0-alpha.1", path = "crates/core/txhash" }
-penumbra-sdk-view                    = { version = "2.0.0-alpha.1", path = "crates/view" }
-penumbra-sdk-wallet                  = { version = "2.0.0-alpha.1", path = "crates/wallet" }
+penumbra-sdk-app                     = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/app" }
+penumbra-sdk-asset                   = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/asset" }
+penumbra-sdk-community-pool          = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/component/community-pool" }
+penumbra-sdk-compact-block           = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/component/compact-block" }
+penumbra-sdk-custody                 = { version = "2.0.0-alpha.2", path = "crates/custody" }
+penumbra-sdk-auction                 = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/component/auction" }
+penumbra-sdk-dex                     = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/component/dex" }
+penumbra-sdk-distributions           = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/component/distributions" }
+penumbra-sdk-fee                     = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/component/fee" }
+penumbra-sdk-funding                 = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/component/funding" }
+penumbra-sdk-governance              = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/component/governance" }
+penumbra-sdk-ibc                     = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/component/ibc" }
+penumbra-sdk-keys                    = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/keys" }
+penumbra-sdk-mock-client             = { version = "2.0.0-alpha.2", path = "crates/test/mock-client" }
+penumbra-sdk-mock-consensus          = { version = "2.0.0-alpha.2", path = "crates/test/mock-consensus" }
+penumbra-sdk-mock-tendermint-proxy   = { version = "2.0.0-alpha.2", path = "crates/test/mock-tendermint-proxy" }
+penumbra-sdk-num                     = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/num" }
+penumbra-sdk-proof-params            = { default-features = false, version = "2.0.0-alpha.2", path = "crates/crypto/proof-params" }
+penumbra-sdk-proof-setup             = { version = "2.0.0-alpha.2", path = "crates/crypto/proof-setup" }
+penumbra-sdk-proto                   = { default-features = false, version = "2.0.0-alpha.2", path = "crates/proto" }
+penumbra-sdk-sct                     = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/component/sct" }
+penumbra-sdk-shielded-pool           = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/component/shielded-pool" }
+penumbra-sdk-stake                   = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/component/stake" }
+penumbra-sdk-tct                     = { default-features = false, version = "2.0.0-alpha.2", path = "crates/crypto/tct" }
+penumbra-sdk-test-subscriber         = { version = "2.0.0-alpha.2", path = "crates/test/tracing-subscriber" }
+penumbra-sdk-tower-trace             = { version = "2.0.0-alpha.2", path = "crates/util/tower-trace" }
+penumbra-sdk-transaction             = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/transaction" }
+penumbra-sdk-txhash                  = { default-features = false, version = "2.0.0-alpha.2", path = "crates/core/txhash" }
+penumbra-sdk-view                    = { version = "2.0.0-alpha.2", path = "crates/view" }
+penumbra-sdk-wallet                  = { version = "2.0.0-alpha.2", path = "crates/wallet" }
 pin-project                      = { version = "1.0.12" }
 pin-project-lite                 = { version = "0.2.9" }
 poseidon377                      = { version = "1.2.0" }

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -61,7 +61,7 @@ once_cell                        = { workspace = true }
 pbjson-types                     = { workspace = true }
 penumbra-sdk-app                     = { workspace = true, default-features = true }
 penumbra-sdk-asset                   = { workspace = true, default-features = true }
-penumbra-sdk-auto-https              = { version = "2.0.0-alpha.1", path = "../../util/auto-https" }
+penumbra-sdk-auto-https              = { version = "2.0.0-alpha.2", path = "../../util/auto-https" }
 penumbra-sdk-compact-block           = { workspace = true, default-features = true }
 penumbra-sdk-custody                 = { workspace = true }
 penumbra-sdk-auction                 = { workspace = true, features = ["parallel"], default-features = true }
@@ -76,7 +76,7 @@ penumbra-sdk-sct                     = { workspace = true, default-features = tr
 penumbra-sdk-shielded-pool           = { workspace = true, features = ["parallel"], default-features = true }
 penumbra-sdk-stake                   = { workspace = true, features = ["parallel"], default-features = true }
 penumbra-sdk-tct                     = { workspace = true, default-features = true }
-penumbra-sdk-tendermint-proxy        = { version = "2.0.0-alpha.1", path = "../../util/tendermint-proxy" }
+penumbra-sdk-tendermint-proxy        = { version = "2.0.0-alpha.2", path = "../../util/tendermint-proxy" }
 penumbra-sdk-tower-trace             = { workspace = true }
 penumbra-sdk-transaction             = { workspace = true, default-features = true }
 pin-project                      = { workspace = true }

--- a/crates/bin/pmonitor/Cargo.toml
+++ b/crates/bin/pmonitor/Cargo.toml
@@ -24,7 +24,7 @@ colored = "2.1.0"
 directories = {workspace = true}
 futures = {workspace = true}
 indicatif = {workspace = true}
-pcli = {version = "2.0.0-alpha.1", path = "../pcli", default-features = true}
+pcli = {version = "2.0.0-alpha.2", path = "../pcli", default-features = true}
 penumbra-sdk-app = {workspace = true}
 penumbra-sdk-asset = {workspace = true, default-features = false}
 penumbra-sdk-compact-block = {workspace = true, default-features = false}

--- a/crates/custody/Cargo.toml
+++ b/crates/custody/Cargo.toml
@@ -17,7 +17,7 @@ blake2b_simd = {workspace = true}
 bytes = {workspace = true, features = ["serde"]}
 chacha20poly1305 = {workspace = true}
 decaf377 = {workspace = true}
-decaf377-frost = { version = "2.0.0-alpha.1", path = "../crypto/decaf377-frost" }
+decaf377-frost = { version = "2.0.0-alpha.2", path = "../crypto/decaf377-frost" }
 decaf377-ka = {workspace = true}
 decaf377-rdsa = {workspace = true}
 ed25519-consensus = {workspace = true}


### PR DESCRIPTION
## Describe your changes

Bumps the version in the LQT branch. Doing this to disambiguate between active versions, in order to roll out https://github.com/penumbra-zone/penumbra/pull/5075 to the active testnet.

## Issue ticket number and link

Refs #5010, #5075.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > version info only, no code changes
