### PR TITLE
LQT: adjust budget every block

### DIFF
--- a/crates/core/component/distributions/src/event.rs
+++ b/crates/core/component/distributions/src/event.rs
@@ -1,15 +1,47 @@
+use anyhow::{anyhow, Context as _};
 use penumbra_sdk_num::Amount;
-use penumbra_sdk_proto::penumbra::core::component::distributions::v1 as pb;
+use penumbra_sdk_proto::{
+    penumbra::core::component::distributions::v1 as pb, DomainType, Name as _,
+};
 
-/// Event for when LQT pool size increases.
-pub fn event_lqt_pool_size_increase(
-    epoch: u64,
-    increase: Amount,
-    new_total: Amount,
-) -> pb::EventLqtPoolSizeIncrease {
-    pb::EventLqtPoolSizeIncrease {
-        epoch,
-        increase: Some(increase.into()),
-        new_total: Some(new_total.into()),
+#[derive(Clone, Debug)]
+pub struct EventLqtPoolSizeIncrease {
+    pub epoch_index: u64,
+    pub increase: Amount,
+    pub new_total: Amount,
+}
+
+impl TryFrom<pb::EventLqtPoolSizeIncrease> for EventLqtPoolSizeIncrease {
+    type Error = anyhow::Error;
+
+    fn try_from(value: pb::EventLqtPoolSizeIncrease) -> Result<Self, Self::Error> {
+        fn inner(value: pb::EventLqtPoolSizeIncrease) -> anyhow::Result<EventLqtPoolSizeIncrease> {
+            Ok(EventLqtPoolSizeIncrease {
+                epoch_index: value.epoch,
+                increase: value
+                    .increase
+                    .ok_or(anyhow!("missing `increase`"))?
+                    .try_into()?,
+                new_total: value
+                    .new_total
+                    .ok_or(anyhow!("missing `new_total`"))?
+                    .try_into()?,
+            })
+        }
+        inner(value).context(format!("parsing {}", pb::EventLqtPoolSizeIncrease::NAME))
     }
+}
+
+impl From<EventLqtPoolSizeIncrease> for pb::EventLqtPoolSizeIncrease {
+    fn from(value: EventLqtPoolSizeIncrease) -> Self {
+        Self {
+            epoch: value.epoch_index,
+            increase: Some(value.increase.into()),
+            new_total: Some(value.new_total.into()),
+        }
+    }
+}
+
+impl DomainType for EventLqtPoolSizeIncrease {
+    type Proto = pb::EventLqtPoolSizeIncrease;
 }


### PR DESCRIPTION
## Describe your changes

This adjusts the issuance budget every block, incrementing it by the issuance per block, every block, rather than clobbering the current value with `issuance_per_block * how_long_the_epoch_was` at the end of an epoch. This has the effects of:

- making the value always match that claimed by the events, simplifying indexing,
- seamlessly rolling over un-issued rewards to the next epoch,
- simplifying the code.

I also pushed a small change to use a proper Event struct.

Testing deferred.

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This breaks consensus, but I think this can be applied to the testnet just by pushing the change to the majority validator, which will then issue the incorrect reward amount for exactly one epoch. This has no bearing on any eventual mainnet upgrade. We could avoid this by using a second state key, but putting in this scar tissue seems more performative than actually valuable, given that the upgrade isn't in a final state yet.
