### PR TITLE
chore: update minifront bundled assets

### DIFF
--- a/assets/minifront.zip
+++ b/assets/minifront.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e23fb7643dd546be0cfa0a6f1f7df0db8837b18cbe9cd6ce0be49f9f6b5d24c1
-size 5253302
+oid sha256:4d63d5dd7c2147b66998ec7559bae3d8edb3ceae43ac8d71f01e90fc3e1b423f
+size 8334728

--- a/assets/node-status.zip
+++ b/assets/node-status.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:229f92d0de1bc9d85fa2fae5e0ba063adc89a5487e11d1d144f3fb85d6ed1436
-size 1240860
+oid sha256:083280e107f251cfbf067e5528056ca80d13293c6ad4b01573f140ac39a547b4
+size 1243050


### PR DESCRIPTION
## Describe your changes

Built from head on web repo 28e2ccb6a8255f793866e5f59d8d334ab32510ad. Tested locally, and I see the new version displayed in my local browser, in the footer. 

## Issue ticket number and link

Closes #4965.

## Testing and review

If you have the patience, pull down this branch and use a local node with prax. On the frontend page, you should see:

![minifront-bundle-after](https://github.com/user-attachments/assets/af2ae518-bd2b-4b8d-b0d1-2e09ed1754d6)

Which maps to this commit: https://github.com/penumbra-zone/web/commit/28e2ccb6a8255f793866e5f59d8d334ab32510ad and notably includes the skip widget fix immediately preceding it, in https://github.com/penumbra-zone/web/commit/03597b714d0025d564d3535e9bb6fdec4d81c006

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > no changes to consensus logic, just updating the already-merged web ui changes, to keep the bundled pd version up to date.
