### PR TITLE
ci: disable testnet integration tests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -67,26 +67,27 @@ jobs:
         run: nix develop --command just integration-pmonitor
 
   # Integration tests that run against the public testnet endpoints.
-  # Temporarily enabling these in CI, to provide assurance during refactoring.
-  testnet:
-    runs-on: buildjet-16vcpu-ubuntu-2204
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-
-      - name: install nix
-        uses: nixbuild/nix-quick-install-action@v28
-
-      - name: setup nix cache
-        uses: nix-community/cache-nix-action@v5
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          backend: buildjet
-
-      - name: Load rust cache
-        uses: astriaorg/buildjet-rust-cache@v2.5.1
-
-      - name: run the testnet integration tests
-        run: nix develop --command just integration-testnet
+  # Temporarily disabling these in CI, as the testnet endpoints are
+  # incompatible with `main`, given GH5010.
+  # testnet:
+  #   runs-on: buildjet-16vcpu-ubuntu-2204
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         lfs: true
+  #
+  #     - name: install nix
+  #       uses: nixbuild/nix-quick-install-action@v28
+  #
+  #     - name: setup nix cache
+  #       uses: nix-community/cache-nix-action@v5
+  #       with:
+  #         primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+  #         restore-prefixes-first-match: nix-${{ runner.os }}-
+  #         backend: buildjet
+  #
+  #     - name: Load rust cache
+  #       uses: astriaorg/buildjet-rust-cache@v2.5.1
+  #
+  #     - name: run the testnet integration tests
+  #       run: nix develop --command just integration-testnet


### PR DESCRIPTION

## Describe your changes

<!--
Describe what's changed and why. If interactive testing is required, explain
to the reviewer how the PR should be tested.
-->
The testnet integration tests are failing PRs targeting main, because the checks assume the code being tested is compatible with the live testnet endpoints. That's not currently the case, due to ongoing LQT development #5010.

Refs https://github.com/penumbra-zone/penumbra/pull/5063#issuecomment-2657853174

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > ci-only, no changes to app code.
