### PR TITLE
Some cometindex robustness improvements

### DIFF
--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -1425,7 +1425,7 @@ impl AppView for Component {
         let mut charts = HashMap::new();
         let mut snapshots = HashMap::new();
         let mut last_time = None;
-        for block in batch.by_height.iter() {
+        for block in batch.events_by_block() {
             let mut events = Events::extract(&block)?;
             let time = events
                 .time

--- a/crates/util/cometindex/src/indexer/indexing_state.rs
+++ b/crates/util/cometindex/src/indexer/indexing_state.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use futures::TryStreamExt;
 use sqlx::{postgres::PgPoolOptions, PgPool, Postgres, Transaction};
@@ -55,6 +55,12 @@ impl Height {
 impl From<u64> for Height {
     fn from(value: u64) -> Self {
         Self(value)
+    }
+}
+
+impl From<Height> for u64 {
+    fn from(value: Height) -> Self {
+        value.0
     }
 }
 
@@ -285,11 +291,7 @@ ORDER BY
             };
             height += 1;
         }
-        Ok(EventBatch {
-            first_height: first.0,
-            last_height: last.0,
-            by_height: Arc::new(by_height),
-        })
+        Ok(EventBatch::new(by_height))
     }
 
     pub async fn init(src_url: &str, dst_url: &str) -> anyhow::Result<Self> {

--- a/crates/util/cometindex/src/indexer/indexing_state.rs
+++ b/crates/util/cometindex/src/indexer/indexing_state.rs
@@ -265,11 +265,11 @@ ORDER BY
             assert!(e.block_height >= height);
             if e.block_height > height {
                 by_height.push(current_batch);
+                height = e.block_height;
                 current_batch = BlockEvents {
                     height,
                     events: Vec::with_capacity(WORKING_CAPACITY),
                 };
-                height = e.block_height;
             }
             current_batch.events.push(e);
         }
@@ -285,11 +285,11 @@ ORDER BY
         // the final block.
         while height <= last.0 {
             by_height.push(current_batch);
+            height += 1;
             current_batch = BlockEvents {
                 height,
                 events: Vec::new(),
             };
-            height += 1;
         }
         Ok(EventBatch::new(by_height))
     }

--- a/crates/util/cometindex/src/indexer/indexing_state.rs
+++ b/crates/util/cometindex/src/indexer/indexing_state.rs
@@ -268,6 +268,15 @@ ORDER BY
             current_batch.events.push(e);
         }
         // Flush the current block, and create empty ones for the remaining heights.
+        //
+        // This is the correct behavior *assuming* that the caller has already checked
+        // that the raw events database has indexed all the blocks up to and including
+        // the provided last height. In that case, imagine if there were never any events
+        // at all. In that case, what we would need to do is to push empty blocks
+        // starting from `first` and up to and including `last`.
+        //
+        // Usually, there are events every block, so this code just serves to push
+        // the final block.
         while height <= last.0 {
             by_height.push(current_batch);
             current_batch = BlockEvents {


### PR DESCRIPTION
## Describe your changes

This tweaks the indexing logic in cometindex to add a bit of extra robustness against indexing the same block twice. The current logic is to generate batches of events, which are then sent over to logical threads for each app view, the idea being to only read each batch once, avoiding duplicate database fetching work from each thread, while allowing parallel processing. One potential race condition which might have been the cause of some oddities we've seen around duplicate processing is that each thread would process the entire batch as long as the next height it needed to index was somewhere inside of that batch. In practice, if the threads were in sync, this would be fine, but if for whatever reason they got desynced (e.g. one app view crashes because there's a bug or some weird data thing, then we patch the bug and restart pindexer, or cometindex dies when some indices have committed a batch, but not others, which can totally happen because some indices are faster than other), it's possible that this might lead to some threads processing some events twice. This adds some logic to truncate the events in each thread so that only the blocks that particular thread needs are indexed.

I also did a pass over on the rest of the indexing logic, and added a comment on a particularly tricky section, justifying its correctness.

CI should be sufficient to test this. We shouldn't observe any difference in behavior.


## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only
