### PR TITLE
lqt: implement basic indexing for testing purposes

### DIFF
--- a/crates/bin/pindexer/src/lqt/mod.rs
+++ b/crates/bin/pindexer/src/lqt/mod.rs
@@ -1,0 +1,75 @@
+use anyhow::anyhow;
+use cometindex::{
+    async_trait, index::EventBatch, sqlx, AppView, ContextualizedEvent, PgTransaction,
+};
+use penumbra_sdk_funding::event::{EventLqtDelegatorReward, EventLqtPositionReward, EventLqtVote};
+use penumbra_sdk_proto::event::EventDomainType;
+
+#[derive(Debug)]
+pub struct Lqt {}
+
+impl Lqt {
+    async fn index_event(
+        &self,
+        dbtx: &mut PgTransaction<'_>,
+        event: &ContextualizedEvent,
+    ) -> anyhow::Result<()> {
+        if let Ok(e) = EventLqtVote::try_from_event(&event.event) {
+            sqlx::query("INSERT INTO lqt_votes VALUES (DEFAULT, $1, $2, $3, $4, $5)")
+                .bind(i64::try_from(e.epoch_index)?)
+                .bind(&e.incentivized_asset_id.to_bytes())
+                .bind(i64::try_from(e.voting_power.value())?)
+                .bind(&e.tx_id.0)
+                .bind(&e.rewards_recipient.to_vec())
+                .execute(dbtx.as_mut())
+                .await?;
+        } else if let Ok(e) = EventLqtDelegatorReward::try_from_event(&event.event) {
+            sqlx::query("INSERT INTO lqt_delegator_rewards VALUES (DEFAULT, $1, $2, $3, $4)")
+                .bind(i64::try_from(e.epoch_index)?)
+                .bind(i64::try_from(e.reward_amount.value())?)
+                .bind(&e.rewards_recipient.to_vec())
+                .bind(&e.incentivized_asset_id.to_bytes())
+                .execute(dbtx.as_mut())
+                .await?;
+        } else if let Ok(e) = EventLqtPositionReward::try_from_event(&event.event) {
+            sqlx::query("INSERT INTO lqt_delegator_rewards VALUES (DEFAULT, $1, $2, $3, $4, $5::NUMERIC, $6::NUMERIC)")
+                .bind(i64::try_from(e.epoch_index)?)
+                .bind(i64::try_from(e.reward_amount.value())?)
+                .bind(&e.position_id.0)
+                .bind(&e.incentivized_asset_id.to_bytes())
+                .bind(e.tournament_volume.to_string())
+                .bind(e.position_volume.to_string())
+                .execute(dbtx.as_mut())
+                .await?;
+        }
+    }
+}
+
+#[async_trait]
+impl AppView for Lqt {
+    async fn init_chain(
+        &self,
+        dbtx: &mut PgTransaction,
+        _: &serde_json::Value,
+    ) -> Result<(), anyhow::Error> {
+        for statement in include_str!("schema.sql").split(";") {
+            sqlx::query(statement).execute(dbtx.as_mut()).await?;
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> String {
+        "lqt".to_string()
+    }
+
+    async fn index_batch(
+        &self,
+        dbtx: &mut PgTransaction,
+        batch: EventBatch,
+    ) -> Result<(), anyhow::Error> {
+        for event in batch.events() {
+            self.index_event(dbtx, event).await?;
+        }
+        Ok(())
+    }
+}

--- a/crates/bin/pindexer/src/lqt/schema.sql
+++ b/crates/bin/pindexer/src/lqt/schema.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS lqt_votes (
+    id SERIAL PRIMARY KEY,
+    epoch INTEGER NOT NULL,
+    incentivized BYTEA NOT NULL,
+    power BIGINT NOT NULL,
+    tx_id BYTEA NOT NULL,
+    rewards_recipient BYTEA NOT NULL
+);
+
+CREATE INDEX ON lqt_votes (epoch, incentivized);
+
+CREATE TABLE IF NOT EXISTS lqt_delegator_rewards (
+    id SERIAL PRIMARY KEY,  
+    epoch INTEGER NOT NULL,
+    reward BIGINT NOT NULL,
+    rewards_recipieint BYTEA NOT NULL,
+    incentivized BYTEA NOT NULL
+);
+
+CREATE INDEX ON lqt_delegator_rewards (epoch);
+
+CREATE TABLE IF NOT EXISTS lqt_position_rewards (
+    id SERIAL PRIMARY KEY,  
+    epoch INTEGER NOT NULL,
+    reward BIGINT NOT NULL,
+    position BYTEA NOT NULL,
+    incentivized BYTEA NOT NULL,
+    pair_volume NUMERIC(39) NOT NULL,
+    position_volume NUMERIC(39) NOT NULL
+);
+
+CREATE INDEX ON lqt_position_rewards (epoch);


### PR DESCRIPTION
## Describe your changes

I expect that we'll want to get rid of this code when we have an actually useful presentation of the data, but in the meantime, this provides a useful stub of indexing LQT stuff, and is useful in testing that the end to end flow of events works.

I ran this on a devnet, and saw events matching what I saw in pcli, and with the parameters I had set for rewards.

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Indexing only
