### PR TITLE
ci: workflow for publishing crates

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,0 +1,44 @@
+name: crates.io publishing
+
+permissions:
+  contents: write
+
+on:
+  push:
+    # Run on all tag formats.
+    tags:
+      - '**[0-9]+.[0-9]+.[0-9]+*'
+  # Support ad-hoc calls, mostly for debugging.
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: buildjet-16vcpu-ubuntu-2204
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: install nix
+        uses: nixbuild/nix-quick-install-action@v28
+
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
+
+      - name: Load rust cache
+        uses: astriaorg/buildjet-rust-cache@v2.5.1
+
+      # The `rust-toolchain.toml` file dictates which version of rust to setup.
+      - name: check rust version
+        run: nix develop --command rustc --version
+
+      # Publish the workspace to crates.io.
+      - name: publish crates
+        run: nix develop --command ./deployments/scripts/publish-crates


### PR DESCRIPTION
## Describe your changes
Adds a simple workflow to handle publishing the workspace's crates to crates.io. Will run whenever a new tag is pushed to the repo, and publish the crates under that tag.

## Issue ticket number and link

Closes #5005. Refs #5104, #4978.

## Testing and review

I've been handling the publication step manually, locally, after tagging release, to ensure that the script is stable enough to stick in automation. It's been well behaved for the past few minor releases, so let's try it out in automation. I'll handle verifying behavior post-merge, post-release.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > ci-only, no code changes