### PR TITLE
export `ClientStatus` and `ConsensusStateWriteExt` in ibc component

### DIFF
--- a/crates/core/component/ibc/src/component.rs
+++ b/crates/core/component/ibc/src/component.rs
@@ -26,6 +26,8 @@ use msg_handler::MsgHandler;
 pub use self::metrics::register_metrics;
 pub use channel::StateReadExt as ChannelStateReadExt;
 pub use channel::StateWriteExt as ChannelStateWriteExt;
+pub use client::ClientStatus;
+pub use client::ConsensusStateWriteExt;
 pub use client::StateReadExt as ClientStateReadExt;
 pub use client::StateWriteExt as ClientStateWriteExt;
 pub use connection::StateReadExt as ConnectionStateReadExt;

--- a/crates/core/component/ibc/src/component/client.rs
+++ b/crates/core/component/ibc/src/component/client.rs
@@ -29,6 +29,7 @@ use super::HostInterface;
 /// ClientStatus represents the current status of an IBC client.
 ///
 /// https://github.com/cosmos/ibc-go/blob/main/modules/core/exported/client.go#L30
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ClientStatus {
     /// Active is a status type of a client. An active client is allowed to be used.
     Active,


### PR DESCRIPTION
## Describe your changes

exported `ClientStatus` and `ConsensusStateWriteExt` types within the IBC component. these were already marked `pub`, but weren't exported outside of the module as `client` was private.

## Issue ticket number and link

n/a

## Checklist before requesting a review

- [ ] I have added guiding text to explain how a reviewer should test these changes.

- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > does not change any code logic, just exports types/adds derives
