### PR TITLE
docs: add pindexer and cometbft to rustdoc

### DIFF
--- a/deployments/scripts/rust-docs
+++ b/deployments/scripts/rust-docs
@@ -22,6 +22,7 @@ cargo +nightly doc --no-deps \
   -p ark-serialize \
   -p cnidarium \
   -p cnidarium-component \
+  -p cometindex \
   -p decaf377-fmd \
   -p decaf377-ka \
   -p decaf377-rdsa \
@@ -58,6 +59,7 @@ cargo +nightly doc --no-deps \
   -p penumbra-sdk-txhash \
   -p penumbra-sdk-view \
   -p penumbra-sdk-wallet \
+  -p pindexer \
   -p poseidon-permutation \
   -p poseidon377 \
   -p tendermint \


### PR DESCRIPTION


## Describe your changes

Eventually all the docs will be published on crates.io, but right now the binaries in particular aren't published from the workspace, so we'll continue to use `rustdoc` as a catch-all reference for developers learning the Rust API.

## Issue ticket number and link

N/A

## Testing and review

CI passing is enough: post-merge we should see the new docs on https://rustdoc.penumbra.zone.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > docs/CI only, no code changes
