### PR TITLE
ci: publish crates even from HEAD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,8 @@ push = false
 dependent-version = "upgrade"
 # Increase default ratelimit on publishing packages
 rate-limit = { existing-packages = 50 }
+# Permit publishing from any branch, because in GHA CI context, HEAD is checked out.
+allow-branch = ["*"]
 
 [workspace.package]
 authors    = ["Penumbra Labs <team@penumbralabs.xyz"]


### PR DESCRIPTION
## Describe your changes
Modifies the `cargo-release` config to permit releasing from the `HEAD` checkout created by GHA in CI. By default, cargo-release disallows `HEAD` via the `!HEAD` match, see docs at [0].

[0] https://github.com/crate-ci/cargo-release/blob/f7c2975325afc6d6fc1793544802a5578d9ef256/docs/reference.md

## Issue ticket number and link

Refs #5005.

## Testing and review

I need this change to land on main in order for it to be active in the release workflow. Shortly I'll publish 1.2.0 and observe behavior then. As long as CI is green on this PR, we're good to merge, then I'll follow up on next steps.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > CI/release logic only, no changes to app code
