### PR TITLE
pindexer: add context to indexing calls, to allow deferring work to after catchup

### DIFF
--- a/crates/bin/pindexer/src/block.rs
+++ b/crates/bin/pindexer/src/block.rs
@@ -1,4 +1,8 @@
-use cometindex::{async_trait, index::EventBatch, sqlx, AppView, PgTransaction};
+use cometindex::{
+    async_trait,
+    index::{EventBatch, EventBatchContext},
+    sqlx, AppView, PgTransaction,
+};
 use penumbra_sdk_proto::{core::component::sct::v1 as pb, event::ProtoEvent};
 use sqlx::types::chrono::DateTime;
 
@@ -35,6 +39,7 @@ CREATE TABLE IF NOT EXISTS block_details (
         &self,
         dbtx: &mut PgTransaction,
         batch: EventBatch,
+        _ctx: EventBatchContext,
     ) -> Result<(), anyhow::Error> {
         for event in batch.events() {
             let pe = match pb::EventBlockRoot::from_event(event.as_ref()) {

--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use cometindex::{
     async_trait,
-    index::{BlockEvents, EventBatch},
+    index::{BlockEvents, EventBatch, EventBatchContext},
     AppView, PgTransaction,
 };
 use penumbra_sdk_asset::asset;
@@ -1465,6 +1465,7 @@ impl AppView for Component {
         &self,
         dbtx: &mut PgTransaction,
         batch: EventBatch,
+        _ctx: EventBatchContext,
     ) -> Result<(), anyhow::Error> {
         metadata::set(dbtx, self.denom).await?;
         let mut charts = HashMap::new();

--- a/crates/bin/pindexer/src/governance.rs
+++ b/crates/bin/pindexer/src/governance.rs
@@ -1,6 +1,8 @@
 use anyhow::{anyhow, Context, Result};
 use cometindex::{
-    async_trait, index::EventBatch, sqlx, AppView, ContextualizedEvent, PgTransaction,
+    async_trait,
+    index::{EventBatch, EventBatchContext},
+    sqlx, AppView, ContextualizedEvent, PgTransaction,
 };
 use penumbra_sdk_governance::{
     proposal::ProposalPayloadToml, proposal_state, DelegatorVote, Proposal, ProposalDepositClaim,
@@ -325,6 +327,7 @@ impl AppView for GovernanceProposals {
         &self,
         dbtx: &mut PgTransaction,
         batch: EventBatch,
+        _ctx: EventBatchContext,
     ) -> Result<(), anyhow::Error> {
         for event in batch.events() {
             self.index_event(dbtx, event).await?;

--- a/crates/bin/pindexer/src/ibc/mod.rs
+++ b/crates/bin/pindexer/src/ibc/mod.rs
@@ -1,5 +1,9 @@
 use anyhow::anyhow;
-use cometindex::{async_trait, index::EventBatch, AppView, ContextualizedEvent, PgTransaction};
+use cometindex::{
+    async_trait,
+    index::{EventBatch, EventBatchContext},
+    AppView, ContextualizedEvent, PgTransaction,
+};
 use penumbra_sdk_asset::Value;
 use penumbra_sdk_keys::Address;
 use penumbra_sdk_proto::{
@@ -213,6 +217,7 @@ impl AppView for Component {
         &self,
         dbtx: &mut PgTransaction,
         batch: EventBatch,
+        _ctx: EventBatchContext,
     ) -> Result<(), anyhow::Error> {
         for event in batch.events() {
             let parsed = match Event::try_from(event) {

--- a/crates/bin/pindexer/src/insights/mod.rs
+++ b/crates/bin/pindexer/src/insights/mod.rs
@@ -1,7 +1,11 @@
 use ethnum::I256;
 use std::{collections::BTreeMap, iter};
 
-use cometindex::{async_trait, index::EventBatch, AppView, ContextualizedEvent, PgTransaction};
+use cometindex::{
+    async_trait,
+    index::{EventBatch, EventBatchContext},
+    AppView, ContextualizedEvent, PgTransaction,
+};
 use penumbra_sdk_app::genesis::Content;
 use penumbra_sdk_asset::{asset, STAKING_TOKEN_ASSET_ID};
 use penumbra_sdk_dex::{
@@ -518,6 +522,7 @@ impl AppView for Component {
         &self,
         dbtx: &mut PgTransaction,
         batch: EventBatch,
+        _ctx: EventBatchContext,
     ) -> Result<(), anyhow::Error> {
         for event in batch.events() {
             self.index_event(dbtx, event).await?;

--- a/crates/bin/pindexer/src/stake/delegation_txs.rs
+++ b/crates/bin/pindexer/src/stake/delegation_txs.rs
@@ -1,5 +1,9 @@
 use anyhow::{anyhow, Result};
-use cometindex::{async_trait, index::EventBatch, sqlx, AppView, PgTransaction};
+use cometindex::{
+    async_trait,
+    index::{EventBatch, EventBatchContext},
+    sqlx, AppView, PgTransaction,
+};
 use penumbra_sdk_num::Amount;
 use penumbra_sdk_proto::{core::component::stake::v1 as pb, event::ProtoEvent};
 use penumbra_sdk_stake::IdentityKey;
@@ -51,7 +55,12 @@ impl AppView for DelegationTxs {
         "stake/delegation_txs".to_string()
     }
 
-    async fn index_batch(&self, dbtx: &mut PgTransaction, batch: EventBatch) -> Result<()> {
+    async fn index_batch(
+        &self,
+        dbtx: &mut PgTransaction,
+        batch: EventBatch,
+        _ctx: EventBatchContext,
+    ) -> Result<()> {
         for event in batch.events() {
             let pe = match pb::EventDelegate::from_event(event.as_ref()) {
                 Ok(pe) => pe,

--- a/crates/bin/pindexer/src/stake/missed_blocks.rs
+++ b/crates/bin/pindexer/src/stake/missed_blocks.rs
@@ -1,5 +1,9 @@
 use anyhow::Result;
-use cometindex::{async_trait, index::EventBatch, sqlx, AppView, PgTransaction};
+use cometindex::{
+    async_trait,
+    index::{EventBatch, EventBatchContext},
+    sqlx, AppView, PgTransaction,
+};
 
 use penumbra_sdk_proto::{core::component::stake::v1 as pb, event::ProtoEvent};
 use penumbra_sdk_stake::IdentityKey;
@@ -53,6 +57,7 @@ impl AppView for MissedBlocks {
         &self,
         dbtx: &mut PgTransaction,
         batch: EventBatch,
+        _ctx: EventBatchContext,
     ) -> Result<(), anyhow::Error> {
         for event in batch.events() {
             let pe = match pb::EventValidatorMissedBlock::from_event(event.as_ref()) {

--- a/crates/bin/pindexer/src/stake/slashings.rs
+++ b/crates/bin/pindexer/src/stake/slashings.rs
@@ -1,6 +1,8 @@
 use anyhow::{anyhow, Result};
 use cometindex::{
-    async_trait, index::EventBatch, sqlx, AppView, ContextualizedEvent, PgTransaction,
+    async_trait,
+    index::{EventBatch, EventBatchContext},
+    sqlx, AppView, ContextualizedEvent, PgTransaction,
 };
 
 use penumbra_sdk_proto::{core::component::stake::v1 as pb, event::ProtoEvent};
@@ -89,6 +91,7 @@ impl AppView for Slashings {
         &self,
         dbtx: &mut PgTransaction,
         batch: EventBatch,
+        _ctx: EventBatchContext,
     ) -> Result<(), anyhow::Error> {
         for event in batch.events() {
             self.index_event(dbtx, event).await?;

--- a/crates/bin/pindexer/src/stake/undelegation_txs.rs
+++ b/crates/bin/pindexer/src/stake/undelegation_txs.rs
@@ -1,5 +1,9 @@
 use anyhow::{anyhow, Result};
-use cometindex::{async_trait, index::EventBatch, sqlx, AppView, PgTransaction};
+use cometindex::{
+    async_trait,
+    index::{EventBatch, EventBatchContext},
+    sqlx, AppView, PgTransaction,
+};
 use penumbra_sdk_num::Amount;
 use penumbra_sdk_proto::{core::component::stake::v1 as pb, event::ProtoEvent};
 use penumbra_sdk_stake::IdentityKey;
@@ -51,7 +55,12 @@ impl AppView for UndelegationTxs {
         "stake/undelegation_txs".to_string()
     }
 
-    async fn index_batch(&self, dbtx: &mut PgTransaction, batch: EventBatch) -> Result<()> {
+    async fn index_batch(
+        &self,
+        dbtx: &mut PgTransaction,
+        batch: EventBatch,
+        _ctx: EventBatchContext,
+    ) -> Result<()> {
         for event in batch.events() {
             let pe = match pb::EventUndelegate::from_event(event.as_ref()) {
                 Ok(pe) => pe,

--- a/crates/bin/pindexer/src/stake/validator_set.rs
+++ b/crates/bin/pindexer/src/stake/validator_set.rs
@@ -2,7 +2,9 @@ use std::collections::BTreeMap;
 
 use anyhow::{anyhow, Result};
 use cometindex::{
-    async_trait, index::EventBatch, sqlx, AppView, ContextualizedEvent, PgTransaction,
+    async_trait,
+    index::{EventBatch, EventBatchContext},
+    sqlx, AppView, ContextualizedEvent, PgTransaction,
 };
 
 use penumbra_sdk_app::genesis::Content;
@@ -144,6 +146,7 @@ impl AppView for ValidatorSet {
         &self,
         dbtx: &mut PgTransaction,
         batch: EventBatch,
+        _ctx: EventBatchContext,
     ) -> Result<(), anyhow::Error> {
         for event in batch.events() {
             self.index_event(dbtx, event).await?;

--- a/crates/bin/pindexer/src/supply.rs
+++ b/crates/bin/pindexer/src/supply.rs
@@ -2,7 +2,9 @@ use std::collections::BTreeMap;
 
 use anyhow::{anyhow, Result};
 use cometindex::{
-    async_trait, index::EventBatch, sqlx, AppView, ContextualizedEvent, PgTransaction,
+    async_trait,
+    index::{EventBatch, EventBatchContext},
+    sqlx, AppView, ContextualizedEvent, PgTransaction,
 };
 use penumbra_sdk_app::genesis::Content;
 use penumbra_sdk_asset::{asset, STAKING_TOKEN_ASSET_ID};
@@ -937,6 +939,7 @@ impl AppView for Component {
         &self,
         dbtx: &mut PgTransaction,
         batch: EventBatch,
+        _ctx: EventBatchContext,
     ) -> Result<(), anyhow::Error> {
         for event in batch.events() {
             let e = match Event::try_from(event) {

--- a/crates/util/cometindex/src/index.rs
+++ b/crates/util/cometindex/src/index.rs
@@ -144,6 +144,19 @@ impl EventBatch {
     }
 }
 
+/// Provides more information about the context a batch of event comes from.
+#[derive(Debug, Clone)]
+pub struct EventBatchContext {
+    pub(crate) is_last: bool,
+}
+
+impl EventBatchContext {
+    /// If true, then no further event batches will be sent before new blocks arrive.
+    pub fn is_last(&self) -> bool {
+        self.is_last
+    }
+}
+
 /// Represents a specific index of raw event data.
 #[async_trait]
 pub trait AppView: Send + Sync {
@@ -160,11 +173,10 @@ pub trait AppView: Send + Sync {
     ) -> Result<(), anyhow::Error>;
 
     /// This allows processing a batch of events, over many blocks.
-    ///
-    /// By using a batch, we can potentially avoid a costly
     async fn index_batch(
         &self,
         dbtx: &mut PgTransaction,
         batch: EventBatch,
+        context: EventBatchContext,
     ) -> Result<(), anyhow::Error>;
 }


### PR DESCRIPTION
## Describe your changes

Right now, every indexer gets called with a batch, with no good way of knowing whether or not more batches will follow. This creates unnecessary work. For example, the the dex explorer component, some tables exist only to provide a *current* summary of information. These only need to be computed once we've caught up to the tip of the chain. Any time we compute them before is wasted.

On the first 1_000_000 blocks, avoiding this summary computation saves 9 minutes, going from 21 minutes to 12.
The component (and others) could probably be re-architected in other ways to take advantage of this.

To test, run pindexer again, check that the results are the same, just computed a bit faster.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > REPLACE THIS TEXT WITH RATIONALE (CAN BE BRIEF)
