### PR TITLE
cometindex: be strict about event heights

### DIFF
--- a/crates/util/cometindex/src/indexer/indexing_state.rs
+++ b/crates/util/cometindex/src/indexer/indexing_state.rs
@@ -169,14 +169,12 @@ impl IndexingManager {
         sqlx::query_as::<_, (i64, String, Vec<u8>)>(
             r#"
 SELECT height, tx_hash, tx_result
-FROM tx_results
-LEFT JOIN LATERAL (
-    SELECT height FROM blocks WHERE blocks.rowid = tx_results.block_id LIMIT 1
-) ON TRUE
+FROM blocks
+JOIN tx_results ON blocks.rowid = tx_results.block_id
 WHERE
-    block_id >= (SELECT rowid FROM blocks where height = $1)
+    height >= $1
 AND
-    block_id <= (SELECT rowid FROM blocks where height = $2)
+    height <= $2
 "#,
         )
         .bind(first)
@@ -203,43 +201,31 @@ AND
             //   attach block
             //   attach transaction hash?
             r#"
-SELECT
-    events.rowid,
-    events.type,
-    events.height,
-    tx_results.tx_hash,
-    events.attrs
-FROM (
-    SELECT 
-        (SELECT height FROM blocks WHERE blocks.rowid = block_id) as height,
-        rowid, 
-        type, 
-        block_id,
-        tx_id,
-        jsonb_object_agg(attributes.key, attributes.value) AS attrs
-    FROM 
-        events 
-    LEFT JOIN
-        attributes ON rowid = attributes.event_id
-    WHERE
-        block_id >= (SELECT rowid FROM blocks where height = $1)
-    AND
-        block_id <= (SELECT rowid FROM blocks where height = $2)
-    GROUP BY 
-        rowid, 
-        type,
-        block_id, 
-        tx_id
-    ORDER BY
-        rowid ASC
-) events
-LEFT JOIN LATERAL (
-    SELECT * FROM tx_results WHERE tx_results.rowid = events.tx_id LIMIT 1
-) tx_results
-ON TRUE
-ORDER BY
-    events.rowid ASC
-        "#,
+WITH blocks AS (
+  SELECT * FROM blocks WHERE height >= $1 AND height <= $2
+),
+filtered_events AS (
+  SELECT e.block_id, e.rowid, e.type, e.tx_id, b.height
+  FROM events e
+  JOIN blocks b ON e.block_id = b.rowid
+),
+events_with_attrs AS (
+  SELECT
+      f.block_id,
+      f.rowid,
+      f.type,
+      f.tx_id,
+      f.height,
+      jsonb_object_agg(a.key, a.value) AS attrs
+  FROM filtered_events f
+  LEFT JOIN attributes a ON f.rowid = a.event_id
+  GROUP BY f.block_id, f.rowid, f.type, f.tx_id, f.height
+)
+SELECT e.rowid, e.type, e.height, tx.tx_hash, e.attrs
+FROM events_with_attrs e
+LEFT JOIN tx_results tx ON tx.rowid = e.tx_id
+ORDER BY e.height ASC, e.rowid ASC;
+"#,
         )
         .bind(first)
         .bind(last)


### PR DESCRIPTION
This adjusts the queries to make sure that only events and txes from the correct height range are returned, removing the assumption that block rowids are monotonic.

The query is also faster than it was before, from what I can tell.

This should paper over #5135 for now, but that might indicate an issue with our reindexing we should investigate.

Currently doing a pindexer run using this PR, that should be enough to test.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Indexing only
