### PR TITLE
Add an integrity check to cometindex / pindexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6123,6 +6123,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "tracing",
+ "tracing-subscriber 0.3.18",
  "url",
 ]
 

--- a/crates/bin/pindexer/Cargo.toml
+++ b/crates/bin/pindexer/Cargo.toml
@@ -41,6 +41,7 @@ penumbra-sdk-sct = {workspace = true, default-features = false}
 penumbra-sdk-transaction = {workspace = true, default-features = false}
 prost = {workspace = true}
 tracing = {workspace = true}
+tracing-subscriber = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
 serde_json = {workspace = true}
 serde = { workspace = true, features = ["derive"] }

--- a/crates/bin/pindexer/src/main.rs
+++ b/crates/bin/pindexer/src/main.rs
@@ -5,11 +5,17 @@ use pindexer::{Indexer, IndexerExt as _, Options};
 #[tokio::main]
 async fn main() -> Result<()> {
     let opts = Options::parse();
-    Indexer::new(opts.cometindex.clone())
-        .with_default_tracing()
-        .with_default_penumbra_app_views(&opts)
-        .run()
-        .await?;
+    let cometindex_opts = opts.cometindex.clone();
+    match cometindex_opts.command {
+        cometindex::opt::Command::Index(index_options) => {
+            Indexer::new(cometindex_opts.src_database_url, index_options)
+                .with_default_tracing()
+                .with_default_penumbra_app_views(&opts)
+                .run()
+                .await?;
+        }
+        cometindex::opt::Command::IntegrityCheck => todo!(),
+    }
 
     Ok(())
 }

--- a/crates/bin/pindexer/src/main.rs
+++ b/crates/bin/pindexer/src/main.rs
@@ -5,19 +5,11 @@ use pindexer::{Indexer, IndexerExt as _, Options};
 #[tokio::main]
 async fn main() -> Result<()> {
     let opts = Options::parse();
-    let cometindex_opts = opts.cometindex.clone();
-    match cometindex_opts.command {
-        cometindex::opt::Command::Index(index_options) => {
-            Indexer::new(cometindex_opts.src_database_url, index_options)
-                .with_default_tracing()
-                .with_default_penumbra_app_views(&opts)
-                .run()
-                .await?;
-        }
-        cometindex::opt::Command::IntegrityCheck => {
-            cometindex::integrity_check(&cometindex_opts.src_database_url).await?
-        }
-    }
+    Indexer::new(opts.cometindex.clone())
+        .with_default_tracing()
+        .with_default_penumbra_app_views(&opts)
+        .run()
+        .await?;
 
     Ok(())
 }

--- a/crates/bin/pindexer/src/main.rs
+++ b/crates/bin/pindexer/src/main.rs
@@ -14,7 +14,9 @@ async fn main() -> Result<()> {
                 .run()
                 .await?;
         }
-        cometindex::opt::Command::IntegrityCheck => todo!(),
+        cometindex::opt::Command::IntegrityCheck => {
+            cometindex::integrity_check(&cometindex_opts.src_database_url).await?
+        }
     }
 
     Ok(())

--- a/crates/util/cometindex/src/database.rs
+++ b/crates/util/cometindex/src/database.rs
@@ -1,0 +1,25 @@
+use sqlx::{postgres::PgPoolOptions, PgPool};
+
+/// Create a Database, with, for sanity, some read only settings.
+///
+/// These will be overrideable by a consumer who knows what they're doing,
+/// but prevents basic mistakes.
+/// c.f. https://github.com/launchbadge/sqlx/issues/481#issuecomment-727011811
+pub async fn read_only_db(url: &str) -> anyhow::Result<PgPool> {
+    PgPoolOptions::new()
+        .after_connect(|conn, _| {
+            Box::pin(async move {
+                sqlx::query("SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY;")
+                    .execute(conn)
+                    .await?;
+                Ok(())
+            })
+        })
+        .connect(url)
+        .await
+        .map_err(Into::into)
+}
+
+pub async fn read_write_db(url: &str) -> anyhow::Result<PgPool> {
+    PgPoolOptions::new().connect(url).await.map_err(Into::into)
+}

--- a/crates/util/cometindex/src/indexer.rs
+++ b/crates/util/cometindex/src/indexer.rs
@@ -2,7 +2,7 @@ mod indexing_state;
 
 use crate::{
     index::{EventBatch, EventBatchContext},
-    opt::Options,
+    opt::IndexOptions,
     AppView,
 };
 use anyhow::{Context as _, Result};
@@ -164,14 +164,16 @@ async fn catchup(
 }
 
 pub struct Indexer {
-    opts: Options,
+    opts: IndexOptions,
+    src_database_url: String,
     indices: Vec<Arc<dyn AppView>>,
 }
 
 impl Indexer {
-    pub fn new(opts: Options) -> Self {
+    pub fn new(src_database_url: String, opts: IndexOptions) -> Self {
         Self {
             opts,
+            src_database_url,
             indices: Vec::new(),
         }
     }
@@ -189,9 +191,9 @@ impl Indexer {
     pub async fn run(self) -> Result<(), anyhow::Error> {
         tracing::info!(?self.opts);
         let Self {
+            src_database_url,
             opts:
-                Options {
-                    src_database_url,
+                IndexOptions {
                     dst_database_url,
                     chain_id: _,
                     poll_ms,

--- a/crates/util/cometindex/src/integrity.rs
+++ b/crates/util/cometindex/src/integrity.rs
@@ -1,0 +1,55 @@
+use sqlx::PgPool;
+
+use crate::database::read_only_db;
+
+pub async fn missing_blocks(name: &'static str, db: PgPool) -> anyhow::Result<()> {
+    let mut dbtx = db.begin().await?;
+    let res: Option<(i64, i64)> = sqlx::query_as(
+        "
+      WITH height_gaps AS (
+        SELECT
+          height as current_height,
+          LEAD(height) OVER (ORDER BY height) as next_height,
+          LEAD(height) OVER (ORDER BY height) - height as gap
+        FROM blocks
+      )
+      SELECT
+        current_height,
+        next_height
+      FROM height_gaps
+      WHERE gap > 1 AND next_height IS NOT NULL
+      ORDER BY current_height ASC
+      LIMIT 1;
+    ",
+    )
+    .fetch_optional(dbtx.as_mut())
+    .await?;
+    dbtx.rollback().await?;
+    match res {
+        Some((current, next)) => {
+            eprintln!("{}:", name);
+            eprintln!("missing blocks between heights {} and {}", current, next);
+            anyhow::bail!("{} check failed", name);
+        }
+        None => {}
+    }
+    Ok(())
+}
+
+pub async fn integrity_check(src_database_url: &str) -> anyhow::Result<()> {
+    let db = read_only_db(src_database_url).await?;
+    let mut tasks = Vec::new();
+    tasks.push(tokio::spawn({
+        let db = db.clone();
+        async move { missing_blocks("# 000 Missing Blocks", db).await }
+    }));
+    let mut failed = false;
+    for task in tasks {
+        let res = task.await?;
+        failed |= res.is_err();
+    }
+    if failed {
+        anyhow::bail!("integrity checks failed, check logs");
+    }
+    Ok(())
+}

--- a/crates/util/cometindex/src/integrity.rs
+++ b/crates/util/cometindex/src/integrity.rs
@@ -2,7 +2,7 @@ use sqlx::PgPool;
 
 use crate::database::read_only_db;
 
-pub async fn missing_blocks(name: &'static str, db: PgPool) -> anyhow::Result<()> {
+pub async fn missing_blocks(name: &'static str, db: PgPool) -> anyhow::Result<bool> {
     let mut dbtx = db.begin().await?;
     let res: Option<(i64, i64)> = sqlx::query_as(
         "
@@ -25,15 +25,44 @@ pub async fn missing_blocks(name: &'static str, db: PgPool) -> anyhow::Result<()
     .fetch_optional(dbtx.as_mut())
     .await?;
     dbtx.rollback().await?;
-    match res {
-        Some((current, next)) => {
-            eprintln!("{}:", name);
-            eprintln!("missing blocks between heights {} and {}", current, next);
-            anyhow::bail!("{} check failed", name);
-        }
-        None => {}
+    if let Some((current, next)) = res {
+        println!("{}:", name);
+        println!("missing blocks between heights {} and {}", current, next);
+        return Ok(false);
     }
-    Ok(())
+    Ok(true)
+}
+
+async fn missing_events(name: &'static str, db: PgPool) -> anyhow::Result<bool> {
+    let mut dbtx = db.begin().await?;
+    let res: Option<(i64, i64, i64)> = sqlx::query_as(
+        "
+      WITH event_heights AS (
+        SELECT e.rowid, b.height,
+               LEAD(e.rowid) OVER (PARTITION BY b.height ORDER BY e.rowid) AS next_rowid
+        FROM events e
+        JOIN blocks b ON e.block_id = b.rowid
+      )
+      SELECT height, rowid, next_rowid
+      FROM event_heights
+      WHERE next_rowid IS NOT NULL
+      AND next_rowid - rowid <> 1
+      ORDER BY height ASC, rowid ASC
+      LIMIT 1;
+    ",
+    )
+    .fetch_optional(dbtx.as_mut())
+    .await?;
+    if let Some((height, next, current)) = res {
+        println!("{}:", name);
+        println!(
+            "missing events at height {}: missing between event #{} and #{}",
+            height, current, next
+        );
+        return Ok(false);
+    };
+    dbtx.rollback().await?;
+    Ok(true)
 }
 
 pub async fn integrity_check(src_database_url: &str) -> anyhow::Result<()> {
@@ -43,10 +72,13 @@ pub async fn integrity_check(src_database_url: &str) -> anyhow::Result<()> {
         let db = db.clone();
         async move { missing_blocks("# 000 Missing Blocks", db).await }
     }));
+    tasks.push(tokio::spawn({
+        let db = db.clone();
+        async move { missing_events("# 001 Missing Events", db).await }
+    }));
     let mut failed = false;
     for task in tasks {
-        let res = task.await?;
-        failed |= res.is_err();
+        failed |= !task.await??;
     }
     if failed {
         anyhow::bail!("integrity checks failed, check logs");

--- a/crates/util/cometindex/src/lib.rs
+++ b/crates/util/cometindex/src/lib.rs
@@ -1,11 +1,14 @@
 mod contextualized;
+pub(crate) mod database;
 pub mod index;
 pub mod indexer;
+mod integrity;
 pub mod opt;
 
 pub use contextualized::ContextualizedEvent;
 pub use index::{AppView, PgPool, PgTransaction};
 pub use indexer::Indexer;
+pub use integrity::integrity_check;
 
 pub use async_trait::async_trait;
 

--- a/crates/util/cometindex/src/lib.rs
+++ b/crates/util/cometindex/src/lib.rs
@@ -8,7 +8,6 @@ pub mod opt;
 pub use contextualized::ContextualizedEvent;
 pub use index::{AppView, PgPool, PgTransaction};
 pub use indexer::Indexer;
-pub use integrity::integrity_check;
 
 pub use async_trait::async_trait;
 

--- a/crates/util/cometindex/src/opt.rs
+++ b/crates/util/cometindex/src/opt.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, time::Duration};
 
 use anyhow::{Error, Result};
-use clap::{Parser, Subcommand};
+use clap::Parser;
 
 /// This struct represents the command-line options
 #[derive(Clone, Debug, Parser)]
@@ -15,23 +15,6 @@ pub struct Options {
     #[clap(short, long)]
     pub src_database_url: String,
 
-    #[clap(subcommand)]
-    pub command: Command,
-}
-
-#[derive(Clone, Debug, Subcommand)]
-pub enum Command {
-    /// Default indexing command
-    #[clap(name = "index")]
-    Index(IndexOptions),
-
-    /// Checks the integrity of the indexed data
-    #[clap(name = "integrity-check")]
-    IntegrityCheck,
-}
-
-#[derive(Clone, Debug, Parser)]
-pub struct IndexOptions {
     /// PostgreSQL database connection string for the destination database with compiled data
     #[clap(short, long)]
     pub dst_database_url: String,
@@ -53,6 +36,10 @@ pub struct IndexOptions {
     /// it has indexed all events in the src database. Useful for batch jobs.
     #[clap(long)]
     pub exit_on_catchup: bool,
+
+    /// If set, don't index, running only integrity checks against the database.
+    #[clap(long)]
+    pub integrity_checks_only: bool,
 }
 
 /// Parses a string containing a [`Duration`], represented as a number of milliseconds.

--- a/crates/util/cometindex/src/opt.rs
+++ b/crates/util/cometindex/src/opt.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, time::Duration};
 
 use anyhow::{Error, Result};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 /// This struct represents the command-line options
 #[derive(Clone, Debug, Parser)]
@@ -15,6 +15,23 @@ pub struct Options {
     #[clap(short, long)]
     pub src_database_url: String,
 
+    #[clap(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum Command {
+    /// Default indexing command
+    #[clap(name = "index")]
+    Index(IndexOptions),
+
+    /// Checks the integrity of the indexed data
+    #[clap(name = "integrity-check")]
+    IntegrityCheck,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub struct IndexOptions {
     /// PostgreSQL database connection string for the destination database with compiled data
     #[clap(short, long)]
     pub dst_database_url: String,


### PR DESCRIPTION
## Describe your changes

This adds a new command, reachable via `pindexer -s <DATABASE> integrity-check` which runs basic integrity checks on the raw database. Right now this can check that:
- there are no missing blocks,
- there are no missing events.

This also makes the indexing command `pindexer -s <DATABASE> index`, because I couldn't find a way to preserve the default command.

This can be run against known good database, and shouldn't fail.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only
