### PR TITLE
Bump pindexer lag allowance in integration test

### DIFF
--- a/crates/bin/pindexer/tests/network_integration.rs
+++ b/crates/bin/pindexer/tests/network_integration.rs
@@ -153,11 +153,12 @@ async fn cometbft_events_are_not_null(#[case] query: &str) -> anyhow::Result<()>
 async fn pindexer_is_working() -> anyhow::Result<()> {
     let height_rpc = get_current_height().await?;
     let height_db: u64 = get_highest_indexed_block_from_pindexer_db().await?;
-    // Check that pindexer's height is within tolerance. We allow lagging by ~2 blocks because
+    // Check that pindexer's height is within tolerance. We allow lagging by ~4 blocks because
     // local devnets and integration test suites run with faster block times, ~1s vs the default
     // 5s, so being a bit behind is quite possible.
+    const ALLOWANCE: u64 = 4;
     assert!(
-        vec![height_rpc, height_rpc - 1, height_rpc - 2].contains(&height_db),
+        (height_rpc - ALLOWANCE..=height_rpc).contains(&height_db),
         "pindexer database is behind chain ({} vs {}); is indexing broken?",
         height_db,
         height_rpc


### PR DESCRIPTION
I observed some flakiness in the test because of this, where it was behind by 3 on one run, and fine on another. I think moving it to 4 is sensible. I also replaced the use of a vec with a more efficient range check.

Smoke tests should be sufficient here.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > tests only
