### PR TITLE
Add ledger as a custody option to pcli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,6 +967,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1001,36 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bluez-async"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce7d4413c940e8e3cb6afc122d3f4a07096aca259d286781128683fc9f39d9b"
+dependencies = [
+ "async-trait",
+ "bitflags 2.6.0",
+ "bluez-generated",
+ "dbus",
+ "dbus-tokio",
+ "futures",
+ "itertools 0.10.5",
+ "log",
+ "serde",
+ "serde-xml-rs",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "bluez-generated"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d1c659dbc82f0b8ca75606c91a371e763589b7f6acf36858eeed0c705afe367"
+dependencies = [
+ "dbus",
 ]
 
 [[package]]
@@ -1039,6 +1075,33 @@ dependencies = [
  "memchr",
  "regex-automata 0.4.9",
  "serde",
+]
+
+[[package]]
+name = "btleplug"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba345f9db94939c72959b2008abe1ffcdbcaa235243fd92ad12436532ff199cf"
+dependencies = [
+ "async-trait",
+ "bitflags 2.6.0",
+ "bluez-async",
+ "cocoa",
+ "dashmap",
+ "dbus",
+ "futures",
+ "jni",
+ "jni-utils",
+ "libc",
+ "log",
+ "objc",
+ "once_cell",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -1117,6 +1180,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -1335,6 +1404,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "cocoa"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types 0.5.0",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
 name = "colored"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,6 +1452,16 @@ dependencies = [
  "serde",
  "serde_json",
  "yansi",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1382,8 +1491,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b103d85ca6e209388771bfb7aa6b68a7aeec4afbf6f0a0264bfbf50360e5212e"
 dependencies = [
  "crossterm",
- "strum",
- "strum_macros",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
  "unicode-width",
 ]
 
@@ -1448,6 +1557,30 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "cosmos-sdk-proto"
@@ -1660,12 +1793,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.9",
+ "darling_macro 0.20.9",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.93",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1684,13 +1841,37 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.9",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1698,6 +1879,30 @@ name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
+name = "dbus-tokio"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007688d459bc677131c063a3a77fb899526e17b7980f390b69644bdbc41fad13"
+dependencies = [
+ "dbus",
+ "libc",
+ "tokio",
+]
 
 [[package]]
 name = "debugless-unwrap"
@@ -2036,6 +2241,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
+name = "encdec"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7aafa197dadfa18575eb62d05adaec89237d0fb0663baf2e141529b3a20b0"
+dependencies = [
+ "encdec-base",
+ "encdec-macros",
+]
+
+[[package]]
+name = "encdec-base"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5abc9d559c177b2a75892e92c1812216e5cec7e1a14e0682b25ed6f5c0bd78a2"
+dependencies = [
+ "byteorder",
+ "heapless 0.8.0",
+ "num-traits",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "encdec-macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace893fa216d3c4cd14239cf2807b48c1ad8abcf583d779a29f410cd35cff413"
+dependencies = [
+ "darling 0.14.4",
+ "encdec-base",
+ "proc-macro2 1.0.93",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,7 +2494,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2 1.0.93",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2262,6 +2523,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2583,6 +2850,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hash_hasher"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2674,10 +2950,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version",
  "serde",
  "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -2722,6 +3008,19 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hidapi"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b876ecf37e86b359573c16c8366bc3eba52b689884a0fc42ba3f67203d2a8b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "hkdf"
@@ -3507,6 +3806,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-utils"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259e9f2c3ead61de911f147000660511f07ab00adeed1d84f5ac4d0386e7a6c4"
+dependencies = [
+ "dashmap",
+ "futures",
+ "jni",
+ "log",
+ "once_cell",
+ "static_assertions",
+ "uuid",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3561,10 +3895,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "ledger-lib"
+version = "0.1.0"
+source = "git+https://github.com/ledger-community/rust-ledger?rev=510bb3ca30639af4bdb12a918b6bbbdb75fa5f52#510bb3ca30639af4bdb12a918b6bbbdb75fa5f52"
+dependencies = [
+ "async-trait",
+ "btleplug",
+ "displaydoc",
+ "encdec",
+ "futures",
+ "hidapi",
+ "ledger-proto",
+ "once_cell",
+ "strum 0.26.3",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+ "uuid",
+]
+
+[[package]]
+name = "ledger-proto"
+version = "0.1.0"
+source = "git+https://github.com/ledger-community/rust-ledger?rev=510bb3ca30639af4bdb12a918b6bbbdb75fa5f52#510bb3ca30639af4bdb12a918b6bbbdb75fa5f52"
+dependencies = [
+ "bitflags 2.6.0",
+ "displaydoc",
+ "encdec",
+ "num_enum",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libflate"
@@ -3726,6 +4102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3822,7 +4207,7 @@ dependencies = [
  "once_cell",
  "procfs",
  "rlimit",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -4108,6 +4493,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro2 1.0.93",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4118,6 +4523,15 @@ name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
 
 [[package]]
 name = "object"
@@ -4174,7 +4588,7 @@ checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -5097,6 +5511,7 @@ name = "penumbra-sdk-custody-ledger-usb"
 version = "1.4.0"
 dependencies = [
  "anyhow",
+ "ledger-lib",
  "penumbra-sdk-custody",
  "penumbra-sdk-keys",
  "penumbra-sdk-proto",
@@ -6328,7 +6743,7 @@ checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
 dependencies = [
  "cobs",
  "embedded-io",
- "heapless",
+ "heapless 0.7.17",
  "serde",
 ]
 
@@ -7591,6 +8006,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-xml-rs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror 1.0.69",
+ "xml-rs",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7731,7 +8158,7 @@ version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
- "darling",
+ "darling 0.20.9",
  "proc-macro2 1.0.93",
  "quote",
  "syn 2.0.96",
@@ -8192,6 +8619,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8202,6 +8638,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2 1.0.93",
+ "quote",
+ "rustversion",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9542,6 +9991,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -9836,6 +10295,12 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4414,6 +4414,7 @@ dependencies = [
  "penumbra-sdk-community-pool",
  "penumbra-sdk-compact-block",
  "penumbra-sdk-custody",
+ "penumbra-sdk-custody-ledger-usb",
  "penumbra-sdk-dex",
  "penumbra-sdk-fee",
  "penumbra-sdk-governance",
@@ -5097,6 +5098,10 @@ version = "1.4.0"
 dependencies = [
  "anyhow",
  "penumbra-sdk-custody",
+ "penumbra-sdk-keys",
+ "penumbra-sdk-proto",
+ "serde",
+ "tonic",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5092,6 +5092,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-sdk-custody-ledger-usb"
+version = "1.4.0"
+dependencies = [
+ "anyhow",
+ "penumbra-sdk-custody",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-sdk-dex"
 version = "1.4.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,6 +3008,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hidapi"
@@ -3923,7 +3926,9 @@ dependencies = [
  "bitflags 2.6.0",
  "displaydoc",
  "encdec",
+ "hex",
  "num_enum",
+ "serde",
  "thiserror 2.0.11",
 ]
 
@@ -5512,6 +5517,7 @@ version = "1.4.0"
 dependencies = [
  "anyhow",
  "ledger-lib",
+ "ledger-proto",
  "penumbra-sdk-custody",
  "penumbra-sdk-keys",
  "penumbra-sdk-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5521,7 +5521,9 @@ dependencies = [
  "penumbra-sdk-custody",
  "penumbra-sdk-keys",
  "penumbra-sdk-proto",
+ "penumbra-sdk-transaction",
  "serde",
+ "tokio",
  "tonic",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ im                               = { version = "^15.1.0" }
 indicatif                        = { version = "0.16" }
 jmt                              = { version = "0.11", features = ["migration"] }
 ledger-lib = { git = "https://github.com/ledger-community/rust-ledger", rev = "510bb3ca30639af4bdb12a918b6bbbdb75fa5f52" }
+ledger-proto = { git = "https://github.com/ledger-community/rust-ledger", rev = "510bb3ca30639af4bdb12a918b6bbbdb75fa5f52" }
 metrics                          = { version = "0.24.1" }
 metrics-exporter-prometheus      = { version = "0.16", features = ["http-listener"] }
 metrics-tracing-context          = { version = "0.17.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,7 @@ ics23                            = { version = "0.12.0" }
 im                               = { version = "^15.1.0" }
 indicatif                        = { version = "0.16" }
 jmt                              = { version = "0.11", features = ["migration"] }
+ledger-lib = { git = "https://github.com/ledger-community/rust-ledger", rev = "510bb3ca30639af4bdb12a918b6bbbdb75fa5f52" }
 metrics                          = { version = "0.24.1" }
 metrics-exporter-prometheus      = { version = "0.16", features = ["http-listener"] }
 metrics-tracing-context          = { version = "0.17.0" }
@@ -231,3 +232,8 @@ tracing                          = { version = "0.1" }
 tracing-subscriber               = { version = "0.3.17", features = ["env-filter"] }
 url                              = { version = "2.2" }
 getrandom                        = { version = "0.2", default-features = false }
+
+[patch.crates-io]
+# Without this, the git dependency for ledger-lib will depend on the crates.io v0.1 version,
+# and will fail to build.
+ledger-proto = { git = "https://github.com/ledger-community/rust-ledger", rev = "510bb3ca30639af4bdb12a918b6bbbdb75fa5f52" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
   "crates/crypto/proof-setup",
   "crates/crypto/tct",
   "crates/custody",
+  "crates/custody-ledger-usb",
   "crates/misc/measure",
   "crates/misc/tct-visualize",
   "crates/proto",
@@ -155,10 +156,11 @@ pbjson                           = { version = "0.7.0" }
 pbjson-types                     = { version = "0.7.0" }
 penumbra-sdk-app                     = { default-features = false, version = "1.4.0", path = "crates/core/app" }
 penumbra-sdk-asset                   = { default-features = false, version = "1.4.0", path = "crates/core/asset" }
+penumbra-sdk-auction                 = { default-features = false, version = "1.4.0", path = "crates/core/component/auction" }
 penumbra-sdk-community-pool          = { default-features = false, version = "1.4.0", path = "crates/core/component/community-pool" }
 penumbra-sdk-compact-block           = { default-features = false, version = "1.4.0", path = "crates/core/component/compact-block" }
 penumbra-sdk-custody                 = { version = "1.4.0", path = "crates/custody" }
-penumbra-sdk-auction                 = { default-features = false, version = "1.4.0", path = "crates/core/component/auction" }
+penumbra-sdk-custody-ledger-usb      = { version = "1.4.0", path = "crates/custody-ledger-usb" }
 penumbra-sdk-dex                     = { default-features = false, version = "1.4.0", path = "crates/core/component/dex" }
 penumbra-sdk-distributions           = { default-features = false, version = "1.4.0", path = "crates/core/component/distributions" }
 penumbra-sdk-fee                     = { default-features = false, version = "1.4.0", path = "crates/core/component/fee" }

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -67,6 +67,7 @@ penumbra-sdk-asset = {workspace = true, default-features = false}
 penumbra-sdk-community-pool = {workspace = true, default-features = false}
 penumbra-sdk-compact-block = {workspace = true, default-features = false}
 penumbra-sdk-custody = {workspace = true}
+penumbra-sdk-custody-ledger-usb = {workspace = true}
 penumbra-sdk-auction = {workspace = true, default-features = false}
 penumbra-sdk-dex = {workspace = true, default-features = false}
 penumbra-sdk-fee = {workspace = true, default-features = false}

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -29,6 +29,7 @@ parallel = [
     "penumbra-sdk-transaction/parallel",
     "penumbra-sdk-wallet/parallel",
 ]
+ledger = ["penumbra-sdk-custody-ledger-usb"]
 
 [dependencies]
 anyhow = {workspace = true}
@@ -67,7 +68,7 @@ penumbra-sdk-asset = {workspace = true, default-features = false}
 penumbra-sdk-community-pool = {workspace = true, default-features = false}
 penumbra-sdk-compact-block = {workspace = true, default-features = false}
 penumbra-sdk-custody = {workspace = true}
-penumbra-sdk-custody-ledger-usb = {workspace = true}
+penumbra-sdk-custody-ledger-usb = {workspace = true, optional = true}
 penumbra-sdk-auction = {workspace = true, default-features = false}
 penumbra-sdk-dex = {workspace = true, default-features = false}
 penumbra-sdk-fee = {workspace = true, default-features = false}

--- a/crates/bin/pcli/src/command/init.rs
+++ b/crates/bin/pcli/src/command/init.rs
@@ -6,6 +6,7 @@ use std::{
 use anyhow::Result;
 use camino::Utf8PathBuf;
 use penumbra_sdk_custody::threshold;
+use penumbra_sdk_custody_ledger_usb as ledger;
 use penumbra_sdk_keys::keys::{Bip44Path, SeedPhrase, SpendKey};
 use rand_core::OsRng;
 use termion::screen::IntoAlternateScreen;
@@ -69,6 +70,9 @@ pub enum InitSubCmd {
     // governance subkey as view-only.
     #[clap(skip, display_order = 200)]
     ViewOnly { full_viewing_key: String },
+    /// Initialize using a ledger hardware wallet.
+    #[clap(display_order = 250)]
+    Ledger,
     /// If relevant, change the current config to an encrypted config, with a password.
     #[clap(display_order = 800)]
     ReEncrypt,
@@ -385,11 +389,23 @@ impl InitCmd {
                             penumbra_sdk_custody::encrypted::InnerConfig::Threshold(c),
                         )?)
                     }
+                    CustodyConfig::Ledger(_config) => {
+                        anyhow::bail!("An additional layer of password encryption is not (currently) possible for hardware wallets.");
+                    }
                 };
                 (fvk, custody)
             }
             (_, InitSubCmd::ReEncrypt, false) => {
                 anyhow::bail!("re-encrypt requires existing config to exist",);
+            }
+            (InitType::SpendKey, InitSubCmd::Ledger, false) => {
+                let config = ledger::Config::initialize(ledger::InitOptions::new()).await?;
+                let service = ledger::Service::new(config.clone());
+                let fvk = service.impl_export_full_viewing_key().await?;
+                (fvk, CustodyConfig::Ledger(config))
+            }
+            (InitType::GovernanceKey, InitSubCmd::Ledger, false) => {
+                anyhow::bail!("governance keys are not supported on ledger devices");
             }
             (InitType::SpendKey, _, true) => {
                 anyhow::bail!(

--- a/crates/bin/pcli/src/command/init.rs
+++ b/crates/bin/pcli/src/command/init.rs
@@ -399,7 +399,7 @@ impl InitCmd {
                 anyhow::bail!("re-encrypt requires existing config to exist",);
             }
             (InitType::SpendKey, InitSubCmd::Ledger, false) => {
-                let config = ledger::Config::initialize(ledger::InitOptions::new()).await?;
+                let config = ledger::Config::initialize(ledger::InitOptions::default()).await?;
                 let service = ledger::Service::new(config.clone());
                 let fvk = service.impl_export_full_viewing_key().await?;
                 (fvk, CustodyConfig::Ledger(config))

--- a/crates/bin/pcli/src/config.rs
+++ b/crates/bin/pcli/src/config.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+#[cfg(feature = "ledger")]
 use penumbra_sdk_custody_ledger_usb::Config as LedgerConfig;
 use penumbra_sdk_stake::GovernanceKey;
 use serde::{Deserialize, Serialize};
@@ -75,6 +76,7 @@ pub enum CustodyConfig {
     /// An encrypted custody service.
     Encrypted(EncryptedConfig),
     /// A custody service using an external ledger device.
+    #[cfg(feature = "ledger")]
     Ledger(LedgerConfig),
 }
 

--- a/crates/bin/pcli/src/config.rs
+++ b/crates/bin/pcli/src/config.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use penumbra_sdk_custody_ledger_usb::Config as LedgerConfig;
 use penumbra_sdk_stake::GovernanceKey;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
@@ -73,6 +74,8 @@ pub enum CustodyConfig {
     Threshold(ThresholdConfig),
     /// An encrypted custody service.
     Encrypted(EncryptedConfig),
+    /// A custody service using an external ledger device.
+    Ledger(LedgerConfig),
 }
 
 /// The governance custody backend to use.

--- a/crates/bin/pcli/src/opt.rs
+++ b/crates/bin/pcli/src/opt.rs
@@ -102,6 +102,12 @@ impl Opt {
                 let custody_svc = CustodyServiceServer::new(encrypted_kms);
                 CustodyServiceClient::new(box_grpc_svc::local(custody_svc))
             }
+            CustodyConfig::Ledger(config) => {
+                tracing::info!("using ledger custody service");
+                let service = penumbra_sdk_custody_ledger_usb::Service::new(config.clone());
+                let custody_svc = CustodyServiceServer::new(service);
+                CustodyServiceClient::new(box_grpc_svc::local(custody_svc))
+            }
         };
 
         // Build the governance custody service...

--- a/crates/bin/pcli/src/opt.rs
+++ b/crates/bin/pcli/src/opt.rs
@@ -102,6 +102,7 @@ impl Opt {
                 let custody_svc = CustodyServiceServer::new(encrypted_kms);
                 CustodyServiceClient::new(box_grpc_svc::local(custody_svc))
             }
+            #[cfg(feature = "ledger")]
             CustodyConfig::Ledger(config) => {
                 tracing::info!("using ledger custody service");
                 let service = penumbra_sdk_custody_ledger_usb::Service::new(config.clone());

--- a/crates/core/transaction/src/auth_data.rs
+++ b/crates/core/transaction/src/auth_data.rs
@@ -5,7 +5,7 @@ use penumbra_sdk_txhash::EffectHash;
 
 /// Authorization data returned in response to a
 /// [`TransactionDescription`](crate::TransactionDescription).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct AuthorizationData {
     /// The computed authorization hash for the approved transaction.
     pub effect_hash: Option<EffectHash>,

--- a/crates/custody-ledger-usb/Cargo.toml
+++ b/crates/custody-ledger-usb/Cargo.toml
@@ -10,6 +10,8 @@ edition = {workspace = true}
 [dependencies]
 anyhow = {workspace = true}
 penumbra-sdk-custody = {workspace = true}
+penumbra-sdk-keys = {workspace = true}
+penumbra-sdk-proto = {workspace = true}
+tonic = {workspace = true}
 tracing = {workspace = true}
-
-[dev-dependencies]
+serde = {workspace = true}

--- a/crates/custody-ledger-usb/Cargo.toml
+++ b/crates/custody-ledger-usb/Cargo.toml
@@ -10,6 +10,7 @@ edition = {workspace = true}
 [dependencies]
 anyhow = {workspace = true}
 ledger-lib = {workspace = true}
+ledger-proto = {workspace = true}
 penumbra-sdk-custody = {workspace = true}
 penumbra-sdk-keys = {workspace = true}
 penumbra-sdk-proto = {workspace = true}

--- a/crates/custody-ledger-usb/Cargo.toml
+++ b/crates/custody-ledger-usb/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "penumbra-sdk-custody-ledger-usb"
+authors = {workspace = true}
+repository = {workspace = true}
+description = "Ledger USB custody for Penumbra"
+version = {workspace = true}
+license = {workspace = true}
+edition = {workspace = true}
+
+[dependencies]
+anyhow = {workspace = true}
+penumbra-sdk-custody = {workspace = true}
+tracing = {workspace = true}
+
+[dev-dependencies]

--- a/crates/custody-ledger-usb/Cargo.toml
+++ b/crates/custody-ledger-usb/Cargo.toml
@@ -14,6 +14,7 @@ ledger-proto = {workspace = true}
 penumbra-sdk-custody = {workspace = true}
 penumbra-sdk-keys = {workspace = true}
 penumbra-sdk-proto = {workspace = true}
+penumbra-sdk-transaction = {workspace = true}
 tonic = {workspace = true}
 tracing = {workspace = true}
 serde = {workspace = true}

--- a/crates/custody-ledger-usb/Cargo.toml
+++ b/crates/custody-ledger-usb/Cargo.toml
@@ -17,3 +17,4 @@ penumbra-sdk-proto = {workspace = true}
 tonic = {workspace = true}
 tracing = {workspace = true}
 serde = {workspace = true}
+tokio = { workspace = true, features = ["sync"] }

--- a/crates/custody-ledger-usb/Cargo.toml
+++ b/crates/custody-ledger-usb/Cargo.toml
@@ -9,6 +9,7 @@ edition = {workspace = true}
 
 [dependencies]
 anyhow = {workspace = true}
+ledger-lib = {workspace = true}
 penumbra-sdk-custody = {workspace = true}
 penumbra-sdk-keys = {workspace = true}
 penumbra-sdk-proto = {workspace = true}

--- a/crates/custody-ledger-usb/Cargo.toml
+++ b/crates/custody-ledger-usb/Cargo.toml
@@ -6,6 +6,8 @@ description = "Ledger USB custody for Penumbra"
 version = {workspace = true}
 license = {workspace = true}
 edition = {workspace = true}
+# TODO: revisit this once git dependencies are removed.
+publish = false
 
 [dependencies]
 anyhow = {workspace = true}

--- a/crates/custody-ledger-usb/src/device.rs
+++ b/crates/custody-ledger-usb/src/device.rs
@@ -117,13 +117,13 @@ impl GenericResponse {
     }
 }
 
-struct Device {
+pub struct Device {
     handle: LedgerHandle,
     buf: [u8; 256],
 }
 
 impl Device {
-    async fn connect_to_first() -> anyhow::Result<Self> {
+    pub async fn connect_to_first() -> anyhow::Result<Self> {
         let mut provider = LedgerProvider::init().await;
         let device_list = provider.list(Filters::Any).await?;
 
@@ -169,7 +169,7 @@ impl Device {
         Ok(GenericResponse { data: out })
     }
 
-    async fn get_fvk(&mut self) -> anyhow::Result<FullViewingKey> {
+    pub async fn get_fvk(&mut self) -> anyhow::Result<FullViewingKey> {
         // https://github.com/Zondax/ledger-penumbra/blob/9f57b82ad3b843bc18e22ba841f971659bcd0fe8/docs/APDUSPEC.md#ins_get_fvk
         let header = ApduHeader {
             cla: 0x80,
@@ -190,7 +190,7 @@ impl Device {
         Ok(fvk)
     }
 
-    async fn confirm_addr(&mut self, index: AddressIndex) -> anyhow::Result<Address> {
+    pub async fn confirm_addr(&mut self, index: AddressIndex) -> anyhow::Result<Address> {
         // https://github.com/Zondax/ledger-penumbra/blob/9f57b82ad3b843bc18e22ba841f971659bcd0fe8/docs/APDUSPEC.md#ins_get_addr        todo!()
         let header = ApduHeader {
             cla: 0x80,

--- a/crates/custody-ledger-usb/src/device.rs
+++ b/crates/custody-ledger-usb/src/device.rs
@@ -171,7 +171,7 @@ impl Device {
         self.buf[2] = header.p1;
         self.buf[3] = header.p2;
         // For empty data, we don't write the length at all.
-        if data.len() > 0 {
+        if !data.is_empty() {
             self.buf[4] = data.len().try_into().expect("data length should be < 256");
             self.buf[5..req_len].copy_from_slice(data);
         }
@@ -256,8 +256,10 @@ impl Device {
         if response_data.len() != 64 + 2 + 2 {
             anyhow::bail!("unexpected signing response");
         }
-        let mut auth_data = AuthorizationData::default();
-        auth_data.effect_hash = Some(EffectHash(response_data[..64].try_into()?));
+        let mut auth_data = AuthorizationData {
+            effect_hash: Some(EffectHash(response_data[..64].try_into()?)),
+            ..Default::default()
+        };
         let spend_auth_count: u8 =
             u16::from_le_bytes(response_data[64..66].try_into()?).try_into()?;
         let delegator_auth_count: u8 =

--- a/crates/custody-ledger-usb/src/device.rs
+++ b/crates/custody-ledger-usb/src/device.rs
@@ -1,0 +1,9 @@
+use ledger_lib::{Filters, LedgerProvider, Transport};
+
+pub async fn main() -> anyhow::Result<()> {
+    let mut provider = LedgerProvider::init().await;
+    let devices = provider.list(Filters::Any).await?;
+    dbg!(&devices);
+    println!("main");
+    Ok(())
+}

--- a/crates/custody-ledger-usb/src/device.rs
+++ b/crates/custody-ledger-usb/src/device.rs
@@ -12,7 +12,10 @@ use penumbra_sdk_transaction::{txhash::EffectHash, AuthorizationData, Transactio
 
 fn is_penumbra_app(info: &AppInfo) -> anyhow::Result<()> {
     if info.name != "Penumbra" {
-        anyhow::bail!("unknown app: {}", &info.name);
+        anyhow::bail!(
+            "unknown app: {}. Make sure to open the Penumbra app on your device.",
+            &info.name
+        );
     }
     Ok(())
 }

--- a/crates/custody-ledger-usb/src/lib.rs
+++ b/crates/custody-ledger-usb/src/lib.rs
@@ -5,9 +5,13 @@
 /// Abstraction layer over the ledger libraries for device interaction.
 mod device;
 
-use penumbra_sdk_keys::FullViewingKey;
+use std::{ops::DerefMut, sync::Arc};
+
+use device::Device;
+use penumbra_sdk_keys::{keys::AddressIndex, Address, FullViewingKey};
 use penumbra_sdk_proto::custody::v1::{self as pb, AuthorizeResponse};
 use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, MutexGuard};
 use tonic::{async_trait, Request, Response, Status};
 
 /// Options needed to create a new config for custodying with a ledger device.
@@ -26,17 +30,35 @@ pub struct Config {}
 impl Config {
     /// Initialize custody with a device.
     pub async fn initialize(_opts: InitOptions) -> anyhow::Result<Self> {
-        device::main().await?;
-        todo!()
+        // In the future, we might do things like actually create some kind
+        // of device checksum or something like that.
+        Ok(Self {})
     }
 }
 
 /// Implements the APIs to allow using
-pub struct Service {}
+pub struct Service {
+    device: Arc<Mutex<Option<Device>>>,
+}
 
 impl Service {
     pub fn new(_config: Config) -> Self {
-        todo!()
+        Self {
+            device: Arc::new(Default::default()),
+        }
+    }
+
+    /// Acquire a new device, potentially initializing it if necessary.
+    ///
+    /// The resulting handle can be dereferenced to get a device.
+    /// This handle will have exclusive access to the device.
+    async fn acquire_device(&self) -> anyhow::Result<impl DerefMut<Target = Device> + '_> {
+        let mut guard = self.device.lock().await;
+        if guard.is_none() {
+            *guard = Some(Device::connect_to_first().await?);
+        }
+        let out = MutexGuard::map(guard, |x| x.as_mut().expect("device should be initialized"));
+        Ok(out)
     }
 
     /// A convenience method for getting the FVK.
@@ -44,7 +66,14 @@ impl Service {
     /// This also exists by virtue of implementing [`pb::custody_service_server::CustodyService`],
     /// but calling that method is less ergonomic, and ultimately defers to this anyways.
     pub async fn impl_export_full_viewing_key(&self) -> anyhow::Result<FullViewingKey> {
-        todo!()
+        self.acquire_device().await?.get_fvk().await
+    }
+
+    /// A convenience method for confirming an address.
+    ///
+    /// This will ask the user to confirm the address on their device.
+    pub async fn impl_confirm_address(&self, index: AddressIndex) -> anyhow::Result<Address> {
+        self.acquire_device().await?.confirm_addr(index).await
     }
 }
 
@@ -61,27 +90,52 @@ impl pb::custody_service_server::CustodyService for Service {
         &self,
         _request: Request<pb::AuthorizeValidatorDefinitionRequest>,
     ) -> Result<Response<pb::AuthorizeValidatorDefinitionResponse>, Status> {
-        todo!()
+        unimplemented!("ledger does not support validator operations")
     }
 
     async fn authorize_validator_vote(
         &self,
         _request: Request<pb::AuthorizeValidatorVoteRequest>,
     ) -> Result<Response<pb::AuthorizeValidatorVoteResponse>, Status> {
-        todo!()
+        unimplemented!("ledger does not support validator operations")
     }
 
     async fn export_full_viewing_key(
         &self,
         _request: Request<pb::ExportFullViewingKeyRequest>,
     ) -> Result<Response<pb::ExportFullViewingKeyResponse>, Status> {
-        todo!()
+        let fvk = self
+            .impl_export_full_viewing_key()
+            .await
+            .map_err(|e| Status::internal(format!("{}", e)))?;
+        Ok(Response::new(pb::ExportFullViewingKeyResponse {
+            full_viewing_key: Some(fvk.into()),
+        }))
     }
 
     async fn confirm_address(
         &self,
-        _request: Request<pb::ConfirmAddressRequest>,
+        request: Request<pb::ConfirmAddressRequest>,
     ) -> Result<Response<pb::ConfirmAddressResponse>, Status> {
-        todo!()
+        let address_index = request
+            .into_inner()
+            .address_index
+            .ok_or_else(|| {
+                Status::invalid_argument("missing address index in confirm address request")
+            })?
+            .try_into()
+            .map_err(|e| {
+                Status::invalid_argument(format!(
+                    "invalid address index in confirm address request: {e:#}"
+                ))
+            })?;
+        let address = self
+            .impl_confirm_address(address_index)
+            .await
+            .map_err(|e| Status::internal(format!("{}", e)))?;
+
+        Ok(Response::new(pb::ConfirmAddressResponse {
+            address: Some(address.into()),
+        }))
     }
 }

--- a/crates/custody-ledger-usb/src/lib.rs
+++ b/crates/custody-ledger-usb/src/lib.rs
@@ -17,13 +17,8 @@ use tokio::sync::{Mutex, MutexGuard};
 use tonic::{async_trait, Request, Response, Status};
 
 /// Options needed to create a new config for custodying with a ledger device.
+#[derive(Default)]
 pub struct InitOptions {}
-
-impl InitOptions {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
 
 /// Contains configuration for custody with a ledger device.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]

--- a/crates/custody-ledger-usb/src/lib.rs
+++ b/crates/custody-ledger-usb/src/lib.rs
@@ -1,3 +1,82 @@
 //! Ledger USB custody for Penumbra.
 //!
 //! This crate implements Penumbra custody support for Ledger hardware wallets via USB.
+use penumbra_sdk_keys::FullViewingKey;
+use penumbra_sdk_proto::custody::v1::{self as pb, AuthorizeResponse};
+use serde::{Deserialize, Serialize};
+use tonic::{async_trait, Request, Response, Status};
+
+/// Options needed to create a new config for custodying with a ledger device.
+pub struct InitOptions {}
+
+impl InitOptions {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Contains configuration for custody with a ledger device.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct Config {}
+
+impl Config {
+    /// Initialize custody with a device.
+    pub async fn initialize(_opts: InitOptions) -> anyhow::Result<Self> {
+        todo!()
+    }
+}
+
+/// Implements the APIs to allow using
+pub struct Service {}
+
+impl Service {
+    pub fn new(_config: Config) -> Self {
+        todo!()
+    }
+
+    /// A convenience method for getting the FVK.
+    ///
+    /// This also exists by virtue of implementing [`pb::custody_service_server::CustodyService`],
+    /// but calling that method is less ergonomic, and ultimately defers to this anyways.
+    pub async fn impl_export_full_viewing_key(&self) -> anyhow::Result<FullViewingKey> {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl pb::custody_service_server::CustodyService for Service {
+    async fn authorize(
+        &self,
+        _request: Request<pb::AuthorizeRequest>,
+    ) -> Result<Response<AuthorizeResponse>, Status> {
+        todo!()
+    }
+
+    async fn authorize_validator_definition(
+        &self,
+        _request: Request<pb::AuthorizeValidatorDefinitionRequest>,
+    ) -> Result<Response<pb::AuthorizeValidatorDefinitionResponse>, Status> {
+        todo!()
+    }
+
+    async fn authorize_validator_vote(
+        &self,
+        _request: Request<pb::AuthorizeValidatorVoteRequest>,
+    ) -> Result<Response<pb::AuthorizeValidatorVoteResponse>, Status> {
+        todo!()
+    }
+
+    async fn export_full_viewing_key(
+        &self,
+        _request: Request<pb::ExportFullViewingKeyRequest>,
+    ) -> Result<Response<pb::ExportFullViewingKeyResponse>, Status> {
+        todo!()
+    }
+
+    async fn confirm_address(
+        &self,
+        _request: Request<pb::ConfirmAddressRequest>,
+    ) -> Result<Response<pb::ConfirmAddressResponse>, Status> {
+        todo!()
+    }
+}

--- a/crates/custody-ledger-usb/src/lib.rs
+++ b/crates/custody-ledger-usb/src/lib.rs
@@ -1,0 +1,3 @@
+//! Ledger USB custody for Penumbra.
+//!
+//! This crate implements Penumbra custody support for Ledger hardware wallets via USB.

--- a/crates/custody-ledger-usb/src/lib.rs
+++ b/crates/custody-ledger-usb/src/lib.rs
@@ -1,6 +1,10 @@
 //! Ledger USB custody for Penumbra.
 //!
 //! This crate implements Penumbra custody support for Ledger hardware wallets via USB.
+
+/// Abstraction layer over the ledger libraries for device interaction.
+mod device;
+
 use penumbra_sdk_keys::FullViewingKey;
 use penumbra_sdk_proto::custody::v1::{self as pb, AuthorizeResponse};
 use serde::{Deserialize, Serialize};
@@ -22,6 +26,7 @@ pub struct Config {}
 impl Config {
     /// Initialize custody with a device.
     pub async fn initialize(_opts: InitOptions) -> anyhow::Result<Self> {
+        device::main().await?;
         todo!()
     }
 }

--- a/deployments/containerfiles/Dockerfile
+++ b/deployments/containerfiles/Dockerfile
@@ -5,6 +5,7 @@ FROM docker.io/rust:1-slim-bookworm AS build-env
 # Install build dependencies. These packages should match what's recommended on
 # https://guide.penumbra.zone/main/pcli/install.html
 # We don't install git-lfs, because the git artifacts are copied in from the build host.
+# In order to build pcli with ledger support, add `libdbus-1-dev` & `libusb-1.0-0-dev`.
 RUN apt-get update && apt-get install -y \
         build-essential \
         pkg-config \
@@ -26,7 +27,9 @@ COPY tools ./tools
 RUN rustup install && cargo fetch
 # Build Penumbra binaries
 COPY . .
-RUN cargo build --release
+# Use `--bins` flag to force dependency resolution per-binary, rather than once for the workspace.
+# Doing so ensures the minimal feature set is used, leaving ledger support for pcli as off by default.
+RUN cargo build --release --bins
 
 # Runtime image.
 FROM docker.io/debian:bookworm-slim

--- a/deployments/scripts/rust-docs
+++ b/deployments/scripts/rust-docs
@@ -47,6 +47,7 @@ cargo $nightly_opt doc --no-deps \
   -p penumbra-sdk-asset \
   -p penumbra-sdk-community-pool \
   -p penumbra-sdk-custody \
+  -p penumbra-sdk-custody-ledger-usb \
   -p penumbra-sdk-dex \
   -p penumbra-sdk-distributions \
   -p penumbra-sdk-fee \

--- a/flake.nix
+++ b/flake.nix
@@ -67,16 +67,18 @@
             cargo-nextest
             cargo-release
             cargo-watch
-            glibcLocales # for postgres initdb locale support
             cometbft
+            dbus
+            glibcLocales # for postgres initdb locale support
             grafana
-            grpcurl
             grpcui
+            grpcurl
             just
+            libusb1
             mdbook
             mdbook-katex
-            mdbook-mermaid
             mdbook-linkcheck
+            mdbook-mermaid
             nix-prefetch-scripts
             postgresql
             process-compose


### PR DESCRIPTION
## Describe your changes

This implements a new custody backend which communicates with a ledger device locally, using the app in https://github.com/Zondax/ledger-penumbra/. I tested that this works as you might expect, and it does, except for an update to the protos that affects the effect hash that needs to be merged into an alpha release in that repo.

I'm not super happy with the quality of the crates I used to communicate with ledger generically, but they get the job done.

You can use `pcli init ledger` to setup pcli with this backend, and then everything should "just work".
Some more polish could be needed in terms of providing informative error handling, but for now I think this code is 90% of what we need.

I also added a default implementation of `AuthorizationData` so that we can easily rebase the lqt branch on top of these changes without breaking it.

It's easiest to test with an actual device, I haven't tried using an emulator.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > This should affect client code only
