### PR TITLE
ci: add nightly rust to nix dev shell

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -16,20 +16,23 @@ jobs:
         with:
           lfs: true
 
-      - name: Install nightly rust toolchain
-        # The script for rustdoc build requires nightly toolchain.
-        run: rustup toolchain install nightly
+      - name: install nix
+        uses: nixbuild/nix-quick-install-action@v28
+
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
 
       # Loading cache takes ~15s, but saves us minutes of build.
       - name: Load rust cache
         uses: astriaorg/buildjet-rust-cache@v2.5.1
 
-      # Don't bother importing nix env, since we only need cargo-nightly,
-      # no other deps.
-
       # Building with warm cache takes ~40s, depending on changes.
       - name: Build rustdocs
-        run: ./deployments/scripts/rust-docs
+        run: nix develop .#nightly --command ./deployments/scripts/rust-docs
 
   # Also validate that the `mdbook` docs (guide & protocol) build correctly.
   # In particular, links are checked within the docs.

--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -20,8 +20,15 @@ jobs:
         with:
           lfs: true
 
-      - name: Install rust toolchain
-        run: rustup toolchain install nightly
+      - name: install nix
+        uses: nixbuild/nix-quick-install-action@v28
+
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
 
       - name: Load Rust caching
         uses: astriaorg/buildjet-rust-cache@v2.5.1
@@ -30,12 +37,6 @@ jobs:
       # Let's still log the version of the docs we intend to build.
       - name: Print version component of deployment path
         run: echo ${{ github.event.inputs.image_tag || github.ref_name }}
-
-      # Ostensibly building from source, but the cache-loading above
-      # ensures we don't need to rebuild frequently.
-      - name: Install mdbook dependencies
-        # Make sure to install with `+nightly`, because that's the toolchain we'll use for building docs.
-        run: cargo +nightly install mdbook mdbook-katex mdbook-mermaid mdbook-linkcheck
 
       - name: Build protocol spec
         run: cd docs/protocol && mdbook build
@@ -58,7 +59,8 @@ jobs:
           PROJECT_PATH: docs/protocol
 
       - name: Build rustdocs
-        run: ./deployments/scripts/rust-docs
+        run: nix develop .#nightly --command ./deployments/scripts/rust-docs
+
       - name: Move API docs to subdirectory
         run: |
           cd docs/rustdoc

--- a/deployments/scripts/rust-docs
+++ b/deployments/scripts/rust-docs
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Rebuild Rust crate documentation
+# Rebuild Rust crate documentation.
+#
+# We use a custom build process for the Rust API docs, in order to provide
+# a landing page that lists all relevant crates on a single page.
 set -euo pipefail
 
 # Set:
@@ -17,7 +20,14 @@ export RUSTDOCFLAGS="--enable-index-page -Zunstable-options --cfg docsrs"
 # Doing this in one go is useful because the JSON file with search
 # indexes is overwritten on each cargo doc invocation.
 
-cargo +nightly doc --no-deps \
+# The nix version of `cargo` does not support the `+nightly` flag.
+# There's a nix devShell specifically for nightly Rust, that's used in CI.
+# We'll still support non-nix Rust nightlies, though.
+nightly_opt=""
+if [[ -z "${IN_NIX_SHELL:-}" ]] ; then
+  nightly_opt="+nightly"
+fi
+cargo $nightly_opt doc --no-deps \
   -p ark-ff \
   -p ark-serialize \
   -p cnidarium \
@@ -66,5 +76,5 @@ cargo +nightly doc --no-deps \
   -p tendermint-config \
   -p tower-abci \
 
->&2 echo "Copying newly built index file to version-controlled path:"
+>&2 echo "Copying newly built index file to docroot for deployment"
 cp -v target/doc/index.html docs/rustdoc/index.html

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1734808813,
-        "narHash": "sha256-3aH/0Y6ajIlfy7j52FGZ+s4icVX0oHhqBzRdlOeztqg=",
+        "lastModified": 1742394900,
+        "narHash": "sha256-vVOAp9ahvnU+fQoKd4SEXB2JG2wbENkpqcwlkIXgUC0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "72e2d02dbac80c8c86bf6bf3e785536acf8ee926",
+        "rev": "70947c1908108c0c551ddfd73d4f750ff2ea67cd",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734991663,
-        "narHash": "sha256-8T660guvdaOD+2/Cj970bWlQwAyZLKrrbkhYOFcY1YE=",
+        "lastModified": 1742937945,
+        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c90912761c43e22b6fb000025ab96dd31c971ff",
+        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735093658,
-        "narHash": "sha256-eIUYGDtairggo7+JXSwN7b6Zr03BJ7tsZL/U0NkDr0s=",
+        "lastModified": 1743042789,
+        "narHash": "sha256-yPlxN0r3pQjUIwyX/qeWSTdpHjWy/AfmM0PK1bYkO18=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ca249a1d98eff27e92665ac462b9d47f58141925",
+        "rev": "b4d2dee9d16e7725b71969f28862ded3a94a7934",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -51,10 +51,11 @@
           craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
           # Add nightly Rust toolchain, required for building the rustdocs with combined index landing page.
-          nightlyRustToolchain = pkgs.rust-bin.nightly.latest.default.override {
+          # https://github.com/oxalica/rust-overlay/blob/master/README.md#cheat-sheet-common-usage-of-rust-bin
+          nightlyRustToolchain = pkgs.rust-bin.selectLatestNightlyWith(toolchain: toolchain.override {
             extensions = [ "rust-src" "rust-analyzer" ];
             targets = [ "wasm32-unknown-unknown" ];
-          };
+          });
           nightlyCraneLib = (crane.mkLib pkgs).overrideToolchain nightlyRustToolchain;
 
           # Important environment variables so that the build can find the necessary libraries

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
 
           # Add nightly Rust toolchain, required for building the rustdocs with combined index landing page.
           # https://github.com/oxalica/rust-overlay/blob/master/README.md#cheat-sheet-common-usage-of-rust-bin
-          nightlyRustToolchain = pkgs.rust-bin.selectLatestNightlyWith(toolchain: toolchain.override {
+          nightlyRustToolchain = pkgs.rust-bin.selectLatestNightlyWith(toolchain: rustToolchain.override {
             extensions = [ "rust-src" "rust-analyzer" ];
             targets = [ "wasm32-unknown-unknown" ];
           });

--- a/flake.nix
+++ b/flake.nix
@@ -52,10 +52,7 @@
 
           # Add nightly Rust toolchain, required for building the rustdocs with combined index landing page.
           # https://github.com/oxalica/rust-overlay/blob/master/README.md#cheat-sheet-common-usage-of-rust-bin
-          nightlyRustToolchain = pkgs.rust-bin.selectLatestNightlyWith(toolchain: rustToolchain.override {
-            extensions = [ "rust-src" "rust-analyzer" ];
-            targets = [ "wasm32-unknown-unknown" ];
-          });
+          nightlyRustToolchain = pkgs.rust-bin.selectLatestNightlyWith(toolchain: toolchain.default);
           nightlyCraneLib = (crane.mkLib pkgs).overrideToolchain nightlyRustToolchain;
 
           # Important environment variables so that the build can find the necessary libraries

--- a/flake.nix
+++ b/flake.nix
@@ -50,11 +50,54 @@
           rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
           craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
+          # Add nightly Rust toolchain, required for building the rustdocs with combined index landing page.
+          nightlyRustToolchain = pkgs.rust-bin.nightly.latest.default.override {
+            extensions = [ "rust-src" "rust-analyzer" ];
+            targets = [ "wasm32-unknown-unknown" ];
+          };
+          nightlyCraneLib = (crane.mkLib pkgs).overrideToolchain nightlyRustToolchain;
+
           # Important environment variables so that the build can find the necessary libraries
           PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig";
           LIBCLANG_PATH="${pkgs.libclang.lib}/lib";
           ROCKSDB_LIB_DIR="${pkgs.rocksdb.out}/lib";
         in with pkgs; with pkgs.lib; let
+          # Common development packages for all shells
+          commonDevPackages = [
+            buf
+            cargo-hack
+            cargo-nextest
+            cargo-release
+            cargo-watch
+            glibcLocales # for postgres initdb locale support
+            cometbft
+            grafana
+            grpcurl
+            grpcui
+            just
+            mdbook
+            mdbook-katex
+            mdbook-mermaid
+            mdbook-linkcheck
+            nix-prefetch-scripts
+            postgresql
+            process-compose
+            prometheus
+            protobuf
+            rocksdb
+            rsync
+            sqlfluff
+            toml-cli
+          ];
+
+          # Common shell hook content
+          commonShellHook = ''
+            export LIBCLANG_PATH=${LIBCLANG_PATH}
+            export RUST_SRC_PATH=${pkgs.rustPlatform.rustLibSrc} # Required for rust-analyzer
+            export ROCKSDB_LIB_DIR=${ROCKSDB_LIB_DIR}
+            export RUST_LOG="info,network_integration=debug,pclientd=debug,pcli=info,pd=info,penumbra=info"
+          '';
+
           # All the Penumbra binaries
           penumbra = (craneLib.buildPackage {
             pname = "penumbra";
@@ -148,41 +191,26 @@
             name = "penumbra-and-cometbft";
             paths = [ penumbra cometbft ];
           };
-          devShells.default = craneLib.devShell {
-            inherit LIBCLANG_PATH ROCKSDB_LIB_DIR;
-            inputsFrom = [ penumbra ];
-            packages = [
-              buf
-              cargo-hack
-              cargo-nextest
-              cargo-release
-              cargo-watch
-              glibcLocales # for postgres initdb locale support
-              cometbft
-              grafana
-              grpcurl
-              grpcui
-              just
-              mdbook
-              mdbook-katex
-              mdbook-mermaid
-              mdbook-linkcheck
-              nix-prefetch-scripts
-              postgresql
-              process-compose
-              prometheus
-              protobuf
-              rocksdb
-              rsync
-              sqlfluff
-              toml-cli
-            ];
-            shellHook = ''
-              export LIBCLANG_PATH=${LIBCLANG_PATH}
-              export RUST_SRC_PATH=${pkgs.rustPlatform.rustLibSrc} # Required for rust-analyzer
-              export ROCKSDB_LIB_DIR=${ROCKSDB_LIB_DIR}
-              export RUST_LOG="info,network_integration=debug,pclientd=debug,pcli=info,pd=info,penumbra=info"
-            '';
+          devShells = {
+            default = craneLib.devShell {
+              inherit LIBCLANG_PATH ROCKSDB_LIB_DIR;
+              inputsFrom = [ penumbra ];
+              packages = commonDevPackages;
+              shellHook = ''
+                ${commonShellHook}
+                echo "Using stable Rust from rust-toolchain.toml"
+              '';
+            };
+
+            nightly = nightlyCraneLib.devShell {
+              inherit LIBCLANG_PATH ROCKSDB_LIB_DIR;
+              inputsFrom = [ penumbra ];
+              packages = commonDevPackages;
+              shellHook = ''
+                ${commonShellHook}
+                echo "Using nightly Rust toolchain"
+              '';
+            };
           };
         }
       );


### PR DESCRIPTION


## Describe your changes

Updates the nix flake setup to provide an optional devshell for nightly rust. This is mostly useful for the "rustdocs"" build, which requires use of rust nightly for the combined index landing page. Also updates the CI workflows to use the nix env for building rustdocs.

## Issue ticket number and link

See related discussion in https://github.com/penumbra-zone/penumbra/pull/5140#issuecomment-2758892215. 

## Testing and review

Certainly we want CI to pass. As a bonus, it's worth confirming that executing the script `./deployments/script/rust-docs` works both inside and outside of a nix shell. 

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > CI/build logic only, no changes to application code
