### PR TITLE
Set memo to ICS-20 packet data via pcli

### DIFF
--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -286,6 +286,9 @@ pub enum TxCmd {
         /// Only withdraw funds from the specified wallet id within Penumbra.
         #[clap(long, default_value = "0", display_order = 200)]
         source: u32,
+        /// Optional. Set the IBC ICS-20 packet memo field to the provided text.
+        #[clap(long)]
+        memo: Option<String>,
         /// The selected fee tier to multiply the fee amount by.
         #[clap(short, long, default_value_t)]
         fee_tier: FeeTier,
@@ -1153,6 +1156,7 @@ impl TxCmd {
                 timeout_timestamp,
                 channel,
                 source,
+                memo,
                 fee_tier,
                 use_transparent_address,
             } => {
@@ -1277,7 +1281,7 @@ impl TxCmd {
                     // TODO: impl From<u64> for ChannelId
                     source_channel: ChannelId::from_str(format!("channel-{}", channel).as_ref())?,
                     use_compat_address: false,
-                    ics20_memo: "".to_string(),
+                    ics20_memo: memo.clone().unwrap_or_default(),
                     use_transparent_address: *use_transparent_address,
                 };
 


### PR DESCRIPTION
## Describe your changes
Currently, `pcli` can't set the memo to the ICS-20 packet when `withdraw`.
This PR adds a new option to `withdraw` command and sets it to the `Ics20Withdrawal`.

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > REPLACE THIS TEXT WITH RATIONALE (CAN BE BRIEF)
