### PR TITLE
UGLY: turn position execution crash into warning

### DIFF
--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -1253,9 +1253,14 @@ impl Component {
         positions: &BTreeMap<PositionId, Position>,
     ) -> anyhow::Result<()> {
         // Get the position that was executed against
-        let position = positions
-            .get(&event.position_id)
-            .expect("position must exist for execution");
+        let position = match positions.get(&event.position_id) {
+            Some(x) => x,
+            None => {
+                tracing::warn!("unknown position {} executed against", event.position_id);
+                return Ok(());
+            }
+        };
+
         let current = Reserves {
             r1: event.reserves_1,
             r2: event.reserves_2,
@@ -1379,7 +1384,12 @@ impl Component {
                 reserves_1,
                 reserves_2,
                 reserves_rowid
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+            )
+            SELECT $1, $2, $3, $4, $5, $6, $7, $8
+            WHERE EXISTS (
+                SELECT 1 FROM dex_ex_position_state WHERE position_id = $1
+            )
+            ",
         )
         .bind(event.position_id.0)
         .bind(height)


### PR DESCRIPTION
This is a stop gap we probably want to revert, but can unblock testing.

Pindexer should no longer crash against the testnet.


## Issue ticket number and link

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Indexing only
