### PR TITLE
Revert "UGLY: turn position execution crash into warning"

### DIFF
--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -1253,14 +1253,9 @@ impl Component {
         positions: &BTreeMap<PositionId, Position>,
     ) -> anyhow::Result<()> {
         // Get the position that was executed against
-        let position = match positions.get(&event.position_id) {
-            Some(x) => x,
-            None => {
-                tracing::warn!("unknown position {} executed against", event.position_id);
-                return Ok(());
-            }
-        };
-
+        let position = positions
+            .get(&event.position_id)
+            .expect("position must exist for execution");
         let current = Reserves {
             r1: event.reserves_1,
             r2: event.reserves_2,
@@ -1384,12 +1379,7 @@ impl Component {
                 reserves_1,
                 reserves_2,
                 reserves_rowid
-            )
-            SELECT $1, $2, $3, $4, $5, $6, $7, $8
-            WHERE EXISTS (
-                SELECT 1 FROM dex_ex_position_state WHERE position_id = $1
-            )
-            ",
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
         )
         .bind(event.position_id.0)
         .bind(height)


### PR DESCRIPTION


## Describe your changes
This reverts commit fa7032674383aa00b29be55d61263d534a6eaa7c, from PR #5147. That was a stopgap measure to facilitate working with ABCI events on the testnet pipeline. We've since [reindexed](https://github.com/penumbra-zone/reindexer/pull/42) the testnet data and the data is sound again—there was _not_ a bug in pindexer.

## Issue ticket number and link

Refs #5147. Closes #5144.

## Checklist before requesting a review

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > no changes to consensus code, just a reversion of a stopgap commit to pindexer