### PR TITLE
ci: fix protocol docs build

### DIFF
--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -39,7 +39,7 @@ jobs:
         run: echo ${{ github.event.inputs.image_tag || github.ref_name }}
 
       - name: Build protocol spec
-        run: cd docs/protocol && mdbook build
+        run: cd docs/protocol/ && nix develop --command mdbook build
 
       - name: Move protocol spec to subdirectory
         run: |


### PR DESCRIPTION
## Describe your changes
Properly uses the `nix develop` invocation to ensure that `mdbook` exists on the PATH. Historically mdbook was installed via `cargo install` and so was present in the CI rust cache. That cache has been evicted, so the workflow recently started failing.

## Issue ticket number and link

Refs #5156.

## Testing and review

The workflow in question only runs on main, so we'll need to merge and then observe again. That's why I've marked as "refs" rather than "closes" the linked issue.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > ci logic only, affects docs presentation, but no app code has changed.