### PR TITLE
chore: fix typo

### DIFF
--- a/crates/core/component/compact-block/src/compact_block.rs
+++ b/crates/core/component/compact-block/src/compact_block.rs
@@ -68,7 +68,7 @@ impl Default for CompactBlock {
 }
 
 impl CompactBlock {
-    /// Returns true if the compact block is empty.
+    /// Returns true if the compact block contains any data that requires scanning.
     pub fn requires_scanning(&self) -> bool {
         !self.state_payloads.is_empty() // need to scan notes
             || !self.nullifiers.is_empty() // need to collect nullifiers


### PR DESCRIPTION
fix requires_scanning doc typo

## Describe your changes

requires_scanning returns true if the block is **not** empty! Corrected typo

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have added guiding text to explain how a reviewer should test these changes.

- [ ] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > REPLACE THIS TEXT WITH RATIONALE (CAN BE BRIEF)
