### PR TITLE
Improve error message when you don't run pd migrate

### DIFF
--- a/crates/core/app/src/app_version/component.rs
+++ b/crates/core/app/src/app_version/component.rs
@@ -48,11 +48,22 @@ fn check_version(ctx: CheckContext, expected: u64, found: Option<u64>) -> anyhow
                 expected, expected_name
             )?;
             write!(&mut error, "  found {} (penumbra {})\n", found, found_name)?;
-            write!(
-                &mut error,
-                "make sure you're running penumbra {}",
-                expected_name
-            )?;
+            write!(&mut error, "Are you using the right node directory?\n")?;
+            // For a greater difference, the wrong directory is probably being used.
+            if found == expected - 1 {
+                write!(&mut error, "Does a migration need to happen?\n")?;
+                write!(
+                    &mut error,
+                    "If so, then run `pd migrate` with version {}",
+                    expected_name
+                )?;
+            } else {
+                write!(
+                    &mut error,
+                    "make sure you're running penumbra {}",
+                    expected_name
+                )?;
+            }
             Err(anyhow!(error))
         }
         CheckContext::Migration => {


### PR DESCRIPTION
This was confusing a lot of people, reading the Discord backscroll.

Now, if you run `pd` and find that the previous version is set, we prompt the user to try running pd migrate.

A lot of people ran into this exact scenario and were confused that the error message was merely telling them to run `pd v1.4.0` but they indeed had that version ready, but had forgotten to migrate first.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Error messages only.
