### PR TITLE
pclientd: read key material interactively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4911,6 +4911,7 @@ dependencies = [
  "prost 0.13.4",
  "rand",
  "rand_core",
+ "rpassword",
  "rustls 0.23.21",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,7 @@ rand_chacha                      = { version = "0.3.1" }
 rand_core                        = { version = "0.6.4" }
 regex                            = { version = "1.8.1" }
 rocksdb                          = { version = "0.21.0" }
+rpassword                        = { version = "7" }
 rstest                           = { version = "0.24.0" }
 rustls                           = { version = "0.23.21" }
 serde                            = { version = "1.0.186" }

--- a/crates/bin/pcli/Cargo.toml
+++ b/crates/bin/pcli/Cargo.toml
@@ -90,7 +90,7 @@ rand = {workspace = true}
 rand_chacha = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}
 regex = {workspace = true}
-rpassword = "7"
+rpassword = {workspace = true}
 rustls = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}

--- a/crates/bin/pclientd/Cargo.toml
+++ b/crates/bin/pclientd/Cargo.toml
@@ -46,6 +46,7 @@ penumbra-sdk-view = {workspace = true}
 prost = {workspace = true}
 rand = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}
+rpassword = {workspace = true}
 rustls = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}


### PR DESCRIPTION

## Describe your changes
Updates `pclientd` to prompt for key material interactively, via a masked prompt, or else read from stdin, rather than accepting key material as CLI args.

## Issue ticket number and link
Closes #5171.

## Testing and review

I updated the integration tests to exercise the CLI invocations, so CI passing is sufficient assurance her.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > CLI-args only, no changes to app code
