### PR TITLE
pindexer: lqt: fix issues with delegator summary

### DIFF
--- a/crates/bin/pindexer/src/lqt/schema.sql
+++ b/crates/bin/pindexer/src/lqt/schema.sql
@@ -196,7 +196,7 @@ WITH delegator_streaks AS (
 ), stage0 AS (
     SELECT
         address,
-        COUNT(*) AS epochs_voted_in,
+        COUNT(DISTINCT lqt._votes.epoch) AS epochs_voted_in,
         SUM(amount) AS total_rewards,
         SUM(power) AS total_voting_power
     FROM lqt._votes


### PR DESCRIPTION
## Describe your changes

This fixes some issues with the calculation of the summary view for delegators.

- The epochs voted in was calculated incorrectly.
- Rewards were not being tallied correctly, leading to overstatement of them.
- In case the user had a continuous streak of voting, without any gaps, the streak would be reported incorrectly.

To test, it should be possible to simply run pindexer again, with no need to reset the database (being able to change views on the fly paying off!), and one should observe much more reasonable results with:
```sql
select epochs_voted_in, total_rewards / 10^6, total_voting_power / 10 ^ 6, streak from lqt.delegator_summary;
```
## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

> indexing only
