### PR TITLE
asset: fix ibc transfer path parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5280,6 +5280,7 @@ dependencies = [
  "getrandom",
  "hex",
  "ibig",
+ "lazy_static",
  "num-bigint",
  "once_cell",
  "pbjson-types",

--- a/crates/core/asset/Cargo.toml
+++ b/crates/core/asset/Cargo.toml
@@ -51,6 +51,7 @@ sha2 = {workspace = true}
 thiserror = {workspace = true}
 tracing = {workspace = true}
 pbjson-types = {workspace = true}
+lazy_static = "1.5.0"
 
 [dev-dependencies]
 proptest = {workspace = true}

--- a/crates/core/component/shielded-pool/src/component/rpc/transfer_query.rs
+++ b/crates/core/component/shielded-pool/src/component/rpc/transfer_query.rs
@@ -68,10 +68,9 @@ impl TransferQuery for Server {
                 let (_key, denom) = i.expect("should not be an error");
 
                 // Convert the key to an IBC asset path
-                match denom.ibc_transfer_path() {
-                    Ok(None) => return None,
-                    Err(e) => return Some(Err(e)),
-                    Ok(Some((path, base_denom))) => Some(Ok(DenomTrace { path, base_denom })),
+                match denom.best_effort_ibc_transfer_parse() {
+                    None => return None,
+                    Some((path, base_denom)) => Some(Ok(DenomTrace { path, base_denom })),
                 }
             })
             .collect::<Vec<_>>()


### PR DESCRIPTION
## Describe your changes

This fix a bug in the Cosmos query service that would prevent certain IBC assets from being returned by `ibc.applications.transfer.v1.Query/DenomTraces`

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.


Querying the total supply:
```bash
echo "{}" | grpcurl -plaintext penumbra-1-skip-grpc.polkachu.com:21990 cosmos.bank.v1beta1.Query/TotalSupply | grep 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
```

Returns:
```
      "denom": "transfer/channel-0/transfer/08-wasm-1369/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
```

as expected.

But querying the denom traces:
```bash
 echo ‘{}’ | grpcurl -plaintext penumbra-1-skip-grpc.polkachu.com:21990 ibc.applications.transfer.v1.Query/DenomTraces | grep 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
```

does not return anything (unexpected).

With this fix, it should return the denom trace as well.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > RPC change