### PR TITLE
pindexer: lqt: augment lqt.summary with epoch prediction

### DIFF
--- a/crates/bin/pindexer/src/lqt/mod.rs
+++ b/crates/bin/pindexer/src/lqt/mod.rs
@@ -1,14 +1,15 @@
+use anyhow::anyhow;
 use cometindex::{
     async_trait,
     index::{EventBatch, EventBatchContext, Version},
     sqlx, AppView, ContextualizedEvent, PgTransaction,
 };
+use penumbra_sdk_app::genesis::Content;
 use penumbra_sdk_asset::asset;
 use penumbra_sdk_dex::event::EventLqtPositionVolume;
 use penumbra_sdk_dex::lp::position;
 use penumbra_sdk_distributions::event::EventLqtPoolSizeIncrease;
 use penumbra_sdk_funding::event::{EventLqtDelegatorReward, EventLqtPositionReward, EventLqtVote};
-use penumbra_sdk_funding::params::LiquidityTournamentParameters;
 use penumbra_sdk_keys::Address;
 use penumbra_sdk_num::Amount;
 use penumbra_sdk_proto::event::EventDomainType;
@@ -18,14 +19,12 @@ use sqlx::types::BigDecimal;
 use crate::parsing::parse_content;
 
 mod _params {
+
     use super::*;
 
     /// Set the params post genesis.
-    pub async fn set_initial(
-        dbtx: &mut PgTransaction<'_>,
-        params: LiquidityTournamentParameters,
-    ) -> anyhow::Result<()> {
-        set_epoch(dbtx, 0, params).await
+    pub async fn set_initial(dbtx: &mut PgTransaction<'_>, content: Content) -> anyhow::Result<()> {
+        set_epoch(dbtx, 0, content).await
     }
 
     // This will be used once we integrate the event for parameter changes.
@@ -34,23 +33,131 @@ mod _params {
     pub async fn set_epoch(
         dbtx: &mut PgTransaction<'_>,
         epoch: u64,
-        params: LiquidityTournamentParameters,
+        content: Content,
     ) -> anyhow::Result<()> {
+        let gauge_threshold = content
+            .funding_content
+            .funding_params
+            .liquidity_tournament
+            .gauge_threshold;
+        let delegator_share = content
+            .funding_content
+            .funding_params
+            .liquidity_tournament
+            .delegator_share;
+        let epoch_duration = content.sct_content.sct_params.epoch_duration;
+        let rewards_per_block = content
+            .distributions_content
+            .distributions_params
+            .liquidity_tournament_incentive_per_block;
         sqlx::query(
             "
             INSERT INTO lqt._params
-            VALUES ($1, $2::NUMERIC / 100, $3::NUMERIC / 100)
+            VALUES ($1, $2::NUMERIC / 100, $3::NUMERIC / 100, $4, $5)
             ON CONFLICT (epoch)
             DO UPDATE SET
                 delegator_share = EXCLUDED.delegator_share,
-                gauge_threshold = EXCLUDED.gauge_threshold
+                gauge_threshold = EXCLUDED.gauge_threshold,
+                epoch_duration = EXCLUDED.epoch_duration,
+                rewards_per_block = EXCLUDED.rewards_per_block
         ",
         )
         .bind(i64::try_from(epoch)?)
-        .bind(i64::try_from(params.gauge_threshold.to_percent())?)
-        .bind(i64::try_from(params.delegator_share.to_percent())?)
+        .bind(i64::try_from(delegator_share.to_percent())?)
+        .bind(i64::try_from(gauge_threshold.to_percent())?)
+        .bind(i64::try_from(epoch_duration)?)
+        .bind(i64::try_from(rewards_per_block)?)
         .execute(dbtx.as_mut())
         .await?;
+        Ok(())
+    }
+}
+
+mod _meta {
+    use penumbra_sdk_sct::event::EventBlockRoot;
+
+    use super::*;
+
+    const DEFAULT_BLOCK_TIME_SECS: f64 = 5.0;
+
+    pub async fn update_with_batch(
+        dbtx: &mut PgTransaction<'_>,
+        batch: &EventBatch,
+    ) -> anyhow::Result<()> {
+        let block_time_s = {
+            let mut timestamps = batch.events().filter_map(|e| {
+                EventBlockRoot::try_from_event(e.event)
+                    .ok()
+                    .map(|x| (x.height, x.timestamp_seconds as f64))
+            });
+            let first = timestamps.next();
+            let last = timestamps.last();
+            match (first, last) {
+                (Some((h0, t0)), Some((h1, t1))) => (t1 - t0) / (h1 - h0) as f64,
+                _ => DEFAULT_BLOCK_TIME_SECS,
+            }
+        };
+        let current_height = batch
+            .events_by_block()
+            .last()
+            .map(|x| x.height())
+            .ok_or(anyhow!("expected there to be at least one block in events"))?;
+        sqlx::query(
+            "
+            INSERT INTO lqt._meta VALUES (0, $1, $2)
+            ON CONFLICT (rowid)
+            DO UPDATE SET
+                current_height = EXCLUDED.current_height,
+                block_time_s = EXCLUDED.block_time_s
+        ",
+        )
+        .bind(i64::try_from(current_height)?)
+        .bind(block_time_s)
+        .execute(dbtx.as_mut())
+        .await?;
+        Ok(())
+    }
+}
+
+mod _epoch_info {
+    use super::*;
+
+    pub async fn start_epoch(
+        dbtx: &mut PgTransaction<'_>,
+        epoch: u64,
+        height: u64,
+    ) -> anyhow::Result<()> {
+        sqlx::query("INSERT INTO lqt._epoch_info VALUES ($1, $2, NULL, 0) ON CONFLICT DO NOTHING")
+            .bind(i64::try_from(epoch)?)
+            .bind(i64::try_from(height)?)
+            .execute(dbtx.as_mut())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn end_epoch(
+        dbtx: &mut PgTransaction<'_>,
+        epoch: u64,
+        height: u64,
+    ) -> anyhow::Result<()> {
+        sqlx::query("UPDATE lqt._epoch_info SET end_block = $2 WHERE epoch = $1")
+            .bind(i64::try_from(epoch)?)
+            .bind(i64::try_from(height)?)
+            .execute(dbtx.as_mut())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn set_rewards_for_epoch(
+        dbtx: &mut PgTransaction<'_>,
+        epoch: u64,
+        amount: Amount,
+    ) -> anyhow::Result<()> {
+        sqlx::query("UPDATE lqt._epoch_info SET available_rewards = $2::NUMERIC WHERE epoch = $1")
+            .bind(i64::try_from(epoch)?)
+            .bind(BigDecimal::from(amount.value()))
+            .execute(dbtx.as_mut())
+            .await?;
         Ok(())
     }
 }
@@ -66,32 +173,6 @@ mod _finished_epochs {
             .bind(i64::try_from(epoch)?)
             .execute(dbtx.as_mut())
             .await?;
-        Ok(())
-    }
-}
-
-mod _available_rewards {
-    use super::*;
-
-    /// Add some amount to the available rewards for an epoch.
-    pub async fn set_for_epoch(
-        dbtx: &mut PgTransaction<'_>,
-        epoch: u64,
-        amount: Amount,
-    ) -> anyhow::Result<()> {
-        sqlx::query(
-            "
-            INSERT INTO lqt._available_rewards
-            VALUES ($1, $2)
-            ON CONFLICT (epoch)
-            DO UPDATE SET
-                amount = EXCLUDED.amount
-        ",
-        )
-        .bind(i64::try_from(epoch)?)
-        .bind(BigDecimal::from(amount.value()))
-        .execute(dbtx.as_mut())
-        .await?;
         Ok(())
     }
 }
@@ -256,8 +337,10 @@ impl Lqt {
             .await?;
         } else if let Ok(e) = EventEpochRoot::try_from_event(&event.event) {
             _finished_epochs::declare_finished(dbtx, e.index).await?;
+            _epoch_info::end_epoch(dbtx, e.index, event.block_height).await?;
+            _epoch_info::start_epoch(dbtx, e.index + 1, event.block_height + 1).await?;
         } else if let Ok(e) = EventLqtPoolSizeIncrease::try_from_event(&event.event) {
-            _available_rewards::set_for_epoch(dbtx, e.epoch_index, e.new_total).await?;
+            _epoch_info::set_rewards_for_epoch(dbtx, e.epoch_index, e.new_total).await?;
         }
         Ok(())
     }
@@ -271,8 +354,7 @@ impl AppView for Lqt {
         app_state: &serde_json::Value,
     ) -> Result<(), anyhow::Error> {
         let content = parse_content(app_state.clone())?;
-        let params = content.funding_content.funding_params.liquidity_tournament;
-        _params::set_initial(dbtx, params).await?;
+        _params::set_initial(dbtx, content).await?;
         Ok(())
     }
 
@@ -281,7 +363,7 @@ impl AppView for Lqt {
     }
 
     fn version(&self) -> Version {
-        Version::with_major(1)
+        Version::with_major(2)
     }
 
     async fn reset(&self, dbtx: &mut PgTransaction) -> Result<(), anyhow::Error> {
@@ -295,6 +377,7 @@ impl AppView for Lqt {
         for statement in include_str!("schema.sql").split(";") {
             sqlx::query(statement).execute(dbtx.as_mut()).await?;
         }
+        _epoch_info::start_epoch(dbtx, 1, 1).await?;
         Ok(())
     }
 
@@ -304,6 +387,7 @@ impl AppView for Lqt {
         batch: EventBatch,
         _ctx: EventBatchContext,
     ) -> Result<(), anyhow::Error> {
+        _meta::update_with_batch(dbtx, &batch).await?;
         for event in batch.events() {
             self.index_event(dbtx, event).await?;
         }


### PR DESCRIPTION
## Describe your changes

This augments the `lqt.summary` view to have information about the start and end block (predicted or actual) along with an estimate of when the block will end, in seconds (matching the Figma design). This also changes the way rewards are presented in the summary to reflect the amount of rewards we *project* to be available during the epoch.

## Issue ticket number and link

Closes #5178.

I tested this by inspecting the data on testnet after these changes.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only
