### PR TITLE
fix: Emit EventAppParametersChange

### DIFF
--- a/crates/core/app/src/app/mod.rs
+++ b/crates/core/app/src/app/mod.rs
@@ -22,7 +22,7 @@ use penumbra_sdk_governance::component::{Governance, StateReadExt as _, StateWri
 use penumbra_sdk_ibc::component::{Ibc, StateWriteExt as _};
 use penumbra_sdk_ibc::StateReadExt as _;
 use penumbra_sdk_proto::core::app::v1::TransactionsByHeightResponse;
-use penumbra_sdk_proto::DomainType;
+use penumbra_sdk_proto::{DomainType, StateWriteProto as _};
 use penumbra_sdk_sct::component::clock::EpochRead;
 use penumbra_sdk_sct::component::sct::Sct;
 use penumbra_sdk_sct::component::{StateReadExt as _, StateWriteExt as _};
@@ -41,6 +41,7 @@ use tokio::time::sleep;
 use tracing::{instrument, Instrument};
 
 use crate::action_handler::AppActionHandler;
+use crate::event::EventAppParametersChange;
 use crate::genesis::AppState;
 use crate::params::change::ParameterChangeExt as _;
 use crate::params::AppParameters;
@@ -320,7 +321,13 @@ impl App {
             match change.apply_changes(old_params) {
                 Ok(new_params) => {
                     tracing::info!(?change, "applied app parameter change");
-                    state_tx.put_app_params(new_params);
+                    state_tx.put_app_params(new_params.clone());
+                    state_tx.record_proto(
+                        EventAppParametersChange {
+                            new_parameters: new_params,
+                        }
+                        .to_proto(),
+                    )
                 }
                 Err(e) => {
                     // N.B. this is an "info" rather than "warn" because it does not report

--- a/crates/core/app/src/event.rs
+++ b/crates/core/app/src/event.rs
@@ -5,8 +5,8 @@ use prost::Name as _;
 use crate::params::AppParameters;
 
 #[derive(Clone, Debug)]
-struct EventAppParametersChange {
-    new_parameters: AppParameters,
+pub struct EventAppParametersChange {
+    pub new_parameters: AppParameters,
 }
 
 impl TryFrom<pb::EventAppParametersChange> for EventAppParametersChange {


### PR DESCRIPTION
Closes #5186

I think this is the only location where the change happens.

For testing it could be useful to try running the reindexer off of this branch, and checking that we see the event appear in the testnet.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > event emission only
