### PR TITLE
pindexer: further LQT fixes

### DIFF
--- a/crates/bin/pindexer/src/lqt/mod.rs
+++ b/crates/bin/pindexer/src/lqt/mod.rs
@@ -182,7 +182,7 @@ mod _epoch_info {
     }
 
     pub async fn current(dbtx: &mut PgTransaction<'_>) -> anyhow::Result<u64> {
-        let out: i64 =
+        let out: i32 =
             sqlx::query_scalar("SELECT epoch FROM lqt._epoch_info ORDER BY epoch DESC LIMIT 1")
                 .fetch_one(dbtx.as_mut())
                 .await?;

--- a/crates/bin/pindexer/src/lqt/mod.rs
+++ b/crates/bin/pindexer/src/lqt/mod.rs
@@ -394,7 +394,7 @@ impl AppView for Lqt {
     }
 
     fn version(&self) -> Version {
-        Version::with_major(2)
+        Version::with_major(3)
     }
 
     async fn reset(&self, dbtx: &mut PgTransaction) -> Result<(), anyhow::Error> {

--- a/crates/bin/pindexer/src/lqt/schema.sql
+++ b/crates/bin/pindexer/src/lqt/schema.sql
@@ -252,7 +252,9 @@ $$Contains voting and reward history for a given delegator$$;
 
 DROP VIEW IF EXISTS lqt.lps;
 CREATE VIEW lqt.lps AS
-SELECT
+WITH non_zero_points AS (
+  SELECT * FROM lqt._lp_rewards WHERE points > 0  
+) SELECT
     epoch,
     position_id,
     asset_id,
@@ -263,7 +265,7 @@ SELECT
     asset_fees,
     points,
     points / SUM(points) OVER (PARTITION BY epoch) AS point_share
-FROM lqt._lp_rewards;
+FROM non_zero_points;
 COMMENT ON VIEW lqt.lps IS
 $$A view of each relevant LP, organized by epoch, and asset.
 

--- a/crates/bin/pindexer/src/lqt/schema.sql
+++ b/crates/bin/pindexer/src/lqt/schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS lqt._params (
     epoch INTEGER PRIMARY KEY,  
     delegator_share NUMERIC(3, 2) NOT NULL,
     gauge_threshold NUMERIC(3, 2) NOT NULL,
-    epoch_duration BIGINT NOT NULL,
+    epoch_duration INTEGER NOT NULL,
     rewards_per_block NUMERIC NOT NULL
 );
 
@@ -138,7 +138,7 @@ SELECT
   -- t + d >= (T + d) * p
   -- (1 - p) d >= p T - t
   -- d >= (p T - t) / (1 - p)
-  CEIL((gauge_threshold * total_tally - tally) / (1 - gauge_threshold))::BIGINT AS missing_votes
+  CEIL((gauge_threshold * total_tally - tally) / (1 - gauge_threshold))::NUMERIC AS missing_votes
 FROM tallies
 JOIN total USING (epoch)
 CROSS JOIN LATERAL (


### PR DESCRIPTION
## Describe your changes

Fixes two bugs:
- avoids a division by 0 by excluding lps with 0 points from being included in the lp table (thus avoiding epochs where no rewards were given out)
- uses `INTEGER` consistently for heights and epoch indices

## Testing

Check that `\d lqt.summary` doesn't show BIGINT as a type for `end_block`.

Check that `select * from lqt.lps` runs successfully against the testnet.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only
