### PR TITLE
pindexer: lqt: fix a couple more bugs

### DIFF
--- a/crates/bin/pindexer/src/lqt/schema.sql
+++ b/crates/bin/pindexer/src/lqt/schema.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS lqt._meta (
 CREATE TABLE IF NOT EXISTS lqt._epoch_info (
     epoch INTEGER PRIMARY KEY,  
     start_block INTEGER NOT NULL,
+    updated_block INTEGER NOT NULL,
     end_block INTEGER,
     available_rewards NUMERIC NOT NULL
 );
@@ -75,7 +76,9 @@ WITH vote_summary AS (
             ELSE 0.0::FLOAT8
         END AS ends_in_s,
         CASE
-            WHEN end_block IS NULL THEN rewards_per_block * epoch_duration
+            WHEN end_block IS NULL THEN
+                available_rewards +
+                rewards_per_block * (epoch_duration + start_block - updated_block - 1)
             ELSE available_rewards
         END AS rewards,
         delegator_share


### PR DESCRIPTION
## Describe your changes

- Fixes an issue where you had multiple entries in the delegator history each epoch.
- Fixes an issue where the projected rewards for an unfinished epoch were too low, not taking into account leftover rewards from the previous epoch.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only
