### PR TITLE
pindexer: lqt: handle an edge case in streak calculation properly

### DIFF
--- a/crates/bin/pindexer/src/lqt/schema.sql
+++ b/crates/bin/pindexer/src/lqt/schema.sql
@@ -189,12 +189,12 @@ WITH delegator_streaks AS (
             epoch AS gap_start,
             next_epoch AS gap_end
         FROM epochs
-        ORDER BY address, next_epoch - epoch > 1 DESC, next_epoch DESC
+        ORDER BY address, next_epoch IS NOT NULL AND next_epoch - epoch > 1 DESC, next_epoch DESC
     ) SELECT
         address,
         CASE
             WHEN max_epoch < (SELECT MAX(epoch) FROM lqt._finished_epochs) THEN 0
-            WHEN gap_end - gap_start > 1 THEN max_epoch - gap_end + 1
+            WHEN gap_end IS NOT NULL AND gap_end - gap_start > 1 THEN max_epoch - gap_end + 1
             ELSE max_epoch - min_epoch + 1
         END AS streak
         FROM gaps


### PR DESCRIPTION
## Describe your changes

We were incorrectly selecting for the most recent non-zero gap,
by not handling the most recent epoch a given delegator has voted in.
In that case, there's no "end" to the gap, and we need to handle
the value being NULL.

The effect of this change is that streaks are now calculated correctly,
with the weird behavior of seeing a streak larger than the number
of epochs voted in not appearing.

Closes https://github.com/penumbra-zone/web/issues/2334

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only
