### PR TITLE
fix: add community-pool rpc support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5416,6 +5416,7 @@ version = "1.5.1"
 dependencies = [
  "anyhow",
  "ark-ff",
+ "async-stream",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
@@ -5439,6 +5440,7 @@ dependencies = [
  "tendermint 0.40.3",
  "tendermint-light-client-verifier",
  "tokio",
+ "tonic",
  "tracing",
 ]
 

--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -231,6 +231,7 @@ pub enum TxCmd {
     #[clap(display_order = 600)]
     CommunityPoolDeposit {
         /// The amounts to send, written as typed values 1.87penumbra, 12cubes, etc.
+        #[clap(min_values = 1, required = true)]
         values: Vec<String>,
         /// Only spend funds originally received by the given account.
         #[clap(long, default_value = "0", display_order = 300)]

--- a/crates/core/app/src/rpc.rs
+++ b/crates/core/app/src/rpc.rs
@@ -24,6 +24,7 @@ use {
         },
     },
     penumbra_sdk_auction::component::rpc::Server as AuctionServer,
+    penumbra_sdk_community_pool::component::rpc::Server as CommunityPoolServer,
     penumbra_sdk_compact_block::component::rpc::Server as CompactBlockServer,
     penumbra_sdk_dex::component::rpc::Server as DexServer,
     penumbra_sdk_fee::component::rpc::Server as FeeServer,
@@ -33,6 +34,7 @@ use {
             app::v1::query_service_server::QueryServiceServer as AppQueryServiceServer,
             component::{
                 auction::v1::query_service_server::QueryServiceServer as AuctionQueryServiceServer,
+                community_pool::v1::query_service_server::QueryServiceServer as CommunityPoolQueryServiceServer,
                 compact_block::v1::query_service_server::QueryServiceServer as CompactBlockQueryServiceServer,
                 dex::v1::{
                     query_service_server::QueryServiceServer as DexQueryServiceServer,
@@ -106,6 +108,9 @@ pub fn routes(
         .add_service(we(BankQueryServer::new(ShieldedPoolServer::new(
             storage.clone(),
         ))))
+        .add_service(we(CommunityPoolQueryServiceServer::new(
+            CommunityPoolServer::new(storage.clone()),
+        )))
         .add_service(we(StakeQueryServiceServer::new(StakeServer::new(
             storage.clone(),
         ))))

--- a/crates/core/component/community-pool/Cargo.toml
+++ b/crates/core/component/community-pool/Cargo.toml
@@ -11,8 +11,11 @@ edition = {workspace = true}
 component = [
     "cnidarium-component",
     "cnidarium",
+    "tonic",
     "penumbra-sdk-proto/cnidarium",
     "penumbra-sdk-shielded-pool/component",
+
+    "async-stream",
 ]
 default = ["component"]
 docsrs = []
@@ -21,6 +24,7 @@ docsrs = []
 anyhow = {workspace = true}
 ark-ff = {workspace = true, default-features = false}
 async-trait = {workspace = true}
+async-stream = {workspace = true, optional = true}
 base64 = {workspace = true}
 blake2b_simd = {workspace = true}
 cnidarium = {workspace = true, optional = true, default-features = true}
@@ -42,6 +46,7 @@ serde = {workspace = true, features = ["derive"]}
 sha2 = {workspace = true}
 tendermint = {workspace = true}
 tendermint-light-client-verifier = {workspace = true}
+tonic = {workspace = true, optional = true}
 tracing = {workspace = true}
 
 [dev-dependencies]

--- a/crates/core/component/community-pool/src/component.rs
+++ b/crates/core/component/community-pool/src/component.rs
@@ -3,6 +3,8 @@
 /// [`CommunityPoolSpend`] and [`CommunityPoolDeposit`] actions.
 pub mod state_key;
 
+pub mod rpc;
+
 mod action_handler;
 mod view;
 

--- a/crates/core/component/community-pool/src/component/rpc.rs
+++ b/crates/core/component/community-pool/src/component/rpc.rs
@@ -1,0 +1,86 @@
+use penumbra_sdk_proto::core::{
+    asset::v1::{AssetId, Value},
+    component::community_pool::v1::{
+        query_service_server::QueryService, CommunityPoolAssetBalancesRequest,
+        CommunityPoolAssetBalancesResponse,
+    },
+};
+
+use async_stream::try_stream;
+use futures::{StreamExt, TryStreamExt};
+use std::pin::Pin;
+use tonic::Status;
+use tracing::instrument;
+
+use cnidarium::Storage;
+
+use super::StateReadExt;
+
+pub struct Server {
+    storage: Storage,
+}
+
+impl Server {
+    pub fn new(storage: Storage) -> Self {
+        Self { storage }
+    }
+}
+
+#[tonic::async_trait]
+impl QueryService for Server {
+    /// Stream of asset balance info within the CommunityPool, to satisfy the "repeated"
+    /// field in the protobuf spec.
+    type CommunityPoolAssetBalancesStream = Pin<
+        Box<
+            dyn futures::Stream<Item = Result<CommunityPoolAssetBalancesResponse, tonic::Status>>
+                + Send,
+        >,
+    >;
+
+    #[instrument(skip(self, request))]
+    async fn community_pool_asset_balances(
+        &self,
+        request: tonic::Request<CommunityPoolAssetBalancesRequest>,
+    ) -> Result<tonic::Response<Self::CommunityPoolAssetBalancesStream>, Status> {
+        let state = self.storage.latest_snapshot();
+        let request = request.into_inner();
+
+        // Asset IDs are optional in the req; if none set, return all balances.
+        let asset_ids: Vec<AssetId> = request.asset_ids;
+
+        // Get all balances; we can filter later.
+        let asset_balances = state.community_pool_balance().await.or_else(|_| {
+            Err(tonic::Status::internal(
+                "failed to find community pool balances",
+            ))
+        })?;
+
+        let s = try_stream! {
+            for asset_balance in asset_balances {
+                let v = Value {
+                    asset_id: Some(asset_balance.0.into()),
+                    amount: Some(asset_balance.1.into())
+                };
+                // Check whether a filter was requested
+                if !asset_ids.is_empty() {
+                    if asset_ids.contains(&v.asset_id.clone().unwrap()) {
+                        yield v;
+                    }
+                } else {
+                    yield v;
+                }
+            }
+        };
+        Ok(tonic::Response::new(
+            s.map_ok(|value: Value| CommunityPoolAssetBalancesResponse {
+                balance: Some(value),
+            })
+            .map_err(|e: anyhow::Error| {
+                tonic::Status::unavailable(format!(
+                    "error getting balances for community pool: {e}"
+                ))
+            })
+            .boxed(),
+        ))
+    }
+}


### PR DESCRIPTION
## Describe your changes
We've been advertising this RPC in the protobuf docs, and even in the pcli subcommands, but it hasn't ever worked. To resolve, this PR:

* hooks up the missing CommunityPool RPC in `pd`
* exercises the already-existing `pcli q community-pool balance` logic via integration tests
* adds a fix for `pcli tx community-pool-deposit` to require a value, along with tests

## Issue ticket number and link

Closes #4381. 

## Testing

I added tests to CI, so give them a visual review as a sanity-check, but green on CI is good enough to merge.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Wires up documented by missing RPC; no changes to consensus logic. 