### PR TITLE
fix: use swap claim address for transaction summary

### DIFF
--- a/crates/bin/pcli/tests/network_integration.rs
+++ b/crates/bin/pcli/tests/network_integration.rs
@@ -1260,3 +1260,24 @@ fn delegate_submit_proposal_and_vote() {
         .assert()
         .success();
 }
+
+#[ignore]
+#[test]
+/// Ensure that the view service can successfully parse all historical
+/// transactions submitted above.
+fn view_tx_hashes() {
+    let tmpdir = load_wallet_into_tmpdir();
+    let mut view_cmd = Command::cargo_bin("pcli").unwrap();
+    view_cmd
+        .args([
+            "--home",
+            tmpdir.path().to_str().unwrap(),
+            "view",
+            "list-tx-hashes",
+        ])
+        .timeout(std::time::Duration::from_secs(TIMEOUT_COMMAND_SECONDS));
+    let _view_result = view_cmd
+        .assert()
+        .try_success()
+        .expect("pcli command failed: 'view list-tx-hashes'");
+}

--- a/crates/core/transaction/src/view.rs
+++ b/crates/core/transaction/src/view.rs
@@ -154,7 +154,7 @@ impl TransactionView {
                     SwapView::Visible {
                         swap: _,
                         swap_plaintext,
-                        output_1,
+                        output_1: _,
                         output_2: _,
                         claim_tx: _,
                         asset_1_metadata: _,
@@ -162,7 +162,7 @@ impl TransactionView {
                         batch_swap_output_data: _,
                     } => {
                         let address = AddressView::Opaque {
-                            address: output_1.clone().expect("sender address").address(),
+                            address: swap_plaintext.claim_address.clone(),
                         };
 
                         let value_fee = Value {

--- a/crates/core/transaction/src/view.rs
+++ b/crates/core/transaction/src/view.rs
@@ -884,6 +884,6 @@ mod test {
 
         let transaction_summary = TransactionView::summary(&transaction_view);
 
-        assert_eq!(transaction_summary.effects.len(), 2);
+        assert_eq!(transaction_summary.effects.len(), 3);
     }
 }


### PR DESCRIPTION
Using only the outputs runs into some niche issues for certain transactions, this method always works.

## Issue ticket number and link

Closes #5200.

Now, `pcli v list-tx-hashes` should not error out again.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > client only