### PR TITLE
fix(pcli): require deposit when submitting proposal

### DIFF
--- a/crates/bin/pcli/src/command/tx/proposal.rs
+++ b/crates/bin/pcli/src/command/tx/proposal.rs
@@ -27,7 +27,7 @@ pub enum ProposalCmd {
         #[clap(long, default_value = "0")]
         source: u32,
         /// The amount of the staking token to deposit alongside the proposal.
-        #[clap(long, default_value = "")]
+        #[clap(long, required = true)]
         deposit_amount: String,
         /// The selected fee tier to multiply the fee amount by.
         #[clap(short, long, default_value_t)]


### PR DESCRIPTION


## Describe your changes
The `--deposit-amount` flag is required when running `pcli tx proposal submit`, but the clap settings weren't enforcing that, and the resulting error message was quite vague. Now, running `pcli tx proposal submit` without providing a `--deposit-amount` flag emits a helpful error message:

  error: The following required arguments were not provided:
      --deposit-amount <DEPOSIT_AMOUNT>

The parsing the amount, e.g. "10penumbra", remains unchanged.

## Testing and review

A visual inspection of the diff is good enough: we already have integration tests that exercise the `--deposit-amount` flag is parsed correctly. Here's a before and after.

### Before

```
❯ cargo run -q --release --bin pcli -- --home ~/.local/share/pcli-localhost/ tx proposal submit --file prop.toml
2025-05-21T20:07:32.356691Z  INFO pcli::opt: using software KMS custody service
2025-05-21T20:07:32.356723Z  INFO pcli::opt: using local view service path=/home/conor/.local/share/pcli-localhost/pcli-view.sqlite
2025-05-21T20:07:32.358649Z  INFO view: penumbra_sdk_view::worker: starting client sync
Scanning blocks from last sync height 448 to latest height 725
[0s] ██████████████████████████████████████████████████     277/277     68143/s ETA: 0s
Error: could not parse  as a value; provide both a numeric value and denomination, e.g. 1penumbra
```

### After

```
❯ cargo run -q --release --bin pcli -- --home ~/.local/share/pcli-localhost/ tx proposal submit --file prop.toml
error: The following required arguments were not provided:
    --deposit-amount <DEPOSIT_AMOUNT>

USAGE:
    pcli transaction proposal submit --file <FILE> --deposit-amount <DEPOSIT_AMOUNT>

For more information try --help
```

## Issue ticket number and link

Closes #3455.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > no changes to consensus logic, just a tweak to pcli arg-handling
