### PR TITLE
feat: wip: use address views in tx summary

### DIFF
--- a/crates/core/transaction/src/view.rs
+++ b/crates/core/transaction/src/view.rs
@@ -125,9 +125,7 @@ impl TransactionView {
                         // Provided imbalance (+)
                         let balance = Balance::from(note.value.value());
 
-                        let address = AddressView::Opaque {
-                            address: note.address(),
-                        };
+                        let address = note.address.clone();
 
                         effects.push(TransactionEffect { address, balance });
                     }
@@ -142,9 +140,7 @@ impl TransactionView {
                         // Required imbalance (-)
                         let balance = -Balance::from(note.value.value());
 
-                        let address = AddressView::Opaque {
-                            address: note.address(),
-                        };
+                        let address = note.address.clone();
 
                         effects.push(TransactionEffect { address, balance });
                     }


### PR DESCRIPTION
Only on the spend and output actions for now. We'll need to think a bit more about how to handle swaps.
- balance attribution for swaps isn't clear to me,
- we either need to pass an FVK, or augment the swap view with a decoded claim address.

This doesn't solve #5205 yet, but I think this already provides value for spend and output actions, which are a lot of the actions, and so I think merging it in this form is a good idea while we figure out the other salient points.

For testing, looking at the resulting pcli changes should be enough.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > view only