### PR TITLE
chore: update minifront bundled assets

### DIFF
--- a/assets/minifront.zip
+++ b/assets/minifront.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5f9cda9dc0169fa467d01a33673253fe8e0d393d52087c7712f3ceb5815d90f
-size 8339485
+oid sha256:e4de08e5ac2ee5f120bb7c668eda947217f6c131f87c2657729a026651a43c93
+size 7786139

--- a/assets/node-status.zip
+++ b/assets/node-status.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d88d6ceabd334ebcd4c8a689cffcc11a58adb51cd24bf63629e70a5b23394b7e
-size 1245178
+oid sha256:ace260a4b444dbfc8b6313a03eefcbb7ca79f9560dfa6ef1b80ef39b64ee194e
+size 1258652


### PR DESCRIPTION

## Describe your changes
Built from head on web repo 23d578b4f14f6d0a562b9699dca606b60c86e27b. Tested locally, and I see the new version displayed in my local browser, in the footer.

### Before
![minifront-before](https://github.com/user-attachments/assets/72ea1323-7c9d-419d-a3c6-ad6165c463b6)

### After
![minifront-after](https://github.com/user-attachments/assets/6ccbe9d7-b7bc-457c-9aa4-3216ec7757b2)


## Issue ticket number and link

Routine maintenance, handling now ahead of upcoming releases #5213 & #5214.

## Testing and review

You can build the dev env locally via `just dev`, navigate to `http://localhost:8080/app/`, attach Prax, then view the footer. Or, you can review the screenshots I've posted above, and approve based on that.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > No changes to consensus, only updated the bundled web assets in pd
