### PR TITLE
Fix various bugs in the Dex metrics

### DIFF
--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -36,10 +36,6 @@ mod candle {
     use penumbra_sdk_dex::CandlestickData;
     use std::fmt::Display;
 
-    fn geo_mean(a: f64, b: f64) -> f64 {
-        (a * b).sqrt()
-    }
-
     /// Candlestick data, unmoored from the prison of a particular block height.
     ///
     /// In other words, this can represent candlesticks which span arbitrary windows,
@@ -86,43 +82,6 @@ mod candle {
             self.high = self.high.max(that.high);
             self.direct_volume += that.direct_volume;
             self.swap_volume += that.swap_volume;
-        }
-
-        /// Mix this candle with a candle going in the opposite direction of the pair.
-        pub fn mix(&mut self, op: &Self) {
-            // We use the geometric mean, resulting in all the prices in a.mix(b) being
-            // the inverse of the prices in b.mix(a), and the volumes being equal.
-            self.close /= geo_mean(self.close, op.close);
-            self.open /= geo_mean(self.open, op.open);
-            self.low = self.low.min(1.0 / op.low);
-            self.high = self.high.min(1.0 / op.high);
-            // Using the closing price to look backwards at volume.
-            self.direct_volume += op.direct_volume / self.close;
-            self.swap_volume += op.swap_volume / self.close;
-        }
-
-        /// Flip this candle to get the equivalent in the other direction.
-        pub fn flip(&self) -> Self {
-            Self {
-                open: 1.0 / self.open,
-                close: 1.0 / self.close,
-                low: 1.0 / self.low,
-                high: 1.0 / self.high,
-                direct_volume: self.direct_volume * self.close,
-                swap_volume: self.swap_volume * self.close,
-            }
-        }
-    }
-
-    impl From<CandlestickData> for Candle {
-        fn from(value: CandlestickData) -> Self {
-            Self::from(&value)
-        }
-    }
-
-    impl From<&CandlestickData> for Candle {
-        fn from(value: &CandlestickData) -> Self {
-            Self::from_candlestick_data(value)
         }
     }
 

--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -590,8 +590,12 @@ mod summary {
                 SELECT
                     SUM(dv) AS direct_volume,
                     SUM(sv) AS swap_volume,
-                    SUM(liquidity) AS liquidity,
                     SUM(trades) AS trades
+                FROM converted_pairs_summary WHERE asset_start < asset_end
+            ),
+            total_liquidity AS (
+                SELECT
+                    SUM(liquidity) AS liquidity
                 FROM converted_pairs_summary
             ),
             undirected_pairs_summary AS (
@@ -653,6 +657,7 @@ mod summary {
         JOIN largest_sv ON TRUE
         JOIN largest_dv ON TRUE
         JOIN top_price_mover ON TRUE
+        JOIN total_liquidity ON TRUE
         JOIN counts ON TRUE
         ON CONFLICT (the_window) DO UPDATE SET
             direct_volume = EXCLUDED.direct_volume,

--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -1579,6 +1579,20 @@ impl AppView for Component {
             }
 
             for (pair, candle) in &events.candles {
+                sqlx::query(
+                    "INSERT INTO dex.candles VALUES (DEFAULT, $1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                )
+                .bind(time)
+                .bind(pair.start.to_bytes())
+                .bind(pair.end.to_bytes())
+                .bind(candle.open)
+                .bind(candle.close)
+                .bind(candle.low)
+                .bind(candle.high)
+                .bind(candle.direct_volume)
+                .bind(candle.swap_volume)
+                .execute(dbtx.as_mut())
+                .await?;
                 for window in Window::all() {
                     let key = (pair.start, pair.end, window);
                     if !charts.contains_key(&key) {

--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -2,7 +2,7 @@ use anyhow::anyhow;
 use clap::Result;
 use cometindex::{
     async_trait,
-    index::{BlockEvents, EventBatch, EventBatchContext},
+    index::{BlockEvents, EventBatch, EventBatchContext, Version},
     AppView, PgTransaction,
 };
 use penumbra_sdk_asset::{asset, Value, STAKING_TOKEN_ASSET_ID};
@@ -1503,17 +1503,32 @@ impl Component {
 impl AppView for Component {
     async fn init_chain(
         &self,
-        dbtx: &mut PgTransaction,
+        _dbtx: &mut PgTransaction,
         _: &serde_json::Value,
     ) -> Result<(), anyhow::Error> {
-        for statement in include_str!("schema.sql").split(";") {
-            sqlx::query(statement).execute(dbtx.as_mut()).await?;
-        }
         Ok(())
     }
 
     fn name(&self) -> String {
         "dex_ex".to_string()
+    }
+
+    fn version(&self) -> Version {
+        Version::with_major(1)
+    }
+
+    async fn reset(&self, dbtx: &mut PgTransaction) -> Result<(), anyhow::Error> {
+        for statement in include_str!("reset.sql").split(";") {
+            sqlx::query(statement).execute(dbtx.as_mut()).await?;
+        }
+        Ok(())
+    }
+
+    async fn on_startup(&self, dbtx: &mut PgTransaction) -> Result<(), anyhow::Error> {
+        for statement in include_str!("schema.sql").split(";") {
+            sqlx::query(statement).execute(dbtx.as_mut()).await?;
+        }
+        Ok(())
     }
 
     async fn index_batch(

--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -292,7 +292,7 @@ mod price_chart {
             .fetch_optional(dbtx.as_mut())
             .await?;
             let state = row.map(
-                |(open, close, low, high, direct_volume, swap_volume, start)| {
+                |(open, close, high, low, direct_volume, swap_volume, start)| {
                     let candle = Candle {
                         open,
                         close,

--- a/crates/bin/pindexer/src/dex_ex/reset.sql
+++ b/crates/bin/pindexer/src/dex_ex/reset.sql
@@ -1,0 +1,15 @@
+-- Version 0
+DROP TABLE IF EXISTS dex_ex_price_charts CASCADE;
+DROP TABLE IF EXISTS dex_ex_pairs_block_snapshot CASCADE;
+DROP TABLE IF EXISTS dex_ex_pairs_summary CASCADE;
+DROP TABLE IF EXISTS dex_ex_aggregate_summary CASCADE;
+DROP TABLE IF EXISTS dex_ex_metadata CASCADE;
+DROP TABLE IF EXISTS dex_ex_position_state CASCADE;
+DROP TABLE IF EXISTS dex_ex_position_reserves CASCADE;
+DROP TABLE IF EXISTS dex_ex_position_executions CASCADE;
+DROP TABLE IF EXISTS dex_ex_position_withdrawals CASCADE;
+DROP TABLE IF EXISTS dex_ex_batch_swap_traces CASCADE;
+DROP TABLE IF EXISTS dex_ex_block_summary CASCADE;
+DROP TABLE IF EXISTS dex_ex_transactions CASCADE;
+-- Version 1
+DROP SCHEMA IF EXISTS dex_ex CASCADE;

--- a/crates/bin/pindexer/src/dex_ex/schema.sql
+++ b/crates/bin/pindexer/src/dex_ex/schema.sql
@@ -1,3 +1,20 @@
+CREATE SCHEMA IF NOT EXISTS dex;
+
+CREATE TABLE IF NOT EXISTS dex.candles (
+  id SERIAL PRIMARY KEY,
+  time TIMESTAMPTZ NOT NULL,
+  asset_start BYTEA NOT NULL,
+  asset_end BYTEA NOT NULL,
+  open FLOAT8 NOT NULL,
+  close FLOAT8 NOT NULL,
+  low FLOAT8 NOT NULL,
+  high FLOAT8 NOT NULL,
+  direct_volume FLOAT8 NOT NULL,
+  swap_volume FLOAT8 NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_dex_candles_000 ON dex.candles (asset_start, asset_end, time);
+
 -- Contains, for each directed asset pair and window type, candle sticks for each window.
 CREATE TABLE IF NOT EXISTS dex_ex_price_charts (
   -- We just want a simple primary key to have here.


### PR DESCRIPTION
## Describe your changes

Closes #5166.

I found several bugs in the code, and fixed those.

One bigger one is that our way of loading back candles from the database swapped the high and low values, leading to corrupted data, all throughout the rest of the pipeline. So that wasn't ideal.

I also went ahead and and avoided the use of the candlestick data event, opting instead to calculate the candles from the swap traces, so that way we're completely sure that what we have makes sense in both directions, and is internally consistent with our market trades.

I tested that veil works with a re-index using this code, and it does. In particular, the total liquidity is correct, after inspection, the candlestick chart looks much better, with closes usually matching openings.
![image](https://github.com/user-attachments/assets/82868e56-49d3-4e18-a9d3-5f13ec94eb6e)
Also, the summary is now well in sync with the market trades, e.g. the most recent price matches what you see there.

There are still some issues on the Veil side. Notably, some metrics need to be summed up for both directions of a pair, which isn't currently done. Also, the data fetching on the Veil side does too much manipulation of the data, and I experienced some new crashes when messing around with some of the less utilized price charts, so I suspect there's some latent bugs in the rendering there.

For testing, I'd recommend running a re-index. In particular, confirm that this code does not require dropping the database, the version migration number mechanism should kick in.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Indexing only
