### PR TITLE
feat: implement LoadRegistry command for pclientd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4937,6 +4937,7 @@ dependencies = [
  "prost 0.13.4",
  "rand",
  "rand_core",
+ "reqwest 0.12.9",
  "rpassword",
  "rustls 0.23.21",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,7 @@ rand                             = { version = "0.8.5" }
 rand_chacha                      = { version = "0.3.1" }
 rand_core                        = { version = "0.6.4" }
 regex                            = { version = "1.8.1" }
+reqwest                          = { version = "0.12.9", features = ["json", "stream"] }
 rocksdb                          = { version = "0.21.0" }
 rpassword                        = { version = "7" }
 rstest                           = { version = "0.24.0" }

--- a/crates/bin/pclientd/Cargo.toml
+++ b/crates/bin/pclientd/Cargo.toml
@@ -46,12 +46,14 @@ penumbra-sdk-view = {workspace = true}
 prost = {workspace = true}
 rand = {workspace = true}
 rand_core = {workspace = true, features = ["getrandom"]}
+reqwest = {workspace = true}
 rpassword = {workspace = true}
 rustls = {workspace = true}
 serde = {workspace = true, features = ["derive"]}
 serde_json = {workspace = true}
 serde_with = {workspace = true, features = ["hex"]}
 sha2 = {workspace = true}
+tempfile = {workspace = true}
 tendermint = {workspace = true}
 tokio = {workspace = true, features = ["full"]}
 tokio-stream = {workspace = true, features = ["sync"]}
@@ -73,4 +75,3 @@ penumbra-sdk-proof-params = {workspace = true, features = [
     "bundled-proving-keys",
     "download-proving-keys",
 ], default-features = true}
-tempfile = {workspace = true}

--- a/crates/bin/pd/Cargo.toml
+++ b/crates/bin/pd/Cargo.toml
@@ -87,7 +87,7 @@ rand                             = { workspace = true }
 rand_chacha                      = { workspace = true }
 rand_core                        = { workspace = true, features = ["getrandom"] }
 regex                            = { workspace = true }
-reqwest                          = { version = "0.12.9", features = ["json", "stream"] }
+reqwest                          = { workspace = true }
 rocksdb                          = { workspace = true }
 rustls                           = { workspace = true }
 serde                            = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Add LoadRegistry command to pclientd that downloads asset registry files from URLs and loads them into the local storage using reqwest and tempfile.

Key features:
- Downloads from HTTP/HTTPS URLs or copies from local file:// paths
- Defaults to Prax wallet registry when no source provided
- Automatically appends chain ID for directory URLs
- Uses temporary files for safe handling
- Integrates with existing Storage::load_asset_metadata method

The utility here is so that when using pclientd, you can use the usual asset fetching mechanisms, enabling other clients to benefit from rich metadata. (in particular the nascent trading sdk)

To test, try running the command yourself on your pclientd instance. `pclientd load-registry` should "just work", but is configurable to whatever we might need.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Client only