### PR TITLE
Skip arb executions for dex explorer price charts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6591,6 +6591,7 @@ version = "2.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "blake2b_simd 1.0.2",
  "chrono",
  "clap",
  "cometindex",

--- a/crates/bin/pindexer/Cargo.toml
+++ b/crates/bin/pindexer/Cargo.toml
@@ -20,6 +20,7 @@ network-integration = []
 
 [dependencies]
 anyhow = {workspace = true}
+blake2b_simd = {workspace = true}
 clap = {workspace = true}
 chrono = {workspace = true, features = ["serde"] }
 cometindex = {workspace = true}

--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -821,7 +821,7 @@ impl Events {
         }
     }
 
-    pub fn extract(block: &BlockEvents) -> anyhow::Result<Self> {
+    pub fn extract(block: &BlockEvents, ignore_arb_executions: bool) -> anyhow::Result<Self> {
         let mut out = Self::new();
         out.height = block.height() as i32;
 
@@ -914,7 +914,9 @@ impl Events {
                 }
                 out.batch_swaps.push(e);
             } else if let Ok(e) = EventArbExecution::try_from_event(&event.event) {
-                out.with_swap_execution(&e.swap_execution);
+                if !ignore_arb_executions {
+                    out.with_swap_execution(&e.swap_execution);
+                }
             }
         }
         Ok(out)
@@ -970,13 +972,15 @@ impl Events {
 pub struct Component {
     denom: asset::Id,
     min_liquidity: f64,
+    ignore_arb_executions: bool,
 }
 
 impl Component {
-    pub fn new(denom: asset::Id, min_liquidity: f64) -> Self {
+    pub fn new(denom: asset::Id, min_liquidity: f64, ignore_arb_executions: bool) -> Self {
         Self {
             denom,
             min_liquidity,
+            ignore_arb_executions,
         }
     }
 
@@ -1505,7 +1509,7 @@ impl AppView for Component {
         let mut snapshots = HashMap::new();
         let mut last_time = None;
         for block in batch.events_by_block() {
-            let mut events = Events::extract(&block)?;
+            let mut events = Events::extract(&block, self.ignore_arb_executions)?;
             let time = events
                 .time
                 .expect(&format!("no block root event at height {}", block.height()));

--- a/crates/bin/pindexer/src/indexer_ext.rs
+++ b/crates/bin/pindexer/src/indexer_ext.rs
@@ -13,6 +13,7 @@ impl IndexerExt for cometindex::Indexer {
             .with_index(Box::new(crate::dex_ex::Component::new(
                 options.indexing_denom,
                 options.dex_ex_min_liquidity as f64,
+                options.dex_ex_ignore_arb,
             )))
             .with_index(Box::new(crate::supply::Component::new()))
             .with_index(Box::new(crate::ibc::Component::new()))

--- a/crates/bin/pindexer/src/insights/reset.sql
+++ b/crates/bin/pindexer/src/insights/reset.sql
@@ -1,0 +1,5 @@
+-- Version 0
+DROP TABLE IF EXISTS insights_supply CASCADE;
+DROP TABLE IF EXISTS _insights_validators CASCADE;
+DROP TABLE IF EXISTS insights_shielded_pool CASCADE;
+DROP TABLE IF EXISTS _insights_shielded_pool_depositors CASCADE;

--- a/crates/bin/pindexer/src/lib.rs
+++ b/crates/bin/pindexer/src/lib.rs
@@ -27,4 +27,6 @@ pub struct Options {
     /// The minimum liquidity for the indexing denom in the dex explorer app view.
     #[clap(long, default_value = "100000000")]
     pub dex_ex_min_liquidity: u128,
+    #[clap(long, default_value = "true")]
+    pub dex_ex_ignore_arb: bool,
 }

--- a/crates/util/cometindex/src/indexer/indexing_state.rs
+++ b/crates/util/cometindex/src/indexer/indexing_state.rs
@@ -84,19 +84,17 @@ impl IndexingManager {
         Ok(res.unwrap_or_default())
     }
 
-    pub async fn index_state(&self, name: &str) -> anyhow::Result<IndexState> {
+    pub async fn index_state(&self, name: &str) -> anyhow::Result<Option<IndexState>> {
         let row: Option<(Height, Option<i64>, Option<[u8; 32]>)> = sqlx::query_as(
             "SELECT height, version, option_hash FROM index_watermarks WHERE index_name = $1",
         )
         .bind(name)
         .fetch_optional(&self.dst)
         .await?;
-        Ok(row
-            .map(|(height, major, option_hash)| IndexState {
-                height,
-                version: Version::new(major, option_hash),
-            })
-            .unwrap_or_default())
+        Ok(row.map(|(height, major, option_hash)| IndexState {
+            height,
+            version: Version::new(major, option_hash),
+        }))
     }
 
     pub async fn index_states(&self) -> anyhow::Result<HashMap<String, IndexState>> {

--- a/crates/util/cometindex/src/opt.rs
+++ b/crates/util/cometindex/src/opt.rs
@@ -40,6 +40,12 @@ pub struct Options {
     /// If set, don't index, running only integrity checks against the database.
     #[clap(long)]
     pub integrity_checks_only: bool,
+
+    /// If set, allow the options for app views to change.
+    ///
+    /// This is a safeguard against accidentally changing them.
+    #[clap(long)]
+    pub new_options: bool,
 }
 
 /// Parses a string containing a [`Duration`], represented as a number of milliseconds.

--- a/deployments/compose/process-compose-postgres.yml
+++ b/deployments/compose/process-compose-postgres.yml
@@ -66,7 +66,8 @@ processes:
       cargo run --release --bin pindexer -- \
           --src-database-url "postgresql://localhost:5432/penumbra_cometbft?sslmode=disable" \
           --dst-database-url "postgresql://localhost:5432/penumbra_pindexer?sslmode=disable" \
-          --genesis-json ~/.penumbra/network_data/node0/cometbft/config/genesis.json
+          --genesis-json ~/.penumbra/network_data/node0/cometbft/config/genesis.json \
+          --new-options
     depends_on:
       postgresql-init:
         condition: process_completed_successfully

--- a/deployments/compose/process-compose-postgres.yml
+++ b/deployments/compose/process-compose-postgres.yml
@@ -67,7 +67,6 @@ processes:
           --src-database-url "postgresql://localhost:5432/penumbra_cometbft?sslmode=disable" \
           --dst-database-url "postgresql://localhost:5432/penumbra_pindexer?sslmode=disable" \
           --genesis-json ~/.penumbra/network_data/node0/cometbft/config/genesis.json \
-          --new-options
     depends_on:
       postgresql-init:
         condition: process_completed_successfully

--- a/deployments/compose/process-compose-postgres.yml
+++ b/deployments/compose/process-compose-postgres.yml
@@ -66,7 +66,7 @@ processes:
       cargo run --release --bin pindexer -- \
           --src-database-url "postgresql://localhost:5432/penumbra_cometbft?sslmode=disable" \
           --dst-database-url "postgresql://localhost:5432/penumbra_pindexer?sslmode=disable" \
-          --genesis-json ~/.penumbra/network_data/node0/cometbft/config/genesis.json \
+          --genesis-json ~/.penumbra/network_data/node0/cometbft/config/genesis.json
     depends_on:
       postgresql-init:
         condition: process_completed_successfully


### PR DESCRIPTION
## Describe your changes

This also creates a backwards compatible mechanism to allow app views to automatically reset themselves if relevant options change. In this case, this allows this change to run on top of an existing indexed database, with the result (test this) of just resetting the dex explorer component, since the options affecting indexing will have changed.

I also added a safeguard to prevent accidentally clobbering over the relevant app view when the options change. Instead, an explicit opt in with `--new-options` is required to indicate that you intended to reset that app view with new options.

In particular, to test, running pindexer SHOULD FAIL without `--new-options`, and then SHOULD SUCCEED with `--new-options`, with the result of re-running the dex_ex app view, this time without arb executions in the price chart. (There's a new flag to enable them again)


## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only
