### PR TITLE
fix(pindexer): store new version in db

### DIFF
--- a/crates/util/cometindex/src/indexer.rs
+++ b/crates/util/cometindex/src/indexer.rs
@@ -132,7 +132,7 @@ async fn catchup(
                 index.init_chain(&mut dbtx, &genesis_cp).await?;
                 tracing::info!(?name, "finished initialization");
                 let new_state = IndexState {
-                    version: index_state.version,
+                    version: index.version(),
                     height: Height::default(),
                 };
                 IndexingManager::update_index_state(&mut dbtx, &name, new_state).await?;


### PR DESCRIPTION

## Describe your changes
Follow-up to #5232. In local testing, the new pindexer logic was resetting historical appviews on subsequent runs, even when the options and code didn't change. That's not right. Tweaked the logic to use the newer version to record in db state, to avoid unnecessary resets.

## Issue ticket number and link
Refs #5232.

## Testing and review

Full testing of this change requires a lot of wall time; I'll own that testing and report back. Opening early for visibility and feedback.
