### PR TITLE
fix(build): permit picturesque in containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,5 @@
 !tools/summonerd/
 # parameter setup tool, for wrangling circuit configuration
 !tools/parameter-setup/
+# picturesque setup tool, for wrangling node configs
+!tools/picturesque/


### PR DESCRIPTION


## Describe your changes

The picturesque dep must be present in the container build context in order to resolve dependencies when building for the workspace, because picturesque is included in the workspace.

## Issue ticket number and link
Follow-up to https://github.com/penumbra-zone/penumbra/pull/5228.

## Checklist before requesting a review
This change will unbreak the failing container builds like https://github.com/penumbra-zone/penumbra/actions/runs/16057260753 since merge of #5228.
