### PR TITLE
feat: pindexer: take in block time as an option for lqt

### DIFF
--- a/crates/bin/pindexer/src/indexer_ext.rs
+++ b/crates/bin/pindexer/src/indexer_ext.rs
@@ -20,6 +20,6 @@ impl IndexerExt for cometindex::Indexer {
             .with_index(Box::new(crate::insights::Component::new(Some(
                 options.indexing_denom,
             ))))
-            .with_index(Box::new(crate::lqt::Lqt {}))
+            .with_index(Box::new(crate::lqt::Lqt::new(options.block_time_s)))
     }
 }

--- a/crates/bin/pindexer/src/lib.rs
+++ b/crates/bin/pindexer/src/lib.rs
@@ -29,4 +29,10 @@ pub struct Options {
     pub dex_ex_min_liquidity: u128,
     #[clap(long, default_value = "true")]
     pub dex_ex_ignore_arb: bool,
+    /// The expected block time, in seconds.
+    ///
+    /// By default this has the mainnet value. For testnets with faster blocks,
+    /// you'll want to adjust this.
+    #[clap(long, default_value = "5.1")]
+    pub block_time_s: f64,
 }


### PR DESCRIPTION
This gives us a much more stable time, since we're not dependent on any kind of variation in actual block. This also works out fine, since as blocks do happen, we only project based on the remaining blocks in an epoch, so we're "off" by less and less as the epoch goes on. Also a much better experience, since now the time is guaranteed to go down monotonically.

## Issue ticket number and link

Closes https://github.com/penumbra-zone/web/issues/2538.

We should test in the usual way.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > indexing only.
