### PR TITLE
Fix Typos in Documentation Comments

### DIFF
--- a/crates/proto/src/gen/cosmos.tx.v1beta1.rs
+++ b/crates/proto/src/gen/cosmos.tx.v1beta1.rs
@@ -311,7 +311,7 @@ impl ::prost::Name for ModeInfo {
 }
 /// Fee includes the amount of coins paid in fees and the maximum
 /// gas to be used by the transaction. The ratio yields an effective "gasprice",
-/// which must be above some miminum to be accepted into the mempool.
+/// which must be above some mininum to be accepted into the mempool.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Fee {
     /// amount is the amount of coins to be paid as a fee

--- a/crates/proto/src/gen/tendermint.crypto.rs
+++ b/crates/proto/src/gen/tendermint.crypto.rs
@@ -59,7 +59,7 @@ impl ::prost::Name for DominoOp {
     }
 }
 /// ProofOp defines an operation used for calculating Merkle root
-/// The data could be arbitrary format, providing nessecary data
+/// The data could be arbitrary format, providing necessary data
 /// for example neighbouring node hash
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProofOp {


### PR DESCRIPTION


**Description:**  
This pull request corrects minor spelling mistakes in documentation comments:
- Replaces "minimun" with "minimum" in `cosmos.tx.v1beta1.rs`
- Fixes "nessecary" to "necessary" in `tendermint.crypto.rs`


