### PR TITLE
feat: make view service respect account ownership in positions

### DIFF
--- a/crates/bin/elcuity/src/lp/mod.rs
+++ b/crates/bin/elcuity/src/lp/mod.rs
@@ -34,7 +34,7 @@ const ADJUST_WAIT_SECS: u64 = 120;
 async fn close_all_positions(clients: &Clients, pair: TradingPair) -> anyhow::Result<()> {
     let mut view = clients.view();
     let position_ids = view
-        .owned_position_ids(Some(position::State::Opened), Some(pair))
+        .owned_position_ids(Some(position::State::Opened), Some(pair), None)
         .await?;
     for chunk in position_ids.chunks(POSITION_CHUNK_SIZE) {
         let tx = build_and_submit(clients, Default::default(), |mut planner| async {
@@ -58,7 +58,7 @@ async fn withdraw_all_positions(clients: &Clients, pair: TradingPair) -> anyhow:
     let mut view = clients.view();
     let mut dex_query_service = clients.dex_query_service();
     let position_ids = view
-        .owned_position_ids(Some(position::State::Closed), Some(pair))
+        .owned_position_ids(Some(position::State::Closed), Some(pair), None)
         .await?;
     for chunk in position_ids.chunks(POSITION_CHUNK_SIZE) {
         let tx = build_and_submit(clients, Default::default(), |mut planner| async {

--- a/crates/bin/pcli/src/command/tx.rs
+++ b/crates/bin/pcli/src/command/tx.rs
@@ -1343,7 +1343,7 @@ impl TxCmd {
                     .context("view service must be initialized")?;
 
                 let owned_position_ids = view
-                    .owned_position_ids(Some(position::State::Opened), *trading_pair)
+                    .owned_position_ids(Some(position::State::Opened), *trading_pair, None)
                     .await?;
 
                 if owned_position_ids.is_empty() {
@@ -1393,7 +1393,7 @@ impl TxCmd {
                     .context("view service must be initialized")?;
 
                 let owned_position_ids = view
-                    .owned_position_ids(Some(position::State::Closed), *trading_pair)
+                    .owned_position_ids(Some(position::State::Closed), *trading_pair, None)
                     .await?;
 
                 if owned_position_ids.is_empty() {

--- a/crates/bin/pcli/src/command/view/lps.rs
+++ b/crates/bin/pcli/src/command/view/lps.rs
@@ -20,7 +20,7 @@ impl LiquidityPositionsCmd {
     pub async fn exec(&self, app: &mut App) -> Result<()> {
         let my_position_ids = app
             .view()
-            .owned_position_ids(Some(State::Opened), None)
+            .owned_position_ids(Some(State::Opened), None, None)
             .await?;
         let mut dex_client = DexQueryServiceClient::new(app.pd_channel().await?);
 

--- a/crates/view/src/client.rs
+++ b/crates/view/src/client.rs
@@ -185,6 +185,7 @@ pub trait ViewClient {
         &mut self,
         position_state: Option<position::State>,
         trading_pair: Option<TradingPair>,
+        subaccount: Option<AddressIndex>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<position::Id>>> + Send + 'static>>;
 
     /// Generates a full perspective for a selected transaction using a full viewing key
@@ -704,6 +705,7 @@ where
         &mut self,
         position_state: Option<position::State>,
         trading_pair: Option<TradingPair>,
+        subaccount: Option<AddressIndex>,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<position::Id>>> + Send + 'static>> {
         // should the return be streamed here? none of the other viewclient responses are, probably fine for now
         // but might be an issue eventually
@@ -714,9 +716,9 @@ where
             let rsp = ViewServiceClient::owned_position_ids(
                 &mut self2,
                 tonic::Request::new(pb::OwnedPositionIdsRequest {
-                    trading_pair: trading_pair.map(TryInto::try_into).transpose()?,
-                    position_state: position_state.map(TryInto::try_into).transpose()?,
-                    subaccount: None,
+                    trading_pair: trading_pair.map(Into::into),
+                    position_state: position_state.map(Into::into),
+                    subaccount: subaccount.map(Into::into),
                 }),
             );
 

--- a/crates/view/src/storage/schema.sql
+++ b/crates/view/src/storage/schema.sql
@@ -128,7 +128,8 @@ CREATE INDEX swaps_nullifier_idx ON swaps (nullifier);
 CREATE TABLE positions (
      position_id            BLOB PRIMARY KEY NOT NULL,
      position_state         TEXT NOT NULL,
-     trading_pair           TEXT NOT NULL
+     trading_pair           TEXT NOT NULL,
+     account                BIGINT
 );
 
 -- This table records the user's own auction state, using the

--- a/crates/view/src/worker.rs
+++ b/crates/view/src/worker.rs
@@ -390,6 +390,13 @@ impl Worker {
                                     note_commitment,
                                 )
                                 .await?;
+                        } else if let Ok(lp_nft) = LpNft::try_from(note_denom) {
+                            self.storage
+                                .update_position_with_account(
+                                    lp_nft.position_id(),
+                                    note_record.address_index.account,
+                                )
+                                .await?;
                         }
                         continue;
                     } else {


### PR DESCRIPTION
Previously, we were ignoring the account index.

This modifies syncing to detect the account by looking at the note you get when you receive an LP NFT.

This is useful, because it allows segregating funds by account, instead of having to make a new wallet.

Smoke testing should be sufficient here.

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > client only
