### PR TITLE
fix: pindexer: don't index candles with NaN

### DIFF
--- a/crates/bin/pindexer/src/dex_ex/mod.rs
+++ b/crates/bin/pindexer/src/dex_ex/mod.rs
@@ -747,6 +747,10 @@ impl Events {
         let pair_2_1 = pair_1_2.flip();
         let input_amount = f64::from(input.amount);
         let output_amount = f64::from(output.amount);
+        if input_amount == 0.0 && output_amount == 0.0 {
+            tracing::warn!(?input, ?output, "ignoring trace with 0 input and output");
+            return;
+        }
         let price_1_2 = output_amount / input_amount;
         let candle_1_2 = Candle::point(price_1_2, input_amount);
         let candle_2_1 = Candle::point(1.0 / price_1_2, output_amount);
@@ -1492,7 +1496,7 @@ impl AppView for Component {
             .as_bytes()
             .try_into()
             .expect("Impossible 000-001: expected 32 byte hash");
-        Version::with_major(1).with_option_hash(hash)
+        Version::with_major(2).with_option_hash(hash)
     }
 
     async fn reset(&self, dbtx: &mut PgTransaction) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
## Describe your changes

This skips indexing candles with a price of NaN, at the source where we ingest point candles, representing a single trace input and output value. For some reason, the dex sometimes produces candles with 0 input and 0 output volume, resulting in a NaN, which then pollutes and corrupts other data. This fix addresses the source of the pollution in indexing.

We should investigate why these traces are being emitted.

To test, run pindexer again, observe that NaNs are out of the candles.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Indexing only.
