### PR TITLE
dex: fix degraded relaxation phase

### DIFF
--- a/crates/core/component/dex/src/component/router/path_cache.rs
+++ b/crates/core/component/dex/src/component/router/path_cache.rs
@@ -39,7 +39,6 @@ impl<S: StateRead + 'static> PathEntry<S> {
             Some(spill) if new_path.price < spill.price => {
                 tracing::debug!(new_spill_price = %new_path.price, old_spill_price = %spill.price, "new path is better than spill path, updating cache");
                 self.spill = Some(new_path);
-                self.active = true;
             }
             Some(spill) => {
                 tracing::debug!(new_spill_price = %new_path.price, old_spill_price = %spill.price, "new path is worse than spill path, ignore");
@@ -47,7 +46,6 @@ impl<S: StateRead + 'static> PathEntry<S> {
             None => {
                 tracing::debug!(new_spill_price = %new_path.price, "new path is a suitable spill path, updating cache");
                 self.spill = Some(new_path);
-                self.active = true;
             }
         }
     }


### PR DESCRIPTION
There is a bug in path search that causes spurious path activation, as a result, path search is far slower than it should. The bug is a divergence from the intended design.

Penumbra uses a variant of Bellman-Ford (SPFA) in order to "lock in" a path for execution. There are a few differences with ordinary SPFA. First, iterations are bounded to `k` hops, rather than potentially finding paths of length `|V|`. Second, is that paths are not directly comparable to one another until they are complete, or if they share the same start/end.

**Bug**

At the moment, path search will mark `PathEntry`s as "active" if their best path OR if their spill path improves. When an entry is marked as active, it will be considered in future rounds and its tip will be tentatively relaxed against candidates.

That is unnecessary work! If the best path is unchanged, the `PathEntry` cost cannot improve. In other words, we do not need to rediscover that path again.

Moreover, excessive rediscovery can cause path search to find identical spill and best paths. As a result, routing execution gets degraded and thrashes. The DEX engine has to work with worse parameters: "fill this route up to this spill price which is also the best price".

**Fix**

Instead, we should only reconsider a path when its cost improves.

**Empirical results**

I tested this against `penumbra-1` by simulating a large swap on a popular USDC pair. It is faster (1s engine execution vs 4s on my M4 macbook), with better execution economy (going deeper in the route book on the same budget). The effect on latency is easily attributed to doing far fewer relaxation rounds. The effect on execution is attributed to providing `fill_route` with better spill price information.

**Consensus breaking**

The fix restores proper algorithmic behavior but it's consensus breaking because it affects execution amounts.

**Testing**

I don't think this requires extensive testing. This is the version of the algorithm that was extensively tested during DEX R&D. 

**Future work**

The DEX engine needs to be faster even with a thousand rounds of execution budget. One path is to scrutinize the amplification factor that `candidates` selection causes. 

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > consensus breaking.