### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/buf-pull-request.yml
+++ b/.github/workflows/buf-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
   backwards-compatibility:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: bufbuild/buf-setup-action@v1
         with:
           buf_api_token: ${{ secrets.BUF_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
     runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
 

--- a/.github/workflows/buf-push.yml
+++ b/.github/workflows/buf-push.yml
@@ -18,7 +18,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: bufbuild/buf-setup-action@v1
         with:
           buf_api_token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -12,7 +12,7 @@ jobs:
     # on PRs, but we'll still only deploy after merge into main.
     runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -40,7 +40,7 @@ jobs:
     # Downgrading runner size to 4vcpu, since we're not compiling code.
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: false
 

--- a/.github/workflows/notes.yml
+++ b/.github/workflows/notes.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
       - name: Checkout the source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           lfs: true
@@ -118,7 +118,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           lfs: true
@@ -177,7 +177,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           lfs: true
@@ -227,7 +227,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           lfs: true
@@ -292,6 +292,6 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -60,7 +60,7 @@ jobs:
   features:
     runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -88,7 +88,7 @@ jobs:
   test:
     runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -16,7 +16,7 @@ jobs:
   smoke:
     runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -42,7 +42,7 @@ jobs:
   pmonitor:
     runs-on: buildjet-16vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -68,7 +68,7 @@ jobs:
   # testnet:
   #   runs-on: buildjet-16vcpu-ubuntu-2204
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #       with:
   #         lfs: true
   #


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0