### PR TITLE
fix: update Apache license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ security@penumbralabs.xyz.
 ## License
 
 By contributing to penumbra you agree that your contributions will be licensed
-under the terms of both the [LICENSE-Apache-2.0](LICENSE-Apache-2.0) and the
+under the terms of both the [LICENSE-APACHE](LICENSE-APACHE) and the
 [LICENSE-MIT](LICENSE-MIT) files in the root of this source tree.
 
 If you're using penumbra you are free to choose one of the provided licenses:


### PR DESCRIPTION
Correct the broken link from LICENSE-Apache-2.0 to LICENSE-APACHE
to match the actual file name in the project root.