### PR TITLE
pd: make it easy to do an upgrade hard-fork

### DIFF
--- a/crates/bin/pd/src/cli.rs
+++ b/crates/bin/pd/src/cli.rs
@@ -163,7 +163,13 @@ pub enum MigrateCommand {
         new_client_id: String,
         /// Optional app version to set during migration.
         #[clap(long, value_name = "VERSION")]
-        app_version: Option<u64>,
+        target_app_version: Option<u64>,
+    },
+    /// Perform a no-op migration that resets the halt bit and produces a new genesis.
+    NoOp {
+        /// Optional app version to set during migration.
+        #[clap(long, value_name = "VERSION")]
+        target_app_version: Option<u64>,
     },
 }
 

--- a/crates/bin/pd/src/migrate/migrate2/mod.rs
+++ b/crates/bin/pd/src/migrate/migrate2/mod.rs
@@ -1,4 +1,5 @@
 pub mod framework;
 pub mod ibc_client_recovery;
+pub mod noop;
 
 pub use framework::Migration;

--- a/crates/bin/pd/src/migrate/migrate2/noop.rs
+++ b/crates/bin/pd/src/migrate/migrate2/noop.rs
@@ -1,0 +1,39 @@
+//! A no-op migration that resets the halt bit and produces a new genesis without changes.
+//! This is useful for all hard-forks that do not require a migration, but break consensus.
+
+use anyhow::Result;
+use cnidarium::StateDelta;
+
+use super::Migration;
+
+/// A migration that performs no changes to the state, except resetting the halt bit.
+/// Creates a different new chain, with a refreshed genesis state.
+pub struct NoOpMigration {
+    target_app_version: Option<u64>,
+}
+
+impl NoOpMigration {
+    /// Create a new NoOp migration with an optional target app version.
+    pub fn new(target_app_version: Option<u64>) -> Self {
+        Self { target_app_version }
+    }
+}
+
+impl Migration for NoOpMigration {
+    fn name(&self) -> &'static str {
+        "no-op"
+    }
+
+    fn target_app_version(&self) -> Option<u64> {
+        // By default, this target no specific versions, but
+        // it is possible to specify a target app version
+        // via a flag. In that case, UIP-4 applies, and version
+        // migration will occur.
+        self.target_app_version
+    }
+
+    async fn migrate_inner(&self, _delta: &mut StateDelta<cnidarium::Snapshot>) -> Result<()> {
+        // No changes to state - the framework handles resetting the halt bit
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Describe your changes

This PR adds `pd migrate no-op [--target-app-version=<APP>]` which is tooling that can be used to produce a hard-fork upgrades. It uses the new migration framework and can serve as an example for prospective protocol engineers.

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > consensus breaking when exercised
