### PR TITLE
docs(stake): update staking documentation to match implementation

### DIFF
--- a/docs/protocol/src/concepts/validators.md
+++ b/docs/protocol/src/concepts/validators.md
@@ -2,53 +2,110 @@
 
 Validators in Penumbra undergo various transitions depending on chain activity.
 
+## State Machine
+
 ```
-                                 ┌────────────────────────────────────────────────────────────────────────────┐
-                                 │                                                                            │
-                                 │            ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─                                           │
-                                 │              Genesis Validator  │                                          │
-                                 │            │                             ┏━━━━━━━━━━━━━━━━━━━━━━━┓         │
-                                 │             ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘        ┃      Tombstoned       ┃         │
-                                 │                       │          ┌──────▶┃     (Misbehavior)     ┃         │
-                                 │                       │          │       ┗━━━━━━━━━━━━━━━━━━━━━━━┛         │
-                                 │                       │          │                                         │
-┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─            │                       ▼          │                                         ▼
-      Validator      │      ┏━━━━━━━━━┓              ╔══════╗       │                                   ┏━━━━━━━━━━━┓
-│     Definition     ──────▶┃Inactive ┃─────────────▶║Active║───────┼────────────────────────────────┬─▶┃ Disabled  ┃
-   (in transaction)  │      ┗━━━━━━━━━┛              ╚══════╝       │                                │  ┗━━━━━━━━━━━┛
-└ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─            ▲                                  │       ┏━━━━━━━━━━━━━━━━━━━━━┓  │        │
-                                 │                                  └──────▶┃ Jailed (Inactivity) ┃──┘        │
-                                 │                                          ┗━━━━━━━━━━━━━━━━━━━━━┛           │
-                                 │                                                     │                      │
-                                 └─────────────────────────────────────────────────────┴──────────────────────┘
+          ┌───────────────────────────────────────────────────────┐
+          │                      ┌──────────────────────────────┐ │
+          ▼                      ▼                              │ │
+  ╔═══════════════╗       ┌────────────┐                        │ │
+ ▶║    Defined    ║◀─────▶│  Disabled  │                        │ │
+  ╚═══════════════╝       └────────────┘                        │ │
+         │                      │                               │ │
+         │                      ▼                               │ │
+         │               ┏━━━━━━━━━━━━┓                         │ │
+         └──────────────▶┃            ┃                         │ │
+                         ┃ Tombstoned ┃◀────────────┐           │ │
+         ┌──────────────▶┃            ┃             │           │ │
+         │               ┗━━━━━━━━━━━━┛             │           │ │
+         │                      ▲                   │           │ │
+         │                      │           ┌──────────────┐    │ │
+  ┌─────────────┐        ┌────────────┐     │              │◀───┘ │
+  │   Jailed    │◀───────│   Active   │◀───▶│   Inactive   │      │
+  └─────────────┘        └────────────┘     │              │◀─────┘
+         │                                  └──────────────┘
+         │                                          ▲
+         └──────────────────────────────────────────┘
+
+  ╔═════════════════╗
+  ║ starting state  ║
+  ╚═════════════════╝
+  ┏━━━━━━━━━━━━━━━━━┓
+  ┃ terminal state  ┃
+  ┗━━━━━━━━━━━━━━━━━┛
 ```
 
-Single lines represent unbonded stake, and double lines represent bonded stake.
+Validators become known to the chain either at genesis, or by means of a transaction with a `ValidatorDefinition` action. Validators transition through six states:
 
-Validators become known to the chain either at genesis, or by means of a transaction with a `ValidatorDefinition` action in them. Validators transition through five states:
+* **Defined**: the initial state for non-genesis validators. The validator definition has been published, but the delegation pool has not yet reached the minimum stake threshold required to be indexed.
+* **Inactive**: a validator whose delegation pool meets the minimum stake threshold but is not large enough to be in the active consensus set.
+* **Active**: a validator whose delegation pool is large enough to participate in consensus and must meet uptime requirements.
+* **Jailed**: a validator that has been slashed for downtime, that may return later.
+* **Tombstoned**: a validator that has been permanently slashed for byzantine misbehavior and may not return.
+* **Disabled**: a validator that has been manually disabled by the operator.
 
-* **Inactive**: a validator whose delegation pool is too small to participate in consensus set
-* **Active**: a validator whose delegation pool is large enough to participate in consensus and must meet uptime requirements
-* **Jailed**: a validator that has been slashed and removed from consensus for downtime, that may return later
-* **Tombstoned**: a validator that has been permanently slashed and removed from consensus for byzantine misbehavior and may not return
-* **Disabled**: a validator that has been manually disabled by the operator, that may return to `Inactive` later
+## Validator Lifecycle
 
-Validators specified in the genesis config begin in the active state, with whatever stake was allocated to their delegation pool at genesis. Otherwise, new validators begin in the inactive state, with no stake in their delegation pool.  At this point, the validator is known to the chain, and stake can be contributed to its delegation pool.  Stake contributed to an inactive validator's delegation pool does not earn rewards (the validator's rates are held constant), but it is also not bonded, so undelegations are effective immediately, with no unbonding period and no output quarantine.
+### Genesis Validators
 
-The chain chooses a validator limit N as a consensus parameter. When a validator's delegation pool (a) has a nonzero balance and (b) its (voting-power-adjusted) size is in the top N validators, it moves into the active state during the next epoch transition.  Active validators participate in consensus, and are communicated to Tendermint. Stake contributed to an active validator's delegation pool earns rewards (the validator's rates are updated at each epoch to track the rewards accruing to the pool). That stake is bonded, so undelegations have an unbonding period and an output quarantine. An active validator can exit the consensus set in four ways.
+Validators specified in the genesis config begin in the **Active** state, with whatever stake was allocated to their delegation pool at genesis. Their stake is immediately bonded.
 
-First, the validator could be jailed and slashed for inactivity.  This can happen in any block, triggering an unscheduled epoch transition.  Jailed validators are immediately removed from the consensus set. The validator's rates are updated to price in the slashing penalty, and are then held constant. Validators jailed for inactivity are not permanently prohibited from participation in consensus, and their operators can re-activate them by re-uploading the validator definition. Stake cannot be delegated to a slashed validator. Stake already contributed to a slashed validator's delegation pool will enter an unbonding period to hold the validator accountable for any byzantine behavior during the unbonding period. Re-delegations may occur after the validator enters the "Inactive" state.
+### New Validators
 
-Second, the validator could be tombstoned and slashed for byzantine misbehavior.  This can happen in any block, triggering an unscheduled epoch transition.  Tombstoned validators are immediately removed from the consensus set. Any pending undelegations from a slashed validator are cancelled: the quarantined output notes are deleted, and the quarantined nullifiers are removed from the nullifier set.  The validator's rates are updated to price in the slashing penalty, and are then held constant. Tombstoned validators are permanently prohibited from participation in consensus (though their operators can create new identity keys, if they'd like to). Stake cannot be delegated to a tombstoned validator. Stake already contributed to a tombstoned validator's delegation pool is not bonded (the validator has already been slashed and tombstoned), so undelegations are effective immediately, with no unbonding period and no quarantine.
+New validators (created via `ValidatorDefinition` transactions) begin in the **Defined** state with zero voting power and unbonded stake. At this point, the validator is known to the chain, and stake can be contributed to its delegation pool.
 
-Third, the validator could be manually disabled by the operator. The validator is then in the disabled state.  It does not participate in consensus, and the stake in its delegation pool does not earn rewards (the validator's rates are held constant).  The stake in its delegation pool will enter an unbonding period at the time the validator becomes disabled. The only valid state a disabled validator may enter into is "inactive", if the operator re-activates it by updating the validator definition.
+When the validator's delegation pool reaches the `min_validator_stake` threshold (a chain parameter), the validator transitions to the **Inactive** state at the next epoch boundary. This transition is checked automatically during epoch processing.
 
-Fourth, the validator could be displaced from the validator set by another validator with more stake in its delegation pool. The validator is then in the inactive state.  It does not participate in consensus, and the stake in its delegation pool does not earn rewards (the validator's rates are held constant).  The stake in its delegation pool will enter an unbonding period at the time the validator becomes inactive.  Inactive validators have three possible state transitions:
+Stake contributed to a Defined or Inactive validator's delegation pool does not earn rewards (the validator's rates are held constant), and is not bonded, so undelegations can be claimed immediately without waiting for an unbonding period.
 
-1. they can become active again, if new delegations boost its weight back into the top N;
-2. they can be tombstoned, if evidence of misbehavior arises during the unbonding period;
-3. they can be disabled, if the operator chooses.
+### Becoming Active
 
-If (2) occurs, the same state transitions as in regular tombstoning occur: all pending undelegations are cancelled, etc.
-If (3) occurs, the unbonding period continues and the validator enters the disabled state.
-If (1) occurs, the validator stops unbonding, and all delegations become bonded again.
+The chain chooses a validator limit N as a consensus parameter. When a validator's delegation pool is in the top N validators by voting power, it moves into the **Active** state during the next epoch transition.
+
+Active validators:
+- Participate in consensus and are communicated to CometBFT
+- Earn rewards (their exchange rates increase each epoch)
+- Have bonded stake (undelegations require waiting through an unbonding period)
+
+### Leaving the Active Set
+
+An active validator can exit the consensus set in four ways:
+
+**1. Jailed for downtime**
+
+If a validator misses too many blocks, it is jailed and slashed. This can happen in any block, triggering an unscheduled epoch transition. Jailed validators are immediately removed from the consensus set. The validator's rates are updated to record the slashing penalty. Validators jailed for downtime are not permanently prohibited from participation in consensus; their operators can re-activate them by re-uploading the validator definition with the `enabled` flag set to true.
+
+**2. Tombstoned for misbehavior**
+
+If evidence of byzantine misbehavior is detected, the validator is tombstoned and slashed. This can happen in any block, triggering an unscheduled epoch transition. Tombstoned validators are immediately removed from the consensus set. The validator's rates are updated to record the slashing penalty. Tombstoned validators are permanently prohibited from participation in consensus (though their operators can create new identity keys if they choose).
+
+**3. Manually disabled**
+
+The operator can disable the validator by uploading a new validator definition with `enabled: false`. The validator enters the **Disabled** state and does not participate in consensus. Its rates are held constant (no rewards). The operator can later re-enable the validator, which transitions it to **Inactive** (or **Defined** if below the minimum stake threshold).
+
+**4. Displaced by higher-stake validator**
+
+If another validator accumulates more stake and pushes this validator out of the top N, the validator transitions to **Inactive** (or **Defined** if it falls below the minimum stake threshold). It does not participate in consensus and its rates are held constant.
+
+### Slashing and Penalties
+
+When a validator is slashed (either jailed or tombstoned), a penalty is recorded in the chain state for that epoch. This penalty affects delegators through the undelegation mechanism:
+
+- Undelegations produce **unbonding tokens** that must be held for an unbonding period
+- During the unbonding period, any penalties applied to the validator accumulate
+- When the unbonding period ends and the delegator claims their stake via `UndelegateClaim`, all accumulated penalties are applied
+
+This design ensures that delegators cannot escape slashing by racing to undelegate before evidence is processed.
+
+### Bonding States
+
+In addition to the validator state, each validator has a **bonding state** that tracks whether its stake is bonded:
+
+* **Bonded**: The validator is in the active set. Delegated stake is locked and subject to slashing. Undelegations require waiting through the unbonding period.
+* **Unbonding**: The validator has left the active set and its stake is transitioning to unbonded. A specific block height marks when unbonding completes.
+* **Unbonded**: The validator is not in the active set and its stake is not locked. Undelegations can be claimed immediately.
+
+The bonding state is managed automatically based on validator state transitions:
+- Active validators are always Bonded
+- When a validator leaves Active, it enters Unbonding (unless Tombstoned, which goes directly to Unbonded)
+- After the unbonding period elapses, the validator becomes Unbonded

--- a/docs/protocol/src/stake/action/delegate.md
+++ b/docs/protocol/src/stake/action/delegate.md
@@ -1,1 +1,65 @@
 # Delegate
+
+The `Delegate` action adds stake to a validator's delegation pool, converting staking tokens into delegation tokens.
+
+## Action Structure
+
+A `Delegate` action contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `validator_identity` | `IdentityKey` | The identity key of the validator to delegate to |
+| `epoch_index` | `u64` | The epoch in which the delegation was prepared |
+| `unbonded_amount` | `Amount` | The amount of staking tokens to delegate |
+| `delegation_amount` | `Amount` | The amount of delegation tokens produced |
+
+## Balance Effect
+
+The action:
+- **Consumes** `unbonded_amount` of staking tokens (`upenumbra`)
+- **Produces** `delegation_amount` of delegation tokens (`udelegation_<validator_identity>`)
+
+## Validation Rules
+
+### Stateless Checks
+
+None.
+
+### Stateful Checks
+
+1. **Epoch match**: The `epoch_index` must match the current epoch. This ensures the exchange rate used to compute `delegation_amount` is still valid.
+
+2. **Correct delegation amount**: The `delegation_amount` must equal the expected amount computed from `unbonded_amount` and the validator's current exchange rate:
+   ```
+   delegation_amount = unbonded_amount / exchange_rate
+   ```
+   Rounding is applied during this calculation.
+
+3. **Validator enabled**: The validator definition must have `enabled: true`.
+
+4. **Valid validator state**: The validator must be in one of these states: `Defined`, `Inactive`, or `Active`. Delegations to `Jailed`, `Tombstoned`, or `Disabled` validators are rejected.
+
+5. **Minimum stake for Defined validators**: If the validator is in the `Defined` state with an empty delegation pool, the delegation must meet the `min_validator_stake` threshold. This ensures new validators start with sufficient stake.
+
+## Execution
+
+When executed, the delegation is queued to take effect at the next epoch boundary. At that time:
+
+1. The delegation tokens are minted to the delegator
+2. The validator's delegation pool size is increased
+3. The validator's voting power is recalculated
+4. If the validator was in `Defined` state and now meets the minimum stake threshold, it transitions to `Inactive`
+
+## Exchange Rate
+
+The exchange rate between staking tokens and delegation tokens varies over time as the validator earns rewards:
+
+- At genesis, the exchange rate is 1:1
+- Each epoch, if the validator is active, the rate increases by the validator's reward rate
+- The reward rate is the base chain reward rate minus the validator's commission
+
+A higher exchange rate means more staking tokens are needed to purchase the same amount of delegation tokens. This reflects the accumulated rewards in the delegation pool.
+
+## Privacy
+
+Currently, delegation amounts are revealed on-chain. The struct includes a TODO to add flow encryption to hide the `unbonded_amount`.

--- a/docs/protocol/src/stake/action/undelegate.md
+++ b/docs/protocol/src/stake/action/undelegate.md
@@ -1,1 +1,79 @@
 # Undelegate
+
+The `Undelegate` action withdraws stake from a validator's delegation pool, converting delegation tokens into unbonding tokens.
+
+This is the first step of the two-step undelegation process. After the unbonding period elapses, an [UndelegateClaim](./undelegate_claim.md) action converts unbonding tokens to staking tokens.
+
+## Action Structure
+
+An `Undelegate` action contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `validator_identity` | `IdentityKey` | The identity key of the validator to undelegate from |
+| `from_epoch` | `Epoch` | The epoch in which the undelegation was prepared |
+| `unbonded_amount` | `Amount` | The amount of unbonding tokens produced |
+| `delegation_amount` | `Amount` | The amount of delegation tokens consumed |
+
+## Balance Effect
+
+The action:
+- **Consumes** `delegation_amount` of delegation tokens (`udelegation_<validator_identity>`)
+- **Produces** `unbonded_amount` of unbonding tokens (`uunbonding_start_at_<start_height>_<validator_identity>`)
+
+The unbonding token asset ID encodes both the validator identity and the block height at which unbonding started (the start of the `from_epoch`).
+
+## Validation Rules
+
+### Stateless Checks
+
+None.
+
+### Stateful Checks
+
+1. **Epoch match**: The `from_epoch` must match the current epoch. This ensures the exchange rate used to compute `unbonded_amount` is still valid.
+
+2. **Correct unbonded amount**: The `unbonded_amount` must equal the expected amount computed from `delegation_amount` and the validator's current exchange rate:
+   ```
+   unbonded_amount = delegation_amount * exchange_rate
+   ```
+   Rounding is applied during this calculation.
+
+3. **Validator exists**: The validator identity must correspond to a known validator with rate data.
+
+## Execution
+
+When executed:
+
+1. The unbonding token denomination is registered in the asset registry
+2. The undelegation is queued for processing at the next epoch boundary
+
+At the epoch boundary:
+1. The delegation tokens are burned
+2. The unbonding tokens are minted
+3. The validator's delegation pool size is decreased
+4. The validator's voting power is recalculated
+
+## Unbonding Tokens
+
+Unlike delegation tokens (which are fungible for a given validator), unbonding tokens are unique to both a validator and an unbonding start height:
+
+```
+uunbonding_start_at_12345_penumbravalid1abc...
+```
+
+This design allows the chain to track when each undelegation started, so the correct unbonding period and accumulated penalties can be applied when the tokens are claimed.
+
+## Privacy
+
+Undelegation reveals:
+- The validator identity
+- The delegation amount being undelegated
+- The epoch at which undelegation occurred
+
+This information is necessary on-chain because:
+- The validator identity determines which unbonding token is minted
+- The amounts must be verified against the exchange rate
+- The epoch determines the unbonding token denomination
+
+The subsequent `UndelegateClaim` action uses a zero-knowledge proof to hide the final unbonded amount.

--- a/docs/protocol/src/stake/undelegation.md
+++ b/docs/protocol/src/stake/undelegation.md
@@ -1,44 +1,69 @@
 # Undelegation
 
-The undelegation process unbonds stake from a validator, converting delegation
-tokens `dPEN` to stake `PEN`. Undelegations may be performed in any block, but
-only settle after the undelegation has exited the unbonding queue.
+The undelegation process unbonds stake from a validator's delegation pool. Unlike delegation (which is a single action), undelegation is a two-step process:
 
-The unbonding queue is a FIFO queue allowing only a limited amount of stake to
-be unbonded in each epoch, according to an unbonding rate selected by
-governance. Undelegations are inserted into the unbonding queue in FIFO order.
-Unlike delegations, where only the total amount of newly bonded stake is
-revealed, undelegations reveal the precise amount of newly unbonded stake,
-allowing the unbonding queue to function.
+1. **Undelegate**: Burns delegation tokens and mints unbonding tokens
+2. **UndelegateClaim**: After the unbonding period, burns unbonding tokens and produces staking tokens
 
-Undelegations are accomplished by creating a transaction with a
-`Undelegate` description. This description has different behaviour
-depending on whether or not the validator was slashed.
+This two-step design ensures that delegators cannot escape slashing by racing to undelegate before misbehavior evidence is processed.
 
-In the unslashed case, the undelegate description spends a note with value
-$y$ `dPEN`, reveals $y$, and produces $y \psi_v(e)$ `PEN` for the transaction's
-balance, where $e$ is the index of the current epoch.  However, the nullifiers
-revealed by undelegate descriptions are not immediately included in the
-nullifier set, and new notes created by a transaction containing an undelegate
-description are not immediately included in the state commitment tree. Instead,
-the transaction is placed into the unbonding queue to be applied later. In the
-first block of each epoch, transactions are applied if the corresponding
-validator remains unslashed, until the unbonding limit is reached.
+## Unbonding Tokens
 
-If a validator is slashed, any undelegate transactions currently in the
-unbonding queue are discarded. Because the nullifiers for the notes those
-transactions spent were not included in the nullifier set, the notes remain
-spendable, allowing a user to create a new undelegation description.
+When a user undelegates, they receive **unbonding tokens** instead of staking tokens directly. Unbonding tokens are unique per validator and per epoch:
 
-Undelegations from a slashed validator are settled immediately. The
-undelegate description spends a note with value $y$ `dPEN` and produces
-$sy \psi_v(e_s)$ `PEN`, where $1-s$ is the slashing penalty and
-$e_s$ is the epoch at which the validator was slashed. The remaining value,
-$(1-s)y\psi_v(e_s)$, is burned.
+```
+uunbonding_start_at_<start_height>_<validator_identity>
+```
 
-Because pending undelegations from a slashed validator are discarded without
-applying their nullifiers, those notes can be spent again in a post-slashing
-undelegation description. This causes linkability between the discarded
-undelegations and the post-slashing undelegations, but this is not a concern
-because slashing is a rare and unplanned event which already imposes worse
-losses on delegators.
+For example: `uunbonding_start_at_12345_penumbravalid1abc...`
+
+The unbonding token encodes:
+- The validator identity being undelegated from
+- The block height at which unbonding started (the start of the epoch when the `Undelegate` action was processed)
+
+This allows the chain to track the unbonding period and apply any penalties that occur during it.
+
+## Unbonding Period
+
+The length of the unbonding period is determined by the validator's bonding state:
+
+- **Bonded validators**: Unbonding takes `unbonding_delay` blocks (a chain parameter)
+- **Unbonding validators**: Unbonding completes when the validator's unbonding completes
+- **Unbonded validators**: No unbonding period; tokens can be claimed immediately
+
+During the unbonding period, if the validator is slashed, a penalty is recorded. This penalty will be applied when the unbonding tokens are claimed.
+
+## Claiming Unbonded Stake
+
+After the unbonding period elapses, the user submits an `UndelegateClaim` action to convert their unbonding tokens to staking tokens.
+
+The claim:
+1. Burns the unbonding tokens
+2. Computes the accumulated penalty over the unbonding window
+3. Produces staking tokens equal to the unbonded amount minus the penalty
+4. Uses a zero-knowledge proof to hide the unbonding amount while proving correct penalty application
+
+See [Undelegate Claim](./action/undelegate_claim.md) for the detailed specification.
+
+## Penalty Accumulation
+
+Penalties are stored per-validator per-epoch. When claiming, the total penalty is computed by compounding all penalties from the unbonding start epoch through the current epoch:
+
+$$\text{total\_penalty} = 1 - \prod_{e=\text{start}}^{\text{current}} (1 - p_e)$$
+
+where $p_e$ is the penalty applied in epoch $e$.
+
+For example, if a validator was slashed 1% in epoch 10 and 2% in epoch 15, a claim covering epochs 5-20 would apply a combined penalty of approximately 2.98%:
+
+$$1 - (1 - 0.01)(1 - 0.02) = 1 - (0.99)(0.98) \approx 0.0298$$
+
+## Privacy Considerations
+
+Unlike delegation (where the amount can be hidden), undelegation reveals:
+- The validator identity
+- The amount of delegation tokens being unbonded
+- The epoch at which unbonding started
+
+This information is visible on-chain because the unbonding period calculation requires knowing when unbonding started.
+
+However, the `UndelegateClaim` action hides the final unbonded amount using a zero-knowledge proof. An observer can see that someone claimed unbonding tokens from a validator, but cannot determine the exact amount received.


### PR DESCRIPTION
Updates the protocol documentation to accurately reflect the current staking component implementation:

- Add the "Defined" validator state and correct state machine diagram
- Rewrite undelegation docs to describe unbonding token model instead of the outdated FIFO queue mechanism
- Document penalty accumulation for slashing
- Write complete Delegate and Undelegate action specifications
- Remove references to nullifier quarantine

## Checklist before requesting a review

- [x] I have added guiding text to explain how a reviewer should test these changes.

- [x] If this code contains consensus-breaking changes, I have added the "consensus-breaking" label. Otherwise, I declare my belief that there are not consensus-breaking changes, for the following reason:

  > Docs
