### PR TITLE
build: bump cometbft to 0.37.18

### DIFF
--- a/deployments/compose/docker-compose.dev.yml
+++ b/deployments/compose/docker-compose.dev.yml
@@ -57,7 +57,7 @@ services:
 
   # The CometBFT node
   cometbft-node0:
-    image: "docker.io/cometbft/cometbft:v0.37.15"
+    image: "docker.io/cometbft/cometbft:v0.37.18"
     ports:
       - "26656:26656"
       - "26657:26657"

--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -57,7 +57,7 @@ services:
 
   # The CometBFT node
   cometbft-node0:
-    image: "docker.io/cometbft/cometbft:v0.37.15"
+    image: "docker.io/cometbft/cometbft:v0.37.18"
     ports:
       - "26656:26656"
       - "26657:26657"

--- a/deployments/scripts/install-cometbft
+++ b/deployments/scripts/install-cometbft
@@ -5,7 +5,7 @@ set -euo pipefail
 
 
 # Sane defaults
-COMETBFT_VERSION="${COMETBFT_VERSION:-0.37.15}"
+COMETBFT_VERSION="${COMETBFT_VERSION:-0.37.18}"
 
 # Download and extract
 cometbft_download_url="https://github.com/cometbft/cometbft/releases/download/v${COMETBFT_VERSION}/cometbft_${COMETBFT_VERSION}_linux_amd64.tar.gz"

--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,9 @@
           # nix-prefetch-git --url https://github.com/cometbft/cometbft --rev <tag>
           # and review the output.
           cometBftRelease = {
-            version = "0.37.15";
+            version = "0.37.18";
             # Set `sha256` to the value `hash` in the nix-prefetch-git output.
-            sha256 = "sha256-sX3hehsMNWWiQYbepMcdVoUAqz+lK4x76/ohjGb/J08=";
+            sha256 = "sha256-Gh5iGBlB5tFn1KCuF0nthb0me9Ts63quHKOYdNwmhIs=";
             # Set `vendorHash` to "", run `nix build`, and review the hash.
             vendorHash = "sha256-F6km3YpvfdpPeIJB1FwA5lQvPda11odny0EHPD8B6kw=";
           };

--- a/testnets/cometbft_config_template.toml
+++ b/testnets/cometbft_config_template.toml
@@ -375,6 +375,9 @@ chunk_request_timeout = "10s"
 # The number of concurrent chunk fetchers to run (default: 1).
 chunk_fetchers = "4"
 
+# Maximum number of chunks allowed in a snapshot (default: 100000).
+max_snapshot_chunks = 100000
+
 #######################################################
 ###       Fast Sync Configuration Connections       ###
 #######################################################


### PR DESCRIPTION
## Describe your changes

Includes bump to v0.36.16 which fixes a security issue [0], and other point releases [1, 2].

Bumps versions across the project. No code changes are required to Penumbra code, other than the bundled default cometbft config, but operators are encouraged to update cometbft on live deployments.

[0] https://github.com/cometbft/cometbft/releases/tag/v0.37.16
[1] https://github.com/cometbft/cometbft/releases/tag/v0.37.17
[1] https://github.com/cometbft/cometbft/releases/tag/v0.37.18

Towards https://github.com/penumbra-zone/penumbra/pull/5278

