### PR TITLE
ci: upgrade macos runners from 13 -> 15

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -25,7 +25,7 @@ install-path = "CARGO_HOME"
 precise-builds = true
 
 [dist.github-custom-runners]
-aarch64-apple-darwin = "macos-13-large"
-x86_64-apple-darwin = "macos-13-large"
+aarch64-apple-darwin = "macos-15-large"
+x86_64-apple-darwin = "macos-15-large"
 x86_64-unknown-linux-gnu = "buildjet-32vcpu-ubuntu-2204"
 aarch64-unknown-linux-gnu = "buildjet-32vcpu-ubuntu-2204-arm"


### PR DESCRIPTION

## Describe your changes

Refs https://github.com/penumbra-zone/penumbra/issues/5281. We can't easily test this change until the next release workflow runs. The build-binaries workflow is currently broken, so trying this out as a potential quickfix.

