### PR TITLE
docs: fix typo

### DIFF
--- a/crates/core/component/ibc/src/component/client_recovery.rs
+++ b/crates/core/component/ibc/src/component/client_recovery.rs
@@ -179,7 +179,7 @@ pub fn validate_client_id_format_ics07(client_id: &ClientId) -> Result<()> {
 /// Check that the field of two client states are coherent.
 ///
 /// The goal is to verify that a subject/substitute couple are fundamentally the same client.
-/// Evne if at different points in their lifecyle. This is directly inspired by Cosmos ADR-26,
+/// Evne if at different points in their lifecycle. This is directly inspired by Cosmos ADR-26,
 /// which recognizes that client recovery is a form of controlled mutation: we are not replacing
 /// one client state with an arbitrary other, but ratehr fast-forwarding a stuck client to a
 /// healthy state.

--- a/crates/core/component/sct/src/source.rs
+++ b/crates/core/component/sct/src/source.rs
@@ -31,7 +31,7 @@ pub enum CommitmentSource {
     },
     /// The commitment was created through the participation in the liquidity tournament.
     LiquidityTournamentReward {
-        /// The epoch in which the reward occured.
+        /// The epoch in which the reward occurred.
         epoch: u64,
         /// Transaction hash of the transaction that did the voting.
         tx_hash: TransactionId,

--- a/crates/proto/src/gen/cosmos.tx.v1beta1.rs
+++ b/crates/proto/src/gen/cosmos.tx.v1beta1.rs
@@ -311,7 +311,7 @@ impl ::prost::Name for ModeInfo {
 }
 /// Fee includes the amount of coins paid in fees and the maximum
 /// gas to be used by the transaction. The ratio yields an effective "gasprice",
-/// which must be above some miminum to be accepted into the mempool.
+/// which must be above some minimum to be accepted into the mempool.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Fee {
     /// amount is the amount of coins to be paid as a fee


### PR DESCRIPTION
Corrected "lifecyle" → "lifecycle"
Corrected "occured" → "occurred"
Corrected "miminum" → "minimum"