### PR TITLE
fix(view): bail on out-of-order compact blocks instead of skipping

### DIFF
--- a/crates/view/src/worker.rs
+++ b/crates/view/src/worker.rs
@@ -228,8 +228,14 @@ impl Worker {
 
             let height = block.height;
             if height != expected_height {
-                tracing::warn!("out of order block detected");
-                continue;
+                anyhow::bail!(
+                    "expected compact block at height {} but got height {} — \
+                     the compact block stream delivered blocks out of order. \
+                     The sync loop will retry from the last committed height, \
+                     rebuilding the in-memory SCT from storage.",
+                    expected_height,
+                    height,
+                );
             }
             expected_height += 1;
 


### PR DESCRIPTION
## Summary

The view worker's sync loop silently skips compact blocks that arrive out of order from the gRPC stream (`continue` on height mismatch at `crates/view/src/worker.rs:230`). Each skipped block permanently corrupts the in-memory State Commitment Tree (SCT) because the block's note commitments are never inserted.

**After corruption:**
- Local SCT root diverges from the chain's canonical root
- Every spend proof built against the local SCT is invalid
- pd rejects all transactions with `"not a valid SCT root"` or `"spend proof did not verify"`
- The wallet is permanently broken until the view DB is manually deleted and resynced

**Impact:** Especially severe for long-running processes like IBC relayers (hermes) that keep the view service alive for days/weeks. Short-lived CLI tools (pcli) rarely hit this because they sync-transact-exit quickly.

## Fix

Replace `continue` with `bail!()`. The `run()` loop already handles errors by logging, sleeping 10s, and retrying `sync()`. On retry, `sync()` reads `last_sync_height()` from storage and rebuilds the in-memory SCT from the persisted (correct) state.

## Root cause

pd's compact block gRPC stream occasionally delivers blocks out of order, especially during initial sync or under load. The `sct-divergence-check` feature flag exists to detect this (line 436), which suggests this is a known edge case.

## Testing

Discovered and verified while operating Penumbra IBC relayers at rotko.net. Both relayers' view databases were consistently corrupted after fresh syncs. After applying this patch, the relayers recover automatically and relay successfully.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)