### PR TITLE
fix(pcli): use human-readable display for proposal state in list-proposals

### DIFF
--- a/crates/bin/pcli/src/command/query/governance.rs
+++ b/crates/bin/pcli/src/command/query/governance.rs
@@ -5,7 +5,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use futures::TryStreamExt;
-use penumbra_sdk_governance::Vote;
+use penumbra_sdk_governance::{proposal_state::State as ProposalState, Vote};
 use penumbra_sdk_proto::core::component::governance::v1::{
     query_service_client::QueryServiceClient as GovernanceQueryServiceClient,
     AllTalliedDelegatorVotesForProposalRequest, ProposalDataRequest, ProposalListRequest,
@@ -72,15 +72,17 @@ impl GovernanceCmd {
                         .expect("proposal should always be set");
                     let proposal_title = proposal.title;
 
-                    let proposal_state = proposal_response
+                    let proposal_state: ProposalState = proposal_response
                         .state
-                        .expect("proposal state should always be set");
+                        .expect("proposal state should always be set")
+                        .try_into()
+                        .context("cannot parse proposal state")?;
 
                     let proposal_id = proposal.id;
 
                     writeln!(
                         writer,
-                        "#{proposal_id} {proposal_state:?}    {proposal_title}"
+                        "#{proposal_id} [{proposal_state}] {proposal_title}"
                     )?;
                 }
                 Ok(())

--- a/crates/core/component/governance/src/proposal_state.rs
+++ b/crates/core/component/governance/src/proposal_state.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 
 use penumbra_sdk_proto::{penumbra::core::component::governance::v1 as pb, DomainType};
@@ -68,6 +70,28 @@ impl State {
                 Outcome::Passed => Withdrawn::No,
                 Outcome::Failed { withdrawn } | Outcome::Slashed { withdrawn } => withdrawn,
             },
+        }
+    }
+}
+
+impl fmt::Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            State::Voting => write!(f, "VOTING"),
+            State::Withdrawn { .. } => write!(f, "WITHDRAWN"),
+            State::Finished { outcome } | State::Claimed { outcome } => {
+                write!(f, "{outcome}")
+            }
+        }
+    }
+}
+
+impl<W> fmt::Display for Outcome<W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Outcome::Passed => write!(f, "PASSED"),
+            Outcome::Failed { .. } => write!(f, "FAILED"),
+            Outcome::Slashed { .. } => write!(f, "SLASHED"),
         }
     }
 }


### PR DESCRIPTION
Add Display impls for governance State and Outcome types, replacing the Debug output in `pcli query governance list-proposals`.  Before, proposals rendered as raw proto structs; now they display as clean labels like `[PASSED]`, `[FAILED]`, `[SLASHED]`.

Closes #4480
